### PR TITLE
lilypond: update to 2.26.0

### DIFF
--- a/app-multimedia/lilypond/spec
+++ b/app-multimedia/lilypond/spec
@@ -1,5 +1,4 @@
-VER=2.24.4
+VER=2.26.0
 SRCS="tbl::http://lilypond.org/download/sources/v${VER:0:4}/lilypond-$VER.tar.gz"
-CHKSUMS="sha256::e96fa03571c79f20e1979653afabdbe4ee42765a3d9fd14953f0cd9eea51781c"
+CHKSUMS="sha256::bbe82dbeba7f7f99ddcd8d1fa134a0d89cafa6e8f815fde5bb01f4208b06fe05"
 CHKUPDATE="anitya::id=9785"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- lilypond: update to 2.26.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- lilypond: 1:2.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lilypond
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
