### PR TITLE
cups-pk-helper: new,0.2.7

### DIFF
--- a/app-admin/cups-pk-helper/autobuild/defines
+++ b/app-admin/cups-pk-helper/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=cups-pk-helper
+PKGSEC=libs
+PKGDEP="shadow polkit cups glib"
+PKGDES="Polkit Helper for configuring CUPS"

--- a/app-admin/cups-pk-helper/spec
+++ b/app-admin/cups-pk-helper/spec
@@ -1,0 +1,4 @@
+VER=0.2.7
+SRCS="tbl::https://www.freedesktop.org/software/cups-pk-helper/releases/cups-pk-helper-$VER.tar.xz"
+CHKSUMS="sha256::66070ddb448fe9fcee76aa26be2ede5a80f85563e3a4afd59d2bfd79fbe2e831"
+CHKUPDATE="anitya::id=17717"

--- a/desktop-gnome/gnome-control-center/autobuild/defines
+++ b/desktop-gnome/gnome-control-center/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=gnome-control-center
 PKGSEC=gnome
 PKGDEP="accountsservice colord-gtk gnome-bluetooth gnome-desktop \
         gnome-online-accounts gnome-settings-daemon libadwaita libgtop \
-        libibus libnma libsoup-3 libwacom malcontent tecla udisks-2"
+        libibus libnma libsoup-3 libwacom malcontent tecla udisks-2 cups-pk-helper"
 BUILDDEP="blueprint-compiler"
 PKGDES="Control center for GNOME"
 

--- a/desktop-gnome/gnome-control-center/spec
+++ b/desktop-gnome/gnome-control-center/spec
@@ -1,4 +1,5 @@
 VER=49.4
+REL=1
 SRCS="https://download.gnome.org/sources/gnome-control-center/${VER%.*}/gnome-control-center-$VER.tar.xz"
 CHKSUMS="sha256::131975e5fddd208f3a30f766a1c667f8cb3f15b689a868d285a641a234204b02"
 CHKUPDATE="anitya::id=5408"


### PR DESCRIPTION
Topic Description
-----------------

- cups-pk-helper: new, 0.2.7
- libgphoto2: rebuild for _spiral marks

Package(s) Affected
-------------------

- cups-pk-helper: 0.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups-pk-helper gnome-control-center
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
