### PR TITLE
motrix-next: update to 3.8.3

### DIFF
--- a/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
+++ b/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
@@ -1,45 +1,42 @@
-From d7893fa7a0f1f0bdc3aebc54c992db5107fb2af3 Mon Sep 17 00:00:00 2001
+From c85a6985d424dcc17289cfa9baceed80e39f899d Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
-Date: Thu, 16 Apr 2026 20:49:19 +0800
+Date: Thu, 23 Apr 2026 19:58:57 +0800
 Subject: [PATCH 1/4] feat: disable auto-update check
 
 ---
- src/components/preference/Basic.vue           | 65 +------------------
- .../__tests__/useBasicPreference.test.ts      |  2 +-
- src/layouts/MainLayout.vue                    | 16 +----
- src/main.ts                                   | 30 +--------
- src/shared/constants.ts                       |  2 +-
- src/stores/app.ts                             |  4 +-
- 6 files changed, 6 insertions(+), 113 deletions(-)
+ src/components/preference/General.vue | 64 +--------------------------
+ src/layouts/MainLayout.vue            | 16 +------
+ src/main.ts                           | 31 +------------
+ 3 files changed, 3 insertions(+), 108 deletions(-)
 
-diff --git a/src/components/preference/Basic.vue b/src/components/preference/Basic.vue
-index 0db74ac..2bd875c 100644
---- a/src/components/preference/Basic.vue
-+++ b/src/components/preference/Basic.vue
-@@ -43,20 +43,15 @@ import {
-   NButton,
+diff --git a/src/components/preference/General.vue b/src/components/preference/General.vue
+index a6f17371..a3f78ef3 100644
+--- a/src/components/preference/General.vue
++++ b/src/components/preference/General.vue
+@@ -24,21 +24,15 @@ import {
+   NFormItem,
+   NSelect,
+   NSwitch,
+-  NButton,
    NDivider,
-   NInputGroup,
--  NText,
+   NText,
    NCollapseTransition,
-   NDynamicTags,
-   NTag,
    NSpace,
+   NTag,
 -  NRadioGroup,
 -  NRadioButton,
+-  NIcon,
    useDialog,
  } from 'naive-ui'
  import PreferenceActionBar from './PreferenceActionBar.vue'
  import MTooltip from '@/components/common/MTooltip.vue'
--import { FolderOpenOutline, CloudDownloadOutline } from '@vicons/ionicons5'
--import { NIcon } from 'naive-ui'
+-import { CloudDownloadOutline } from '@vicons/ionicons5'
 -import UpdateDialog from '@/components/preference/UpdateDialog.vue'
-+import { FolderOpenOutline } from '@vicons/ionicons5'
  
  const { t, locale } = useI18n()
  const preferenceStore = usePreferenceStore()
-@@ -81,16 +76,6 @@ async function copyVersionToClipboard(text: string, label: string) {
-     /* Clipboard API may fail in some contexts — silently ignore. */
+@@ -61,15 +55,6 @@ async function copyVersionToClipboard(text: string, label: string) {
+     logger.debug('General.clipboard', `writeText failed: ${e}`)
    }
  }
 -const updateDialogRef = ref<InstanceType<typeof UpdateDialog> | null>(null)
@@ -51,13 +48,12 @@ index 0db74ac..2bd875c 100644
 -  { label: t('preferences.interval-semi-annual'), value: 4320 },
 -  { label: t('preferences.interval-yearly'), value: 8760 },
 -]
--
+ 
  function buildForm() {
-   return buildBasicForm(preferenceStore.config, defaultDownloadDir.value)
- }
-@@ -598,10 +583,6 @@ function loadForm() {
-   downloadUnit.value = dl.unit
- }
+   return buildGeneralForm(preferenceStore.config)
+@@ -219,10 +204,6 @@ const themeOptions = computed(() => [
+   { label: t('preferences.theme-dark'), value: 'dark' },
+ ])
  
 -function handleCheckUpdate() {
 -  updateDialogRef.value?.open()
@@ -66,10 +62,11 @@ index 0db74ac..2bd875c 100644
  const { restartEngine } = useEngineRestart()
  
  function handleManualRestart() {
-@@ -762,50 +743,6 @@ onMounted(async () => {
+@@ -331,50 +312,7 @@ onMounted(async () => {
          <NSelect v-model:value="form.locale" :options="localeOptions" style="width: 280px" />
        </NFormItem>
  
+-      <!-- ③ Auto Update -->
 -      <NDivider title-placement="left">{{ t('preferences.auto-update') }}</NDivider>
 -      <NFormItem :label="t('preferences.auto-check-update')">
 -        <NSwitch v-model:value="form.autoCheckUpdate" />
@@ -87,8 +84,6 @@ index 0db74ac..2bd875c 100644
 -            async (v: string) => {
 -              const ok = await preferenceStore.updateAndSave({ updateChannel: v as 'stable' | 'beta' })
 -              if (ok) {
--                // Only sync updateChannel in the snapshot — preserve dirty state
--                // for other unsaved fields (download dir, speed limits, etc.).
 -                patchSnapshot({ updateChannel: v } as Partial<typeof form.value>)
 -              }
 -            }
@@ -114,24 +109,13 @@ index 0db74ac..2bd875c 100644
 -      </NFormItem>
 -      <UpdateDialog ref="updateDialogRef" />
 -
+-      <!-- ④ Appearance -->
++      <!-- ③ Appearance -->
        <NDivider title-placement="left">{{ t('preferences.appearance-section') }}</NDivider>
        <NFormItem :label="t('preferences.appearance')">
          <NSelect v-model:value="form.theme" :options="themeOptions" style="width: 200px" />
-diff --git a/src/composables/__tests__/useBasicPreference.test.ts b/src/composables/__tests__/useBasicPreference.test.ts
-index 1637b51..51f82cd 100644
---- a/src/composables/__tests__/useBasicPreference.test.ts
-+++ b/src/composables/__tests__/useBasicPreference.test.ts
-@@ -24,7 +24,7 @@ describe('buildBasicForm', () => {
- 
-   it('returns sensible defaults for empty config', () => {
-     const form = buildBasicForm(emptyConfig)
--    expect(form.autoCheckUpdate).toBe(true)
-+    expect(form.autoCheckUpdate).toBe(false)
-     expect(form.autoCheckUpdateInterval).toBe(24)
-     expect(form.updateChannel).toBe('stable')
-     expect(form.locale).toBe('en-US')
 diff --git a/src/layouts/MainLayout.vue b/src/layouts/MainLayout.vue
-index b9244af..f9e207e 100644
+index 3abda0fe..b368a645 100644
 --- a/src/layouts/MainLayout.vue
 +++ b/src/layouts/MainLayout.vue
 @@ -1,6 +1,6 @@
@@ -142,7 +126,7 @@ index b9244af..f9e207e 100644
  import { useRoute, useRouter } from 'vue-router'
  import { onMounted, onUnmounted } from 'vue'
  import { useI18n } from 'vue-i18n'
-@@ -35,7 +35,6 @@ import WindowControls from '@/components/layout/WindowControls.vue'
+@@ -41,7 +41,6 @@ import WindowControls from '@/components/layout/WindowControls.vue'
  import EngineOverlay from '@/components/layout/EngineOverlay.vue'
  import AboutPanel from '@/components/about/AboutPanel.vue'
  import AddTask from '@/components/task/AddTask.vue'
@@ -150,16 +134,16 @@ index b9244af..f9e207e 100644
  import MagnetFileSelect from '@/components/task/MagnetFileSelect.vue'
  import { useTaskStore } from '@/stores/task'
  import { usePreferenceStore } from '@/stores/preference'
-@@ -66,8 +65,6 @@ const isMaximized = ref(false)
- const { platform: currentPlatform, isMac } = usePlatform()
- const showEngineOverlay = ref(false)
+@@ -78,8 +77,6 @@ const shutdownCountdown = ref(60)
+ let shutdownTimer: ReturnType<typeof setInterval> | null = null
+ let unlistenPowerCountdown: (() => void) | null = null
  
 -const updateDialogRef = ref<InstanceType<typeof UpdateDialog> | null>(null)
 -
  let unlistenDragDrop: (() => void) | null = null
  let unlistenMenuEvent: (() => void) | null = null
  let unlistenCloseRequested: (() => void) | null = null
-@@ -385,16 +382,6 @@ async function onMaximizeToggled() {
+@@ -399,16 +396,6 @@ async function onMaximizeToggled() {
    }, 300)
  }
  
@@ -176,7 +160,7 @@ index b9244af..f9e207e 100644
  async function handleExitConfirm() {
    // Checkbox means "always minimize to tray from now on" —
    // save the setting even when quitting this time.
-@@ -827,7 +814,6 @@ onUnmounted(() => {
+@@ -961,7 +948,6 @@ onUnmounted(() => {
      <Speedometer />
      <AboutPanel :show="showAbout" @close="showAbout = false" />
      <AddTask :show="appStore.addTaskVisible" @close="appStore.hideAddTaskDialog()" />
@@ -185,7 +169,7 @@ index b9244af..f9e207e 100644
        :show="showEngineOverlay"
        @recovered="showEngineOverlay = false"
 diff --git a/src/main.ts b/src/main.ts
-index 63934db..dce6142 100644
+index bfcb0bc0..ffdeef70 100644
 --- a/src/main.ts
 +++ b/src/main.ts
 @@ -65,33 +65,6 @@ window.addEventListener('unhandledrejection', (e) => {
@@ -222,16 +206,17 @@ index 63934db..dce6142 100644
    async function autoSyncTrackerOnStartup() {
      const config = preferenceStore.config
      if (!config.autoSyncTracker) return
-@@ -130,7 +103,7 @@ window.addEventListener('unhandledrejection', (e) => {
+@@ -130,8 +103,7 @@ window.addEventListener('unhandledrejection', (e) => {
    //  Phase 2 (engine, async)   – rpcSecret → save config → start engine
    //                              → on_engine_ready (Rust) → wait_for_engine
    //  Phase 3 (non-critical)    – deep-link, autostart (parallel)
 -  //  Phase 4 (deferred)        – update check, tracker sync, FS warmup,
-+  //  Phase 4 (deferred)        – tracker sync, FS warmup,
-   //                              clipboard monitor
+-  //                              clipboard monitor
++  //  Phase 4 (deferred)        – tracker sync, FS warmup, clipboard monitor
    // ---------------------------------------------------------------------------
  
-@@ -400,7 +373,6 @@ window.addEventListener('unhandledrejection', (e) => {
+   /** Start the aria2 engine, wait for readiness, and connect the RPC client.
+@@ -413,7 +385,6 @@ window.addEventListener('unhandledrejection', (e) => {
      }
  
      // ── Phase 4: deferred non-critical tasks ───────────────────────────────
@@ -239,48 +224,6 @@ index 63934db..dce6142 100644
      autoSyncTrackerOnStartup()
  
      // Initialize download history database, then schedule stale record cleanup
-diff --git a/src/shared/constants.ts b/src/shared/constants.ts
-index e10b517..37f2374 100644
---- a/src/shared/constants.ts
-+++ b/src/shared/constants.ts
-@@ -252,7 +252,7 @@ export const DEFAULT_APP_CONFIG = {
-   resumeAllWhenAppLaunched: false, // don't flood bandwidth on launch
- 
-   // ── Auto Update ───────────────────────────────────────────────
--  autoCheckUpdate: true, // qBT checks every launch; security best practice
-+  autoCheckUpdate: false, // qBT checks every launch; security best practice
-   autoCheckUpdateInterval: 24, // 24h (daily) is standard check frequency
-   /** Linux-only: DMA-BUF GPU rendering ON by default for best performance.
-    *  Crash sentinel in gpu_guard auto-reverts to software rendering on failure. */
-diff --git a/src/stores/app.ts b/src/stores/app.ts
-index 45c1bbb..698c082 100644
---- a/src/stores/app.ts
-+++ b/src/stores/app.ts
-@@ -16,7 +16,7 @@ import { decodeThunderLink } from '@shared/utils'
- import { logger } from '@shared/logger'
- import { STAT_BASE_INTERVAL, STAT_PER_TASK_INTERVAL, STAT_MIN_INTERVAL, STAT_MAX_INTERVAL } from '@shared/timing'
- import { detectKind, createBatchItem } from '@shared/utils/batchHelpers'
--import type { Aria2RawGlobalStat, Aria2EngineOptions, TauriUpdate, AppConfig, BatchItem } from '@shared/types'
-+import type { Aria2RawGlobalStat, Aria2EngineOptions, AppConfig, BatchItem } from '@shared/types'
- 
- /** Payload shape emitted by Rust stat_service via `stat:update`. */
- interface StatPayload {
-@@ -54,7 +54,6 @@ export const useAppStore = defineStore('app', () => {
-   const pendingBatch = ref<BatchItem[]>([])
-   const addTaskOptions = ref<Aria2EngineOptions>({})
-   const progress = ref(0)
--  const pendingUpdate = ref<TauriUpdate | null>(null)
-   const engineRestarting = ref(true)
-   let engineRestartingSince = Date.now()
-   const MIN_BANNER_MS = 1000
-@@ -287,7 +286,6 @@ export const useAppStore = defineStore('app', () => {
-     pendingBatch,
-     addTaskOptions,
-     progress,
--    pendingUpdate,
-     engineRestarting,
-     setEngineRestarting,
-     engineReady,
 -- 
 2.52.0
 

--- a/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
+++ b/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
@@ -1,4 +1,4 @@
-From d5548b5bc552b796985912124cfb1d1d29ac3d41 Mon Sep 17 00:00:00 2001
+From f080f5efb2c34239c5332b1ae437958ff95ec4d2 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Tue, 14 Apr 2026 12:42:31 +0800
 Subject: [PATCH 2/4] feat: add more architectures support
@@ -10,7 +10,7 @@ Subject: [PATCH 2/4] feat: add more architectures support
  3 files changed, 43 insertions(+), 2 deletions(-)
 
 diff --git a/src/composables/__tests__/usePlatform.test.ts b/src/composables/__tests__/usePlatform.test.ts
-index a09fbf7..3d293fd 100644
+index a09fbf7e..3d293fdc 100644
 --- a/src/composables/__tests__/usePlatform.test.ts
 +++ b/src/composables/__tests__/usePlatform.test.ts
 @@ -117,11 +117,32 @@ describe('usePlatform', () => {
@@ -49,10 +49,10 @@ index a09fbf7..3d293fd 100644
    })
  
 diff --git a/src/composables/usePlatform.ts b/src/composables/usePlatform.ts
-index fe2dcc0..97aa2c0 100644
+index 1e978e2c..6f57ce16 100644
 --- a/src/composables/usePlatform.ts
 +++ b/src/composables/usePlatform.ts
-@@ -48,6 +48,10 @@ const ARCH_LABELS: Record<string, string> = {
+@@ -49,6 +49,10 @@ const ARCH_LABELS: Record<string, string> = {
    aarch64: 'ARM64',
    x86_64: 'x64',
    x86: 'x86',
@@ -64,7 +64,7 @@ index fe2dcc0..97aa2c0 100644
  
  /**
 diff --git a/src/shared/__tests__/sidecarBinaries.test.ts b/src/shared/__tests__/sidecarBinaries.test.ts
-index c51b965..908b4e9 100644
+index c51b965a..908b4e9e 100644
 --- a/src/shared/__tests__/sidecarBinaries.test.ts
 +++ b/src/shared/__tests__/sidecarBinaries.test.ts
 @@ -33,6 +33,10 @@ const EXPECTED_TARGETS = [

--- a/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
+++ b/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
@@ -1,4 +1,4 @@
-From 2606224016b465932a2db66b23280f7a87c2690f Mon Sep 17 00:00:00 2001
+From cc49b2a01700bbd676826c78b0857b0fda50dbf0 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Tue, 14 Apr 2026 13:47:55 +0800
 Subject: [PATCH 3/4] feat: use system aria2c
@@ -9,7 +9,7 @@ Subject: [PATCH 3/4] feat: use system aria2c
  2 files changed, 7 insertions(+), 16 deletions(-)
 
 diff --git a/src-tauri/src/engine/lifecycle.rs b/src-tauri/src/engine/lifecycle.rs
-index ed5b0d1..2df0b0e 100644
+index ed5b0d16..2df0b0e3 100644
 --- a/src-tauri/src/engine/lifecycle.rs
 +++ b/src-tauri/src/engine/lifecycle.rs
 @@ -99,13 +99,10 @@ pub fn start_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Resul
@@ -47,7 +47,7 @@ index ed5b0d1..2df0b0e 100644
          .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
  
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index b5339a2..35f2367 100644
+index b5339a2d..35f23675 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -35,9 +35,6 @@

--- a/app-web/motrix-next/autobuild/patches/0004-Revert-chore-restrict-supported-architectures-to-cur.patch
+++ b/app-web/motrix-next/autobuild/patches/0004-Revert-chore-restrict-supported-architectures-to-cur.patch
@@ -1,4 +1,4 @@
-From 707bc0e06b1fbb66a4a8fa27b6f84d580c9c8f1b Mon Sep 17 00:00:00 2001
+From ec3854fe2141b30f5f5d0e0b8d7cbdda89eb2d50 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Thu, 16 Apr 2026 21:47:51 +0800
 Subject: [PATCH 4/4] Revert "chore: restrict supported architectures to
@@ -10,7 +10,7 @@ This reverts commit 3359b2a3e3561529c356e2b7d5ddcea51fa21ea1.
  1 file changed, 4 insertions(+)
 
 diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
-index 47281cf..550c724 100644
+index 47281cff..550c7241 100644
 --- a/pnpm-workspace.yaml
 +++ b/pnpm-workspace.yaml
 @@ -4,6 +4,10 @@ ignoredBuiltDependencies:

--- a/app-web/motrix-next/spec
+++ b/app-web/motrix-next/spec
@@ -1,4 +1,4 @@
-VER=3.7.0
+VER=3.8.3
 SRCS="git::commit=tags/v$VER::https://github.com/AnInsomniacy/motrix-next.git"
 CHKSUMS="SKIP"
 SUBDIR="motrix-next"


### PR DESCRIPTION
Topic Description
-----------------

- motrix-next: update to 3.8.3

Package(s) Affected
-------------------

- motrix-next: 3.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit motrix-next
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
