### PR TITLE
metasploit-framework: new,6.4.131

### DIFF
--- a/app-penetration/metasploit-framework/autobuild/build
+++ b/app-penetration/metasploit-framework/autobuild/build
@@ -1,0 +1,38 @@
+abinfo "Building metasploit-framework bundle ..."
+bundle config set --local deployment 'true'
+
+# FIXME: Compiling the Nokogiri component on the Loongson 3 platform results in the following error:
+# `Invalid configuration 'mips64el-aosc-linux-abi64': OS 'abi64' not recognized`. 
+# Use the `--use-system-libraries` flag to bypass this issue.
+if ab_match_arch loongson3; then
+    bundle config set --local build.nokogiri "--use-system-libraries"
+fi
+
+abinfo "Installing metasploit-framework ..."
+bundle install -j"$(nproc)" --no-cache --verbose
+install -dv "$PKGDIR"/usr/share/metasploit-framework
+install -dv "$PKGDIR"/usr/bin
+
+abinfo "Removing unnecessary files ..."
+rsync -av --exclude ".git" --exclude abdist --exclude abdist-dbg --exclude autobuild \
+    --exclude ".github" --exclude "Dockerfile" --exclude "/kubernetes" --exclude "/test" \
+    "$SRCDIR"/ "$PKGDIR"/usr/share/metasploit-framework/
+
+rm -rv "$PKGDIR"/usr/share/metasploit-framework/vendor/bundle/ruby/*/cache
+find "$PKGDIR"/usr/share/metasploit-framework/ -name "*.log" -print -delete
+find "$PKGDIR"/usr/share/metasploit-framework/vendor/bundle -name "gem_make.out" -print -delete
+
+abinfo "Creating wrapper scripts ..."
+for f in "$PKGDIR"/usr/share/metasploit-framework/msf*; do
+    if [ -f "$f" ] && [ -x "$f" ]; then
+        _msffile="$PKGDIR/usr/bin/$(basename "$f")"
+        cat > "${_msffile}" << EOF
+#!/bin/sh
+BUNDLE_GEMFILE=/usr/share/metasploit-framework/Gemfile exec bundle exec ruby /usr/share/metasploit-framework/$(basename "$f") "\$@"
+EOF
+        chmod -v 755 "${_msffile}"
+    fi
+done
+
+abinfo "Removing executable for launching automatic updates ..."
+rm -v "$PKGDIR"/usr/bin/msfupdate

--- a/app-penetration/metasploit-framework/autobuild/defines
+++ b/app-penetration/metasploit-framework/autobuild/defines
@@ -1,0 +1,19 @@
+PKGNAME=metasploit-framework
+PKGSEC=utils
+PKGDEP="git inetutils libpcap libxml2 libxslt postgresql ruby ruby-bundler sqlite"
+PKGDES="Penetration testing platform to discover, exploit, and validate system vulnerabilities"
+
+ABTYPE=self
+
+# FIXME: This is a Ruby package that does not generate debug symbols; if enabled, the following error will occur:
+# ABSPLITDBG is set, but we can't find any symbol files in /var/cache/acbs/build/acbs.ed_c9fic/metasploit-framework/abdist-dbg
+ABSTRIP=0
+
+# FIXME: For architectures other than amd64 and arm64, enabling LTO optimization leads to the following issues; 
+# the solution is to enable LTO optimization only for amd and arm.
+# Error fragment:
+#   /usr/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': 
+#   undefined symbol: Init_nokogiri (LoadError)
+NOLTO=1
+NOLTO__AMD64=0
+NOLTO__ARM64=0

--- a/app-penetration/metasploit-framework/spec
+++ b/app-penetration/metasploit-framework/spec
@@ -1,0 +1,4 @@
+VER=6.4.131
+SRCS="git::commit=tags/$VER::https://github.com/rapid7/metasploit-framework"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=190993"


### PR DESCRIPTION
Topic Description
-----------------

- metasploit-framework: new, 6.4.131
    Signed-off-by: neko205 <neko200553@gmail.com>
- metasploit-framework: new, 6.4.131
    Signed-off-by: neko205 <neko200553@gmail.com>

Package(s) Affected
-------------------

- metasploit-framework: 6.4.131

Security Update?
----------------

No

Build Order
-----------

```
#buildit metasploit-framework
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
