### PR TITLE
conan: update to 2.27.1

### DIFF
--- a/app-devel/conan/autobuild/defines
+++ b/app-devel/conan/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=conan
 PKGSEC=devel
-PKGDEP="python-3 jinja2 pyyaml colorama distro fasteners patch-ng"
+PKGDEP="python-3 requests urllib3 colorama pyyaml patch-ng fasteners distro jinja2 dateutil"
 BUILDDEP="setuptools wheel"
 PKGDES="C/C++ package manager"
 

--- a/app-devel/conan/spec
+++ b/app-devel/conan/spec
@@ -1,4 +1,4 @@
-VER=2.26.2
+VER=2.27.1
 SRCS="git::commit=tags/$VER::https://github.com/conan-io/conan"
 CHKSUMS="SKIP"
 CHKUPDATE="antiya::id=34518"

--- a/lang-python/patch-ng/autobuild/defines
+++ b/lang-python/patch-ng/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=patch-ng
 PKGSEC=python
 PKGDEP="python-3"
 BUILDDEP="setuptools-python3"
-PKGDES="A Python library to parse and apply unified diffs"
+PKGDES="Python library to parse and apply unified diffs"
 
 ABHOST=noarch
 ABTYPE=pep517

--- a/lang-python/patch-ng/spec
+++ b/lang-python/patch-ng/spec
@@ -1,5 +1,4 @@
-VER=1.17.4
-REL="4"
-SRCS="tbl::https://pypi.io/packages/source/p/patch-ng/patch-ng-$VER.tar.gz"
-CHKSUMS="sha256::627abc5bd723c8b481e96849b9734b10065426224d4d22cd44137004ac0d4ace"
+VER=1.19.0
+SRCS="pypi::version=$VER::patch-ng"
+CHKSUMS="sha256::27484792f4ac1c15fe2f3e4cecf74bb9833d33b75c715b71d199f7e1e7d1f786"
 CHKUPDATE="anitya::id=27132"


### PR DESCRIPTION
Topic Description
-----------------

- conan: update to 2.27.1
- patch-ng: update to 1.19.0

Package(s) Affected
-------------------

- conan: 2.27.1
- patch-ng: 1.19.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit patch-ng conan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
