### PR TITLE
openvdb: rework rebuilds

### DIFF
--- a/app-creativity/blender/spec
+++ b/app-creativity/blender/spec
@@ -1,4 +1,5 @@
 VER=5.1.0
+REL=1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://projects.blender.org/blender/blender.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=201"

--- a/app-creativity/superslicer/spec
+++ b/app-creativity/superslicer/spec
@@ -1,5 +1,5 @@
 VER=2.7.61.10
-REL=2
+REL=3
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/supermerill/SuperSlicer.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370825"

--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.5.2
-REL=4
+REL=5
 SRCS="git::commit=tags/v${VER}::https://gitlab.kitware.com/vtk/vtk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15084"

--- a/runtime-common/openvdb/autobuild/defines
+++ b/runtime-common/openvdb/autobuild/defines
@@ -68,4 +68,5 @@ CMAKE_AFTER__ARM64=(
     '-DNANOVDB_USE_INTRINSICS=ON'
 )
 
-PKGBREAK="superslicer<=2.5.59.3-0 openimageio<=2.4.12.0-3 blender<=3.6.4-0"
+PKGBREAK="blender<=5.1.0 openimageio<=2.5.19.1-5 superslicer<=2.7.61.10-2 \
+          vtk<=9.5.2-4"

--- a/runtime-common/openvdb/spec
+++ b/runtime-common/openvdb/spec
@@ -1,4 +1,5 @@
 VER=12.1.1
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/AcademySoftwareFoundation/openvdb.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21124"

--- a/runtime-imaging/openimageio/spec
+++ b/runtime-imaging/openimageio/spec
@@ -1,5 +1,5 @@
 VER=2.5.19.1
-REL=5
+REL=6
 SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/OpenImageIO"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2548"


### PR DESCRIPTION
Topic Description
-----------------

- vtk: bump REL due to openvdb update to 12.1.1
- superslicer: bump REL due to openvdb update to 12.1.1
- openimageio: bump REL due to openvdb update to 12.1.1
- blender: bump REL due to openvdb update to 12.1.1
- openvdb: update PKGBREAK

Package(s) Affected
-------------------

- blender: 5.1.0-1
- openimageio: 2.5.19.1-6
- openvdb: 12.1.1
- superslicer: 2.7.61.10-3
- vtk: 9.5.2-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit openvdb:-pkgbreak openimageio blender superslicer vtk openvdb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
