### PR TITLE
imhex: patch to use dotnet 10

### DIFF
--- a/app-editors/imhex/autobuild/defines
+++ b/app-editors/imhex/autobuild/defines
@@ -1,12 +1,17 @@
 PKGNAME=imhex
 PKGSEC=devel
 PKGDEP="capstone curl fmt glfw file fmt fontconfig mbedtls yara"
-PKGDEP__DOTNET="${PKGDEP} dotnet-runtime-8.0"
+PKGDEP__DOTNET="${PKGDEP} dotnet-runtime-10.0"
 BUILDDEP="nlohmann-json llvm boost"
+ABTYPE=cmakeninja
 PKGDES="Hex editor with Pattern and YARA Rule support"
 
 PKGDEP__AMD64="${PKGDEP__DOTNET}"
 PKGDEP__ARM64="${PKGDEP__DOTNET}"
+PKGDEP__LOONGARCH64="${PKGDEP__DOTNET}"
+PKGDEP__LOONGARCH64_NOSIMD="${PKGDEP__DOTNET}"
+PKGDEP__PPC64EL="${PKGDEP__DOTNET}"
+PKGDEP__RISCV64="${PKGDEP__DOTNET}"
 
 CMAKE_AFTER=(
     '-DUSE_SYSTEM_FMT=ON'
@@ -28,18 +33,7 @@ CMAKE_AFTER__NODOTNET=(
     "${CMAKE_AFTER[@]}"
     '-DIMHEX_EXCLUDE_PLUGINS=script_loader'
 )
-CMAKE_AFTER__LOONGARCH64=(
-    "${CMAKE_AFTER__NODOTNET[@]}"
-)
-CMAKE_AFTER__LOONGARCH64_NOSIMD=(
-    "${CMAKE_AFTER__NODOTNET[@]}" 
-)
-CMAKE_AFTER__PPC64EL=(
-    "${CMAKE_AFTER__NODOTNET[@]}" 
-)
+
 CMAKE_AFTER__LOONGSON3=(
-    "${CMAKE_AFTER__NODOTNET[@]}" 
-)
-CMAKE_AFTER__RISCV64=(
     "${CMAKE_AFTER__NODOTNET[@]}" 
 )

--- a/app-editors/imhex/autobuild/patches/0002-update-dotnet-to-10.0.patch
+++ b/app-editors/imhex/autobuild/patches/0002-update-dotnet-to-10.0.patch
@@ -1,0 +1,46 @@
+From 53e1b714cc03cbeb95f28968266161cc2c2f912c Mon Sep 17 00:00:00 2001
+From: gray <3059305632@qq.com>
+Date: Thu, 16 Apr 2026 04:57:00 +0800
+Subject: [PATCH] update dotnet to 10.0
+
+---
+ cmake/modules/FindCoreClrEmbed.cmake                          | 4 ++--
+ .../support/dotnet/AssemblyLoader/AssemblyLoader.csproj       | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/modules/FindCoreClrEmbed.cmake b/cmake/modules/FindCoreClrEmbed.cmake
+index 6bea2c57b..049ee4358 100644
+--- a/cmake/modules/FindCoreClrEmbed.cmake
++++ b/cmake/modules/FindCoreClrEmbed.cmake
+@@ -24,7 +24,7 @@ if (NOT DOTNET_EXECUTABLE)
+     set(DOTNET_EXECUTABLE dotnet)
+ endif ()
+ 
+-set(CORECLR_VERSION "8.0")
++set(CORECLR_VERSION "10.0")
+ 
+ execute_process(COMMAND ${DOTNET_EXECUTABLE} "--list-runtimes" OUTPUT_VARIABLE CORECLR_LIST_RUNTIMES_OUTPUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+ if (CORECLR_LIST_RUNTIMES_OUTPUT STREQUAL "")
+@@ -90,4 +90,4 @@ if (CoreClrEmbed_INCLUDE_DIR AND CoreClrEmbed_LIBRARY)
+     set(CoreClrEmbed_SHARED_LIBRARIES "${CoreClrEmbed_SHARED_LIBRARY}" CACHE STRING "CoreClrEmbed shared libraries" FORCE)
+     set(CoreClrEmbed_INCLUDE_DIRS "${CoreClrEmbed_INCLUDE_DIR}" CACHE STRING "CoreClrEmbed include directories" FORCE)
+     set(CoreClrEmbed_VERSION "${CORECLR_RUNTIME_VERSION_FULL}" CACHE STRING "CoreClrEmbed version" FORCE)
+-endif()
+\ No newline at end of file
++endif()
+diff --git a/plugins/script_loader/support/dotnet/AssemblyLoader/AssemblyLoader.csproj b/plugins/script_loader/support/dotnet/AssemblyLoader/AssemblyLoader.csproj
+index 73a16c058..d17db60aa 100644
+--- a/plugins/script_loader/support/dotnet/AssemblyLoader/AssemblyLoader.csproj
++++ b/plugins/script_loader/support/dotnet/AssemblyLoader/AssemblyLoader.csproj
+@@ -2,7 +2,7 @@
+ 
+     <PropertyGroup>
+         <OutputType>Library</OutputType>
+-        <TargetFramework>net8.0</TargetFramework>
++        <TargetFramework>net10.0</TargetFramework>
+         <ImplicitUsings>enable</ImplicitUsings>
+         <Nullable>enable</Nullable>
+         <AssemblyName>AssemblyLoader</AssemblyName>
+-- 
+2.52.0
+

--- a/app-editors/imhex/spec
+++ b/app-editors/imhex/spec
@@ -1,4 +1,5 @@
 VER=1.38.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/WerWolv/ImHex.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141621"


### PR DESCRIPTION
Topic Description
-----------------

- imhex:patch to use dotnet 10 to support more architectures

Package(s) Affected
-------------------

- imhex: 1.38.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit imhex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
