### PR TITLE
regex: update to 2026.4.4

### DIFF
--- a/lang-python/regex/autobuild/defines
+++ b/lang-python/regex/autobuild/defines
@@ -4,5 +4,5 @@ PKGDEP="python-3"
 BUILDDEP="setuptools-python3"
 PKGDES="Alternative regular expression module for Python"
 
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/regex/spec
+++ b/lang-python/regex/spec
@@ -1,5 +1,4 @@
-VER=2025.11.3
-SRCS="tbl::https://pypi.io/packages/source/r/regex/regex-$VER.tar.gz"
-CHKSUMS="sha256::1fedc720f9bb2494ce31a58a1631f9c82df6a09b49c19517ea5cc280b4541e01"
+VER=2026.4.4
+SRCS="pypi::version=$VER::regex"
+CHKSUMS="sha256::e08270659717f6973523ce3afbafa53515c4dc5dcad637dc215b6fd50f689423"
 CHKUPDATE="anitya::id=5548"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- regex: update to 2026.4.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- regex: 2026.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit regex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
