### PR TITLE
fcitx5-qt: (upstream patch) Fix Qt 6.10+ compatibility

### DIFF
--- a/app-i18n/fcitx5-qt/autobuild/patches/0001-Remove-custom-xdg_popup_reposition-implementation-wh.patch
+++ b/app-i18n/fcitx5-qt/autobuild/patches/0001-Remove-custom-xdg_popup_reposition-implementation-wh.patch
@@ -1,0 +1,253 @@
+From eb3cb2e32dae87c7be606342d0d7ab3260375823 Mon Sep 17 00:00:00 2001
+From: Weng Xuetian <wengxt@gmail.com>
+Date: Wed, 11 Mar 2026 19:36:39 -0700
+Subject: [PATCH] Remove custom xdg_popup_reposition() implementation when Qt
+ version is greater equal than 6.10.
+
+When both side are doing xdg_popup_reposition, the position token may
+conflict with each together and having issue on the Qt's internal.
+
+Fix #81
+---
+ .../fcitxcandidatewindow.cpp                  | 69 ++++++++++++-------
+ .../fcitxcandidatewindow.h                    |  4 +-
+ .../qfcitxplatforminputcontext.cpp            | 16 +++--
+ .../qfcitxplatforminputcontext.h              |  2 +-
+ 4 files changed, 61 insertions(+), 30 deletions(-)
+
+diff --git a/qt5/platforminputcontext/fcitxcandidatewindow.cpp b/qt5/platforminputcontext/fcitxcandidatewindow.cpp
+index afa6d8e..20f54e6 100644
+--- a/qt5/platforminputcontext/fcitxcandidatewindow.cpp
++++ b/qt5/platforminputcontext/fcitxcandidatewindow.cpp
+@@ -23,21 +23,27 @@
+ 
+ #if defined(FCITX_ENABLE_QT6_WAYLAND_WORKAROUND) &&                            \
+     QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
++
+ #include <QtGui/private/qhighdpiscaling_p.h>
++#include <QtWaylandClient/private/qwaylandwindow_p.h>
++
++#if QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
+ #include <QtWaylandClient/private/qwayland-xdg-shell.h>
+ #include <QtWaylandClient/private/qwaylanddisplay_p.h>
+ #include <QtWaylandClient/private/qwaylandintegration_p.h>
+-#include <QtWaylandClient/private/qwaylandwindow_p.h>
+ #include <QtWaylandClient/private/wayland-xdg-shell-client-protocol.h>
+ #include <qpa/qplatformnativeinterface.h>
+ #endif
+ 
++#endif
++
+ namespace fcitx {
+ 
+ namespace {
+ 
+ #if defined(FCITX_ENABLE_QT6_WAYLAND_WORKAROUND) &&                            \
+-    QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
++    QT_VERSION >= QT_VERSION_CHECK(6, 6, 0) &&                                 \
++    QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
+ class XdgWmBase : public QtWayland::xdg_wm_base {
+ public:
+     using xdg_wm_base::xdg_wm_base;
+@@ -125,6 +131,7 @@ FcitxCandidateWindow::FcitxCandidateWindow(QWindow *window,
+         setFlags(Qt::ToolTip | commonFlags);
+ #if defined(FCITX_ENABLE_QT6_WAYLAND_WORKAROUND) &&                            \
+     QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
++#if QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
+         if (auto instance = QtWaylandClient::QWaylandIntegration::instance()) {
+             for (QtWaylandClient::QWaylandDisplay::RegistryGlobal global :
+                  instance->display()->globals()) {
+@@ -136,6 +143,7 @@ FcitxCandidateWindow::FcitxCandidateWindow(QWindow *window,
+                 }
+             }
+         }
++#endif
+         setProperty("_q_waylandPopupAnchor",
+                     QVariant::fromValue(Qt::BottomEdge | Qt::LeftEdge));
+         setProperty("_q_waylandPopupGravity",
+@@ -470,26 +478,20 @@ void FcitxCandidateWindow::updateClientSideUI(
+         return;
+     }
+ 
+-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
+-    QSize sizeWithoutShadow = actualSize_.shrunkBy(theme_->shadowMargin());
+-#else
+-    QSize sizeWithoutShadow =
+-        actualSize_ -
+-        QSize(theme_->shadowMargin().left() + theme_->shadowMargin().right(),
+-              theme_->shadowMargin().top() + theme_->shadowMargin().bottom());
+-#endif
+-    if (sizeWithoutShadow.width() < 0) {
+-        sizeWithoutShadow.setWidth(0);
+-    }
+-    if (sizeWithoutShadow.height() < 0) {
+-        sizeWithoutShadow.setHeight(0);
+-    }
+-
+     if (size() != actualSize_) {
+         resize(actualSize_);
+     }
+     update();
+ 
++    updatePosition();
++}
++
++void FcitxCandidateWindow::updatePosition() {
++    auto *window = context_->focusWindowWrapper();
++    if (!window) {
++        hide();
++        return;
++    }
+     QRect cursorRect = context_->cursorRectangleWrapper();
+     QRect screenGeometry;
+ 
+@@ -498,8 +500,6 @@ void FcitxCandidateWindow::updateClientSideUI(
+     if (isWayland_) {
+         auto *waylandWindow =
+             static_cast<QtWaylandClient::QWaylandWindow *>(window->handle());
+-        const auto windowMargins = waylandWindow->windowContentMargins() -
+-                                   waylandWindow->clientSideMargins();
+         auto windowGeometry = waylandWindow->windowContentGeometry();
+         if (!cursorRect.isValid()) {
+             if (cursorRect.width() <= 0) {
+@@ -529,14 +529,22 @@ void FcitxCandidateWindow::updateClientSideUI(
+                 nativeCursorRect.setHeight(1);
+             }
+         }
+-        bool wasVisible = isVisible();
++
+         bool cursorRectChanged = false;
++        Q_UNUSED(cursorRectChanged);
+         if (property("_q_waylandPopupAnchorRect") != nativeCursorRect) {
+             cursorRectChanged = true;
+             setProperty("_q_waylandPopupAnchorRect", nativeCursorRect);
++            setPosition(cursorRect.topLeft());
+         }
+-        // This try to ensure xdg_popup is available.
++#if QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
++        const auto windowMargins = waylandWindow->windowContentMargins() -
++                                   waylandWindow->clientSideMargins();
++        bool wasVisible = isVisible();
++#endif
++
+         show();
++#if QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
+         xdg_popup *xdgPopup = static_cast<xdg_popup *>(
+             QGuiApplication::platformNativeInterface()->nativeResourceForWindow(
+                 "xdg_popup", this));
+@@ -585,12 +593,13 @@ void FcitxCandidateWindow::updateClientSideUI(
+             hide();
+             show();
+         }
++#endif
+         return;
+     }
+ #endif
+     // Try to apply the screen edge detection over the window, because if we
+-    // intent to use this with wayland. It we have no information above screen
+-    // edge.
++    // intent to use this with wayland. It we have no information above
++    // screen edge.
+     if (isWayland_) {
+         screenGeometry = window->frameGeometry();
+         cursorRect.translate(window->framePosition());
+@@ -602,6 +611,20 @@ void FcitxCandidateWindow::updateClientSideUI(
+         cursorRect.moveTo(pos);
+     }
+ 
++#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
++    QSize sizeWithoutShadow = actualSize_.shrunkBy(theme_->shadowMargin());
++#else
++    QSize sizeWithoutShadow =
++        actualSize_ -
++        QSize(theme_->shadowMargin().left() + theme_->shadowMargin().right(),
++              theme_->shadowMargin().top() + theme_->shadowMargin().bottom());
++#endif
++    if (sizeWithoutShadow.width() < 0) {
++        sizeWithoutShadow.setWidth(0);
++    }
++    if (sizeWithoutShadow.height() < 0) {
++        sizeWithoutShadow.setHeight(0);
++    }
+     int x = cursorRect.left();
+     int y = cursorRect.bottom();
+     if (cursorRect.left() + sizeWithoutShadow.width() >
+diff --git a/qt5/platforminputcontext/fcitxcandidatewindow.h b/qt5/platforminputcontext/fcitxcandidatewindow.h
+index 5b3f3f3..8101467 100644
+--- a/qt5/platforminputcontext/fcitxcandidatewindow.h
++++ b/qt5/platforminputcontext/fcitxcandidatewindow.h
+@@ -47,6 +47,7 @@ public Q_SLOTS:
+                             const FcitxQtStringKeyValueList &candidates,
+                             int candidateIndex, int layoutHint, bool hasPrev,
+                             bool hasNext);
++    void updatePosition();
+ 
+     QSize sizeHint();
+ 
+@@ -95,7 +96,8 @@ private:
+     QPointer<QWindow> parent_;
+ 
+ #if defined(FCITX_ENABLE_QT6_WAYLAND_WORKAROUND) &&                            \
+-    QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
++    QT_VERSION >= QT_VERSION_CHECK(6, 6, 0) &&                                 \
++    QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
+     QScopedPointer<QtWayland::xdg_wm_base> xdgWmBase_;
+ #endif
+ };
+diff --git a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+index c5c7763..a3acddf 100644
+--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
++++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.cpp
+@@ -226,8 +226,8 @@ bool FcitxQtICData::eventFilter(QObject * /*watched*/, QEvent *event) {
+     return false;
+ }
+ 
+-FcitxCandidateWindow *FcitxQtICData::candidateWindow() {
+-    if (!candidateWindow_) {
++FcitxCandidateWindow *FcitxQtICData::candidateWindow(bool create) {
++    if (!candidateWindow_ && create) {
+         candidateWindow_ = new FcitxCandidateWindow(window(), context_);
+         QObject::connect(
+             candidateWindow_, &FcitxCandidateWindow::candidateSelected, proxy,
+@@ -592,6 +592,12 @@ void QFcitxPlatformInputContext::cursorRectChanged() {
+         return;
+     }
+ 
++    if (auto *candidateWindow = data.candidateWindow(/*create=*/false)) {
++        if (candidateWindow->isVisible()) {
++            candidateWindow->updatePosition();
++        }
++    }
++
+     // not sure if this is necessary but anyway, qt's screen used to be buggy.
+     if (!inputWindow->screen()) {
+         return;
+@@ -777,9 +783,9 @@ void QFcitxPlatformInputContext::updateClientSideUI(
+     auto *w = data->window();
+     auto *window = focusWindowWrapper();
+     if (window && w == window) {
+-        data->candidateWindow()->updateClientSideUI(
+-            preedit, cursorpos, auxUp, auxDown, candidates, candidateIndex,
+-            layoutHint, hasPrev, hasNext);
++        data->candidateWindow(/*create=*/true)
++            ->updateClientSideUI(preedit, cursorpos, auxUp, auxDown, candidates,
++                                 candidateIndex, layoutHint, hasPrev, hasNext);
+     }
+ }
+ 
+diff --git a/qt5/platforminputcontext/qfcitxplatforminputcontext.h b/qt5/platforminputcontext/qfcitxplatforminputcontext.h
+index 542efb7..975185b 100644
+--- a/qt5/platforminputcontext/qfcitxplatforminputcontext.h
++++ b/qt5/platforminputcontext/qfcitxplatforminputcontext.h
+@@ -35,7 +35,7 @@ public:
+     FcitxQtICData(const FcitxQtICData &that) = delete;
+     ~FcitxQtICData() override;
+ 
+-    FcitxCandidateWindow *candidateWindow();
++    FcitxCandidateWindow *candidateWindow(bool create);
+ 
+     QWindow *window() { return window_.data(); }
+ 
+-- 
+2.52.0
+

--- a/app-i18n/fcitx5-qt/spec
+++ b/app-i18n/fcitx5-qt/spec
@@ -1,5 +1,5 @@
 VER=5.1.11
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-qt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138234"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-qt: (upstream patch) Fix Qt 6.10+ compatibility

Package(s) Affected
-------------------

- fcitx5-qt: 1:5.1.11-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-qt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
