### PR TITLE
scribus: update to 1.6.6

### DIFF
--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,5 +1,4 @@
-VER=1.6.5
-REL=2
+VER=1.6.6
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
-CHKSUMS="sha256::09bdb736a8ff8a437191458a36d847cc0adeca0fc059cf696474e0ba6f59ac6a"
+CHKSUMS="sha256::fdfe3e7cbe84b760b38d0561ed8736f9d25d4923adde6e15e03760d83be6166d"
 CHKUPDATE="anitya::id=4773"


### PR DESCRIPTION
Topic Description
-----------------

- scribus: update to 1.6.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scribus: 1.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit scribus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
