### PR TITLE
fcitx5-pinyin-moegirl: update to 20260412

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260315
+VER=20260412
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::62737502b1f28a45749000eab87da4c2993b72989729c2fa6305315495e540a3 \
-         sha256::88d44342c0e0f06e7c9929039f3a065157d65f761ecc8595c25e4224c281fb01 \
+CHKSUMS="sha256::62c759539e9d074a35a55ed2246d7f48c85284ca199a2489e778d2b1ba61f609 \
+         sha256::a88164683762bc4eed3909a4d13a4d07cc28bf989acde817ede263301fa515ed \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260412

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260412
- rime-pinyin-moegirl: 20260412

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
