### PR TITLE
vscode: update to 1.115.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.114.0
+VER=1.115.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::6eedc7d7cf13b7133c8c4c8b4bf4f5ae2a826bbdf890504f0d58b2f95e203cd4"
-CHKSUMS__ARM64="sha256::b4c12d5b0c199e08dcb0bb7d2e2f5fa5781ad48775ad38f14f237630ca6a8492"
+CHKSUMS__AMD64="sha256::54457e868d2d0eca02919e787d26a9614520589145e10d3aac62911a8ffd8b00"
+CHKSUMS__ARM64="sha256::5d771366be7a3ff5f1ef21e4ed2aa8af60d6003b8282ba95e03b36a6d4ba690b"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.115.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.115.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
