### PR TITLE
fwupd: update to 2.1.2

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=fwupd
 PKGSEC=admin
 PKGDES="Firmware update daemon and utilities"
 PKGDEP="bluez curl flashrom fwupd-efi gcc-runtime glib glibc gnutls \
-        libcbor libdrm libjcat libmbim libmnl libqmi libusb libxmlb \
+        libdrm libjcat libmbim libmnl libqmi libusb libxmlb \
         modemmanager passim polkit readline sqlite systemd tpm2-tss \
         udisks-2 util-linux-runtime xz zlib"
 BUILDDEP="cairo gobject-introspection jinja2 vala"
@@ -15,13 +15,12 @@ MESON_AFTER=(
     '-Dblkid=enabled'
     '-Dbluez=enabled'
     '-Dbuild=all'
-    '-Dcbor=enabled'
     '-Ddocs=disabled'
     '-Defi_binary=false'
     '-Dfirmware-packager=true'
     '-Dfish_completion=true'
     '-Dgnutls=enabled'
-    '-Dhsi=enabled'
+    '-Dhsi=disabled'
     '-Dintrospection=enabled'
     '-Dlibdrm=enabled'
     '-Dlibmnl=enabled'
@@ -47,6 +46,12 @@ MESON_AFTER=(
     '-Dumockdev_tests=disabled'
     '-Dvalgrind=disabled'
     '-Dvendor_metadata=false'
+)
+# Note: hsi only available on amd64.
+# Ref: https://github.com/fwupd/fwupd/blob/2f9790bab88a0c3bb68e693b4f20404bd816db3a/meson.build#L279
+MESON_AFTER__AMD64=(
+    "${MESON_AFTER[@]}"
+    '-Dhsi=enabled'
 )
 
 PKGBREAK="fwupdate<=12-2 discover<=5.27.12 gnome-software<=42.4-1"

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=2.1.1
+VER=2.1.2
 SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 2.1.2

Package(s) Affected
-------------------

- fwupd: 2.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
