### PR TITLE
libzapojit: drop, orphaned

### DIFF
--- a/runtime-web/libzapojit/autobuild/defines
+++ b/runtime-web/libzapojit/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=libzapojit
-PKGSEC=libs
-PKGDEP="libsoup gnome-online-accounts"
-BUILDDEP="intltool gobject-introspection gtk-doc"
-PKGDES="GLib/GObject wrapper for the SkyDrive and Hotmail REST APIs"
-
-AUTOTOOLS_AFTER="--enable-gtk-doc"
-RECONF=0

--- a/runtime-web/libzapojit/spec
+++ b/runtime-web/libzapojit/spec
@@ -1,5 +1,0 @@
-VER=0.0.3
-REL=3
-SRCS="tbl::https://download.gnome.org/sources/libzapojit/${VER%.*}/libzapojit-$VER.tar.xz"
-CHKSUMS="sha256::3d25f99329105abb99d1e9651b0aa1842065456ea54c22970a7330e9f3d1c37e"
-CHKUPDATE="anitya::id=13151"


### PR DESCRIPTION
Topic Description
-----------------

- libzapojit: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
