### PR TITLE
pip: update to 26.0.1

### DIFF
--- a/lang-python/pip/autobuild/patches/0001-UPSTREAM-Refactor-unpacking-logic-for-archive-files.patch
+++ b/lang-python/pip/autobuild/patches/0001-UPSTREAM-Refactor-unpacking-logic-for-archive-files.patch
@@ -1,0 +1,95 @@
+From e0b67e9ccbdfe91b5b63580d4a54259d0b7e290c Mon Sep 17 00:00:00 2001
+From: Dmitrii Sutiagin <f3flight@gmail.com>
+Date: Thu, 26 Mar 2026 09:37:36 -0700
+Subject: [PATCH] UPSTREAM: Refactor unpacking logic for archive files
+
+Make unpacking logic resilient against ambiguous signature check, and order logic by check confidence instead of by file format.
+
+Link: https://github.com/pypa/pip/pull/13870
+Link: https://www.cve.org/CVERecord?id=CVE-2026-3219
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/pip/_internal/utils/unpacking.py | 70 +++++++++++++++++++---------
+ 1 file changed, 47 insertions(+), 23 deletions(-)
+
+diff --git a/src/pip/_internal/utils/unpacking.py b/src/pip/_internal/utils/unpacking.py
+index b3f52e85e..488befa9b 100644
+--- a/src/pip/_internal/utils/unpacking.py
++++ b/src/pip/_internal/utils/unpacking.py
+@@ -337,26 +337,50 @@ def unpack_file(
+     content_type: str | None = None,
+ ) -> None:
+     filename = os.path.realpath(filename)
+-    if (
+-        content_type == "application/zip"
+-        or filename.lower().endswith(ZIP_EXTENSIONS)
+-        or zipfile.is_zipfile(filename)
+-    ):
+-        unzip_file(filename, location, flatten=not filename.endswith(".whl"))
+-    elif (
+-        content_type == "application/x-gzip"
+-        or tarfile.is_tarfile(filename)
+-        or filename.lower().endswith(TAR_EXTENSIONS + BZ2_EXTENSIONS + XZ_EXTENSIONS)
+-    ):
+-        untar_file(filename, location)
+-    else:
+-        # FIXME: handle?
+-        # FIXME: magic signatures?
+-        logger.critical(
+-            "Cannot unpack file %s (downloaded from %s, content-type: %s); "
+-            "cannot detect archive format",
+-            filename,
+-            location,
+-            content_type,
+-        )
+-        raise InstallationError(f"Cannot determine archive format of {location}")
++    zip_flatten = not filename.endswith(".whl")
++    
++    ZIP = "zip"
++    TAR = "tar"
++    zip_fn = lambda: unzip_file(filename, location, flatten=zip_flatten)
++    tar_fn = lambda: untar_file(filename, location)
++    unpack_function = {ZIP: zip_fn, TAR: tar_fn}
++
++    # order checks from most to least reliable / explicit
++    content_chk = {"application/zip": ZIP, "application/x-gzip": TAR}.get(content_type)
++    if content:
++        return unpack_function[content_chk]
++
++    filename_chk = (
++        ZIP if filename.lower().endswith(ZIP_EXTENSIONS) else
++        TAR if filename.lower().endswith(
++            TAR_EXTENSIONS + BZ2_EXTENSIONS + XZ_EXTENSIONS
++        ) else
++        None
++    )
++    if filename_chk:
++        return unpack_function[filename_chk]
++
++    # avoid ambiguous case where both signature checks return True
++    is_zipfile = zipfile.is_zipfile(filename)
++    is_tarfile = tarfile.is_tarfile(filename)
++    magic_sig_check = (
++        ZIP if is_zipfile and not is_tarfile else
++        TAR if is_tarfile and not is_zipfile else
++        None
++    )
++    if magic_sig_check:
++        return unpack_function[magic_sig_check]
++    elif is_zipfile and is_tarfile:
++        log.error("Ambiguous file signature in %s.", filename)
++
++    # FIXME: handle?
++    # FIXME: magic signatures?
++    logger.critical(
++        "Cannot unpack file %s (downloaded from %s, content-type: %s); "
++        "cannot detect archive format",
++        filename,
++        location,
++        content_type,
++    )
++    raise InstallationError(f"Cannot determine archive format of {location}")
++        
+-- 
+2.52.0
+

--- a/lang-python/pip/spec
+++ b/lang-python/pip/spec
@@ -1,5 +1,4 @@
-VER=25.3
+VER=26.0.1
 SRCS="git::commit=tags/$VER::https://github.com/pypa/pip"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6529"
-REL="1"

--- a/topics/pip-26.0.1.toml
+++ b/topics/pip-26.0.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "pip 26.0.1"
+
+[caution]
+default = "Fixes a Interpretation Conflict, Misinterpretation of Input, or Unrestricted Upload of File with Dangerous Type vulnerability - CVE-2026-3219 (severity: Medium)"
+zh_CN = "修复一个解释冲突、错误解析输入或危险类型文件的不加限制上传漏洞，漏洞编号 CVE-2026-3219（严重性：中）"
+
+[packages-v2]
+"pip" = "< 26.0.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add pip-26.0.1.toml
- pip: update to 26.0.1
    Backport a patch for https://www.cve.org/CVERecord?id=CVE-2026-3219.
    Link: https://www.cve.org/CVERecord?id=CVE-2026-3219
    Link: https://github.com/pypa/pip/pull/13870

Package(s) Affected
-------------------

- pip: 26.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
