### PR TITLE
just: update to 1.50.0

### DIFF
--- a/app-devel/autobuild4/autobuild/defines
+++ b/app-devel/autobuild4/autobuild/defines
@@ -3,9 +3,8 @@ PKGSEC=devel
 PKGDES="Multi-backend and extensible packaging toolkit"
 PKGDEP="autoconf autoconf-archive automake apt dpkg bash config coreutils \
         spdx-licenses gcc-runtime glibc tomli python-build python-installer
-        wheel elfutils"
+        wheel elfutils cargo-audit"
 BUILDDEP="nlohmann-json"
-PKGRECOM="cargo-audit"
 
 VER_NONE=1
 ABTYPE=cmakeninja

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.17.4
+VER=4.17.5
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-devel/just/autobuild/beyond
+++ b/app-devel/just/autobuild/beyond
@@ -5,6 +5,3 @@ mkdir -pv "$PKGDIR"/usr/share/zsh/site-functions \
 "$PKGDIR"/usr/bin/just --completions zsh > "$PKGDIR"/usr/share/zsh/site-functions/_just
 "$PKGDIR"/usr/bin/just --completions bash > "$PKGDIR"/usr/share/bash-completion/completions/just
 "$PKGDIR"/usr/bin/just --completions fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/just.fish
-
-abinfo "Removing extraneous binaries ..."
-rm -vf "$PKGDIR"/usr/bin/{generate-book,update-contributors}

--- a/app-devel/just/autobuild/defines
+++ b/app-devel/just/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME="just"
 PKGDES="A tool for creating and running project-specific commands"
 PKGDEP="glibc gcc-runtime"
-BUILDDEP="rustc llvm-20"
+BUILDDEP="rustc llvm"
 PKGSEC="utils"
 
 USECLANG=1
+ABTYPE=rust
+CARGO_AFTER=('--bin' 'just')

--- a/app-devel/just/spec
+++ b/app-devel/just/spec
@@ -1,4 +1,4 @@
-VER=1.45.0
+VER=1.50.0
 SRCS="git::commit=tags/$VER::https://github.com/casey/just"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141393"

--- a/lang-rust/cargo-audit/autobuild/defines
+++ b/lang-rust/cargo-audit/autobuild/defines
@@ -5,14 +5,11 @@ PKGDEP="glibc libgit2"
 BUILDDEP="llvm rustc"
 
 USECLANG=1
-CARGO_AFTER="--features fix"
-ABSPLITDBG=0
+ABTYPE=rust
+CARGO_AFTER=('--features' 'fix')
 
 # It is not necessary to check the audit itself to build a new version of cargo-audit
 NOCARGOAUDIT=1
 
-# FIXME: Segfaults during linkage.
-NOLTO__LOONGSON3=1
-
-# FIXME: lld not yet available for loongarch64.
-NOLTO__LOONGARCH64=1
+# FIXME: note: ld.lld: error: undefined symbol: aws_lc_0_37_0_EVP_parse_private_key
+NOLTO=1

--- a/lang-rust/cargo-audit/spec
+++ b/lang-rust/cargo-audit/spec
@@ -1,4 +1,4 @@
-VER=0.22.0
+VER=0.22.1
 SRCS="git::commit=tags/cargo-audit/v$VER::https://github.com/RustSec/cargo-audit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231457"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.17.5
    - Move cargo-audit to PKGDEP.
- cargo-audit: update to 0.22.1
- just: update to 1.50.0

Package(s) Affected
-------------------

- autobuild4: 4.17.5
- cargo-audit: 0.22.1
- just: 1.50.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cargo-audit autobuild4 just
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
