### PR TITLE
motrix-next: update to 3.7.0

### DIFF
--- a/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
+++ b/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
@@ -1,16 +1,19 @@
-From 3a67e3ecfb70ce5ef2b1279d909a0ca9cb9c29bc Mon Sep 17 00:00:00 2001
+From d7893fa7a0f1f0bdc3aebc54c992db5107fb2af3 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
-Date: Sun, 12 Apr 2026 18:13:45 +0800
-Subject: [PATCH 1/3] feat: disable auto-update check
+Date: Thu, 16 Apr 2026 20:49:19 +0800
+Subject: [PATCH 1/4] feat: disable auto-update check
 
 ---
  src/components/preference/Basic.vue           | 65 +------------------
  .../__tests__/useBasicPreference.test.ts      |  2 +-
+ src/layouts/MainLayout.vue                    | 16 +----
+ src/main.ts                                   | 30 +--------
  src/shared/constants.ts                       |  2 +-
- 3 files changed, 3 insertions(+), 66 deletions(-)
+ src/stores/app.ts                             |  4 +-
+ 6 files changed, 6 insertions(+), 113 deletions(-)
 
 diff --git a/src/components/preference/Basic.vue b/src/components/preference/Basic.vue
-index 898ec12..898e549 100644
+index 0db74ac..2bd875c 100644
 --- a/src/components/preference/Basic.vue
 +++ b/src/components/preference/Basic.vue
 @@ -43,20 +43,15 @@ import {
@@ -52,7 +55,7 @@ index 898ec12..898e549 100644
  function buildForm() {
    return buildBasicForm(preferenceStore.config, defaultDownloadDir.value)
  }
-@@ -578,10 +563,6 @@ function loadForm() {
+@@ -598,10 +583,6 @@ function loadForm() {
    downloadUnit.value = dl.unit
  }
  
@@ -63,7 +66,7 @@ index 898ec12..898e549 100644
  const { restartEngine } = useEngineRestart()
  
  function handleManualRestart() {
-@@ -738,50 +719,6 @@ onMounted(async () => {
+@@ -762,50 +743,6 @@ onMounted(async () => {
          <NSelect v-model:value="form.locale" :options="localeOptions" style="width: 280px" />
        </NFormItem>
  
@@ -115,7 +118,7 @@ index 898ec12..898e549 100644
        <NFormItem :label="t('preferences.appearance')">
          <NSelect v-model:value="form.theme" :options="themeOptions" style="width: 200px" />
 diff --git a/src/composables/__tests__/useBasicPreference.test.ts b/src/composables/__tests__/useBasicPreference.test.ts
-index 9e988c9..65cbd75 100644
+index 1637b51..51f82cd 100644
 --- a/src/composables/__tests__/useBasicPreference.test.ts
 +++ b/src/composables/__tests__/useBasicPreference.test.ts
 @@ -24,7 +24,7 @@ describe('buildBasicForm', () => {
@@ -127,11 +130,120 @@ index 9e988c9..65cbd75 100644
      expect(form.autoCheckUpdateInterval).toBe(24)
      expect(form.updateChannel).toBe('stable')
      expect(form.locale).toBe('en-US')
+diff --git a/src/layouts/MainLayout.vue b/src/layouts/MainLayout.vue
+index b9244af..f9e207e 100644
+--- a/src/layouts/MainLayout.vue
++++ b/src/layouts/MainLayout.vue
+@@ -1,6 +1,6 @@
+ <script setup lang="ts">
+ /** @fileoverview Main application layout with sidebar, subnav, and IPC event handling. */
+-import { computed, h, ref, nextTick, watch } from 'vue'
++import { computed, h, ref, watch } from 'vue'
+ import { useRoute, useRouter } from 'vue-router'
+ import { onMounted, onUnmounted } from 'vue'
+ import { useI18n } from 'vue-i18n'
+@@ -35,7 +35,6 @@ import WindowControls from '@/components/layout/WindowControls.vue'
+ import EngineOverlay from '@/components/layout/EngineOverlay.vue'
+ import AboutPanel from '@/components/about/AboutPanel.vue'
+ import AddTask from '@/components/task/AddTask.vue'
+-import UpdateDialog from '@/components/preference/UpdateDialog.vue'
+ import MagnetFileSelect from '@/components/task/MagnetFileSelect.vue'
+ import { useTaskStore } from '@/stores/task'
+ import { usePreferenceStore } from '@/stores/preference'
+@@ -66,8 +65,6 @@ const isMaximized = ref(false)
+ const { platform: currentPlatform, isMac } = usePlatform()
+ const showEngineOverlay = ref(false)
+ 
+-const updateDialogRef = ref<InstanceType<typeof UpdateDialog> | null>(null)
+-
+ let unlistenDragDrop: (() => void) | null = null
+ let unlistenMenuEvent: (() => void) | null = null
+ let unlistenCloseRequested: (() => void) | null = null
+@@ -385,16 +382,6 @@ async function onMaximizeToggled() {
+   }, 300)
+ }
+ 
+-watch(
+-  () => appStore.pendingUpdate,
+-  (update) => {
+-    if (update) {
+-      nextTick(() => updateDialogRef.value?.open())
+-      appStore.pendingUpdate = null
+-    }
+-  },
+-)
+-
+ async function handleExitConfirm() {
+   // Checkbox means "always minimize to tray from now on" —
+   // save the setting even when quitting this time.
+@@ -827,7 +814,6 @@ onUnmounted(() => {
+     <Speedometer />
+     <AboutPanel :show="showAbout" @close="showAbout = false" />
+     <AddTask :show="appStore.addTaskVisible" @close="appStore.hideAddTaskDialog()" />
+-    <UpdateDialog ref="updateDialogRef" />
+     <EngineOverlay
+       :show="showEngineOverlay"
+       @recovered="showEngineOverlay = false"
+diff --git a/src/main.ts b/src/main.ts
+index 63934db..dce6142 100644
+--- a/src/main.ts
++++ b/src/main.ts
+@@ -65,33 +65,6 @@ window.addEventListener('unhandledrejection', (e) => {
+     }
+   }
+ 
+-  async function autoCheckForUpdate() {
+-    const config = preferenceStore.config
+-    if (config.autoCheckUpdate === false) return
+-
+-    const lastCheck = Number(config.lastCheckUpdateTime) || 0
+-    const intervalMs = (Number(config.autoCheckUpdateInterval) || 24) * 3_600_000
+-    if (Date.now() - lastCheck < intervalMs) return
+-
+-    try {
+-      const { invoke } = await import('@tauri-apps/api/core')
+-      const channel = config.updateChannel || 'stable'
+-      const proxy = config.proxy
+-      const proxyServer =
+-        proxy?.enable && proxy.server && (proxy.scope || []).includes('update-app') ? proxy.server : null
+-      const update = await invoke<{ version: string; body: string | null; date: string | null } | null>(
+-        'check_for_update',
+-        { channel, proxy: proxyServer },
+-      )
+-      if (update) {
+-        appStore.pendingUpdate = { version: update.version, body: update.body, date: update.date }
+-      }
+-      preferenceStore.updateAndSave({ lastCheckUpdateTime: Date.now() })
+-    } catch (e) {
+-      logger.warn('Updater', 'auto check failed: ' + (e as Error).message)
+-    }
+-  }
+-
+   async function autoSyncTrackerOnStartup() {
+     const config = preferenceStore.config
+     if (!config.autoSyncTracker) return
+@@ -130,7 +103,7 @@ window.addEventListener('unhandledrejection', (e) => {
+   //  Phase 2 (engine, async)   – rpcSecret → save config → start engine
+   //                              → on_engine_ready (Rust) → wait_for_engine
+   //  Phase 3 (non-critical)    – deep-link, autostart (parallel)
+-  //  Phase 4 (deferred)        – update check, tracker sync, FS warmup,
++  //  Phase 4 (deferred)        – tracker sync, FS warmup,
+   //                              clipboard monitor
+   // ---------------------------------------------------------------------------
+ 
+@@ -400,7 +373,6 @@ window.addEventListener('unhandledrejection', (e) => {
+     }
+ 
+     // ── Phase 4: deferred non-critical tasks ───────────────────────────────
+-    autoCheckForUpdate()
+     autoSyncTrackerOnStartup()
+ 
+     // Initialize download history database, then schedule stale record cleanup
 diff --git a/src/shared/constants.ts b/src/shared/constants.ts
-index 2ab7e64..bb102a6 100644
+index e10b517..37f2374 100644
 --- a/src/shared/constants.ts
 +++ b/src/shared/constants.ts
-@@ -251,7 +251,7 @@ export const DEFAULT_APP_CONFIG = {
+@@ -252,7 +252,7 @@ export const DEFAULT_APP_CONFIG = {
    resumeAllWhenAppLaunched: false, // don't flood bandwidth on launch
  
    // ── Auto Update ───────────────────────────────────────────────
@@ -140,6 +252,35 @@ index 2ab7e64..bb102a6 100644
    autoCheckUpdateInterval: 24, // 24h (daily) is standard check frequency
    /** Linux-only: DMA-BUF GPU rendering ON by default for best performance.
     *  Crash sentinel in gpu_guard auto-reverts to software rendering on failure. */
+diff --git a/src/stores/app.ts b/src/stores/app.ts
+index 45c1bbb..698c082 100644
+--- a/src/stores/app.ts
++++ b/src/stores/app.ts
+@@ -16,7 +16,7 @@ import { decodeThunderLink } from '@shared/utils'
+ import { logger } from '@shared/logger'
+ import { STAT_BASE_INTERVAL, STAT_PER_TASK_INTERVAL, STAT_MIN_INTERVAL, STAT_MAX_INTERVAL } from '@shared/timing'
+ import { detectKind, createBatchItem } from '@shared/utils/batchHelpers'
+-import type { Aria2RawGlobalStat, Aria2EngineOptions, TauriUpdate, AppConfig, BatchItem } from '@shared/types'
++import type { Aria2RawGlobalStat, Aria2EngineOptions, AppConfig, BatchItem } from '@shared/types'
+ 
+ /** Payload shape emitted by Rust stat_service via `stat:update`. */
+ interface StatPayload {
+@@ -54,7 +54,6 @@ export const useAppStore = defineStore('app', () => {
+   const pendingBatch = ref<BatchItem[]>([])
+   const addTaskOptions = ref<Aria2EngineOptions>({})
+   const progress = ref(0)
+-  const pendingUpdate = ref<TauriUpdate | null>(null)
+   const engineRestarting = ref(true)
+   let engineRestartingSince = Date.now()
+   const MIN_BANNER_MS = 1000
+@@ -287,7 +286,6 @@ export const useAppStore = defineStore('app', () => {
+     pendingBatch,
+     addTaskOptions,
+     progress,
+-    pendingUpdate,
+     engineRestarting,
+     setEngineRestarting,
+     engineReady,
 -- 
 2.52.0
 

--- a/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
+++ b/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
@@ -1,7 +1,7 @@
-From 59215b9513375d56eb5e33ec9cec5b61ffd5e59c Mon Sep 17 00:00:00 2001
+From d5548b5bc552b796985912124cfb1d1d29ac3d41 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Tue, 14 Apr 2026 12:42:31 +0800
-Subject: [PATCH 2/3] feat: add more architectures support
+Subject: [PATCH 2/4] feat: add more architectures support
 
 ---
  src/composables/__tests__/usePlatform.test.ts | 25 +++++++++++++++++--

--- a/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
+++ b/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
@@ -1,7 +1,7 @@
-From 2d6365bfced3606e58281e7139005fd26c179b37 Mon Sep 17 00:00:00 2001
+From 2606224016b465932a2db66b23280f7a87c2690f Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Tue, 14 Apr 2026 13:47:55 +0800
-Subject: [PATCH 3/3] feat: use system aria2c
+Subject: [PATCH 3/4] feat: use system aria2c
 
 ---
  src-tauri/src/engine/lifecycle.rs | 18 ++++++------------
@@ -9,7 +9,7 @@ Subject: [PATCH 3/3] feat: use system aria2c
  2 files changed, 7 insertions(+), 16 deletions(-)
 
 diff --git a/src-tauri/src/engine/lifecycle.rs b/src-tauri/src/engine/lifecycle.rs
-index a682751..a111a70 100644
+index ed5b0d1..2df0b0e 100644
 --- a/src-tauri/src/engine/lifecycle.rs
 +++ b/src-tauri/src/engine/lifecycle.rs
 @@ -99,13 +99,10 @@ pub fn start_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Resul
@@ -29,7 +29,7 @@ index a682751..a111a70 100644
          .spawn()
          .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
  
-@@ -366,13 +363,10 @@ pub fn restart_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Res
+@@ -310,13 +307,10 @@ pub fn restart_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Res
          session_path.exists(),
      );
  
@@ -47,7 +47,7 @@ index a682751..a111a70 100644
          .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
  
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index e38423b..fef4e5c 100644
+index b5339a2..35f2367 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -35,9 +35,6 @@
@@ -58,9 +58,9 @@ index e38423b..fef4e5c 100644
 -      "binaries/motrixnext-aria2c"
 -    ],
      "resources": [
-       "binaries/aria2.conf"
-     ],
-@@ -128,4 +125,4 @@
+       "binaries/aria2.conf",
+       "data/dbip-country-lite.mmdb"
+@@ -129,4 +126,4 @@
        "preload": ["sqlite:history.db"]
      }
    }

--- a/app-web/motrix-next/autobuild/patches/0004-Revert-chore-restrict-supported-architectures-to-cur.patch
+++ b/app-web/motrix-next/autobuild/patches/0004-Revert-chore-restrict-supported-architectures-to-cur.patch
@@ -1,0 +1,29 @@
+From 707bc0e06b1fbb66a4a8fa27b6f84d580c9c8f1b Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Thu, 16 Apr 2026 21:47:51 +0800
+Subject: [PATCH 4/4] Revert "chore: restrict supported architectures to
+ current OS and specific CPU types in pnpm-workspace.yaml"
+
+This reverts commit 3359b2a3e3561529c356e2b7d5ddcea51fa21ea1.
+---
+ pnpm-workspace.yaml | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
+index 47281cf..550c724 100644
+--- a/pnpm-workspace.yaml
++++ b/pnpm-workspace.yaml
+@@ -4,6 +4,10 @@ ignoredBuiltDependencies:
+ supportedArchitectures:
+   os:
+     - current
++    - win32
++    - darwin
++    - linux
+   cpu:
++    - current
+     - x64
+     - arm64
+-- 
+2.52.0
+

--- a/app-web/motrix-next/spec
+++ b/app-web/motrix-next/spec
@@ -1,4 +1,4 @@
-VER=3.6.10
+VER=3.7.0
 SRCS="git::commit=tags/v$VER::https://github.com/AnInsomniacy/motrix-next.git"
 CHKSUMS="SKIP"
 SUBDIR="motrix-next"


### PR DESCRIPTION
Topic Description
-----------------

- motrix-next: update to 3.7.0

Package(s) Affected
-------------------

- motrix-next: 3.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit motrix-next
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
