### PR TITLE
warzone2100: update to 4.7.0+sequences3

### DIFF
--- a/app-games/warzone2100/spec
+++ b/app-games/warzone2100/spec
@@ -1,8 +1,8 @@
-UPSTREAM_VER=4.5.5
+UPSTREAM_VER=4.7.0
 SEQUENCES_VER=3
 VER=${UPSTREAM_VER}+sequences${SEQUENCES_VER}
 SRCS="tbl::https://github.com/Warzone2100/warzone2100/releases/download/$UPSTREAM_VER/warzone2100_src.tar.xz \
       file::rename=sequences.wz::https://github.com/Warzone2100/wz-sequences/releases/download/v${SEQUENCES_VER}/high-quality-en-sequences.wz"
-CHKSUMS="sha256::07f61bae721687edeb62da4877e85030a03a053a593d645194fc65778e0480ff \
+CHKSUMS="sha256::95ee4d5b88680ea1b1cf230b67ea84028e08a2458b84605ac9f7fb9eb97c4e37 \
          sha256::90ff552ca4a70e2537e027e22c5098ea4ed1bc11bb7fc94138c6c941a73d29fa"
 CHKUPDATE="anitya::id=5118"


### PR DESCRIPTION
Topic Description
-----------------

- warzone2100: update to 4.7.0+sequences3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- warzone2100: 4.7.0+sequences3

Security Update?
----------------

No

Build Order
-----------

```
#buildit warzone2100
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
