### PR TITLE
libfido2: fix missing PKGBREAK and PKGREP

### DIFF
--- a/runtime-devices/libfido2/autobuild/defines
+++ b/runtime-devices/libfido2/autobuild/defines
@@ -3,6 +3,9 @@ PKGSEC=libs
 PKGDES="Library and command-line tools for communicating with FIDO devices"
 PKGDEP="hidapi libcbor zlib openssl"
 
+PKGBREAK="libu2f-host<=1.1.10-3"
+PKGREP="libu2f-host<=1.1.10-3"
+
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
    "-DUDEV_RULES_DIR=/usr/lib/udev/rules.d"

--- a/runtime-devices/libfido2/spec
+++ b/runtime-devices/libfido2/spec
@@ -1,4 +1,5 @@
 VER=1.17.0
+REL=1
 SRCS="https://developers.yubico.com/libfido2/Releases/libfido2-${VER}.tar.gz"
 CHKSUMS="sha256::c1012c8871d71b65872fd5ff1a9d6b0838a55683a03e85ba97479ce57129c736"
 CHKUPDATE="anitya::id=78296"


### PR DESCRIPTION
Topic Description
-----------------

- libfido2: fix missing PKGBREAK and PKGREP

Package(s) Affected
-------------------

- libfido2: 1.17.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfido2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
