### PR TITLE
libspnav: update to 1.2

### DIFF
--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -8,3 +8,4 @@ BUILDDEP="nlohmann-json"
 PKGRECOM="cargo-audit"
 
 VER_NONE=1
+ABTYPE=cmakeninja

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.17.1
+VER=4.17.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/runtime-devices/libspnav/autobuild/beyond
+++ b/runtime-devices/libspnav/autobuild/beyond
@@ -1,7 +1,0 @@
-rm -f "$PKGDIR"/usr/lib/libspnav.so.0
-rm -f "$PKGDIR"/usr/lib/libspnav.so
-
-pushd "$PKGDIR"/usr/lib
-ln -s libspnav.so.0.1 libspnav.so.0
-ln -s libspnav.so.0.1 libspnav.so
-popd

--- a/runtime-devices/libspnav/autobuild/defines
+++ b/runtime-devices/libspnav/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=libspnav
 PKGSEC=libs
-PKGDEP="glibc"
+PKGDEP="glibc x11-lib"
 PKGDES="Alternative to the proprietary 3Dconnexion device driver and SDK for their 3D input devices"
 
-ABTYPE=autotools
+ABTYPE=autosetup
+
+# FIXME:
+# make: *** No rule to make target 'src/spnav.o', needed by 'libspnav.a'.  Stop.
 ABSHADOW=0
-RECONF=0

--- a/runtime-devices/libspnav/spec
+++ b/runtime-devices/libspnav/spec
@@ -1,5 +1,4 @@
-VER=0.2.3
-REL=6
+VER=1.2
 SRCS="tbl::https://sourceforge.net/projects/spacenav/files/spacenav%20library%20%28SDK%29/libspnav%20$VER/libspnav-$VER.tar.gz/download"
-CHKSUMS="sha256::7ae4d7bb7f6a5dda28b487891e01accc856311440f582299760dace6ee5f1f93"
+CHKSUMS="sha256::093747e7e03b232e08ff77f1ad7f48552c06ac5236316a5012db4269951c39db"
 CHKUPDATE="anitya::id=9632"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.17.2
- libspnav: update to 1.2

Package(s) Affected
-------------------

- autobuild4: 4.17.2
- libspnav: 1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 libspnav
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
