### PR TITLE
yubikey-manager: update to 5.9.1

### DIFF
--- a/app-devices/yubikey-manager/autobuild/defines
+++ b/app-devices/yubikey-manager/autobuild/defines
@@ -7,5 +7,6 @@ PKGDES="Command line and GUI tool for configuring YubiKeys, over all transports"
 
 PKGBREAK="yubioath-desktop<=5.1.0-2"
 
+ABTYPE=pep517
 NOPYTHON2=1
 ABHOST=noarch

--- a/app-devices/yubikey-manager/spec
+++ b/app-devices/yubikey-manager/spec
@@ -1,4 +1,4 @@
-VER=5.9.0
+VER=5.9.1
 SRCS="pypi::version=$VER::yubikey-manager"
-CHKSUMS="sha256::fb97e8013d426d5107602152b151e32a099204617b34e8673497346c902e96f7"
+CHKSUMS="sha256::83bda2a4bbb6a93bc07e5de73a0f30e5a8b811c85a9116aaca6dd3eed8abb0eb"
 CHKUPDATE="anitya::id=67946"


### PR DESCRIPTION
Topic Description
-----------------

- yubikey-manager: update to 5.9.1

Package(s) Affected
-------------------

- yubikey-manager: 5.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit yubikey-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
