### PR TITLE
zen-browser: update to 1.19.8~beta

### DIFF
--- a/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
+++ b/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
@@ -1,4 +1,4 @@
-From f50394f225b04e89e1e35f8602f9467be2504f3a Mon Sep 17 00:00:00 2001
+From 2a5e63173159df2da87ea90013f1eea416e74471 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:14:20 -0800
 Subject: [PATCH 1/7] AOSCOS: Disable LASX by default for libyuv
@@ -14,7 +14,7 @@ Co-Authored-By: Xuan Chen <henry.chen@oss.cipunited.com>
 
 diff --git a/src/media/libyuv/libyuv/libyuv-gyp.patch b/src/media/libyuv/libyuv/libyuv-gyp.patch
 new file mode 100644
-index 0000000000000..83d8e76881b98
+index 000000000..83d8e7688
 --- /dev/null
 +++ b/src/media/libyuv/libyuv/libyuv-gyp.patch
 @@ -0,0 +1,16 @@

--- a/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
+++ b/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
@@ -1,4 +1,4 @@
-From e9c7bfff603ea0fded5925ef5c7493f93029af6a Mon Sep 17 00:00:00 2001
+From e68372bf27b8307ded950b989c07fa59282c3eef Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:17:48 -0800
 Subject: [PATCH 2/7] Enable GLES on riscv64
@@ -11,7 +11,7 @@ Co-Authored-By: Han Gao <rabenda.cn@gmail.com>
 
 diff --git a/src/toolkit/xre/glxtest/glxtest-cpp.patch b/src/toolkit/xre/glxtest/glxtest-cpp.patch
 new file mode 100644
-index 0000000000000..8c807d7c92e65
+index 000000000..8c807d7c9
 --- /dev/null
 +++ b/src/toolkit/xre/glxtest/glxtest-cpp.patch
 @@ -0,0 +1,13 @@

--- a/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
+++ b/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
@@ -1,4 +1,4 @@
-From ff67756af9ff0638020fc6ec002bc0120923c4fc Mon Sep 17 00:00:00 2001
+From 17cb7230711047b8f177db00608593fea1abc92c Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:20:35 -0800
 Subject: [PATCH 3/7] Disable BROTLI_MODEL macro for some targets
@@ -14,7 +14,7 @@ Signed-off-by: Rong "Mantle" Bao <webmaster@csmantle.top>
 
 diff --git a/src/modules/brotli/common/platform-h.patch b/src/modules/brotli/common/platform-h.patch
 new file mode 100644
-index 0000000000000..c4b092053ad1d
+index 000000000..c4b092053
 --- /dev/null
 +++ b/src/modules/brotli/common/platform-h.patch
 @@ -0,0 +1,32 @@

--- a/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
+++ b/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
@@ -1,4 +1,4 @@
-From 224a6a469db08dd3a3bd0b7f5f11c3e00c25e961 Mon Sep 17 00:00:00 2001
+From a429b8ec7b2c8f1d5ee9c8e6ae9a600c68bbd2d4 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:23:13 -0800
 Subject: [PATCH 4/7] AOSCOS: Fix unistd.h header inclusion in libwebrtc
@@ -15,7 +15,7 @@ Co-Authored-By: Rong "Mantle" Bao <webmaster@csmantle.top>
 
 diff --git a/src/third_party/libwebrtc/rtc_base/platform_thread_types-cc.patch b/src/third_party/libwebrtc/rtc_base/platform_thread_types-cc.patch
 new file mode 100644
-index 0000000000000..a0385692eed95
+index 000000000..a0385692e
 --- /dev/null
 +++ b/src/third_party/libwebrtc/rtc_base/platform_thread_types-cc.patch
 @@ -0,0 +1,13 @@

--- a/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
+++ b/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
@@ -1,4 +1,4 @@
-From 3f113e46b8a6830c25812bc424e8a987cf7cbdaf Mon Sep 17 00:00:00 2001
+From 8d38f4e2077bf2baf733a129c6a5fd92b13d47ee Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 23:32:26 -0800
 Subject: [PATCH 5/7] AOSCOS: Update Google API keyfile path
@@ -8,7 +8,7 @@ Subject: [PATCH 5/7] AOSCOS: Update Google API keyfile path
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/configs/common/mozconfig b/configs/common/mozconfig
-index 3d41bc83aff94..297b559a1089a 100644
+index 3d41bc83a..297b559a1 100644
 --- a/configs/common/mozconfig
 +++ b/configs/common/mozconfig
 @@ -36,8 +36,9 @@ if ! test "$SCCACHE_GHA_ENABLED" = "false"; then

--- a/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
+++ b/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
@@ -1,4 +1,4 @@
-From a17e48caa2bb7496c2591a15b8cc04bbce09b6a0 Mon Sep 17 00:00:00 2001
+From 7df0851541200d96169142abdb0a5ed829cc562f Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <the@salted.fish>
 Date: Sat, 21 Feb 2026 20:28:31 -0500
 Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
@@ -8,7 +8,7 @@ Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/surfer.json b/surfer.json
-index c2d36b089c0b2..cdfb7cabb4082 100644
+index 0d514c975..3b8a98daf 100644
 --- a/surfer.json
 +++ b/surfer.json
 @@ -2,7 +2,7 @@
@@ -19,7 +19,7 @@ index c2d36b089c0b2..cdfb7cabb4082 100644
 +  "binaryName": "zen-browser",
    "version": {
      "product": "firefox",
-     "version": "148.0.2",
+     "version": "149.0.2",
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
+++ b/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
@@ -1,4 +1,4 @@
-From 6a3d3c571018edf9e21a0c11fa162a283b2e4d24 Mon Sep 17 00:00:00 2001
+From 783d781278830682aa8678e78e7e02652d58efcb Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 3 Feb 2026 05:56:14 -0500
 Subject: [PATCH 7/7] AOSCOS: Adjust mozconfig
@@ -15,7 +15,7 @@ Ref: aosc-os-abbs/app-web/firefox.
  2 files changed, 38 insertions(+), 37 deletions(-)
 
 diff --git a/configs/common/mozconfig b/configs/common/mozconfig
-index 297b559a1089a..947f1593e1166 100644
+index 297b559a1..947f1593e 100644
 --- a/configs/common/mozconfig
 +++ b/configs/common/mozconfig
 @@ -6,9 +6,6 @@
@@ -58,7 +58,7 @@ index 297b559a1089a..947f1593e1166 100644
  
  ac_add_options --enable-unverified-updates
 diff --git a/configs/linux/mozconfig b/configs/linux/mozconfig
-index b15dcd399af59..ec024ff4b8e1f 100644
+index b15dcd399..ec024ff4b 100644
 --- a/configs/linux/mozconfig
 +++ b/configs/linux/mozconfig
 @@ -11,30 +11,40 @@ else

--- a/app-web/zen-browser/autobuild/prepare
+++ b/app-web/zen-browser/autobuild/prepare
@@ -29,6 +29,12 @@ fi
 # FIXME: SIGBUS during build.
 if ab_match_arch loongarch64; then
 	export CARGO_PROFILE_RELEASE_BUILD_OVERRIDE_DEBUG=true
+	# FIXME: Huge libxul links can overflow LoongArch R_LARCH_B26 branch range
+	# with the default code model; use medium code model to avoid
+	# ld.lld: error: relocation R_LARCH_B26 out of range.
+	abinfo "Applying medium code model workaround for LoongArch libxul links ..."
+	export CFLAGS="${CFLAGS} -mcmodel=medium"
+	export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
 fi
 
 # FIXME

--- a/app-web/zen-browser/spec
+++ b/app-web/zen-browser/spec
@@ -1,4 +1,4 @@
-__VER="1.19.3"
+__VER="1.19.8"
 VER="${__VER}~beta"
 SRCS="git::commit=tags/${__VER}b;copy-repo=true::https://github.com/zen-browser/desktop"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- zen-browser: update to 1.19.8\~beta

Package(s) Affected
-------------------

- zen-browser: 1.19.8~beta

Security Update?
----------------

No

Build Order
-----------

```
#buildit zen-browser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
