### PR TITLE
arise-linux-graphics-driver-dri: remove gf_asserts 16k check 

### DIFF
--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.53/0009-fix-3b6000-3c6000-3b6000m-2k3000-arise-drm-panic.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.53/0009-fix-3b6000-3c6000-3b6000m-2k3000-arise-drm-panic.patch
@@ -246,3 +246,19 @@ index fe85434..d7c3727 100644
  {
      gf_info("gf vkms only support drm version >= 4.19.0\n");
      return 0;
+diff --git a/core/e3k/vidmm/vidmm_gart_table_e3k.c b/core/e3k/vidmm/vidmm_gart_table_e3k.c
+index 7db972f..b5ac4e1 100644
+--- a/core/e3k/vidmm/vidmm_gart_table_e3k.c
++++ b/core/e3k/vidmm/vidmm_gart_table_e3k.c
+@@ -247,11 +247,6 @@ void vidmm_unmap_gart_table_e3k(adapter_t *adapter, vidmm_allocation_t *allocati
+         page_phy_addr = adapter->dummy_page_addr;
+         page_phy_addr >>= 12;
+ 
+-#if defined(__mips64__) || defined(__loongarch__)
+-        gf_assert(!(page_phy_addr & 0xFFFFFFFFF0000000), "cpu PA need under 36bits");
+-        gf_assert(!(page_phy_addr &0x3), "page_phy_addr not 16k");
+-#endif
+-
+         for(j = 0; j < gart_page_num_per_kernel_page; j++)
+         {
+             //set sys page PA

--- a/runtime-display/arise-linux-graphics-driver-dri/spec
+++ b/runtime-display/arise-linux-graphics-driver-dri/spec
@@ -14,3 +14,4 @@ CHKSUMS__AMD64="sha256::2ba0c067bbcc9e907434fa419fc4be1f2efd1c9d3ede023aaa1b76a0
 CHKSUMS__ARM64="sha256::89d72af8d9489fb8c82a19ea7d9662ac4229d09ff79c4b54b05cf33ba2214072"
 CHKSUMS__LOONGARCH64="sha256::c0d877adfed280792d4f0c1d1d7a656bd7aea68cea7af5e420819ad3db531d93"
 # FIXME: Impossible to generate CHKUPDATE for architecture-version-pairs.
+REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- arise-linux-graphics-driver-dri: remove gf_assert 16k check

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit arise-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
