### PR TITLE
libdwarf: update to 2.3.1

### DIFF
--- a/runtime-common/libdwarf/autobuild/defines
+++ b/runtime-common/libdwarf/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=libdwarf
 PKGSEC=libs
-PKGDEP="elfutils"
+PKGDEP="glibc gcc-runtime zstd"
+PKGEPOCH=1
 PKGDES="A library for handling DWARF debugging information format"
 
-NOSTATIC=0
-ABSHADOW=0
-AUTOTOOLS_AFTER="--includedir=/usr/include/libdwarf"
+ABTYPE=meson

--- a/runtime-common/libdwarf/spec
+++ b/runtime-common/libdwarf/spec
@@ -1,5 +1,4 @@
-VER=20210305
-SRCS="tbl::https://www.prevanders.net/libdwarf-$VER.tar.gz"
-CHKSUMS="sha256::b86bef41725326d13ee3e7e45b929e0ca97b639e93cc1a9214c90a1774fa1c1a"
+VER=2.3.1
+SRCS="git::commit=tags/v$VER::https://github.com/davea42/libdwarf-code.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1597"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libdwarf: update to 2.3.1

Package(s) Affected
-------------------

- libdwarf: 1:2.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdwarf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
