### PR TITLE
zerotier-one: update to 1.16.0

### DIFF
--- a/app-network/zerotier-one/spec
+++ b/app-network/zerotier-one/spec
@@ -1,5 +1,4 @@
-VER=1.14.2
-REL=1
+VER=1.16.0
 SRCS="git::commit=tags/$VER::https://github.com/zerotier/ZeroTierOne"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17578"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

zerotier-one: update to 1.16.0

- Update version from 1.14.2 to 1.16.0
- Add LoongArch 64-bit (loongarch64) build support

Package(s) Affected
-------------------

app-network/zerotier-one

Security Update?
----------------

No

Build Order
-------------

```
zerotier-one
```

Build Logs
-----------

<details>
<summary>Build Logs</summary>

```
(ssh)houge@aosc-loongarch64-lg110 [ ~ ] ! sudo cp aosc-os-abbs/app-network/zerotier-one/spec TREE/app-network/zerotier-one/spec 
(ssh)houge@aosc-loongarch64-lg110 [ ~ ] $ sudo ciel list
NAME          MOUNTED  RUNNING  BOOTED
zerotier-one  Yes      No       -
(ssh)houge@aosc-loongarch64-lg110 [ ~ ] $ sudo ciel build -i zerotier-one zer
zeroconf      zerofree      zeromq        zerotier-one  
(ssh)houge@aosc-loongarch64-lg110 [ ~ ] $ sudo ciel build -i zerotier-one zerotier-one 
.....
30 warnings generated.
clang++ -ggdb -fno-permissive -pipe -Wno-error -fstack-protector-strong --param=ssp-buffer-size=4 -fexceptions -fPIC -fPIC -ggdb -O2 -fno-omit-frame-pointer -flto -mabi=lp64d -mno-strict-align -march=la64v1.0 -mtune=la664 -Wall -Wno-deprecated -std=c++17 -pthread -Irustybits/target -isystem ext -Iext/prometheus-cpp-lite-1.0/core/include -Iext-prometheus-cpp-lite-1.0/3rdparty/http-client-lite/include -Iext/prometheus-cpp-lite-1.0/simpleapi/include -Iext/opentelemetry-cpp-api-only/include -DNDEBUG -DZT_USE_MINIUPNPC -DZT_USE_SYSTEM_MINIUPNPC -DZT_NO_TYPE_PUNNING -DZT_BUILD_PLATFORM=1 -DZT_BUILD_ARCHITECTURE=17 -DZT_SOFTWARE_UPDATE_DEFAULT="\"disable\"" -D_MT_ALLOCATOR_H -D_POOL_ALLOCATOR_H -D_EXTPTR_ALLOCATOR_H -D_DEBUG_ALLOCATOR_H -fPIC -fPIE -Wl,-O1,--sort-common,--as-needed -Wl,-build-id=sha1 -Wl,-z,relro -Wl,-z,now -fPIC -fPIE -flto -fuse-linker-plugin -Wl,-z,pack-relative-relocs -Wl,-z,noexecstack -o zerotier-one node/AES.o node/AES_aesni.o node/AES_armcrypto.o node/ECC.o node/Capability.o node/CertificateOfMembership.o node/CertificateOfOwnership.o node/Identity.o node/IncomingPacket.o node/InetAddress.o node/Membership.o node/Metrics.o node/Multicaster.o node/Network.o node/NetworkConfig.o node/Node.o node/OutboundMulticast.o node/Packet.o node/Path.o node/Peer.o node/Poly1305.o node/Revocation.o node/Salsa20.o node/SelfAwareness.o node/SHA512.o node/Switch.o node/Tag.o node/Topology.o node/Trace.o node/Utils.o node/Bond.o node/PacketMultiplexer.o osdep/OSUtils.o osdep/EthernetTap.o osdep/ManagedRoute.o osdep/Http.o service/OneService.o osdep/LinuxEthernetTap.o osdep/LinuxNetLink.o osdep/PortMapper.o ext/libnatpmp/natpmp.o ext/libnatpmp/getgateway.o ext/http-parser/http_parser.o one.o -lminiupnpc
ln -sf zerotier-one zerotier-idtool
ln -sf zerotier-one zerotier-cli
[INFO]:  Installing zerotier-one...
mkdir -p /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-one
cp -f zerotier-one /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-one
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-cli
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-idtool
ln -s zerotier-one /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-cli
ln -s zerotier-one /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-idtool
mkdir -p /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-one
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-cli
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-idtool
ln -s ../../../usr/bin/zerotier-one /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-one
ln -s ../../../usr/bin/zerotier-one /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-cli
ln -s ../../../usr/bin/zerotier-one /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-idtool
mkdir -p /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man8
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man8/zerotier-one.8.gz
cat doc/zerotier-one.8 | gzip -9 >/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man8/zerotier-one.8.gz
mkdir -p /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man1
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man1/zerotier-idtool.1.gz
rm -f /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man1/zerotier-cli.1.gz
cat doc/zerotier-cli.1 | gzip -9 >/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man1/zerotier-cli.1.gz
cat doc/zerotier-idtool.1 | gzip -9 >/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/man/man1/zerotier-idtool.1.gz
cp ext/installfiles/linux/zerotier-one.te /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/var/lib/zerotier-one/zerotier-one.te
install: creating directory '/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/lib'
install: creating directory '/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/lib/systemd'
install: creating directory '/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/lib/systemd/system'
'/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/debian/zerotier-one.service' -> '/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/lib/systemd/system/zerotier-one.service'
[INFO]:  self > Running install step ...
[INFO]:  HWCAPS is not active. Skipping builds for HWCAPS subtargtes.
[INFO]:  Running post-build filter: filter_perl ...
[INFO]:  Removed perllocal.pod.
[INFO]:  Removed .packlist.
[INFO]:  Running post-build filter: filter_retro_drop_docs ...
[DEBUG]: Member '64bit' in Architecture group '64bit mainline without_dotnet' mismatches retro.
[DEBUG]: Member 'mainline' in Architecture group '64bit mainline without_dotnet' mismatches retro.
[DEBUG]: Member 'without_dotnet' in Architecture group '64bit mainline without_dotnet' mismatches retro.
[INFO]:  All architecture group members '64bit mainline without_dotnet' mismatches retro: taking false branch.
[INFO]:  Non-Retro architectures detected, skipping retro_drop_docs ...
[INFO]:  Running post-build filter: filter_optenv_drop_shared_files ...
[INFO]:  Non-optenv target detected, skipping optenv_drop_shared_files ...
[INFO]:  Running post-build filter: filter_infodir ...
[INFO]:  Running post-build filter: filter_infocompress ...
[INFO]:  Running post-build filter: filter_mancompress ...
[INFO]:  Running post-build filter: filter_lib_archives ...
[INFO]:  Purging libtool archives from build tree.
[INFO]:  Purging static libraries from build tree.
[INFO]:  Running post-build filter: filter_elf ...
[INFO]:  Saving and stripping debug symbols from /var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/bin/zerotier-one
[INFO]:  Running post-build filter: filter_pdb ...
[DEBUG]: No Debian-compatible (Spiral) provides generated
'/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/LICENSE-MPL.txt' -> '/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/doc/zerotier-one/LICENSE-MPL.txt'
'/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/LICENSE.txt' -> '/var/cache/acbs/build/acbs.5b_mgw4r/zerotier-one/abdist/usr/share/doc/zerotier-one/LICENSE.txt'
[INFO]:  Creating empty postinst.
[INFO]:  Creating empty prerm.
[INFO]:  Creating empty postrm.
[INFO]:  Creating empty preinst.
[INFO]:  Running scriptlet generator scriptlet_alternative ...
[INFO]:  No alternatives file found.
[INFO]:  Running scriptlet generator scriptlet_pax ...
[INFO]:  No pax file found.
[INFO]:  Running scriptlet generator scriptlet_usergroup ...
[INFO]:  No usergroup file found.
[INFO]:  Running post-build QA tests ...
[INFO]:  Packing dpkg package(s) ...
dpkg-deb: building package 'zerotier-one' in 'zerotier-one_1.16.0-1_loongarch64.deb'.
dpkg-deb: building package 'zerotier-one-dbg' in 'zerotier-one-dbg_1.16.0-1_loongarch64.deb'.
Selecting previously unselected package zerotier-one.
(Reading database ... 191854 files and directories currently installed.)
Preparing to unpack zerotier-one_1.16.0-1_loongarch64.deb ...
Unpacking zerotier-one (1.16.0-1) ...
(Noting disappearance of cargo, which has been completely replaced.)
Setting up zerotier-one (1.16.0-1) ...
Processing triggers for systemd (1:259-4) ...
Reloading systemd manager configuration ...
Selecting previously unselected package zerotier-one-dbg.
(Reading database ... 191869 files and directories currently installed.)
Preparing to unpack zerotier-one-dbg_1.16.0-1_loongarch64.deb ...
Unpacking zerotier-one-dbg (1.16.0-1) ...
Setting up zerotier-one-dbg (1.16.0-1) ...
[INFO]:  Archiving package(s) ...
[INFO]:  Using abpm_aosc_archive as autobuild archiver ...
'zerotier-one_1.16.0-1_loongarch64.deb' -> '/debs/z/zerotier-one_1.16.0-1_loongarch64.deb'
'zerotier-one-dbg_1.16.0-1_loongarch64.deb' -> '/debs/z/zerotier-one-dbg_1.16.0-1_loongarch64.deb'
[INFO]: Asking ciel to refresh repository...
[INFO]: Waiting for ciel to refresh repository...
info: Scanning 2 packages...
                            ..
                              [INFO]: Ciel finished refreshing repository...

========================================
    ACBS Build Successful
========================================

Package(s) built:
zerotier-one (loongarch64 @ 1.16.0-1)   0:01:36.532217     

info: zerotier-one: stopping...
info: zerotier-one: instance stopped.
info: zerotier-one: filesystem un-mounted.
info: zerotier-one: mount point removed.
info: zerotier-one: rolling back instance...
info: zerotier-one: instance has been rolled back.
BUILD SUCCESSFUL - 1 packages in 00:08:24
```

</details>

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
