### PR TITLE
microsoft-edge: new, 147.0.3912.60

### DIFF
--- a/app-web/microsoft-edge/autobuild/build
+++ b/app-web/microsoft-edge/autobuild/build
@@ -1,0 +1,24 @@
+abinfo "Extracting archive file ..."
+dpkg -x "$SRCDIR"/microsoft-edge-stable_current_amd64.deb \
+    "$SRCDIR"/msedge/
+
+abinfo "Deploying files ..."
+mkdir -pv "$PKGDIR"/usr/{lib/microsoft-edge,share/pixmaps}
+cp -arv "$SRCDIR"/msedge/opt/microsoft/msedge/* \
+    "$PKGDIR"/usr/lib/microsoft-edge/
+cp -rv "$SRCDIR"/msedge/usr \
+    "$PKGDIR"/
+
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/microsoft-edge/*.so*
+
+abinfo "Installing icons ..."
+ln -sfv ../../lib/microsoft-edge/product_logo_256.png \
+       "$PKGDIR"/usr/share/pixmaps/microsoft-edge.png
+
+abinfo "Installing symlink to microsoft-edge ..."
+ln -sfv ../lib/microsoft-edge/microsoft-edge \
+       "$PKGDIR"/usr/bin/microsoft-edge-stable
+
+abinfo "Removing cron job for APT updates ..."
+rm -fv /etc/cron.daily/microsoft-edge

--- a/app-web/microsoft-edge/autobuild/defines
+++ b/app-web/microsoft-edge/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=microsoft-edge
+PKGSEC=non-free/web
+PKGDEP="alsa-lib desktop-file-utils flac harfbuzz hicolor-icon-theme icu libpng \
+        nss opus snappy speech-dispatcher perl-file-basedir at-spi2-core \
+        cups gtk-3 ca-certs cairo x11-lib libxcb curl libdrm mesa expat \
+        wget xdg-utils libxml2"
+PKGRECOM="liberation-fonts pipewire kdialog gnome-keyring kwallet"
+PKGDES="A Chromium-based web browser from Microsoft"
+FAIL_ARCH="!(amd64)"
+ABSTRIP=0

--- a/app-web/microsoft-edge/autobuild/prepare
+++ b/app-web/microsoft-edge/autobuild/prepare
@@ -1,0 +1,8 @@
+_BINPACK_VER=$(dpkg -f "${SRCDIR}"/microsoft-edge-stable_current_amd64.deb Version | cut -f '1' -d '-')
+abinfo "Downloaded binary: ${_BINPACK_VER}"
+abinfo "Version from SPEC: ${PKGVER}"
+if [[ "x${_BINPACK_VER}" != "x${PKGVER}" ]]; then
+	aberr "Binary package version does not match SPEC!"
+	aberr "Either update SPEC or invalidate tarball cache."
+	abdie
+fi

--- a/app-web/microsoft-edge/spec
+++ b/app-web/microsoft-edge/spec
@@ -1,0 +1,3 @@
+VER=147.0.3912.60
+SRCS="file::rename=microsoft-edge-stable_current_amd64.deb::https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/microsoft-edge-stable_$VER-1_amd64.deb"
+CHKSUMS="sha256::7dbec190fba23f72a32f0e21ea277232268cb9eb152ec79381b94b9f3e997d35"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
- microsoft-edge: new, 147.0.3912.60
-  Move default target /opt/microsoft/edge to /usr/lib to keep same as google-chrome
- Packing scripts is modified from google-chrome, the source is official original .deb package from Microsoft
<!-- Please input topic description here. -->

Package(s) Affected
-------------------
- microsoft-edge: 147.0.3912.60
<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No.
<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit microsoft-edge
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
