### PR TITLE
qwt: rename and update to 6.3.0

### DIFF
--- a/runtime-desktop/qwt/autobuild/defines
+++ b/runtime-desktop/qwt/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=qwt
+PKGSEC=libs
+PKGDEP="qt-5"
+PKGDES="Qt Widgets for Technical Applications"
+
+PKGBREAK="pyqwt<=5.2.0 qwt5"
+PKGREP="qwt5"

--- a/runtime-desktop/qwt/autobuild/patches/0001-remove-docs.patch
+++ b/runtime-desktop/qwt/autobuild/patches/0001-remove-docs.patch
@@ -1,0 +1,13 @@
+diff --git a/qwt.pro b/qwt.pro
+index 344d545..127c9fc 100644
+--- a/qwt.pro
++++ b/qwt.pro
+@@ -22,7 +22,7 @@ CONFIG   += ordered
+ SUBDIRS = \
+     src \
+     classincludes \
+-    doc
++#    doc
+ 
+ contains(QWT_CONFIG, QwtDesigner ) {
+     SUBDIRS += designer 

--- a/runtime-desktop/qwt/autobuild/patches/0002-install-paths.patch
+++ b/runtime-desktop/qwt/autobuild/patches/0002-install-paths.patch
@@ -1,0 +1,48 @@
+diff --git a/qwtconfig.pri b/qwtconfig.pri
+index b8f534f..56fcbf7 100644
+--- a/qwtconfig.pri
++++ b/qwtconfig.pri
+@@ -16,20 +16,20 @@ QWT_VERSION      = $${QWT_VER_MAJ}.$${QWT_VER_MIN}.$${QWT_VER_PAT}
+ # Install paths
+ ######################################################################
+ 
+-QWT_INSTALL_PREFIX = $$[QT_INSTALL_PREFIX]
++QWT_INSTALL_PREFIX = /usr
+ 
+ unix {
+-    QWT_INSTALL_PREFIX    = /usr/local/qwt-$$QWT_VERSION-dev
++    QWT_INSTALL_PREFIX    = /usr
+     # QWT_INSTALL_PREFIX = /usr/local/qwt-$$QWT_VERSION-dev-qt-$$QT_VERSION
+ }
+ 
+ win32 {
+-    QWT_INSTALL_PREFIX    = C:/Qwt-$$QWT_VERSION-dev
++    QWT_INSTALL_PREFIX    = /usr
+     # QWT_INSTALL_PREFIX = C:/Qwt-$$QWT_VERSION-dev-qt-$$QT_VERSION
+ }
+ 
+-QWT_INSTALL_DOCS      = $${QWT_INSTALL_PREFIX}/doc
+-QWT_INSTALL_HEADERS   = $${QWT_INSTALL_PREFIX}/include
++QWT_INSTALL_DOCS      = $${QWT_INSTALL_PREFIX}/share/doc/qwt
++QWT_INSTALL_HEADERS   = $${QWT_INSTALL_PREFIX}/include/qwt
+ QWT_INSTALL_LIBS      = $${QWT_INSTALL_PREFIX}/lib
+ 
+ ######################################################################
+@@ -42,7 +42,7 @@ QWT_INSTALL_LIBS      = $${QWT_INSTALL_PREFIX}/lib
+ # runtime environment of designer/creator.
+ ######################################################################
+ 
+-QWT_INSTALL_PLUGINS   = $${QWT_INSTALL_PREFIX}/plugins/designer
++QWT_INSTALL_PLUGINS   = $${QWT_INSTALL_PREFIX}/lib/qt6/plugins/designer
+ 
+ # linux distributors often organize the Qt installation
+ # their way and QT_INSTALL_PREFIX doesn't offer a good
+@@ -63,7 +63,7 @@ QWT_INSTALL_PLUGINS   = $${QWT_INSTALL_PREFIX}/plugins/designer
+ # with every Qt upgrade.
+ ######################################################################
+ 
+-QWT_INSTALL_FEATURES  = $${QWT_INSTALL_PREFIX}/features
++QWT_INSTALL_FEATURES  = $${QWT_INSTALL_PREFIX}/lib/qt6/mkspecs/features
+ # QWT_INSTALL_FEATURES  = $$[QT_INSTALL_PREFIX]/features
+ 
+ ######################################################################

--- a/runtime-desktop/qwt/spec
+++ b/runtime-desktop/qwt/spec
@@ -1,0 +1,4 @@
+VER=6.3.0
+SRCS="git::commit=tags/v$VER::https://git.code.sf.net/p/qwt/git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=4147"

--- a/runtime-desktop/qwt5/autobuild/defines
+++ b/runtime-desktop/qwt5/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=qwt5
-PKGSEC=libs
-PKGDEP="qt-5"
-PKGDES="Qt Widgets for Technical Applications"
-
-PKGBREAK="pyqwt<=5.2.0"

--- a/runtime-desktop/qwt5/autobuild/prepare
+++ b/runtime-desktop/qwt5/autobuild/prepare
@@ -1,7 +1,0 @@
-abinfo "Tweaking component installation paths ..."
-sed -e '/^\s*QWT_INSTALL_PREFIX/ s|=.*|= /usr|' \
-    -e '/^QWT_INSTALL_DOCS/ s|/doc|/share/doc/qwt|' \
-    -e '/^QWT_INSTALL_HEADERS/ s|include|&/qwt|' \
-    -e '/^QWT_INSTALL_PLUGINS/ s|plugins/designer|lib/qt5/&|' \
-    -e '/^QWT_INSTALL_FEATURES/ s|features|lib/qt5/mkspecs/&|' \
-    -i "$SRCDIR"/qwtconfig.pri

--- a/runtime-desktop/qwt5/spec
+++ b/runtime-desktop/qwt5/spec
@@ -1,5 +1,0 @@
-VER=6.1.5
-REL=2
-SRCS="tbl::https://downloads.sourceforge.net/sourceforge/qwt/qwt-$VER.tar.bz2"
-CHKSUMS="sha256::4076de63ec2b5e84379ddfebf27c7b29b8dc9074f3db7e2ca61d11a1d8adc041"
-CHKUPDATE="anitya::id=4147"


### PR DESCRIPTION
Topic Description
-----------------

- qwt5: update to 6.3.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- qwt5: 6.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qwt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
