### PR TITLE
passim: update to 0.1.11

### DIFF
--- a/app-network/passim/spec
+++ b/app-network/passim/spec
@@ -1,4 +1,4 @@
-VER=0.1.10
+VER=0.1.11
 SRCS="tbl::https://github.com/hughsie/passim/releases/download/$VER/passim-$VER.tar.xz"
-CHKSUMS="sha256::53ede935a788fbb9bd569ca16347e02a2a4d39f6154beb672161dbb79f56419b"
+CHKSUMS="sha256::2ada050658dca16aba7dd7772617227f13a388107966d87637a7760250acd32b"
 CHKUPDATE="anitya::id=377308"


### PR DESCRIPTION
Topic Description
-----------------

- passim: update to 0.1.11
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- passim: 0.1.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit passim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
