### PR TITLE
valgrind: update to 3.27.0

### DIFF
--- a/app-devel/valgrind/autobuild/defines
+++ b/app-devel/valgrind/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=valgrind
 PKGSEC=devel
 PKGDEP="glibc-dbg openmpi perl"
-PKGDES="A tool to help find memory management problems in programs"
+PKGDEP__RETRO="glibc-dbg perl"
+PKGDES="Tool to help identify memory management problems in programs"
 
 # Filter out some flags that cause lots of valgrind test failures.
 # Also filter away -O2, valgrind adds it wherever suitable, but
@@ -19,17 +20,10 @@ NOLTO=1
 AUTOTOOLS_AFTER=(
     '--with-mpicc=mpicc'
 )
-
-PKGDEP__RETRO="glibc-dbg perl"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
-AUTOTOOLS_AFTER__RETRO="--without-mpicc"
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--without-mpicc'
+)
 
 # configure: error: Unsupported host architecture. Sorry
-FAIL_ARCH="(loongarch64)"
+FAIL_ARCH="(loongarch64|loongarch64_nosimd)"

--- a/app-devel/valgrind/autobuild/patches/0001-AOSCOS-cachegrind-improvements.patch
+++ b/app-devel/valgrind/autobuild/patches/0001-AOSCOS-cachegrind-improvements.patch
@@ -1,4 +1,4 @@
-From b8b4c0ee4ba348344c356b6256db2eac02d47e66 Mon Sep 17 00:00:00 2001
+From bce891987802a854e40dc1be0b89c75ac83c993f Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:18:56 +0800
 Subject: [PATCH 1/5] AOSCOS: cachegrind improvements
@@ -9,7 +9,7 @@ Signed-off-by: Jiajie Chen <c@jia.je>
  1 file changed, 12 insertions(+), 12 deletions(-)
 
 diff --git a/cachegrind/cg_sim.c b/cachegrind/cg_sim.c
-index c2ea3791b..67fd382e3 100644
+index 8383e290b..7fd2e56b4 100644
 --- a/cachegrind/cg_sim.c
 +++ b/cachegrind/cg_sim.c
 @@ -40,27 +40,30 @@ typedef struct {
@@ -65,5 +65,5 @@ index c2ea3791b..67fd382e3 100644
  
  /* This attribute forces GCC to inline the function, getting rid of a
 -- 
-2.47.1.windows.1
+2.52.0
 

--- a/app-devel/valgrind/autobuild/patches/0002-AOSCOS-helgrind-race-supp.patch
+++ b/app-devel/valgrind/autobuild/patches/0002-AOSCOS-helgrind-race-supp.patch
@@ -1,4 +1,4 @@
-From 0bea9b4f7d3d07908a9c85472ffe9563fe091d4f Mon Sep 17 00:00:00 2001
+From 65bcbcd8bc1dafa0a6e8331489d7f68f5e56b696 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:19:17 +0800
 Subject: [PATCH 2/5] AOSCOS: helgrind race supp
@@ -9,7 +9,7 @@ Signed-off-by: Jiajie Chen <c@jia.je>
  1 file changed, 6 insertions(+)
 
 diff --git a/glibc-2.X-helgrind.supp.in b/glibc-2.X-helgrind.supp.in
-index 9b1ef9ae4..c447b3a55 100644
+index 61d4e1d72..e932f4a4c 100644
 --- a/glibc-2.X-helgrind.supp.in
 +++ b/glibc-2.X-helgrind.supp.in
 @@ -118,6 +118,12 @@
@@ -26,5 +26,5 @@ index 9b1ef9ae4..c447b3a55 100644
     helgrind-glibc2X-103
     Helgrind:Race
 -- 
-2.47.1.windows.1
+2.52.0
 

--- a/app-devel/valgrind/autobuild/patches/0003-AOSCOS-ldso-supp.patch
+++ b/app-devel/valgrind/autobuild/patches/0003-AOSCOS-ldso-supp.patch
@@ -1,4 +1,4 @@
-From 1713d4dfcd0d075f634ff6bcbeafbcf26dcc594f Mon Sep 17 00:00:00 2001
+From 4803ad9700ac102c86fb11f6d46ab812831bc367 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:19:32 +0800
 Subject: [PATCH 3/5] AOSCOS: ldso supp
@@ -9,7 +9,7 @@ Signed-off-by: Jiajie Chen <c@jia.je>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/glibc-2.X.supp.in b/glibc-2.X.supp.in
-index fc346d803..51b403ada 100644
+index f606dd5df..307ce0849 100644
 --- a/glibc-2.X.supp.in
 +++ b/glibc-2.X.supp.in
 @@ -124,7 +124,7 @@
@@ -39,5 +39,5 @@ index fc346d803..51b403ada 100644
  
  {
 -- 
-2.47.1.windows.1
+2.52.0
 

--- a/app-devel/valgrind/autobuild/patches/0004-AOSCOS-some-Wl-z-now.patch
+++ b/app-devel/valgrind/autobuild/patches/0004-AOSCOS-some-Wl-z-now.patch
@@ -1,4 +1,4 @@
-From 7fb7bb9bf894199715f1c5eddd2b1e3342400791 Mon Sep 17 00:00:00 2001
+From d5eb0c8ade74b97cba2cd1b40646f2ca892f0cb1 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Sun, 4 Feb 2024 22:20:18 +0800
 Subject: [PATCH 4/5] AOSCOS: some -Wl,-z,now
@@ -10,30 +10,30 @@ Signed-off-by: Jiajie Chen <c@jia.je>
  2 files changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/auxprogs/Makefile.am b/auxprogs/Makefile.am
-index 3a9709da6..bcbd3e0eb 100644
+index f5be90eb1..107d6f1db 100644
 --- a/auxprogs/Makefile.am
 +++ b/auxprogs/Makefile.am
-@@ -32,7 +32,7 @@ valgrind_listener_SOURCES = valgrind-listener.c
+@@ -52,7 +52,7 @@ valgrind_listener_SOURCES = valgrind-listener.c
  valgrind_listener_CPPFLAGS  = $(AM_CPPFLAGS_PRI) -I$(top_srcdir)/coregrind
- valgrind_listener_CFLAGS    = $(AM_CFLAGS_PRI)
+ valgrind_listener_CFLAGS    = $(AM_CFLAGS_PRI) -fhosted
  valgrind_listener_CCASFLAGS = $(AM_CCASFLAGS_PRI)
 -valgrind_listener_LDFLAGS   = $(AM_CFLAGS_PRI)
 +valgrind_listener_LDFLAGS   = $(AM_CFLAGS_PRI) -Wl,-z,now
  if VGCONF_PLATVARIANT_IS_ANDROID
  valgrind_listener_CFLAGS    += -static
  endif
-@@ -51,7 +51,7 @@ valgrind_di_server_SOURCES   = valgrind-di-server.c
+@@ -71,7 +71,7 @@ valgrind_di_server_SOURCES   = valgrind-di-server.c
  valgrind_di_server_CPPFLAGS  = $(AM_CPPFLAGS_PRI) -I$(top_srcdir)/coregrind
- valgrind_di_server_CFLAGS    = $(AM_CFLAGS_PRI)
+ valgrind_di_server_CFLAGS    = $(AM_CFLAGS_PRI) -fhosted
  valgrind_di_server_CCASFLAGS = $(AM_CCASFLAGS_PRI)
 -valgrind_di_server_LDFLAGS   = $(AM_CFLAGS_PRI)
 +valgrind_di_server_LDFLAGS   = $(AM_CFLAGS_PRI) -Wl,-z,now
  if VGCONF_PLATVARIANT_IS_ANDROID
  valgrind_di_server_CFLAGS    += -static
  endif
-@@ -86,7 +86,7 @@ getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_SOURCES   = getoff.c
+@@ -106,7 +106,7 @@ getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_SOURCES   = getoff.c
  getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_CPPFLAGS  = $(AM_CPPFLAGS_@VGCONF_PLATFORM_PRI_CAPS@)
- getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_CFLAGS    = $(AM_CFLAGS_@VGCONF_PLATFORM_PRI_CAPS@)
+ getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_CFLAGS    = $(AM_CFLAGS_@VGCONF_PLATFORM_PRI_CAPS@) -fhosted
  getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_CCASFLAGS = $(AM_CCASFLAGS_PRI)
 -getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_LDFLAGS   = $(AM_CFLAGS_PRI) @LIB_UBSAN@
 +getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_LDFLAGS   = $(AM_CFLAGS_PRI) @LIB_UBSAN@ -Wl,-z,now
@@ -41,21 +41,21 @@ index 3a9709da6..bcbd3e0eb 100644
  getoff_@VGCONF_ARCH_PRI@_@VGCONF_OS@_LDADD = $(LDADD) -ldl
  endif
 diff --git a/coregrind/Makefile.am b/coregrind/Makefile.am
-index e3e31a73b..509c17909 100644
+index 5bef81e1c..e0d9c0005 100644
 --- a/coregrind/Makefile.am
 +++ b/coregrind/Makefile.am
-@@ -62,7 +62,7 @@ RANLIB = ${LTO_RANLIB}
+@@ -64,7 +64,7 @@ RANLIB = ${LTO_RANLIB}
  valgrind_CPPFLAGS  = $(AM_CPPFLAGS_PRI)
- valgrind_CFLAGS    = $(AM_CFLAGS_PRI) $(LTO_CFLAGS)
+ valgrind_CFLAGS    = $(AM_CFLAGS_PRI) $(LTO_CFLAGS) -fhosted
  valgrind_CCASFLAGS = $(AM_CCASFLAGS_PRI)
 -valgrind_LDFLAGS   = $(AM_CFLAGS_PRI) @LIB_UBSAN@
 +valgrind_LDFLAGS   = $(AM_CFLAGS_PRI) @LIB_UBSAN@ -Wl,-z,now
  # If there is no secondary platform, and the platforms include x86-darwin,
  # then the primary platform must be x86-darwin.  Hence:
  if ! VGCONF_HAVE_PLATFORM_SEC
-@@ -104,7 +104,7 @@ endif
+@@ -106,7 +106,7 @@ endif
  vgdb_CPPFLAGS  = $(AM_CPPFLAGS_PRI) $(GDB_SCRIPTS_DIR)
- vgdb_CFLAGS    = $(AM_CFLAGS_PRI) $(LTO_CFLAGS)
+ vgdb_CFLAGS    = $(AM_CFLAGS_PRI) $(LTO_CFLAGS) -fhosted
  vgdb_CCASFLAGS = $(AM_CCASFLAGS_PRI)
 -vgdb_LDFLAGS   = $(AM_CFLAGS_PRI) @LIB_UBSAN@
 +vgdb_LDFLAGS   = $(AM_CFLAGS_PRI) @LIB_UBSAN@ -Wl,-z,now
@@ -63,5 +63,5 @@ index e3e31a73b..509c17909 100644
  vgdb_CFLAGS    += -static
  endif
 -- 
-2.47.1.windows.1
+2.52.0
 

--- a/app-devel/valgrind/autobuild/patches/0005-AOSCOS-mips-detect-Loongson-CPU-model-names-without-.patch
+++ b/app-devel/valgrind/autobuild/patches/0005-AOSCOS-mips-detect-Loongson-CPU-model-names-without-.patch
@@ -1,4 +1,4 @@
-From a56d5d333376551e65eacf0866cac3bef9d3eaed Mon Sep 17 00:00:00 2001
+From 1cadd240f91cdc3593cbed00f84fb3adf83adc99 Mon Sep 17 00:00:00 2001
 From: Kexy Biscuit <kexybiscuit@aosc.io>
 Date: Wed, 11 Dec 2024 17:24:20 +0800
 Subject: [PATCH 5/5] AOSCOS: mips: detect Loongson CPU model names without ICT
@@ -15,10 +15,10 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/coregrind/m_machine.c b/coregrind/m_machine.c
-index 234efb312..ece336503 100644
+index 15227efcf..ba450f12a 100644
 --- a/coregrind/m_machine.c
 +++ b/coregrind/m_machine.c
-@@ -680,7 +680,8 @@ static Bool VG_(parse_cpuinfo)(void)
+@@ -719,7 +719,8 @@ static Bool VG_(parse_cpuinfo)(void)
     const char *search_Broadcom_str = "cpu model\t\t: Broadcom";
     const char *search_Cavium_str= "cpu model\t\t: Cavium";
     const char *search_Ingenic_str= "cpu model\t\t: Ingenic";
@@ -28,7 +28,7 @@ index 234efb312..ece336503 100644
     const char *search_MIPS_str = "cpu model\t\t: MIPS";
     const char *search_Netlogic_str = "cpu model\t\t: Netlogic";
  
-@@ -734,7 +735,7 @@ static Bool VG_(parse_cpuinfo)(void)
+@@ -773,7 +774,7 @@ static Bool VG_(parse_cpuinfo)(void)
         vai.hwcaps = VEX_PRID_COMP_MIPS;
     else if (VG_(strstr)(file_buf, search_Ingenic_str) != NULL)
         vai.hwcaps = VEX_PRID_COMP_INGENIC_E1;
@@ -38,5 +38,5 @@ index 234efb312..ece336503 100644
     else {
         /* Did not find string in the proc file. */
 -- 
-2.47.1.windows.1
+2.52.0
 

--- a/app-devel/valgrind/spec
+++ b/app-devel/valgrind/spec
@@ -1,4 +1,4 @@
-VER=3.25.0
+VER=3.27.0
 SRCS="tbl::https://sourceware.org/pub/valgrind/valgrind-$VER.tar.bz2"
-CHKSUMS="sha256::295f60291d6b64c0d90c1ce645634bdc5361d39b0c50ecf9de6385ee77586ecc"
+CHKSUMS="sha256::5b5937de8257ee8f51698ea71b9711adce98061aa07daa4a685efc3af9215bef"
 CHKUPDATE="anitya::id=13639"


### PR DESCRIPTION
Topic Description
-----------------

- valgrind: update to 3.27.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- valgrind: 3.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit valgrind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
