### PR TITLE
xf86-input-libinput: update to 1.5.0

### DIFF
--- a/runtime-display/xf86-input-libinput/spec
+++ b/runtime-display/xf86-input-libinput/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
-REL=1
+VER=1.5.0
 SRCS="tbl::https://xorg.freedesktop.org/releases/individual/driver/xf86-input-libinput-$VER.tar.xz"
-CHKSUMS="sha256::3a3d14cd895dc75b59ae2783b888031956a0bac7a1eff16d240dbb9d5df3e398"
+CHKSUMS="sha256::2524c35f196554ea11aef3bba1cf324759454e1d49f98ac026ace2f6003580e6"
 CHKUPDATE="anitya::id=5782"


### PR DESCRIPTION
Topic Description
-----------------

- xf86-input-libinput: update to 1.5.0
    Co-authored-by: Icenowy Zheng \(@Icenowy\) <uwu@icenowy.me>

Package(s) Affected
-------------------

- xf86-input-libinput: 1.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xf86-input-libinput
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
