### PR TITLE
xwayland-satellite: fix cast ExitStatus to correct type, remove Boxes

### DIFF
--- a/runtime-display/xwayland-satellite/autobuild/patches/0002-fix-cast-ExitStatus-to-correct-type-remove-Boxes-399.patch
+++ b/runtime-display/xwayland-satellite/autobuild/patches/0002-fix-cast-ExitStatus-to-correct-type-remove-Boxes-399.patch
@@ -1,0 +1,102 @@
+From a879e5e0896a326adc79c474bf457b8b99011027 Mon Sep 17 00:00:00 2001
+From: En-En <39373446+En-En-Code@users.noreply.github.com>
+Date: Mon, 16 Mar 2026 00:51:05 +0000
+Subject: [PATCH] fix: cast ExitStatus to correct type, remove Boxes (#399)
+
+* fix: cast ExitStatus to correct type, remove Boxes
+
+Absolutely no clue why Past Me thought `usize` was the correct type
+to convert `ExitStatus` from. Rust docs make it really clear it is a
+`c_int` (i32) on Unix.
+
+Past Me also decided both leaking memory with `Box::into_raw` then
+unsoundly calling `Box::from_raw` on a pointer to a stack-allocated
+array was smart. Dunno why. Loser did not even leave a safety comment
+smh.
+
+* fix: use `mem::size_of` to get size of `i32`
+---
+ src/lib.rs           | 19 +++++++++----------
+ tests/integration.rs |  3 +--
+ 2 files changed, 10 insertions(+), 12 deletions(-)
+
+diff --git a/src/lib.rs b/src/lib.rs
+index 611c959..8c27f2d 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -9,7 +9,7 @@ use server::selection::{Clipboard, Primary};
+ use smithay_client_toolkit::data_device_manager::WritePipe;
+ use std::io::{BufRead, BufReader, Read, Write};
+ use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
+-use std::os::unix::net::UnixStream;
++use std::os::unix::{net::UnixStream, process::ExitStatusExt};
+ use std::process::{Command, ExitStatus, Stdio};
+ use wayland_server::{Display, ListeningSocket};
+ use xcb::x;
+@@ -121,9 +121,9 @@ pub fn main(mut data: impl RunData) -> Option<()> {
+             let line = line.unwrap();
+             info!(target: "xwayland_process", "{line}");
+         }
+-        let status = Box::new(xwayland.wait().unwrap());
+-        let status = Box::into_raw(status) as usize;
+-        finish_tx.write_all(&status.to_ne_bytes()).unwrap();
++        let status = xwayland.wait().unwrap().into_raw();
++        // On a successful integration test, the rx will be dropped, so keep logs/GDB clean
++        let _ = finish_tx.write_all(&status.to_ne_bytes());
+     });
+ 
+     let mut ready_fds = [
+@@ -131,11 +131,10 @@ pub fn main(mut data: impl RunData) -> Option<()> {
+         PollFd::new(&finish_rx, PollFlags::IN),
+     ];
+ 
+-    fn xwayland_exit_code(rx: &mut UnixStream) -> Box<ExitStatus> {
+-        let mut data = [0; (usize::BITS / 8) as usize];
++    fn xwayland_exit_code(rx: &mut UnixStream) -> ExitStatus {
++        let mut data = [0; std::mem::size_of::<i32>()];
+         rx.read_exact(&mut data).unwrap();
+-        let data = usize::from_ne_bytes(data);
+-        unsafe { Box::from_raw(data as *mut _) }
++        ExitStatus::from_raw(i32::from_ne_bytes(data))
+     }
+ 
+     let connection = match poll(&mut ready_fds, None) {
+@@ -179,7 +178,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
+             Ok(_) => {
+                 if !fds[3].revents().is_empty() {
+                     let status = xwayland_exit_code(&mut quit_rx);
+-                    if *status != ExitStatus::default() {
++                    if status != ExitStatus::default() {
+                         error!("Xwayland exited early with {status}");
+                     }
+                     return None;
+@@ -246,7 +245,7 @@ pub fn main(mut data: impl RunData) -> Option<()> {
+             Ok(_) => {
+                 if !fds[3].revents().is_empty() {
+                     let status = xwayland_exit_code(&mut quit_rx);
+-                    if *status != ExitStatus::default() {
++                    if status != ExitStatus::default() {
+                         error!("Xwayland exited early with {status}");
+                     }
+                     return None;
+diff --git a/tests/integration.rs b/tests/integration.rs
+index c49b5cb..df08a07 100644
+--- a/tests/integration.rs
++++ b/tests/integration.rs
+@@ -102,12 +102,11 @@ impl Drop for Fixture {
+         let thread = unsafe { ManuallyDrop::take(&mut self.thread) };
+         // Sending anything to the quit receiver to stop the main loop. Then we guarantee a main
+         // thread does not use file descriptors which outlive the Fixture's BorrowedFd
+-        let return_ptr = Box::into_raw(Box::new(0_usize)) as usize;
+         // If the receiver end of the pipe closed, the main thread dropped it, which means that
+         // thread already terminated
+         if self
+             .quit_tx
+-            .write_all(&return_ptr.to_ne_bytes())
++            .write_all(&0_i32.to_ne_bytes())
+             .is_err_and(|e| e.kind() != std::io::ErrorKind::BrokenPipe)
+         {
+             panic!("could not message the main thread to terminate");
+-- 
+2.52.0
+

--- a/runtime-display/xwayland-satellite/spec
+++ b/runtime-display/xwayland-satellite/spec
@@ -1,4 +1,5 @@
 VER=0.8.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/Supreeeme/xwayland-satellite.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377600"


### PR DESCRIPTION
Topic Description
-----------------

- xwayland-satellite: fix cast ExitStatus to correct type, remove Boxes

Package(s) Affected
-------------------

- xwayland-satellite: 0.8.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xwayland-satellite
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
