### PR TITLE
the-honkers-railway-launcher:  update to 1.14.4+git20260404

### DIFF
--- a/app-games/the-honkers-railway-launcher/autobuild/defines
+++ b/app-games/the-honkers-railway-launcher/autobuild/defines
@@ -1,12 +1,9 @@
 PKGNAME=the-honkers-railway-launcher
 PKGSEC=games
-PKGDES="The Honkers Railway launcher for Linux"
+PKGDES="Launcher for Honkai: Star Rail"
 PKGDEP="libadwaita libwebp gtk-4 git p7zip xdg-desktop-portal"
 BUILDDEP="rustc llvm"
 ABTYPE=rust
-
-# NOTE: only x86 and emu-x86 supported archs
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
 
 # FIXME: `ring` seems broken in LTO
 NOLTO=1

--- a/app-games/the-honkers-railway-launcher/autobuild/overrides/usr/share/applications/the-honkers-railway-launcher.desktop
+++ b/app-games/the-honkers-railway-launcher/autobuild/overrides/usr/share/applications/the-honkers-railway-launcher.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=The Honkers Railway Launcher
 Name[zh_CN]=某铁启动器
-Comment=The Honkers Railway launcher for Linux with automatic patching and telemetry disabling 
+Comment=Honkai: Star Rail launcher for Linux with automatic patching and telemetry disabling
 Comment[zh_CN]=带有自动打补丁及禁用遥测功能的某铁启动器
 Exec=honkers-railway-launcher
 Terminal=false

--- a/app-games/the-honkers-railway-launcher/spec
+++ b/app-games/the-honkers-railway-launcher/spec
@@ -1,4 +1,5 @@
-VER=1.14.3
-SRCS="git::commit=$VER::https://github.com/an-anime-team/the-honkers-railway-launcher.git"
+UPSTREAM_VER=1.14.4
+VER=${UPSTREAM_VER//\-/+}+git20260401
+SRCS="git::commit=dd59378a94aeb5d3148734eb9ceb2c1bed3d3bfa::https://github.com/an-anime-team/the-honkers-railway-launcher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=387765"


### PR DESCRIPTION
Topic Description
-----------------

- the-honkers-railway-launcher: update to 1.14.4+git20260404
    - Link for downloading mfc140 provided by Winetricks has become unavailable. Commits beyond latest tag change mfc140 installation not to depend on Winetricks.

Package(s) Affected
-------------------

- the-honkers-railway-launcher: 1.14.4+git20260401

Security Update?
----------------

No

Build Order
-----------

```
#buildit the-honkers-railway-launcher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
