### PR TITLE
vscode: update to 1.116.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.115.0
+VER=1.116.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::54457e868d2d0eca02919e787d26a9614520589145e10d3aac62911a8ffd8b00"
-CHKSUMS__ARM64="sha256::5d771366be7a3ff5f1ef21e4ed2aa8af60d6003b8282ba95e03b36a6d4ba690b"
+CHKSUMS__AMD64="sha256::cb23885bdd830b83f64f259395ce5264d232666274ac999ab2de0f4e8f7995a2"
+CHKSUMS__ARM64="sha256::3e213f6a146f0a80314ba07fbe8a6addb3ff44f99fea1e8bb8f325050f10d940"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.116.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- vscode: 1.116.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
