### PR TITLE
cx4-linux-graphics-driver-dri: update to 26.00.46

### DIFF
--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
@@ -1,4 +1,4 @@
-From 8474339f73efb5d2febd95c964bac038c573b654 Mon Sep 17 00:00:00 2001
+From 30f60b2563c2214d9f45dbf33ed89fd3db66d6a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 7 Nov 2025 23:50:09 +0800
 Subject: [PATCH 1/3] AOSCOS: fix(dkms.conf): drop check_gcc_version()
@@ -11,7 +11,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 46 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 371ddde..880b7a9 100644
+index 0a239dc..8b97cbc 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -19,50 +19,5 @@ num_cpu_cores()

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
@@ -1,4 +1,4 @@
-From 96226c8a8507b6a2d05bdb94ebebd60958e228c8 Mon Sep 17 00:00:00 2001
+From dd0046d224145aaf3a60e7b777a1981ef1533745 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 7 Nov 2025 23:50:49 +0800
 Subject: [PATCH 2/3] AOSCOS: fix(dkms.conf): drop unused options
@@ -9,12 +9,12 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 880b7a9..89bd2fe 100644
+index 8b97cbc..a1d8982 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,8 +1,6 @@
  PACKAGE_NAME="cx4"
- PACKAGE_VERSION=26.00.45
+ PACKAGE_VERSION=26.00.46
  AUTOINSTALL="yes"
 -#REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
@@ -1,4 +1,4 @@
-From 55901864132726cfaeda945ad5ffeb4e50fd3284 Mon Sep 17 00:00:00 2001
+From 9faec9235268b84293639296bb13bb215f8d52af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 22:45:52 +0800
 Subject: [PATCH 3/3] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
@@ -6,8 +6,13 @@ for i in postinst prerm; do
         "$SRCDIR/autobuild/$i"
 done
 
+abinfo "Unpacking upstream driver archive ..."
+7z x "$SRCDIR"/KX-6000G-Linux\ OS_x64-"$__UPSTREAM_VER".7z
+
 abinfo "Unpacking upstream deb package ..."
-dpkg-deb -X "$SRCDIR"/cx4-linux-graphics-driver-dri-glvnd-"$__UPSTREAM_VER"_amd64.deb "$SRCDIR"
+dpkg-deb -X \
+"$SRCDIR"/KX-6000G-Linux\ OS_x64-"$__UPSTREAM_VER"/cx4-linux-graphics-driver-dri-glvnd_"$__UPSTREAM_VER"_amd64.deb \
+"$SRCDIR"
 
 abinfo "Entering kernel module sources directory"
 cd "$SRCDIR"/usr/src/cx4-"$__UPSTREAM_VER"

--- a/runtime-display/cx4-linux-graphics-driver-dri/spec
+++ b/runtime-display/cx4-linux-graphics-driver-dri/spec
@@ -1,6 +1,6 @@
-UPSTREAM_VER=26.00.45
+UPSTREAM_VER=26.00.46
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3419&tag=0&ref=qdxz&pre=0&t=20ce3b68fe29466a"
-CHKSUMS="sha256::9d3ddcb33a9fc243472385b0b84ac58601a2a38b40185ddaa8cf266864f18bf4"
+CHKSUMS="sha256::d4c4cc9ebfc81f9c4e5dd23ca9ca95e005517c9c13203a360ea982965f8701f2"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- cx4-linux-graphics-driver-dri: update to 26.00.46
    - Track patches at AOSC-Tracking/cx4-kernel-dkms @ aosc/v26.00.46
    \(HEAD: 9faec9235268b84293639296bb13bb215f8d52af\).

Package(s) Affected
-------------------

- cx4-linux-graphics-driver-dri: 26.00.46

Security Update?
----------------

No

Build Order
-----------

```
#buildit cx4-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
