### PR TITLE
libgphoto2: rebuild for _spiral mark

### DIFF
--- a/runtime-devices/libgphoto2/spec
+++ b/runtime-devices/libgphoto2/spec
@@ -1,4 +1,5 @@
 VER=2.5.30
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/gphoto/files/libgphoto/$VER/libgphoto2-$VER.tar.gz"
 CHKSUMS="sha256::3e7eb9500fbf73ffaf4aa5eb65efde1998fb7ac702e689c274aacf52646f7ea4"
 CHKUPDATE="anitya::id=12558"


### PR DESCRIPTION
Topic Description
-----------------

- libgphoto2: rebuild for _spiral marks

Package(s) Affected
-------------------

- libgphoto2: 2.5.30-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgphoto2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
