### PR TITLE
ouch: rework manpage generation

### DIFF
--- a/app-utils/ouch/autobuild/beyond
+++ b/app-utils/ouch/autobuild/beyond
@@ -1,7 +1,6 @@
 abinfo "Installing manpage and completions ..."
-for i in ouch*.1; do
-    install -Dvm644 "$SRCDIR"/artifacts/$i \
-        -t "$PKGDIR"/usr/share/man/man1/
+for i in "$SRCDIR"/artifacts/ouch*.1; do
+    install -Dvm644 $i -t "$PKGDIR"/usr/share/man/man1/
 done
 
 install -Dvm644 "$SRCDIR"/artifacts/ouch.bash \

--- a/app-utils/ouch/autobuild/prepare
+++ b/app-utils/ouch/autobuild/prepare
@@ -1,3 +1,3 @@
-# Note: To generated manpage and completions.
+# Note: To generate manpage and completions.
 abinfo "Setting OUCH_ARTIFACTS_FOLDER ..."
 export OUCH_ARTIFACTS_FOLDER="$SRCDIR"/artifacts

--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,4 +1,5 @@
 VER=0.7.1
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"


### PR DESCRIPTION
Topic Description
-----------------

- ouch: rework manpage generation

Package(s) Affected
-------------------

- ouch: 0.7.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
