### PR TITLE
codex: update to 0.120.0

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From 31689016994f336fe877a8427ed5756d42845660 Mon Sep 17 00:00:00 2001
+From 84391a0deda3ffc75a680e48ff94a0a4f61e4d29 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 31 Mar 2026 15:36:13 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
@@ -9,10 +9,10 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 2edc559c1..2ba3e9613 100644
+index 4d173d203..4323055b1 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -10809,8 +10809,6 @@ dependencies = [
+@@ -11390,8 +11390,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "146.4.0"
@@ -22,10 +22,10 @@ index 2edc559c1..2ba3e9613 100644
   "bindgen",
   "bitflags 2.10.0",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index ae810b696..3970f3fc8 100644
+index 4f5800755..98518a370 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -419,5 +419,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -435,5 +435,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
@@ -1,15 +1,15 @@
-From 022712decfac4dcd8b0fab00652dc21b6e6db725 Mon Sep 17 00:00:00 2001
+From cfb80b8eba2b266d97ede6c88b346c129b6d41eb Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Wed, 1 Apr 2026 09:16:50 +0800
+Date: Mon, 13 Apr 2026 10:58:37 +0800
 Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
 
 https://github.com/openai/codex/issues/14065
 ---
- codex-rs/Cargo.lock | 172 ++++++++++++++++++++++----------------------
- 1 file changed, 86 insertions(+), 86 deletions(-)
+ codex-rs/Cargo.lock | 186 ++++++++++++++++++++++----------------------
+ 1 file changed, 93 insertions(+), 93 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 2ba3e9613..eeeddd11d 100644
+index 4323055b1..147ce19fe 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -402,7 +402,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
@@ -17,556 +17,615 @@ index 2ba3e9613..eeeddd11d 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1335,7 +1335,7 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
+@@ -1368,7 +1368,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1352,7 +1352,7 @@ dependencies = [
+@@ -1386,7 +1386,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1361,7 +1361,7 @@ dependencies = [
+@@ -1395,7 +1395,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1391,7 +1391,7 @@ dependencies = [
+@@ -1428,7 +1428,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -1455,7 +1455,7 @@ dependencies = [
+@@ -1500,7 +1500,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -1476,7 +1476,7 @@ dependencies = [
+@@ -1523,7 +1523,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1504,7 +1504,7 @@ dependencies = [
+@@ -1551,7 +1551,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1525,7 +1525,7 @@ dependencies = [
+@@ -1572,7 +1572,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -1541,7 +1541,7 @@ dependencies = [
+@@ -1591,7 +1591,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -1556,7 +1556,7 @@ dependencies = [
+@@ -1608,7 +1608,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "async-trait",
   "pretty_assertions",
-@@ -1566,7 +1566,7 @@ dependencies = [
+@@ -1618,7 +1618,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-backend-openapi-models",
-@@ -1581,7 +1581,7 @@ dependencies = [
+@@ -1633,7 +1633,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "serde",
   "serde_json",
-@@ -1590,7 +1590,7 @@ dependencies = [
+@@ -1642,7 +1642,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1609,7 +1609,7 @@ dependencies = [
+@@ -1662,7 +1662,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -1658,7 +1658,7 @@ dependencies = [
+@@ -1714,7 +1714,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "async-trait",
   "bytes",
-@@ -1688,7 +1688,7 @@ dependencies = [
+@@ -1744,7 +1744,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-requirements"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "async-trait",
   "base64 0.22.1",
-@@ -1711,7 +1711,7 @@ dependencies = [
+@@ -1769,7 +1769,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -1742,7 +1742,7 @@ dependencies = [
+@@ -1801,7 +1801,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -1757,7 +1757,7 @@ dependencies = [
+@@ -1815,7 +1815,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-cloud-tasks-mock-client"
+-version = "0.0.0"
++version = "0.120.0"
+ dependencies = [
+  "async-trait",
+  "chrono",
+@@ -1825,7 +1825,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "async-trait",
   "pretty_assertions",
-@@ -1771,7 +1771,7 @@ dependencies = [
+@@ -1839,11 +1839,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-collaboration-mode-templates"
+-version = "0.0.0"
++version = "0.120.0"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -1795,7 +1795,7 @@ dependencies = [
+@@ -1874,7 +1874,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -1807,7 +1807,7 @@ dependencies = [
+@@ -1886,7 +1886,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -1927,7 +1927,7 @@ dependencies = [
+@@ -2006,7 +2006,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-skills"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-analytics",
-@@ -1956,7 +1956,7 @@ dependencies = [
+@@ -2035,7 +2035,7 @@ dependencies = [
  
  [[package]]
  name = "codex-debug-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1968,7 +1968,7 @@ dependencies = [
+@@ -2047,7 +2047,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2010,7 +2010,7 @@ dependencies = [
+@@ -2091,7 +2091,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2035,7 +2035,7 @@ dependencies = [
+@@ -2118,7 +2118,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2052,7 +2052,7 @@ dependencies = [
+@@ -2135,7 +2135,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy-legacy"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "allocative",
   "anyhow",
-@@ -2072,7 +2072,7 @@ dependencies = [
+@@ -2155,7 +2155,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2081,7 +2081,7 @@ dependencies = [
+@@ -2164,7 +2164,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
-  "codex-login",
   "codex-otel",
-@@ -2095,7 +2095,7 @@ dependencies = [
+  "codex-protocol",
+@@ -2177,7 +2177,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
-  "codex-protocol",
-@@ -2107,7 +2107,7 @@ dependencies = [
+  "codex-login",
+@@ -2190,7 +2190,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2123,7 +2123,7 @@ dependencies = [
+@@ -2206,7 +2206,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "assert_matches",
   "codex-utils-absolute-path",
-@@ -2142,7 +2142,7 @@ dependencies = [
+@@ -2225,7 +2225,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2160,7 +2160,7 @@ dependencies = [
+@@ -2243,7 +2243,7 @@ dependencies = [
  
  [[package]]
  name = "codex-instructions"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-protocol",
   "pretty_assertions",
-@@ -2169,7 +2169,7 @@ dependencies = [
+@@ -2252,7 +2252,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "keyring",
   "tracing",
-@@ -2177,7 +2177,7 @@ dependencies = [
+@@ -2260,7 +2260,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "cc",
   "clap",
-@@ -2199,7 +2199,7 @@ dependencies = [
+@@ -2283,7 +2283,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-core",
-  "reqwest",
-@@ -2212,7 +2212,7 @@ dependencies = [
+  "codex-model-provider-info",
+@@ -2297,7 +2297,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2251,7 +2251,7 @@ dependencies = [
+@@ -2338,7 +2338,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-mcp"
+-version = "0.0.0"
++version = "0.120.0"
+ dependencies = [
+  "anyhow",
+  "async-channel",
+@@ -2367,7 +2367,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-arg0",
-@@ -2280,7 +2280,7 @@ dependencies = [
+@@ -2399,7 +2399,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-model-provider-info"
+-version = "0.0.0"
++version = "0.120.0"
+ dependencies = [
+  "codex-api",
+  "codex-app-server-protocol",
+@@ -2416,7 +2416,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-models-manager"
+-version = "0.0.0"
++version = "0.120.0"
+ dependencies = [
+  "base64 0.22.1",
+  "chrono",
+@@ -2447,7 +2447,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2311,7 +2311,7 @@ dependencies = [
+@@ -2478,7 +2478,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -2329,7 +2329,7 @@ dependencies = [
+@@ -2497,7 +2497,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -2361,7 +2361,7 @@ dependencies = [
+@@ -2529,7 +2529,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-utils-absolute-path",
   "codex-utils-plugins",
-@@ -2370,7 +2370,7 @@ dependencies = [
+@@ -2538,7 +2538,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -2378,7 +2378,7 @@ dependencies = [
+@@ -2546,7 +2546,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
-  "codex-execpolicy",
-@@ -2407,7 +2407,7 @@ dependencies = [
+  "chardetng",
+@@ -2586,7 +2586,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-realtime-webrtc"
+-version = "0.0.0"
++version = "0.120.0"
+ dependencies = [
+  "libwebrtc",
+  "thiserror 2.0.18",
+@@ -2595,7 +2595,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-response-debug-context"
+-version = "0.0.0"
++version = "0.120.0"
+ dependencies = [
+  "base64 0.22.1",
+  "codex-api",
+@@ -2606,7 +2606,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2423,7 +2423,7 @@ dependencies = [
+@@ -2623,7 +2623,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2457,7 +2457,7 @@ dependencies = [
+@@ -2657,7 +2657,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2482,7 +2482,7 @@ dependencies = [
+@@ -2682,7 +2682,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-network-proxy",
   "codex-protocol",
-@@ -2499,7 +2499,7 @@ dependencies = [
+@@ -2699,7 +2699,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "age",
   "anyhow",
-@@ -2520,7 +2520,7 @@ dependencies = [
+@@ -2720,7 +2720,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -2540,7 +2540,7 @@ dependencies = [
+@@ -2740,7 +2740,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2561,7 +2561,7 @@ dependencies = [
+@@ -2761,7 +2761,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-utils-absolute-path",
   "include_dir",
-@@ -2570,7 +2570,7 @@ dependencies = [
+@@ -2770,7 +2770,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2593,7 +2593,7 @@ dependencies = [
+@@ -2793,7 +2793,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "codex-utils-cargo-bin",
-@@ -2604,7 +2604,7 @@ dependencies = [
+@@ -2804,7 +2804,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -2612,7 +2612,7 @@ dependencies = [
+@@ -2812,7 +2812,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-code-mode",
-@@ -2625,7 +2625,7 @@ dependencies = [
+@@ -2829,7 +2829,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "arboard",
-@@ -2716,7 +2716,7 @@ dependencies = [
+@@ -2928,7 +2928,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "dirs",
-  "path-absolutize",
-@@ -2730,14 +2730,14 @@ dependencies = [
+  "dunce",
+@@ -2942,14 +2942,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-protocol",
  ]
@@ -574,125 +633,125 @@ index 2ba3e9613..eeeddd11d 100644
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "lru 0.16.3",
   "sha1",
-@@ -2746,7 +2746,7 @@ dependencies = [
+@@ -2958,7 +2958,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -2755,7 +2755,7 @@ dependencies = [
+@@ -2967,7 +2967,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -2766,15 +2766,15 @@ dependencies = [
+@@ -2978,15 +2978,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "dirs",
   "pretty_assertions",
-@@ -2783,7 +2783,7 @@ dependencies = [
+@@ -2995,7 +2995,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -2795,7 +2795,7 @@ dependencies = [
+@@ -3007,7 +3007,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -2804,7 +2804,7 @@ dependencies = [
+@@ -3016,7 +3016,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -2813,7 +2813,7 @@ dependencies = [
+@@ -3026,7 +3026,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -2822,7 +2822,7 @@ dependencies = [
+@@ -3035,7 +3035,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -2832,7 +2832,7 @@ dependencies = [
+@@ -3045,7 +3045,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
+  "codex-login",
   "serde",
-  "serde_json",
-@@ -2841,7 +2841,7 @@ dependencies = [
+@@ -3055,7 +3055,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -2857,7 +2857,7 @@ dependencies = [
+@@ -3071,7 +3071,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "assert_matches",
   "async-trait",
-@@ -2868,14 +2868,14 @@ dependencies = [
+@@ -3082,14 +3082,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "rustls",
  ]
@@ -700,25 +759,25 @@ index 2ba3e9613..eeeddd11d 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "codex-core",
-  "codex-protocol",
-@@ -2885,7 +2885,7 @@ dependencies = [
+  "codex-model-provider-info",
+@@ -3100,7 +3100,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -2895,14 +2895,14 @@ dependencies = [
+@@ -3110,14 +3110,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -726,16 +785,16 @@ index 2ba3e9613..eeeddd11d 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -2910,14 +2910,14 @@ dependencies = [
+@@ -3125,14 +3125,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -743,37 +802,37 @@ index 2ba3e9613..eeeddd11d 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -2925,7 +2925,7 @@ dependencies = [
+@@ -3140,7 +3140,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3139,7 +3139,7 @@ dependencies = [
+@@ -3360,7 +3360,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -5959,7 +5959,7 @@ checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
+@@ -6396,7 +6396,7 @@ checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.118.0"
++version = "0.120.0"
  dependencies = [
   "anyhow",
-  "codex-core",
+  "codex-login",
 -- 
 2.53.0
 

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.118.0
+VER=0.120.0
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=146.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \
@@ -7,3 +7,4 @@ CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=387692"
 SUBDIR="codex/codex-rs"
+ENVREQ__ARM64="total_mem=30"


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.120.0

Package(s) Affected
-------------------

- codex: 0.120.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
