### PR TITLE
ouch: update to 0.7.1

### DIFF
--- a/app-utils/ouch/autobuild/beyond
+++ b/app-utils/ouch/autobuild/beyond
@@ -1,0 +1,12 @@
+abinfo "Installing manpage and completions ..."
+for i in ouch*.1; do
+    install -Dvm644 "$SRCDIR"/artifacts/$i \
+        -t "$PKGDIR"/usr/share/man/man1/
+done
+
+install -Dvm644 "$SRCDIR"/artifacts/ouch.bash \
+    "$PKGDIR"/usr/share/bash-completion/completions/ouch
+install -Dvm644 "$SRCDIR"/artifacts/_ouch \
+    "$PKGDIR"/usr/share/zsh/site-functions/_ouch
+install -Dvm644 "$SRCDIR"/artifacts/ouch.fish \
+    "$PKGDIR"/usr/share/fish/vendor_completions.d/ouch.fish

--- a/app-utils/ouch/autobuild/defines
+++ b/app-utils/ouch/autobuild/defines
@@ -4,10 +4,6 @@ PKGDEP="glibc zlib bzip2 xz gcc-runtime bzip3"
 BUILDDEP="rustc llvm"
 PKGSEC="util"
 
-# FIXME: ld.lld: error: undefined symbol: std::bad_alloc::bad_alloc()
-NOLTO=1
-
-ABSPLITDBG=0
 USECLANG=1
-
-CARGO_AFTER__I486="${CARGO_AFTER} --target=i486-unknown-linux-gnu"
+ABTYPE=rust
+CARGO_AFTER__I486=('--target=i486-unknown-linux-gnu')

--- a/app-utils/ouch/autobuild/prepare
+++ b/app-utils/ouch/autobuild/prepare
@@ -1,0 +1,3 @@
+# Note: To generated manpage and completions.
+abinfo "Setting OUCH_ARTIFACTS_FOLDER ..."
+export OUCH_ARTIFACTS_FOLDER="$SRCDIR"/artifacts

--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,4 +1,4 @@
-VER=0.6.1
+VER=0.7.1
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"


### PR DESCRIPTION
Topic Description
-----------------

- ouch: update to 0.7.1

Package(s) Affected
-------------------

- ouch: 0.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
