### PR TITLE
Rework Ghostscript 10.07.0

### DIFF
--- a/app-doc/ghostscript/autobuild/preinst
+++ b/app-doc/ghostscript/autobuild/preinst
@@ -1,8 +1,14 @@
 # Cleanup old symlinks
+GHOSTSCRIPT_DATA_DIR="/usr/share/ghostscript"
 for directory in "iccprofiles" "lib" "Resource"; do
-	full_path="/usr/lib/ghostscript/${directory}"
+	full_path="${GHOSTSCRIPT_DATA_DIR}/${directory}"
 	if [ ! -h "${full_path}" ]; then
 		continue
 	fi
 	rm -v "${full_path}"
 done
+
+# Remove old data directory
+if [ -d "${GHOSTSCRIPT_DATA_DIR}/9.54.0" ]; then
+	rm -rv "${GHOSTSCRIPT_DATA_DIR}/9.54.0"
+fi

--- a/app-doc/ghostscript/spec
+++ b/app-doc/ghostscript/spec
@@ -1,4 +1,5 @@
 VER=10.07.0
+REL=1
 SRCS="git::commit=tags/ghostpdl-${VER}::https://github.com/ArtifexSoftware/ghostpdl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1157"


### PR DESCRIPTION
Topic Description
-----------------

- ghostscript: bump REL, fix preinst

Package(s) Affected
-------------------

- ghostscript: 10.07.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghostscript
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
