### PR TITLE
hmcl: update to 3.6.18

### DIFF
--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,4 @@
-VER=3.12.2
+VER=3.6.18
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKUPDATE="anitya::id=371893"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.6.18
    Co-authored-by: Gray David \(@grayawa\)

Package(s) Affected
-------------------

- hmcl: 3.6.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
