### PR TITLE
cpptrace: new, 1.0.4

### DIFF
--- a/runtime-common/cpptrace/autobuild/defines
+++ b/runtime-common/cpptrace/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=cpptrace
+PKGSEC=libs
+PKGDEP="gcc-runtime glibc libdwarf libunwind"
+PKGDES="Simple, portable, and self-contained stacktrace library for C++11 and newer"
+BUILDDEP="pkg-config"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_SHARED_LIBS=ON'
+    '-DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON'
+    '-DCPPTRACE_FIND_LIBDWARF_WITH_PKGCONFIG=ON'
+    '-DCPPTRACE_UNWIND_WITH_LIBUNWIND=ON'
+)

--- a/runtime-common/cpptrace/spec
+++ b/runtime-common/cpptrace/spec
@@ -1,0 +1,4 @@
+VER=1.0.4
+SRCS="git::commit=tags/v$VER::https://github.com/jeremy-rifkin/cpptrace.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378001"

--- a/runtime-common/libdwarf/autobuild/defines
+++ b/runtime-common/libdwarf/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=libdwarf
 PKGSEC=libs
-PKGDEP="elfutils"
+PKGDEP="glibc gcc-runtime zstd"
+PKGEPOCH=1
 PKGDES="A library for handling DWARF debugging information format"
 
-NOSTATIC=0
-ABSHADOW=0
-AUTOTOOLS_AFTER="--includedir=/usr/include/libdwarf"
+ABTYPE=meson

--- a/runtime-common/libdwarf/spec
+++ b/runtime-common/libdwarf/spec
@@ -1,5 +1,4 @@
-VER=20210305
-SRCS="tbl::https://www.prevanders.net/libdwarf-$VER.tar.gz"
-CHKSUMS="sha256::b86bef41725326d13ee3e7e45b929e0ca97b639e93cc1a9214c90a1774fa1c1a"
+VER=2.3.1
+SRCS="tbl::https://github.com/davea42/libdwarf-code/archive/refs/tags/v$VER.tar.gz"
+CHKSUMS="sha256::0caec41d0a6294de5548273d7d47d7944a0d25b003b64b119bf2580c2ee49ad9"
 CHKUPDATE="anitya::id=1597"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- cpptrace: new, 1.0.4
- libdwarf: update to 2.3.1

Package(s) Affected
-------------------

- cpptrace: 1.0.4
- libdwarf: 1:2.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdwarf cpptrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
