### PR TITLE
p4lang-p4c: new, 1.2.5.12

### DIFF
--- a/app-devel/p4lang-p4c/autobuild/defines
+++ b/app-devel/p4lang-p4c/autobuild/defines
@@ -1,0 +1,20 @@
+PKGNAME=p4lang-p4c
+PKGSEC=devel
+PKGDES="Reference compiler for P4 programming language"
+PKGDEP="glibc libtool gc boost tcpdump"
+BUILDDEP="cmake gcc git automake libtool gc bison flex boost llvm pkg-config python-3 tcpdump uv abseil-cpp protobuf"
+ABTYPE=cmake
+
+CMAKE_AFTER="
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DENABLE_MULTITHREAD=ON \
+    -DP4C_USE_PREINSTALLED_ABSEIL=ON \
+    -DP4C_USE_PREINSTALLED_PROTOBUF=ON \
+    -DENABLE_ABSEIL_STATIC=OFF \
+    -DENABLE_PROTOBUF_STATIC=OFF \
+    -DBUILD_LINK_WITH_LLD=OFF
+"
+
+# FIXME: Symbol `main` losses after do LTO on bison generated cpp files, that causes linking error
+NOLTO=1

--- a/app-devel/p4lang-p4c/spec
+++ b/app-devel/p4lang-p4c/spec
@@ -1,0 +1,4 @@
+VER=1.2.5.12
+SRCS="git::commit=tags/v$VER::https://github.com/p4lang/p4c"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=389743"


### PR DESCRIPTION
Topic Description
-----------------

- p4lang-p4c: new, 1.2.5.12

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit p4lang-p4c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
