### PR TITLE
libsixel: update to 1.8.7+r1

### DIFF
--- a/runtime-imaging/libsixel/autobuild/defines
+++ b/runtime-imaging/libsixel/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libsixel
 PKGSEC=libs
 PKGDEP="curl gdk-pixbuf libgd libjpeg-turbo libpng python-3"
-PKGDES="A SIXEL (terminal graphics and printing format by DEC) codec implementation"
+PKGDES="SIXEL (terminal graphics and printing format by DEC) codec implementation"
 
 AUTOTOOLS_AFTER=(
     '--disable-img2sixel'

--- a/runtime-imaging/libsixel/spec
+++ b/runtime-imaging/libsixel/spec
@@ -1,5 +1,5 @@
-VER=1.8.7
-SRCS="git::commit=tags/v$VER::https://github.com/saitoha/libsixel"
+UPSTREAM_VER=1.8.7-r1
+VER=${UPSTREAM_VER/\-/+}
+SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/saitoha/libsixel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243242"
-REL="1"

--- a/topics/libsixel-1.8.7+r1.toml
+++ b/topics/libsixel-1.8.7+r1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libsixel 1.8.7+r1"
+
+[caution]
+default = "Fixes 7 security vulnerabilities (including 5 of high severity)"
+zh_CN = "修复 7 处安全漏洞（含 5 个高危漏洞）"
+
+[packages-v2]
+"libsixel" = "< 1.8.7+r1"


### PR DESCRIPTION
Topic Description
-----------------

- libsixel: update to 1.8.7+r1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libsixel: 1.8.7+r1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsixel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
