### PR TITLE
libevdev: update to 1.13.6

### DIFF
--- a/runtime-devices/libevdev/spec
+++ b/runtime-devices/libevdev/spec
@@ -1,5 +1,4 @@
-VER=1.13.5
-REL=1
+VER=1.13.6
 SRCS="git::commit=libevdev-${VER}::https://gitlab.freedesktop.org/libevdev/libevdev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20540"


### PR DESCRIPTION
Topic Description
-----------------

- libevdev: update to 1.13.6
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libevdev: 1.13.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit libevdev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
