### PR TITLE
adguardhome: update to 0.107.74

### DIFF
--- a/app-web/adguardhome/spec
+++ b/app-web/adguardhome/spec
@@ -1,8 +1,7 @@
-VER=0.107.73
-REL=1
+VER=0.107.74
 SRCS="git::commit=tags/v${VER}::https://github.com/AdguardTeam/AdGuardHome \
       tbl::https://github.com/AdguardTeam/AdGuardHome/releases/download/v${VER}/AdGuardHome_frontend.tar.gz"
 CHKSUMS="SKIP \
-         sha256::a69c540fe6959575330bdea150e31eee0c0c204985bf50e3522ce6d292e3c64e"
+         sha256::bca5a8a4d777f984d9a6992214dc158cb35c12e6fd6fd61a30f677896aaa1758"
 CHKUPDATE="anitya::id=301521"
 SUBDIR="adguardhome"


### PR DESCRIPTION
Topic Description
-----------------

- adguardhome: update to 0.107.74
    Co-authored-by: Gray David \(@grayawa\)

Package(s) Affected
-------------------

- adguardhome: 0.107.74

Security Update?
----------------

No

Build Order
-----------

```
#buildit adguardhome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
