### PR TITLE
vim: update to 9.2.0387

### DIFF
--- a/app-editors/vim/01-vim/patches/0001-Fix-for-kmscon.patch
+++ b/app-editors/vim/01-vim/patches/0001-Fix-for-kmscon.patch
@@ -1,19 +1,9 @@
-From 893f643a47087e2ed4bde09dbb205e2205625a5b Mon Sep 17 00:00:00 2001
-From: Icenowy Zheng <icenowy@aosc.io>
-Date: Sat, 31 Oct 2020 18:59:34 +0800
-Subject: [PATCH] Fix for kmscon
-
-Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
----
- src/term.c | 7 +++++++
- 1 file changed, 7 insertions(+)
-
 diff --git a/src/term.c b/src/term.c
-index 7e39b037c..ad1d02c36 100644
+index 876e15d95..fefcccbd2 100644
 --- a/src/term.c
 +++ b/src/term.c
-@@ -5198,6 +5198,13 @@ handle_version_response(int first, int *arg, int argc, char_u *tp)
- 	    term_props[TPR_CURSOR_BLINK].tpr_status = TPR_NO;
+@@ -5317,6 +5317,13 @@ handle_version_response(int first, int *arg, int argc, char_u *tp)
+ 							// sequences
  	}
  
 +	// KMSCON sends 1;1;0 and it cannot handle cursor style and blink
@@ -26,6 +16,3 @@ index 7e39b037c..ad1d02c36 100644
  	// Xterm first responded to this request at patch level
  	// 95, so assume anything below 95 is not xterm and hopefully supports
  	// the underline RGB color sequence.
--- 
-2.46.0
-

--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,5 +1,4 @@
-VER=9.2.0360
-REL=1
+VER=9.2.0387
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0387
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.0387
- vim: 9.2.0387

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
