### PR TITLE
ntfs-3g: update to 2026.2.25

### DIFF
--- a/app-admin/ntfs-3g/spec
+++ b/app-admin/ntfs-3g/spec
@@ -1,10 +1,9 @@
-VER=2022.10.3
-REL=1
+VER=2026.2.25
 SRCS="tbl::https://download.tuxera.com/opensource/ntfs-3g_ntfsprogs-$VER.tgz \
       tbl::https://github.com/ebiggers/ntfs-3g-system-compression/releases/download/v1.0/ntfs-3g-system-compression-1.0.tar.gz \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/dedup.zip \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/onedrive.zip"
-CHKSUMS="sha256::f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c \
+CHKSUMS="sha256::7754f3b32e8baf9c472459b4e9c981e3ae0f5039107cdd8d8201aed0a949008a \
          sha256::c4a26f3a704f5503ec1b3af5e4bb569590c6752616e68a3227fc717417efaaae \
          sha256::a435efd5a81c69cf2ff7ba5f93a5672923e8548b9e287e3f3db30902a286be9b \
          sha256::fd5e1b7d58d2590254de176654e7c2b90340dde904ecd2e8640c30bc6b9e6684"


### PR DESCRIPTION
Topic Description
-----------------

- ntfs-3g: update to 2026.2.25
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ntfs-3g: 1:2026.2.25

Security Update?
----------------

No

Build Order
-----------

```
#buildit ntfs-3g
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
