### PR TITLE
util-linux: update to 2.42

### DIFF
--- a/app-utils/util-linux/01-libraries/defines
+++ b/app-utils/util-linux/01-libraries/defines
@@ -15,6 +15,87 @@ BUILDDEP__M68K="${BUILDDEP__RETRO}"
 BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
 BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
+AUTOTOOLS_AFTER=(
+    '--localstatedir=/run'
+    '--disable-werror'
+    '--disable-asan'
+    '--disable-ubsan'
+    '--disable-fuzzing-engine'
+    '--enable-symvers'
+    '--enable-largefile'
+    '--enable-assert'
+    '--enable-nls'
+    '--disable-rpath'
+    '--enable-asciidoc'
+# FIXME: --disable-poman, this feature requires po4a but references a non-
+# existent po4a.cfg in the build routine.
+    '--disable-poman'
+    '--enable-tls'
+    '--enable-widechar'
+    '--enable-libuuid'
+    '--enable-libuuid-force-uuidd'
+    '--enable-libblkid'
+    '--enable-libmount'
+    '--enable-libsmartcols'
+    '--enable-libfdisk'
+    '--enable-fdisks'
+    '--enable-mount'
+    '--enable-losetup'
+    '--enable-zramctl'
+    '--enable-fsck'
+    '--enable-partx'
+    '--enable-uuidd'
+    '--enable-uuidgen'
+    '--enable-blkid'
+    '--enable-wipefs'
+    '--enable-mountpoint'
+    '--enable-fallocate'
+    '--enable-unshare'
+    '--enable-nsenter'
+    '--enable-setpriv'
+    '--enable-hardlink'
+    '--enable-eject'
+    '--enable-agetty'
+    '--enable-plymouth_support'
+    '--enable-cramfs'
+    '--enable-bfs'
+    '--enable-minix'
+    '--enable-fdformat'
+# Note: --disable-hwclock-cmos, the Linux Kernel provides the necessary
+# interface for access to the hardware clock.
+    '--enable-hwclock'
+    '--disable-hwclock-cmos'
+    '--enable-hwclock-gplv3'
+    '--enable-mkfs'
+    '--enable-fstrim'
+    '--enable-swapon'
+    '--enable-lscpu'
+    '--enable-lsfd'
+    '--enable-lslogins'
+    '--enable-wdctl'
+    '--enable-cal'
+    '--enable-logger'
+    '--enable-whereis'
+    '--enable-switch_root'
+    '--enable-pivot_root'
+    '--enable-lsmem'
+    '--enable-chmem'
+    '--enable-ipcmk'
+    '--enable-ipcrm'
+    '--enable-ipcs'
+    '--enable-irqtop'
+    '--enable-lsirq'
+    '--enable-lsns'
+    '--enable-rfkill'
+    '--enable-scriptutils'
+    '--enable-tunelp'
+    '--enable-kill'
+    '--enable-last'
+    '--enable-utmpdump'
+# Note: line was a demo provided by Mesa, which displays a triangle. `line' is
+# not enabled in other distros.
+    '--disable-line'
+    '--enable-mesg'
 # FIXME: raw(8) is no longer available as of Linux API headers 5.14.
 #
 # Ref: https://src.fedoraproject.org/rpms/util-linux/blob/rawhide/f/util-linux.spec#_965
@@ -24,150 +105,73 @@ BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 #
 # Disable raw for all architectures, because linux/raw.h was deprecated since commit:
 # 603e4922f1c81fc2ed3a87b4f91a8d3aafc7e093.
-#
+    '--disable-raw'
+    '--enable-rename'
+    '--disable-vipw'
+    '--disable-newgrp'
+# Note: chfn, chsh, login, nologin, su and vipw are provided by shadow.
+    '--disable-chfn-chsh-password'
+    '--disable-chfn-chsh'
+    '--disable-chsh-only-listed'
+    '--disable-login'
+    '--disable-login-chown-vcs'
+    '--disable-login-stat-mail'
+    '--disable-nologin'
+    '--enable-sulogin'
+    '--disable-su'
+    '--enable-runuser'
+    '--enable-ul'
+    '--enable-more'
+    '--enable-pg'
+    '--enable-setterm'
+    '--enable-schedutils'
+    '--enable-wall'
+    '--enable-write'
+    '--enable-bash-completion'
+    '--enable-pylibmount'
+    '--enable-pg-bell'
+    '--enable-fs-paths-default=/usr/bin'
+    '--enable-use-tty-group'
+    '--disable-sulogin-emergency-mount'
+    '--enable-usrdir-path'
+    '--enable-makeinstall-chown'
+    '--enable-makeinstall-setuid'
+    '--enable-colors-default'
+    '--with-util'
+    '--without-selinux'
+    '--without-audit'
+    '--with-udev'
+# Note:
+# because the variable `CURSES_LIB_NAME` may be covered,
+# so only one lib in ncursesw, ncurses and slang can be enabled
+# ncursesw is more featured so ncurses and slang are disabled
+# https://github.com/util-linux/util-linux/blob/v2.42/configure.ac#L1211
+    '--with-ncursesw'
+    '--without-ncurses'
+    '--without-slang'
+    '--with-tinfo'
+    '--with-readline'
+    '--with-utempter'
+    '--with-cap-ng'
+    '--with-libz'
+    '--with-libmagic'
 # Note: --without-user, libuser is needed for remote chsh, but we don't ship
 # chsh from this package.
-#
-# FIXME: --disable-poman, this feature requires po4a but references a non-
-# existent po4a.cfg in the build routine.
-#
-# Note: chfn, chsh, login, nologin, su and vipw are provided by shadow.
-#
-# Note: line was a demo provided by Mesa, which displays a triangle. `line' is
-# not enabled in other distros.
-#
-# Note: --disable-hwclock-cmos, the Linux Kernel provides the necessary
-# interface for access to the hardware clock.
-AUTOTOOLS_AFTER="--localstatedir=/run \
-                 --disable-werror \
-                 --disable-asan \
-                 --disable-ubsan \
-                 --disable-fuzzing-engine \
-                 --enable-symvers \
-                 --enable-largefile \
-                 --enable-assert \
-                 --enable-nls \
-                 --disable-rpath \
-                 --enable-asciidoc \
-                 --disable-poman \
-                 --enable-tls \
-                 --enable-widechar \
-                 --enable-libuuid \
-                 --enable-libuuid-force-uuidd \
-                 --enable-libblkid \
-                 --enable-libmount \
-                 --enable-libsmartcols \
-                 --enable-libfdisk \
-                 --enable-fdisks \
-                 --enable-mount \
-                 --enable-losetup \
-                 --enable-zramctl \
-                 --enable-fsck \
-                 --enable-partx \
-                 --enable-uuidd \
-                 --enable-uuidgen \
-                 --enable-blkid \
-                 --enable-wipefs \
-                 --enable-mountpoint \
-                 --enable-fallocate \
-                 --enable-unshare \
-                 --enable-nsenter \
-                 --enable-setpriv \
-                 --enable-hardlink \
-                 --enable-eject \
-                 --enable-agetty \
-                 --enable-plymouth_support \
-                 --enable-cramfs \
-                 --enable-bfs \
-                 --enable-minix \
-                 --enable-fdformat \
-                 --enable-hwclock \
-                 --disable-hwclock-cmos \
-                 --enable-hwclock-gplv3 \
-                 --enable-mkfs \
-                 --enable-fstrim \
-                 --enable-swapon \
-                 --enable-lscpu \
-                 --enable-lsfd \
-                 --enable-lslogins \
-                 --enable-wdctl \
-                 --enable-cal \
-                 --enable-logger \
-                 --enable-whereis \
-                 --enable-switch_root \
-                 --enable-pivot_root \
-                 --enable-lsmem \
-                 --enable-chmem \
-                 --enable-ipcmk \
-                 --enable-ipcrm \
-                 --enable-ipcs \
-                 --enable-irqtop \
-                 --enable-lsirq \
-                 --enable-lsns \
-                 --enable-rfkill \
-                 --enable-scriptutils \
-                 --enable-tunelp \
-                 --enable-kill \
-                 --enable-last \
-                 --enable-utmpdump \
-                 --disable-line \
-                 --enable-mesg \
-                 --disable-raw \
-                 --enable-rename \
-                 --disable-vipw \
-                 --disable-newgrp \
-                 --disable-chfn-chsh-password \
-                 --disable-chfn-chsh \
-                 --disable-chsh-only-listed \
-                 --disable-login \
-                 --disable-login-chown-vcs \
-                 --disable-login-stat-mail \
-                 --disable-nologin \
-                 --enable-sulogin \
-                 --disable-su \
-                 --enable-runuser \
-                 --enable-ul \
-                 --enable-more \
-                 --enable-pg \
-                 --enable-setterm \
-                 --enable-schedutils \
-                 --enable-wall \
-                 --enable-write \
-                 --enable-bash-completion \
-                 --enable-pylibmount \
-                 --enable-pg-bell \
-                 --enable-fs-paths-default=/usr/bin \
-                 --enable-use-tty-group \
-                 --disable-sulogin-emergency-mount \
-                 --enable-usrdir-path \
-                 --enable-makeinstall-chown \
-                 --enable-makeinstall-setuid \
-                 --enable-colors-default \
-                 --with-util \
-                 --without-selinux \
-                 --without-audit \
-                 --with-udev \
-                 --with-ncursesw \
-                 --without-ncurses \
-                 --with-slang \
-                 --with-tinfo \
-                 --with-readline \
-                 --with-utempter \
-                 --with-cap-ng \
-                 --with-libz \
-                 --with-libmagic \
-                 --without-user \
-                 --with-btrfs \
-                 --with-systemd \
-                 --without-smack \
-                 --without-econf \
-                 --with-python=3 \
-                 --with-cryptsetup"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --without-python \
-                 --disable-asciidoc \
-                 --disable-pylibmount"
+    '--without-user'
+    '--with-btrfs'
+    '--with-systemd'
+    '--without-smack'
+    '--without-econf'
+    '--with-python=3'
+    '--with-cryptsetup'
+)
+
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--without-python'
+    '--disable-asciidoc'
+    '--disable-pylibmount'
+)
 
 PKGREP="util-linux<=2.39.3-2"
 PKGBREAK="util-linux<=2.39.3-2"

--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,4 @@
-VER=2.40.4
+VER=2.42
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::5c1daf733b04e9859afdc3bd87cc481180ee0f88b5c0946b16fdec931975fb79"
+CHKSUMS="sha256::3452b260bbaa775d6e749ac3bb22111785003fc1f444970025c8da26dfa758e9"
 CHKUPDATE="anitya::id=8179"
-REL="1"

--- a/topics/util-linux-2.42.toml
+++ b/topics/util-linux-2.42.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "util-linux 2.42"
+
+[caution]
+default = "Fixes a TOCTOU (Time-Of-Check to Time-of-Use) race condition vulnerability - CVE-2026-27456 (severity: Medium)"
+zh_CN = "修复一处 TOCTOU（检查到使用时间）竞态条件漏洞，漏洞编号 CVE-2026-27456（严重性：中）"
+
+[packages-v2]
+"util-lilnux" = "< 2.42"


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: update to 2.42
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- util-linux: 2.42
- util-linux-runtime: 2.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
