### PR TITLE
y-cruncher: new, 0.8.7.9547

### DIFF
--- a/app-benchmarks/y-cruncher/autobuild/build
+++ b/app-benchmarks/y-cruncher/autobuild/build
@@ -1,0 +1,25 @@
+abinfo "Installing y-cruncher program files ..."
+install -vdm755 "$PKGDIR/usr/lib/y-cruncher"
+cp -rv --no-preserve=ownership y-cruncher Binaries "Custom Formulas" \
+    -t "$PKGDIR/usr/lib/y-cruncher/"
+
+abinfo "Installing y-cruncher launcher ..."
+install -vdm755 "$PKGDIR/usr/bin"
+ln -sv ../lib/y-cruncher/y-cruncher "$PKGDIR/usr/bin/y-cruncher"
+
+abinfo "Installing system-wide y-cruncher username config file ..."
+install -vd "$PKGDIR/etc/xdg"
+install -vm755 "$SRCDIR/y-cruncher-username.txt" \
+    "$PKGDIR/etc/xdg/y-cruncher-username.conf"
+
+abinfo "Linking Username.txt to system-wide configuration ..."
+ln -sv ../../../etc/xdg/y-cruncher-username.conf \
+    "$PKGDIR/usr/lib/y-cruncher/Username.txt"
+
+abinfo "Installing usage documentation ..."
+install -vDm644 "Command Lines.txt" \
+    "$PKGDIR/usr/share/doc/y-cruncher/USAGE"
+
+abinfo "Installing license file ..."
+install -vDm644 "Read Me.txt" \
+    "$PKGDIR/usr/share/licenses/y-cruncher/LICENSE"

--- a/app-benchmarks/y-cruncher/autobuild/defines
+++ b/app-benchmarks/y-cruncher/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=y-cruncher
+PKGSEC=non-free/misc
+PKGDEP="numactl glibc tbb gcc-runtime"
+PKGDES="Multi-threaded Pi-benchmark program with optimizations for multiple x86-64 microarchitectures"
+
+ABTYPE=self
+# Note: Use binary from upstream, no need to strip
+ABSTRIP=0
+FAIL_ARCH="!(amd64)"

--- a/app-benchmarks/y-cruncher/autobuild/patches/0001-username-config-path.patch
+++ b/app-benchmarks/y-cruncher/autobuild/patches/0001-username-config-path.patch
@@ -1,0 +1,13 @@
+diff --git a/Username.txt b/y-cruncher-username.txt
+similarity index 83%
+rename from Username.txt
+rename to y-cruncher-username.txt
+index 08600bc..386646f 100644
+--- a/Username.txt
++++ b/y-cruncher-username.txt
+@@ -13,4 +13,4 @@
+ #       2.  This file needs to be saved as either UTF-8 or UTF-16 with byte order mark.
+ #
+ 
+-Username:   None Specified - You can edit this in "Username.txt".
++Username:   None Specified - You can edit this in "/etc/xdg/y-cruncher-username.conf".

--- a/app-benchmarks/y-cruncher/spec
+++ b/app-benchmarks/y-cruncher/spec
@@ -1,0 +1,4 @@
+VER=0.8.7.9547
+SRCS="tbl::https://www.numberworld.org/y-cruncher/y-cruncher%20v${VER}-dynamic.tar.xz"
+CHKSUMS="sha256::bee23ee59464d71635a054bb4f6f09c06b8ef0bdc441fb70d4cd81a9bd42a7a7"
+CHKUPDATE="anitya::id=389715"


### PR DESCRIPTION
Topic Description
-----------------

y-cruncher: new, 0.8.7.9547

Package(s) Affected
-------------------

y-cruncher

Security Update?
----------------

No

Build Order
-----------

```
#buildit y-cruncher
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->


<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
