### PR TITLE
lirc: improve packaging

### DIFF
--- a/app-devices/lirc/autobuild/defines
+++ b/app-devices/lirc/autobuild/defines
@@ -1,5 +1,12 @@
 PKGNAME=lirc
 PKGSEC=libs
-PKGDEP="alsa-lib libftdi libirman python-3"
+PKGDEP="alsa-lib gcc-runtime glibc libftdi libusb libusb-compat systemd x11-lib \
+        libftdi libirman python-3 pyyaml pygobject-3 portaudio"
 BUILDDEP="libxslt"
 PKGDES="Linux Infrared Remote Control"
+
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--enable-uinput'
+    '--enable-devinput'
+)

--- a/app-devices/lirc/autobuild/patches/0001-UPSTREAM-config.py-is-needed-by-the-python-package.patch
+++ b/app-devices/lirc/autobuild/patches/0001-UPSTREAM-config.py-is-needed-by-the-python-package.patch
@@ -1,0 +1,30 @@
+From 3e2e9758aac0d51bc4168d863763c8e3a4c537f5 Mon Sep 17 00:00:00 2001
+From: Sean Young <sean@mess.org>
+Date: Sun, 12 Mar 2023 11:24:47 +0000
+Subject: [PATCH] config.py is needed by the python package
+
+Partial revert of commit 0ab24de56c8a282ffd356e929e71b48a69685dda
+---
+ Makefile.am | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 6718af1..cb8f7c9 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -84,11 +84,10 @@ dist_py_pkg_DATA        = python-pkg/setup.py \
+ 
+ py_pkg_lircdir          = $(pkgdatadir)/python-pkg/lirc
+ py_PYTHON               = python-pkg/lirc/__init__.py \
++                          python-pkg/lirc/config.py \
+                           python-pkg/lirc/database.py \
+                           python-pkg/lirc/paths.py
+ 
+-nodist_py_pkg_PYTHON    = python-pkg/lirc/config.py
+-
+ if HAVE_PYTHON35
+ py_PYTHON               += python-pkg/lirc/async_client.py \
+                           python-pkg/lirc/client.py
+-- 
+2.52.0
+

--- a/app-devices/lirc/spec
+++ b/app-devices/lirc/spec
@@ -1,5 +1,5 @@
 VER=0.10.2
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/lirc/files/LIRC/$VER/lirc-$VER.tar.bz2"
 CHKSUMS="sha256::3d44ec8274881cf262f160805641f0827ffcc20ade0d85e7e6f3b90e0d3d222a"
 CHKUPDATE="anitya::id=10762"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- lirc: improve packaging
    - Backport upstream patch to fix ModuleNotFoundError.
    - Link: https://sourceforge.net/p/lirc/tickets/339/
    - Enable devinput and uinput to fix lircd.service start failure.
    - Add missing ABTYPE.

Package(s) Affected
-------------------

- lirc: 0.10.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit lirc
```

Test Build(s) Done
------------------

