### PR TITLE
intel-media-driver: update to 26.1.5

### DIFF
--- a/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0001-AOSCOS-remove-compiler-options-exceeding-baseline.am
@@ -1,7 +1,7 @@
-From 5bc5156ecaacc417f57e2445a2d7bdc42778fca1 Mon Sep 17 00:00:00 2001
+From e65b85076cc1d4e54a82b662dc5f116e7165cc64 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Thu, 24 Apr 2025 10:20:33 +0800
-Subject: [PATCH 1/3] AOSCOS: remove compiler options exceeding baseline
+Subject: [PATCH 1/4] AOSCOS: remove compiler options exceeding baseline
 
 Signed-off-by: Qing Yun <kf@aosc.io>
 ---
@@ -11,7 +11,7 @@ Signed-off-by: Qing Yun <kf@aosc.io>
  3 files changed, 24 deletions(-)
 
 diff --git a/Source/GmmLib/CMakeLists.txt b/Source/GmmLib/CMakeLists.txt
-index b190d8b..f6660a2 100644
+index e8f8d6a..4f7c86b 100644
 --- a/Source/GmmLib/CMakeLists.txt
 +++ b/Source/GmmLib/CMakeLists.txt
 @@ -165,12 +165,6 @@ else()

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMLIST-Disable-AuxTable-test-on-aarch64.am
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0002-ARM64-FROMLIST-Disable-AuxTable-test-on-aarch64.am
@@ -1,7 +1,7 @@
-From 6fd4869dfe851af6c6f0414b3766f45ade22eb64 Mon Sep 17 00:00:00 2001
+From 6b91fb835921f4c0687018b006e4893445e600d1 Mon Sep 17 00:00:00 2001
 From: Vihang Mehta <vihang@gimletlabs.ai>
 Date: Wed, 26 Feb 2025 09:59:15 -0800
-Subject: [PATCH 2/3] ARM64: FROMLIST: Disable AuxTable test on aarch64
+Subject: [PATCH 2/4] ARM64: FROMLIST: Disable AuxTable test on aarch64
 
 Link: https://github.com/intel/gmmlib/commit/5f7d53ef6c1a6c40d0ff2d717dca59533ad633d5
 Signed-off-by: Vihang Mehta <vihang@gimletlabs.ai>

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0003-LOONGARCH64-HACK-add-experimental-support-for-LoongA.am.loongarch64
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0003-LOONGARCH64-HACK-add-experimental-support-for-LoongA.am.loongarch64
@@ -1,7 +1,7 @@
-From 327bffc900b369814917093f5b7a5762e9bd7268 Mon Sep 17 00:00:00 2001
+From fb2f43bc85b934d94c0ca7121f0add7e12ca9316 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:03:47 +0800
-Subject: [PATCH 3/3] LOONGARCH64: HACK: add experimental support for LoongArch
+Subject: [PATCH 3/4] LOONGARCH64: HACK: add experimental support for LoongArch
 
 Ref: https://github.com/FanFansfan/gmmlib/commit/5b95524c513b00f93bbcf0f23b4d7226facf773d
 ---
@@ -26,7 +26,7 @@ index 0000000..e5233a0
 +	path = third_party/simde
 +	url = https://github.com/simd-everywhere/simde
 diff --git a/Source/GmmLib/CMakeLists.txt b/Source/GmmLib/CMakeLists.txt
-index f6660a2..888b906 100644
+index 4f7c86b..216eed2 100644
 --- a/Source/GmmLib/CMakeLists.txt
 +++ b/Source/GmmLib/CMakeLists.txt
 @@ -442,6 +442,8 @@ include_directories(BEFORE ${PROJECT_SOURCE_DIR})

--- a/runtime-devices/intel-gmmlib/autobuild/patches/0004-LOONGARCH64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64
+++ b/runtime-devices/intel-gmmlib/autobuild/patches/0004-LOONGARCH64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64
@@ -1,0 +1,19 @@
+From 43a5ed813b03554fbd56b65918d8555fdf17adc7 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 22 Apr 2026 22:04:20 +0800
+Subject: [PATCH 4/4] LOONGARCH64: AOSCOS: bump simde to 0.8.4-rc3
+
+---
+ third_party/simde | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/third_party/simde b/third_party/simde
+index 4379740..c86a433 160000
+--- a/third_party/simde
++++ b/third_party/simde
+@@ -1 +1 @@
+-Subproject commit 4379740aae4f17fd04b992d2024d934eb70a1c18
++Subproject commit c86a433df3086512b0b12240defa9d9ddcc9decf
+-- 
+2.52.0
+

--- a/runtime-devices/intel-gmmlib/autobuild/prepare
+++ b/runtime-devices/intel-gmmlib/autobuild/prepare
@@ -15,10 +15,6 @@ if ab_match_arch loongarch64; then
     git am "$SRCDIR"/autobuild/patches/*.am.loongarch64
     git submodule update --init --recursive
 
-    # FIXME: To be addressed.
-    abinfo "Appending -mno-lsx, -mno-lasx to workaround build failure ..."
-    export CFLAGS="${CFLAGS} -mno-lsx -mno-lasx"
-    export CXXFLAGS="${CXXFLAGS} -mno-lsx -mno-lasx"
 elif ab_match_arch arm64; then
     # FIXME: 
     # cc1plus: error：‘-Wformat-security’ ignored without ‘-Wformat’

--- a/runtime-devices/intel-gmmlib/spec
+++ b/runtime-devices/intel-gmmlib/spec
@@ -1,4 +1,5 @@
 VER=22.10.0
+REL=1
 SRCS="git::commit=tags/intel-gmmlib-$VER;copy-repo=true::https://github.com/intel/gmmlib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20342"

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.arm64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.arm64
@@ -1,1 +1,1 @@
-0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.loongarch64
+./0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.loongarch64

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.loongarch64
@@ -1,7 +1,7 @@
-From a7a9b2a1e5d62a3e1355855fd94ea567262f3052 Mon Sep 17 00:00:00 2001
+From 22ca859d258359d0d38fb5c0e426d1c08b2ecaea Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:23:27 +0800
-Subject: [PATCH 1/2] LOONGARCH64: ARM64: FROMEXT: use simde to support
+Subject: [PATCH 1/3] LOONGARCH64: ARM64: FROMEXT: use simde to support
  loongarch64 and arm64
 
 Link: https://github.com/FanFansfan/media-driver/commit/538521b276c2dd33a1ef80969a45b35b3d31ed3f

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.arm64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.arm64
@@ -1,0 +1,1 @@
+./0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64
@@ -1,0 +1,19 @@
+From 5efc9f6f3e6f197c2cf337d418127788de3898b5 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 22 Apr 2026 16:00:55 +0800
+Subject: [PATCH 2/3] LOONGARCH64: ARM64: AOSCOS: bump simde to 0.8.4-rc3
+
+---
+ third_party/simde | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/third_party/simde b/third_party/simde
+index 87cd663a9..c86a433df 160000
+--- a/third_party/simde
++++ b/third_party/simde
+@@ -1 +1 @@
+-Subproject commit 87cd663a92e78a38b203a9aaa082c8fbd67781d8
++Subproject commit c86a433df3086512b0b12240defa9d9ddcc9decf
+-- 
+2.52.0
+

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
@@ -1,7 +1,7 @@
-From 99aecac9a0794d72b8aaa289253e35a78f36d8bc Mon Sep 17 00:00:00 2001
+From b57ab666fbde45eee715abdba0e258905273f036 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Fri, 18 Apr 2025 09:21:59 +0800
-Subject: [PATCH 2/2] ARM64: AOSCOS: fix __stdcall and __cdecl redefined on
+Subject: [PATCH 3/3] ARM64: AOSCOS: fix __stdcall and __cdecl redefined on
  arm64
 
 Signed-off-by: Qing Yun <kf@aosc.io>

--- a/runtime-multimedia/intel-media-driver/spec
+++ b/runtime-multimedia/intel-media-driver/spec
@@ -1,4 +1,4 @@
-VER=25.4.6
+VER=26.1.5
 SRCS="git::commit=tags/intel-media-$VER;copy-repo=true::https://github.com/intel/media-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

- intel-media-driver: update to 26.1.5
    - bump simde to 0.8.4-rc3
    - - Track patches at AOSC-Tracking/media-driver @ aosc/intel-media-26.1.5
    \(HEAD: b57ab666fbde45eee715abdba0e258905273f036\).
- intel-gmmlib: bump simde to 0.8.4-rc3 and enable LSX on LoongArch
    - - Track patches at AOSC-Tracking/gmmlib @ aosc/intel-gmmlib-22.10.0
    \(HEAD: 43a5ed813b03554fbd56b65918d8555fdf17adc7\).

Package(s) Affected
-------------------

- intel-gmmlib: 22.10.0-1
- intel-media-driver: 26.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-gmmlib intel-media-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
