### PR TITLE
gettext: Add fix for MIME database XML

### DIFF
--- a/app-devel/gettext/autobuild/patches/0001-xml-add-switch-to-use-POSIX-language-tags-in-xml-lan.patch
+++ b/app-devel/gettext/autobuild/patches/0001-xml-add-switch-to-use-POSIX-language-tags-in-xml-lan.patch
@@ -1,0 +1,240 @@
+From fecd046ff95c3d46f9e0fe191d3adc301849da62 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Fri, 10 Apr 2026 13:37:11 +0800
+Subject: [PATCH] xml: add switch to use POSIX language tags in xml:lang attr
+
+Some projects like shared-mime-info uses POSIX language tags in the
+xml:lang attribute. This doesn't conform the standard and common
+practice, however this issue was filed 4 years ago and is still open.
+Considering the vast impact if we begin to use BCP 47 tags in the MIME
+database (we need to change every project to adapt the BCP 47 tags), a
+switch is added to use POSIX tags in the xml:lang attribute.
+---
+ gettext-tools/src/its.c       | 28 ++++++++++++++++++++++------
+ gettext-tools/src/its.h       |  3 ++-
+ gettext-tools/src/msgfmt.c    | 15 +++++++++++++++
+ gettext-tools/src/write-xml.c |  6 +++++-
+ gettext-tools/src/write-xml.h |  2 ++
+ 5 files changed, 46 insertions(+), 8 deletions(-)
+
+diff --git a/gettext-tools/src/its.c b/gettext-tools/src/its.c
+index 4eb9c64e6..50e222c27 100644
+--- a/gettext-tools/src/its.c
++++ b/gettext-tools/src/its.c
+@@ -2812,7 +2812,8 @@ its_merge_context_merge_node (struct its_merge_context_ty *context,
+                               xmlNode *node,
+                               const char *language,
+                               message_list_ty *mlp,
+-                              bool replace_text)
++                              bool replace_text,
++                              bool preserve_tags)
+ {
+   if (node->type == XML_ELEMENT_NODE)
+     {
+@@ -2889,10 +2890,23 @@ its_merge_context_merge_node (struct its_merge_context_ty *context,
+               /* Set the xml:lang attribute.
+                  <https://www.w3.org/International/questions/qa-when-xmllang.en.html>
+                  says: "The value of the xml:lang attribute is a language tag
+-                 defined by BCP 47."  */
++                 defined by BCP 47."
++
++                 WARNING:
++                 Some projects like shared-mime-info uses POSIX language tags
++                 in the xml:lang attribute. This doesn't conform the standard
++                 and common practice, however this issue was filed 4 years
++                 ago and is still open.
++                 Considering the vast impact if we begin to use BCP 47 tags
++                 in the MIME database (we need to change every project to
++                 adapt the BCP 47 tags), a switch is added to use POSIX tags
++                 in the xml:lang attribute.  */
+               char language_bcp47[BCP47_MAX];
+-              xpg_to_bcp47 (language_bcp47, language);
+-              xmlSetProp (translated, BAD_CAST "xml:lang", BAD_CAST language_bcp47);
++              if (!preserve_tags)
++                xpg_to_bcp47 (language_bcp47, language);
++
++              xmlSetProp (translated, BAD_CAST "xml:lang",
++                BAD_CAST (preserve_tags ? language : language_bcp47));
+ 
+               const char *msgstr = mp->msgstr;
+               /* libxml2 offers two functions for setting the content of an
+@@ -2995,7 +3009,8 @@ void
+ its_merge_context_merge (its_merge_context_ty *context,
+                          const char *language,
+                          message_list_ty *mlp,
+-                         bool replace_text)
++                         bool replace_text,
++                         bool preserve_tags)
+ {
+   if (setjmp (xml_error_exit) == 0)
+     {
+@@ -3006,7 +3021,8 @@ its_merge_context_merge (its_merge_context_ty *context,
+         its_merge_context_merge_node (context, context->nodes.items[i],
+                                       language,
+                                       mlp,
+-                                      replace_text);
++                                      replace_text,
++                                      preserve_tags);
+     }
+   else
+     /* Caught a libxml error.  */
+diff --git a/gettext-tools/src/its.h b/gettext-tools/src/its.h
+index 55ed0f789..f6a9d4476 100644
+--- a/gettext-tools/src/its.h
++++ b/gettext-tools/src/its.h
+@@ -85,7 +85,8 @@ extern void its_merge_context_free (its_merge_context_ty *context);
+ extern void its_merge_context_merge (its_merge_context_ty *context,
+                                      const char *language,
+                                      message_list_ty *mlp,
+-                                     bool replace_text);
++                                     bool replace_text,
++                                     bool preserve_tags);
+ 
+ extern void its_merge_context_write (its_merge_context_ty *context,
+                                      FILE *fp);
+diff --git a/gettext-tools/src/msgfmt.c b/gettext-tools/src/msgfmt.c
+index 452212aec..88a6cbbee 100644
+--- a/gettext-tools/src/msgfmt.c
++++ b/gettext-tools/src/msgfmt.c
+@@ -120,6 +120,7 @@ static bool desktop_default_keywords = true;
+ /* XML mode output file specification.  */
+ static bool xml_mode;
+ static bool xml_replace_text;
++static bool xml_preserve_tags;
+ static const char *xml_locale_name;
+ static const char *xml_template_name;
+ static const char *xml_base_directory;
+@@ -192,6 +193,7 @@ static int msgfmt_desktop_bulk (const char *directory,
+ static int msgfmt_xml_bulk (const char *directory,
+                             const char *template_file_name,
+                             its_rule_list_ty *its_rules,
++                            const bool preserve_tags,
+                             const char *file_name);
+ 
+ 
+@@ -250,6 +252,7 @@ main (int argc, char *argv[])
+     { "no-hash",             CHAR_MAX + 6,  no_argument       },
+     { "no-redundancy",       CHAR_MAX + 18, no_argument       },
+     { "output-file",         'o',           required_argument },
++    { "preserve-tags",       CHAR_MAX + 21, no_argument       },
+     { "properties-input",    'P',           no_argument       },
+     { "qt",                  CHAR_MAX + 9,  no_argument       },
+     { "replace-text",        CHAR_MAX + 19, no_argument       },
+@@ -437,6 +440,9 @@ main (int argc, char *argv[])
+         case CHAR_MAX + 19: /* --replace-text */
+           xml_replace_text = true;
+           break;
++        case CHAR_MAX + 21: /* --posix-tags */
++          xml_preserve_tags = true;
++          break;
+         default:
+           usage (EXIT_FAILURE);
+           break;
+@@ -746,6 +752,7 @@ There is NO WARRANTY, to the extent permitted by law.\n\
+       exit_status = msgfmt_xml_bulk (xml_base_directory,
+                                      xml_template_name,
+                                      xml_its_rules,
++                                     xml_preserve_tags,
+                                      output_file_name);
+       exit (exit_status);
+     }
+@@ -882,6 +889,7 @@ There is NO WARRANTY, to the extent permitted by law.\n\
+                                    xml_template_name,
+                                    xml_its_rules,
+                                    xml_replace_text,
++                                   xml_preserve_tags,
+                                    domain->file_name))
+             exit_status = EXIT_FAILURE;
+         }
+@@ -1056,6 +1064,10 @@ XML mode options:\n"));
+       printf (_("\
+   -d DIRECTORY                base directory of .po files\n"));
+       printf (_("\
++  --preserve-tags             preserve the original language tags in the\n\
++                              xml:lang attribute instead of convert them\n\
++                              into BCP 47 language tags\n"));
++      printf (_("\
+   --replace-text              output XML with translated text replacing the\n\
+                               original text, not augmenting the original text\n"));
+       printf (_("\
+@@ -1699,6 +1711,7 @@ static int
+ msgfmt_xml_bulk (const char *directory,
+                  const char *template_file_name,
+                  its_rule_list_ty *its_rules,
++                 const bool preserve_tags,
+                  const char *file_name)
+ {
+   msgfmt_operand_list_ty operands;
+@@ -1713,10 +1726,12 @@ msgfmt_xml_bulk (const char *directory,
+     }
+ 
+   /* Write the messages into .xml file.  */
++
+   int status = msgdomain_write_xml_bulk (&operands,
+                                          template_file_name,
+                                          its_rules,
+                                          false,
++                                         preserve_tags,
+                                          file_name);
+ 
+   msgfmt_operand_list_destroy (&operands);
+diff --git a/gettext-tools/src/write-xml.c b/gettext-tools/src/write-xml.c
+index b787c5e8c..fe84d789f 100644
+--- a/gettext-tools/src/write-xml.c
++++ b/gettext-tools/src/write-xml.c
+@@ -44,6 +44,7 @@ msgdomain_write_xml_bulk (msgfmt_operand_list_ty *operands,
+                           const char *template_file_name,
+                           its_rule_list_ty *its_rules,
+                           bool replace_text,
++                          bool preserve_tags,
+                           const char *file_name)
+ {
+   FILE *fp;
+@@ -66,7 +67,8 @@ msgdomain_write_xml_bulk (msgfmt_operand_list_ty *operands,
+     its_merge_context_merge (context,
+                              operands->items[i].language,
+                              operands->items[i].mlp,
+-                             replace_text);
++                             replace_text,
++                             preserve_tags);
+   its_merge_context_write (context, fp);
+   its_merge_context_free (context);
+ 
+@@ -88,6 +90,7 @@ msgdomain_write_xml (message_list_ty *mlp,
+                      const char *template_file_name,
+                      its_rule_list_ty *its_rules,
+                      bool replace_text,
++                     bool preserve_tags,
+                      const char *file_name)
+ {
+   /* Convert the messages to Unicode.  */
+@@ -110,5 +113,6 @@ msgdomain_write_xml (message_list_ty *mlp,
+                                    template_file_name,
+                                    its_rules,
+                                    replace_text,
++                                   preserve_tags,
+                                    file_name);
+ }
+diff --git a/gettext-tools/src/write-xml.h b/gettext-tools/src/write-xml.h
+index 38e2bcbcd..eaf7b2932 100644
+--- a/gettext-tools/src/write-xml.h
++++ b/gettext-tools/src/write-xml.h
+@@ -37,6 +37,7 @@ extern int
+                             const char *template_file_name,
+                             its_rule_list_ty *its_rules,
+                             bool replace_text,
++                            bool preserve_tags,
+                             const char *file_name);
+ 
+ extern int
+@@ -44,6 +45,7 @@ extern int
+                                  const char *template_file_name,
+                                  its_rule_list_ty *its_rules,
+                                  bool replace_text,
++                                 bool preserve_tags,
+                                  const char *file_name);
+ 
+ #ifdef __cplusplus
+-- 
+2.52.0
+

--- a/app-devel/gettext/spec
+++ b/app-devel/gettext/spec
@@ -1,5 +1,5 @@
 VER=1.0
-REL=1
+REL=2
 SRCS="https://ftp.gnu.org/gnu/gettext/gettext-$VER.tar.xz"
 CHKSUMS="sha256::71132a3fb71e68245b8f2ac4e9e97137d3e5c02f415636eb508ae607bc01add7"
 CHKUPDATE="anitya::id=898"


### PR DESCRIPTION
Topic Description
-----------------

- gettext: add a switch to disable BCP 47 language tag conversion
    MIME database uses POSIX tags as everyone who use shared-mime-info to
    look up MIME types are providing POSIX language codes.

Package(s) Affected
-------------------

- gettext: 1:1.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gettext
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
