### PR TITLE
motrix-next: new, 3.6.10

### DIFF
--- a/app-web/motrix-next/autobuild/build
+++ b/app-web/motrix-next/autobuild/build
@@ -1,0 +1,18 @@
+abinfo "Building motrix-next..."
+cd "$SRCDIR"
+pnpm install
+cargo tauri build --no-bundle
+
+abinfo "Installing Motrix Next ..."
+install -Dvm755 "$SRCDIR"/src-tauri/target/release/motrix-next \
+    "$PKGDIR"/usr/bin/motrix-next
+
+abinfo "Installing aria2 config..."
+install -Dvm644 "$SRCDIR"/src-tauri/binaries/aria2.conf \
+    "$PKGDIR"/usr/lib/motrix-next/binaries/aria2.conf
+
+abinfo "Installing application icon ..."
+for i in 32 64 128; do
+    install -Dvm644 "$SRCDIR"/src-tauri/icons/${i}x${i}.png \
+                    "$PKGDIR"/usr/share/icons/hicolor/${i}x${i}/apps/motrix-next.png
+done

--- a/app-web/motrix-next/autobuild/defines
+++ b/app-web/motrix-next/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=motrix-next
+PKGSEC=web
+PKGDEP="cairo gcc-runtime glib glibc gdk-pixbuf\
+        gtk-3 libsoup-3 pango webkit2gtk \
+        libayatana-appindicator aria2"
+BUILDDEP="nodejs rustc llvm tauri-cli"
+PKGDES="Full-featured download manager rebuilt with Tauri 2"
+PKGPROV="motrixnext"
+
+# Note: rollup not supported on mips64el
+FAIL_ARCH="loongson3"
+NOLTO=1

--- a/app-web/motrix-next/autobuild/overrides/usr/share/applications/motrix-next.desktop
+++ b/app-web/motrix-next/autobuild/overrides/usr/share/applications/motrix-next.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Categories=Utility;
+Comment=A full-featured download manager
+Exec=motrix-next
+StartupWMClass=motrix-next
+Icon=motrix-next
+Name=Motrix Next
+Terminal=false
+Type=Application
+MimeType=application/x-bittorrent;application/metalink+xml;x-scheme-handler/magnet;x-scheme-handler/thunder;x-scheme-handler/motrixnext

--- a/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
+++ b/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
@@ -1,0 +1,145 @@
+From 3a67e3ecfb70ce5ef2b1279d909a0ca9cb9c29bc Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Sun, 12 Apr 2026 18:13:45 +0800
+Subject: [PATCH 1/3] feat: disable auto-update check
+
+---
+ src/components/preference/Basic.vue           | 65 +------------------
+ .../__tests__/useBasicPreference.test.ts      |  2 +-
+ src/shared/constants.ts                       |  2 +-
+ 3 files changed, 3 insertions(+), 66 deletions(-)
+
+diff --git a/src/components/preference/Basic.vue b/src/components/preference/Basic.vue
+index 898ec12..898e549 100644
+--- a/src/components/preference/Basic.vue
++++ b/src/components/preference/Basic.vue
+@@ -43,20 +43,15 @@ import {
+   NButton,
+   NDivider,
+   NInputGroup,
+-  NText,
+   NCollapseTransition,
+   NDynamicTags,
+   NTag,
+   NSpace,
+-  NRadioGroup,
+-  NRadioButton,
+   useDialog,
+ } from 'naive-ui'
+ import PreferenceActionBar from './PreferenceActionBar.vue'
+ import MTooltip from '@/components/common/MTooltip.vue'
+-import { FolderOpenOutline, CloudDownloadOutline } from '@vicons/ionicons5'
+-import { NIcon } from 'naive-ui'
+-import UpdateDialog from '@/components/preference/UpdateDialog.vue'
++import { FolderOpenOutline } from '@vicons/ionicons5'
+ 
+ const { t, locale } = useI18n()
+ const preferenceStore = usePreferenceStore()
+@@ -81,16 +76,6 @@ async function copyVersionToClipboard(text: string, label: string) {
+     /* Clipboard API may fail in some contexts — silently ignore. */
+   }
+ }
+-const updateDialogRef = ref<InstanceType<typeof UpdateDialog> | null>(null)
+-
+-const checkIntervalOptions = [
+-  { label: t('preferences.interval-daily'), value: 24 },
+-  { label: t('preferences.interval-weekly'), value: 168 },
+-  { label: t('preferences.interval-monthly'), value: 720 },
+-  { label: t('preferences.interval-semi-annual'), value: 4320 },
+-  { label: t('preferences.interval-yearly'), value: 8760 },
+-]
+-
+ function buildForm() {
+   return buildBasicForm(preferenceStore.config, defaultDownloadDir.value)
+ }
+@@ -578,10 +563,6 @@ function loadForm() {
+   downloadUnit.value = dl.unit
+ }
+ 
+-function handleCheckUpdate() {
+-  updateDialogRef.value?.open()
+-}
+-
+ const { restartEngine } = useEngineRestart()
+ 
+ function handleManualRestart() {
+@@ -738,50 +719,6 @@ onMounted(async () => {
+         <NSelect v-model:value="form.locale" :options="localeOptions" style="width: 280px" />
+       </NFormItem>
+ 
+-      <NDivider title-placement="left">{{ t('preferences.auto-update') }}</NDivider>
+-      <NFormItem :label="t('preferences.auto-check-update')">
+-        <NSwitch v-model:value="form.autoCheckUpdate" />
+-      </NFormItem>
+-      <NCollapseTransition :show="form.autoCheckUpdate" class="collapse-indent">
+-        <NFormItem :label="t('preferences.check-frequency')">
+-          <NSelect v-model:value="form.autoCheckUpdateInterval" :options="checkIntervalOptions" style="width: 180px" />
+-        </NFormItem>
+-      </NCollapseTransition>
+-      <NFormItem :label="t('preferences.update-channel')">
+-        <NRadioGroup
+-          v-model:value="form.updateChannel"
+-          size="small"
+-          @update:value="
+-            async (v: string) => {
+-              const ok = await preferenceStore.updateAndSave({ updateChannel: v as 'stable' | 'beta' })
+-              if (ok) {
+-                // Only sync updateChannel in the snapshot — preserve dirty state
+-                // for other unsaved fields (download dir, speed limits, etc.).
+-                patchSnapshot({ updateChannel: v } as Partial<typeof form.value>)
+-              }
+-            }
+-          "
+-        >
+-          <NRadioButton value="stable">{{ t('preferences.update-channel-stable') }}</NRadioButton>
+-          <NRadioButton value="beta">{{ t('preferences.update-channel-beta') }}</NRadioButton>
+-        </NRadioGroup>
+-      </NFormItem>
+-      <NFormItem :label="t('preferences.last-check-update-time')">
+-        <div style="display: flex; align-items: center; gap: 16px">
+-          <NButton size="small" @click="handleCheckUpdate">
+-            <template #icon>
+-              <NIcon :size="14"><CloudDownloadOutline /></NIcon>
+-            </template>
+-            {{ t('app.check-updates-now') }}
+-          </NButton>
+-          <NText v-if="preferenceStore.config.lastCheckUpdateTime" depth="3" style="font-size: 13px">
+-            {{ new Date(preferenceStore.config.lastCheckUpdateTime).toLocaleString() }}
+-          </NText>
+-          <NText v-else depth="3" style="font-size: 13px">—</NText>
+-        </div>
+-      </NFormItem>
+-      <UpdateDialog ref="updateDialogRef" />
+-
+       <NDivider title-placement="left">{{ t('preferences.appearance-section') }}</NDivider>
+       <NFormItem :label="t('preferences.appearance')">
+         <NSelect v-model:value="form.theme" :options="themeOptions" style="width: 200px" />
+diff --git a/src/composables/__tests__/useBasicPreference.test.ts b/src/composables/__tests__/useBasicPreference.test.ts
+index 9e988c9..65cbd75 100644
+--- a/src/composables/__tests__/useBasicPreference.test.ts
++++ b/src/composables/__tests__/useBasicPreference.test.ts
+@@ -24,7 +24,7 @@ describe('buildBasicForm', () => {
+ 
+   it('returns sensible defaults for empty config', () => {
+     const form = buildBasicForm(emptyConfig)
+-    expect(form.autoCheckUpdate).toBe(true)
++    expect(form.autoCheckUpdate).toBe(false)
+     expect(form.autoCheckUpdateInterval).toBe(24)
+     expect(form.updateChannel).toBe('stable')
+     expect(form.locale).toBe('en-US')
+diff --git a/src/shared/constants.ts b/src/shared/constants.ts
+index 2ab7e64..bb102a6 100644
+--- a/src/shared/constants.ts
++++ b/src/shared/constants.ts
+@@ -251,7 +251,7 @@ export const DEFAULT_APP_CONFIG = {
+   resumeAllWhenAppLaunched: false, // don't flood bandwidth on launch
+ 
+   // ── Auto Update ───────────────────────────────────────────────
+-  autoCheckUpdate: true, // qBT checks every launch; security best practice
++  autoCheckUpdate: false, // qBT checks every launch; security best practice
+   autoCheckUpdateInterval: 24, // 24h (daily) is standard check frequency
+   /** Linux-only: DMA-BUF GPU rendering ON by default for best performance.
+    *  Crash sentinel in gpu_guard auto-reverts to software rendering on failure. */
+-- 
+2.52.0
+

--- a/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
+++ b/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
@@ -1,0 +1,102 @@
+From 59215b9513375d56eb5e33ec9cec5b61ffd5e59c Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Tue, 14 Apr 2026 12:42:31 +0800
+Subject: [PATCH 2/3] feat: add more architectures support
+
+---
+ src/composables/__tests__/usePlatform.test.ts | 25 +++++++++++++++++--
+ src/composables/usePlatform.ts                |  4 +++
+ src/shared/__tests__/sidecarBinaries.test.ts  | 16 ++++++++++++
+ 3 files changed, 43 insertions(+), 2 deletions(-)
+
+diff --git a/src/composables/__tests__/usePlatform.test.ts b/src/composables/__tests__/usePlatform.test.ts
+index a09fbf7..3d293fd 100644
+--- a/src/composables/__tests__/usePlatform.test.ts
++++ b/src/composables/__tests__/usePlatform.test.ts
+@@ -117,11 +117,32 @@ describe('usePlatform', () => {
+       expect(archLabel('x86_64')).toBe('x64')
+     })
+ 
+-    it('returns raw value for unknown architectures', async () => {
++    it('returns label for loongarch64', async () => {
+       mockPlatform.mockReturnValue('linux')
+       const mod = await import('../usePlatform')
+       const { archLabel } = mod.usePlatform()
+-      expect(archLabel('riscv64')).toBe('riscv64')
++      expect(archLabel('loongarch64')).toBe('LoongArch64')
++    })
++
++    it('returns label for mips64', async () => {
++      mockPlatform.mockReturnValue('linux')
++      const mod = await import('../usePlatform')
++      const { archLabel } = mod.usePlatform()
++      expect(archLabel('mips64')).toBe('MIPS64el')
++    })
++
++    it('returns label for powerpc64', async () => {
++      mockPlatform.mockReturnValue('linux')
++      const mod = await import('../usePlatform')
++      const { archLabel } = mod.usePlatform()
++      expect(archLabel('powerpc64')).toBe('PowerPC64el')
++    })
++
++    it('returns label for riscv64', async () => {
++      mockPlatform.mockReturnValue('linux')
++      const mod = await import('../usePlatform')
++      const { archLabel } = mod.usePlatform()
++      expect(archLabel('riscv64')).toBe('RISC-V64')
+     })
+   })
+ 
+diff --git a/src/composables/usePlatform.ts b/src/composables/usePlatform.ts
+index fe2dcc0..97aa2c0 100644
+--- a/src/composables/usePlatform.ts
++++ b/src/composables/usePlatform.ts
+@@ -48,6 +48,10 @@ const ARCH_LABELS: Record<string, string> = {
+   aarch64: 'ARM64',
+   x86_64: 'x64',
+   x86: 'x86',
++  loongarch64: 'LoongArch64',
++  mips64: 'MIPS64el',
++  powerpc64: 'PowerPC64el',
++  riscv64: 'RISC-V64',
+ }
+ 
+ /**
+diff --git a/src/shared/__tests__/sidecarBinaries.test.ts b/src/shared/__tests__/sidecarBinaries.test.ts
+index c51b965..908b4e9 100644
+--- a/src/shared/__tests__/sidecarBinaries.test.ts
++++ b/src/shared/__tests__/sidecarBinaries.test.ts
+@@ -33,6 +33,10 @@ const EXPECTED_TARGETS = [
+   // Linux
+   'x86_64-unknown-linux-gnu',
+   'aarch64-unknown-linux-gnu',
++  'loongarch64-unknown-linux-gnu',
++  'mips64el-unknown-linux-gnu',
++  'powerpc64le-unknown-linux-gnu',
++  'riscv64gc-unknown-linux-gnu',
+ ] as const
+ 
+ /** Minimum valid sidecar size in bytes (1 MB). Anything smaller is likely corrupt. */
+@@ -128,6 +132,18 @@ describe('sidecar binaries', () => {
+         } else if (target.includes('aarch64')) {
+           // EM_AARCH64 = 183
+           expect(machine).toBe(183)
++        } else if (target.includes('loongarch64')) {
++          // EM_LOONGARCH = 258
++          expect(machine).toBe(258)
++        } else if (target.includes('mips64el')) {
++          // EM_MIPS = 8 (MIPS64 little-endian)
++          expect(machine).toBe(8)
++        } else if (target.includes('powerpc64')) {
++          // EM_PPC64 = 21
++          expect(machine).toBe(21)
++        } else if (target.includes('riscv64')) {
++          // EM_RISCV = 243
++          expect(machine).toBe(243)
+         }
+       })
+     }
+-- 
+2.52.0
+

--- a/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
+++ b/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
@@ -1,0 +1,72 @@
+From 2d6365bfced3606e58281e7139005fd26c179b37 Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Tue, 14 Apr 2026 13:47:55 +0800
+Subject: [PATCH 3/3] feat: use system aria2c
+
+---
+ src-tauri/src/engine/lifecycle.rs | 18 ++++++------------
+ src-tauri/tauri.conf.json         |  5 +----
+ 2 files changed, 7 insertions(+), 16 deletions(-)
+
+diff --git a/src-tauri/src/engine/lifecycle.rs b/src-tauri/src/engine/lifecycle.rs
+index a682751..a111a70 100644
+--- a/src-tauri/src/engine/lifecycle.rs
++++ b/src-tauri/src/engine/lifecycle.rs
+@@ -99,13 +99,10 @@ pub fn start_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Resul
+         session_path.exists(),
+     );
+ 
+-    let sidecar = app
++    let (mut rx, child) = app
+         .shell()
+-        .sidecar("motrixnext-aria2c")
+-        .map_err(|e| format!("Failed to create sidecar: {}", e))?
+-        .args(&args);
+-
+-    let (mut rx, child) = sidecar
++        .command("aria2c")
++        .args(&args)
+         .spawn()
+         .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
+ 
+@@ -366,13 +363,10 @@ pub fn restart_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Res
+         session_path.exists(),
+     );
+ 
+-    let sidecar = app
++    let (mut rx, child) = app
+         .shell()
+-        .sidecar("motrixnext-aria2c")
+-        .map_err(|e| format!("Failed to create sidecar: {}", e))?
+-        .args(&args);
+-
+-    let (mut rx, child) = sidecar
++        .command("aria2c")
++        .args(&args)
+         .spawn()
+         .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
+ 
+diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
+index e38423b..fef4e5c 100644
+--- a/src-tauri/tauri.conf.json
++++ b/src-tauri/tauri.conf.json
+@@ -35,9 +35,6 @@
+     "publisher": "AnInsomniacy",
+     "copyright": "Copyright © 2025 AnInsomniacy. All rights reserved.",
+     "createUpdaterArtifacts": true,
+-    "externalBin": [
+-      "binaries/motrixnext-aria2c"
+-    ],
+     "resources": [
+       "binaries/aria2.conf"
+     ],
+@@ -128,4 +125,4 @@
+       "preload": ["sqlite:history.db"]
+     }
+   }
+-}
+\ No newline at end of file
++}
+-- 
+2.52.0
+

--- a/app-web/motrix-next/spec
+++ b/app-web/motrix-next/spec
@@ -1,0 +1,6 @@
+VER=3.6.10
+SRCS="git::commit=tags/v$VER::https://github.com/AnInsomniacy/motrix-next.git"
+CHKSUMS="SKIP"
+SUBDIR="motrix-next"
+CHKUPDATE="anitya::id=389590"
+ENVREQ="total_mem=16"


### PR DESCRIPTION
Topic Description
-----------------

- motrix-next: new, 3.6.10

Package(s) Affected
-------------------

- motrix-next: 3.6.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit motrix-next
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
