### PR TITLE
libsigrokdecode: rebuild for undefined symbol

### DIFF
--- a/app-electronics/pulseview/spec
+++ b/app-electronics/pulseview/spec
@@ -1,5 +1,5 @@
 VER=0.4.2
 SRCS="tbl::https://sigrok.org/download/source/pulseview/pulseview-$VER.tar.gz"
 CHKSUMS="sha256::f042f77a3e1b35bf30666330e36ec38fab8d248c3693c37b7e35d401c3bfabcb"
-REL=5
+REL=6
 CHKUPDATE="anitya::id=9549"

--- a/runtime-electronics/libsigrokdecode/autobuild/patches/0001-configure.ac-Add-support-for-Python-3.14.patch
+++ b/runtime-electronics/libsigrokdecode/autobuild/patches/0001-configure.ac-Add-support-for-Python-3.14.patch
@@ -7,7 +7,7 @@ index f9958b3..2917cb3 100644
  # https://docs.python.org/3/whatsnew/3.8.html#debug-build-uses-the-same-abi-as-release-build
  SR_PKG_CHECK([python3], [SRD_PKGLIBS],
 -	[python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
-+	[python-3.10-embed], [python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
++	[python-3.14-embed], [python-3.10-embed], [python-3.9-embed], [python-3.8-embed], [python-3.8 >= 3.8], [python-3.7 >= 3.7], [python-3.6 >= 3.6], [python-3.5 >= 3.5], [python-3.4 >= 3.4], [python-3.3 >= 3.3], [python-3.2 >= 3.2], [python3 >= 3.2])
  AS_IF([test "x$sr_have_python3" = xno],
  	[AC_MSG_ERROR([Cannot find Python 3 development headers.])])
  

--- a/runtime-electronics/libsigrokdecode/spec
+++ b/runtime-electronics/libsigrokdecode/spec
@@ -1,5 +1,5 @@
 VER=0.5.3
-REL="5"
+REL="6"
 SRCS="tbl::https://sigrok.org/download/source/libsigrokdecode/libsigrokdecode-$VER.tar.gz"
 CHKSUMS="sha256::c50814aa6743cd8c4e88c84a0cdd8889d883c3be122289be90c63d7d67883fc0"
 CHKUPDATE="anitya::id=9552"


### PR DESCRIPTION
Topic Description
-----------------

- pulseview: rebuild for undefined symbol PyType_GenericNew
- libsigrokdecode: rebuild for undefined symbol PyType_GenericNew

Package(s) Affected
-------------------

- libsigrokdecode: 0.5.3-6
- pulseview: 0.4.2-6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libsigrokdecode pulseview
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
