### PR TITLE
fastfetch: update to 2.62.1

### DIFF
--- a/app-utils/fastfetch/autobuild/patches/0001-AOSCOS-LOONGSON3-CPU-Linux-detect-cpu-via-proc-cpuin.patch.loongson3
+++ b/app-utils/fastfetch/autobuild/patches/0001-AOSCOS-LOONGSON3-CPU-Linux-detect-cpu-via-proc-cpuin.patch.loongson3
@@ -1,4 +1,4 @@
-From 3c98703a464209b56f0d38b2b869cf985e714da2 Mon Sep 17 00:00:00 2001
+From cef6429b649ee94e460f5b00dd3f6cbeae96bbaa Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Mon, 4 Aug 2025 10:17:45 +0800
 Subject: [PATCH] AOSCOS: LOONGSON3: CPU (Linux): detect cpu via /proc/cpuinfo
@@ -9,31 +9,32 @@ Subject: [PATCH] AOSCOS: LOONGSON3: CPU (Linux): detect cpu via /proc/cpuinfo
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/src/detection/cpu/cpu_linux.c b/src/detection/cpu/cpu_linux.c
-index 46ab37b7..9761f46c 100644
+index da73a207..8feac75e 100644
 --- a/src/detection/cpu/cpu_linux.c
 +++ b/src/detection/cpu/cpu_linux.c
-@@ -297,7 +297,8 @@ static const char* parseCpuInfo(
+@@ -583,7 +583,8 @@ static const char* parseCpuInfo(
              (cpuMHz->length == 0 && ffParsePropLine(line, "clock :", cpuMHz)) ||
              (cpu->name.length == 0 && ffParsePropLine(line, "cpu :", &cpu->name)) ||
-             #elif __mips__ || __mips
+ #elif __mips__ || __mips
 -            (cpu->name.length == 0 && ffParsePropLine(line, "cpu model :", &cpu->name)) ||
 +            (cpu->name.length == 0 && ffParsePropLine(line, "model name :", &cpu->name)) ||
 +            (cpuMHz->length == 0 && ffParsePropLine(line, "CPU MHz :", cpuMHz)) ||
-             #elif __loongarch__
+ #elif __loongarch__
              (cpu->name.length == 0 && ffParsePropLine(line, "Model Name :", &cpu->name)) ||
              (cpuMHz->length == 0 && ffParsePropLine(line, "CPU MHz :", cpuMHz)) ||
-@@ -633,6 +634,12 @@ FF_MAYBE_UNUSED static void detectSocName(FFCPUResult* cpu)
-         for (const char* p = model; *p; ++p)
-             ffStrbufAppendC(&cpu->name, (char) toupper(*p));
+@@ -943,6 +944,12 @@ FF_A_UNUSED static void detectSocName(FFCPUResult* cpu) {
+         ffStrbufSetStatic(&cpu->vendor, "Apple");
      }
+     #endif
 +    #if __mips__ || __mips
 +    else if (ffStrEquals(vendor, "loongson"))
 +    {
 +        ffStrbufSetStatic(&cpu->vendor, "Loongson");
 +    }
 +    #endif
-     else
-     {
-         ffStrbufSetS(&cpu->name, model);
---
-2.50.1
+     else if (ffStrEquals(vendor, "qcom")) {
+         // https://elixir.bootlin.com/linux/v6.11/source/arch/arm64/boot/dts/qcom
+         if (ffStrStartsWith(model, "x")) {
+-- 
+2.52.0
+

--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,4 +1,4 @@
-VER=2.61.0
+VER=2.62.1
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: update to 2.62.1
    Co-authored-by: kf \(@HmnSn\) <kf@aosc.io>

Package(s) Affected
-------------------

- fastfetch: 2.62.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
