### PR TITLE
lychee: update to 0.23.0

### DIFF
--- a/app-web/lychee/autobuild/defines
+++ b/app-web/lychee/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME="lychee"
-PKGDES="A command-line broken link checker"
+PKGDES="Async and stream-based link checker"
 PKGDEP="openssl gcc-runtime glibc"
 BUILDDEP="rustc llvm"
 PKGSEC="web"
@@ -7,8 +7,5 @@ PKGSEC="web"
 USECLANG=1
 ABSPLITDBG=0
 
-# ld.lld does not support loongson3 and loongarch64
-USECLANG__LOONGSON3=0
-USECLANG__LOONGARCH64=0
-NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1
+# FIXME: error: undefined symbol: awc_lc_0_37_1_EVP_parse_private_key
+NOLTO=1

--- a/app-web/lychee/spec
+++ b/app-web/lychee/spec
@@ -1,4 +1,4 @@
-VER=0.18.1
+VER=0.23.0
 SRCS="git::commit=lychee-v$VER::https://github.com/lycheeverse/lychee"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370221"


### PR DESCRIPTION
Topic Description
-----------------

- lychee: update to 0.23.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- lychee: 0.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lychee
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
