### PR TITLE
arise-linux-graphics-driver-dri: remove gf_asserts for 4k page size 

### DIFF
--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.53/0009-AOSCOS-fix-3b6000-3c6000-3b6000m-2k3000-arise-drm-panic.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.53/0009-AOSCOS-fix-3b6000-3c6000-3b6000m-2k3000-arise-drm-panic.patch
@@ -1,4 +1,3 @@
-From: Xinmu <xinmu@loongfans.cn>
 diff --git a/core/e3k/vidsch/vidsch_setup_e3k.c b/core/e3k/vidsch/vidsch_setup_e3k.c
 index 3728a69..7b7d227 100644
 --- a/core/e3k/vidsch/vidsch_setup_e3k.c
@@ -26,7 +25,7 @@ index 90b5761..30fe72a 100644
 --- a/core/global/global.c
 +++ b/core/global/global.c
 @@ -38,7 +38,7 @@ void glb_init_chip_id(adapter_t *adapter, krnl_adapter_init_info_t *info)
-
+ 
          adapter->hw_caps.support_snooping = TRUE;
          //from loongson, loonson 3A3000 not support snoop
 -#if defined(__mips64__) || defined(__loongarch__)
@@ -54,7 +53,7 @@ index ef9589a..ff14928 100644
 @@ -207,12 +207,16 @@ static  void krnl_get_adapter_info(void*  adp, adapter_info_t*  adapter_info)
      }
  }
-
+ 
 -static  void  krnl_update_adapter_info(void* adp, adapter_info_t*  adapter_info, krnl_adapter_init_info_t* a_info)
 +static  void  krnl_update_adapter_info(void* adp, adapter_info_t*  adapter_info, krnl_adapter_init_info_t* a_info, int force_enable_snoop)
  {
@@ -76,34 +75,34 @@ index 08424b2..9f9ae41 100644
 @@ -1471,7 +1471,7 @@ void disp_deinit_state_info(disp_info_t* disp_info)
      disp_info->state_info = NULL;
  }
-
+ 
 -int  gf_init_modeset(struct drm_device *dev)
 +int  gf_init_modeset(struct drm_device *dev, int force_enable_snoop)
  {
      gf_card_t*  gf_card = dev->dev_private;
      adapter_info_t* adapter_info = &gf_card->adapter_info;
 @@ -1506,7 +1506,7 @@ int  gf_init_modeset(struct drm_device *dev)
-
+ 
      disp_cbios_get_slice_num(disp_info);
-
+ 
 -    gf_core_interface->update_adapter_info(gf_card->adapter, adapter_info, a_info);
 +    gf_core_interface->update_adapter_info(gf_card->adapter, adapter_info, a_info, force_enable_snoop);
-
+ 
      disp_cbios_get_crtc_resource(disp_info);
-
+ 
 diff --git a/linux/gf_driver.c b/linux/gf_driver.c
 index 832cb6d..da61d81 100644
 --- a/linux/gf_driver.c
 +++ b/linux/gf_driver.c
 @@ -977,7 +977,7 @@ ATTRIBUTE_GROUPS(gf_hwmon);
-
+ 
  #endif
-
+ 
 -int gf_card_init(gf_card_t *gf, void *pdev)
 +int gf_card_init(gf_card_t *gf, void *pdev, int force_enable_snoop)
  {
      int ret = 0;
-
+ 
 @@ -1003,11 +1003,11 @@ int gf_card_init(gf_card_t *gf, void *pdev)
      gf->cbios_flags = gf_modparams.gf_cbios_flags;
      if (gf_modparams.gf_virtual_display)
@@ -116,7 +115,7 @@ index 832cb6d..da61d81 100644
 -        gf_init_modeset(gf->drm_dev);
 +        gf_init_modeset(gf->drm_dev, force_enable_snoop);
      }
-
+ 
      gf_disable_async_suspend(gf);
 diff --git a/linux/gf_driver.h b/linux/gf_driver.h
 index b129381..b1328a6 100644
@@ -125,7 +124,7 @@ index b129381..b1328a6 100644
 @@ -113,11 +113,11 @@ extern struct class *gf_class;
  extern struct drm_ioctl_desc gf_ioctls[];
  extern struct drm_ioctl_desc gf_ioctls_compat[];
-
+ 
 -extern int  gf_card_init(gf_card_t *gf, void *pdev);
 +extern int  gf_card_init(gf_card_t *gf, void *pdev, int force_enable_snoop);
  extern int  gf_card_deinit(gf_card_t *gf);
@@ -135,28 +134,28 @@ index b129381..b1328a6 100644
 -extern int gf_vkms_init_modeset(struct drm_device *ddev);
 +extern int gf_vkms_init_modeset(struct drm_device *ddev, int force_enable_snoop);
  extern void gf_vkms_deinit_modeset(struct drm_device *ddev);
-
+ 
  extern int gf_debugfs_crtc_dump(struct seq_file* file, struct drm_device* dev, int index);
 diff --git a/linux/gf_hw_null.c b/linux/gf_hw_null.c
 index 4ef8dd0..4e3c42e 100644
 --- a/linux/gf_hw_null.c
 +++ b/linux/gf_hw_null.c
 @@ -139,7 +139,7 @@ int gf_register_driver(void)
-
+ 
      gf_fb_mode = "640x480-32@60";
-
+ 
 -    result = gf_card_init(gf, NULL);
 +    result = gf_card_init(gf, NULL, FALSE);
      gf_dev = gf;
      return result;
  }
 diff --git a/linux/gf_pcie.c b/linux/gf_pcie.c
-index 19b30fa..1d786cc 100644
+index 19b30fa..cb6543d 100644
 --- a/linux/gf_pcie.c
 +++ b/linux/gf_pcie.c
 @@ -371,7 +371,7 @@ void gf_selftest(gf_card_t *gf)
  }
-
+ 
  #define PCI_EN_IO_SPACE     1
 -static int gf_drm_load_kms(struct drm_device *dev, unsigned long flags)
 +static int gf_drm_load_kms(struct drm_device *dev, unsigned long flags, int force_enable_snoop)
@@ -164,7 +163,7 @@ index 19b30fa..1d786cc 100644
      struct pci_dev *pdev = to_pci_dev(dev->dev);
      struct device* device = &pdev->dev;
 @@ -445,7 +445,7 @@ static int gf_drm_load_kms(struct drm_device *dev, unsigned long flags)
-
+ 
      gf_init_adapter_info_by_params(&gf->a_info, &gf_modparams);
      gf->a_info.minor_index = gf->index;
 -    ret = gf_card_init(gf, pdev);
@@ -172,23 +171,25 @@ index 19b30fa..1d786cc 100644
      if(ret)
      {
          gf_error("%s_card_init() failed. ret:0x%x\n", STR(DRIVER_NAME), ret);
-@@ -840,8 +840,24 @@ static int gf_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+@@ -840,8 +840,26 @@ static int gf_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
  #endif
-
+ 
      pci_set_drvdata(pdev, dev);
 -
 -    ret = gf_drm_load_kms(dev, flags);
 +    int force_enable_snoop = FALSE;
 +#if defined(__loongarch_lp64)
 +    struct pci_bus * dev_bus = pdev->bus;
-+    gf_info("pdev(vendor:0x%X, device:0x%X) \n", pdev->vendor, pdev->device);
 +    if (dev_bus)
 +    {
 +        struct pci_dev * parent_dev = dev_bus->self;
 +        if (parent_dev)
 +        {
 +            gf_info("pci parent(vendor:0x%X, device:0x%X) \n", parent_dev->vendor, parent_dev->device);
-+            if (parent_dev->vendor == PCI_VENDOR_ID_LOONGSON && ((parent_dev->device >= 0x3c00 && parent_dev->device <= 0x3cff) || (parent_dev->device == 0x7a99)))
++            // 3C6000/3B6000 pcie bridge device_id is 3c09 3c19 3c29
++            // 2K3000/3B6000M pcie bridge device_id is 7a99
++            if (parent_dev->vendor == PCI_VENDOR_ID_LOONGSON &&
++             ((parent_dev->device >= 0x3c00 && parent_dev->device <= 0x3cff) || (parent_dev->device == 0x7a99)))
 +            {
 +                force_enable_snoop = TRUE;
 +            }
@@ -206,41 +207,41 @@ index fe85434..d7c3727 100644
 @@ -516,13 +516,13 @@ static void gf_vkms_get_adapter_info(disp_info_t *disp_info)
      gf_core_interface->get_adapter_info(gf_card->adapter, disp_info->adp_info);
  }
-
+ 
 -static void gf_vkms_update_adapter_info(disp_info_t *disp_info)
 +static void gf_vkms_update_adapter_info(disp_info_t *disp_info, int force_enable_snoop)
  {
      gf_card_t *gf_card = (gf_card_t *)disp_info->gf_card;
      adapter_info_t* adapter_info = disp_info->adp_info;
      krnl_adapter_init_info_t* a_info = &gf_card->a_info;
-
+ 
 -    gf_core_interface->update_adapter_info(gf_card->adapter, adapter_info, a_info);
 +    gf_core_interface->update_adapter_info(gf_card->adapter, adapter_info, a_info, force_enable_snoop);
-
+ 
  }
-
+ 
 @@ -555,7 +555,7 @@ static void gf_vkms_deinit_cbios(disp_info_t *disp_info)
      disp_info_deinit(disp_info);
  }
-
+ 
 -int gf_vkms_init_modeset(struct drm_device *ddev)
 +int gf_vkms_init_modeset(struct drm_device *ddev, int force_enable_snoop)
  {
      int ret, i;
      gf_card_t *gf_card = ddev->dev_private;
 @@ -587,7 +587,7 @@ int gf_vkms_init_modeset(struct drm_device *ddev)
-
+ 
      gf_vkms_init_cbios(disp_info);
-
+ 
 -    gf_vkms_update_adapter_info(disp_info);
 +    gf_vkms_update_adapter_info(disp_info, force_enable_snoop);
-
+ 
      gf_vkms_mode_config_init(ddev);
-
+ 
 @@ -675,7 +675,7 @@ void gf_vkms_deinit_modeset(struct drm_device *ddev)
-
+ 
  #else
-
+ 
 -int gf_vkms_init_modeset(struct drm_device *ddev)
 +int gf_vkms_init_modeset(struct drm_device *ddev, int force_enable_snoop)
  {

--- a/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.53/0010-AOSCOS-remove-gf_assert-for-4k-page-size.patch
+++ b/runtime-display/arise-linux-graphics-driver-dri/autobuild/module-patches/25.00.53/0010-AOSCOS-remove-gf_assert-for-4k-page-size.patch
@@ -1,0 +1,16 @@
+diff --git a/core/e3k/vidmm/vidmm_gart_table_e3k.c b/core/e3k/vidmm/vidmm_gart_table_e3k.c
+index 7db972f..b5ac4e1 100644
+--- a/core/e3k/vidmm/vidmm_gart_table_e3k.c
++++ b/core/e3k/vidmm/vidmm_gart_table_e3k.c
+@@ -247,11 +247,6 @@ void vidmm_unmap_gart_table_e3k(adapter_t *adapter, vidmm_allocation_t *allocati
+         page_phy_addr = adapter->dummy_page_addr;
+         page_phy_addr >>= 12;
+ 
+-#if defined(__mips64__) || defined(__loongarch__)
+-        gf_assert(!(page_phy_addr & 0xFFFFFFFFF0000000), "cpu PA need under 36bits");
+-        gf_assert(!(page_phy_addr &0x3), "page_phy_addr not 16k");
+-#endif
+-
+         for(j = 0; j < gart_page_num_per_kernel_page; j++)
+         {
+             //set sys page PA

--- a/runtime-display/arise-linux-graphics-driver-dri/spec
+++ b/runtime-display/arise-linux-graphics-driver-dri/spec
@@ -14,3 +14,4 @@ CHKSUMS__AMD64="sha256::2ba0c067bbcc9e907434fa419fc4be1f2efd1c9d3ede023aaa1b76a0
 CHKSUMS__ARM64="sha256::89d72af8d9489fb8c82a19ea7d9662ac4229d09ff79c4b54b05cf33ba2214072"
 CHKSUMS__LOONGARCH64="sha256::c0d877adfed280792d4f0c1d1d7a656bd7aea68cea7af5e420819ad3db531d93"
 # FIXME: Impossible to generate CHKUPDATE for architecture-version-pairs.
+REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- arise-linux-graphics-driver-dri: remove gf_assert for 4k page size

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit arise-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
