### PR TITLE
libgovirt: update to 0.3.11

### DIFF
--- a/runtime-virtualization/libgovirt/spec
+++ b/runtime-virtualization/libgovirt/spec
@@ -1,4 +1,4 @@
-VER=0.3.8
+VER=0.3.11
 SRCS="tbl::https://download.gnome.org/sources/libgovirt/${VER:0:3}/libgovirt-$VER.tar.xz"
-CHKSUMS="sha256::1dc9186229176bdfa9f25fd8fa82c0a058b6a60c1cc807c7507ec8a93c0f1df8"
+CHKSUMS="sha256::081c1fb5091cb8a1660ea9c152b689de9ba191d10a1109df503f5754f318af7e"
 CHKUPDATE="anitya::id=229567"


### PR DESCRIPTION
Topic Description
-----------------

- libgovirt: update to 0.3.11
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libgovirt: 0.3.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgovirt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
