### PR TITLE
snes9x: new, 1.63+git20260413

### DIFF
--- a/app-games/snes9x/autobuild/defines
+++ b/app-games/snes9x/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=snes9x
+PKGSEC=games
+PKGDEP="sdl2 gtk-3 gtkmm-3 glib glibmm x11-lib wayland libpng zlib minizip \
+        pulseaudio alsa-lib portaudio cairo cairomm gdk-pixbuf libsigc++"
+PKGDES="Super Famicom/Super Nintendo Entertainment System (SFC/SNES) emulator"
+
+ABTYPE=cmakeninja

--- a/app-games/snes9x/spec
+++ b/app-games/snes9x/spec
@@ -1,0 +1,7 @@
+VER=1.63+git20260413
+
+COMMIT=121bb374d0d9a5ba2dd73c7b14a58c95c236a9bf
+SRCS="git::commit=$COMMIT;copy-repo=true::https://github.com/snes9xgit/snes9x"
+CHKSUMS="SKIP"
+SUBDIR="snes9x/gtk"
+CHKUPDATE="anitya::id=12317"


### PR DESCRIPTION
Topic Description
-----------------

- snes9x: new, 1.63+git20260413

Package(s) Affected
-------------------

- snes9x: 1.63+git20260413

Security Update?
----------------

No

Build Order
-----------

```
#buildit snes9x
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
