### PR TITLE
qt-6: fix false alarm of telegram-desktop on x11


### DIFF
--- a/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
@@ -1,7 +1,7 @@
 From 6b7a1f914371a4ce610d1098357ad236a161367b Mon Sep 17 00:00:00 2001
 From: Ruikai Liu <rickliu2000@outlook.com>
 Date: Thu, 6 Nov 2025 14:22:16 +0800
-Subject: [PATCH 1/5] ARCHLINUX: qtbase: respect system compiler/linker flags
+Subject: [PATCH 1/6] ARCHLINUX: qtbase: respect system compiler/linker flags
 
 Link: https://gitlab.archlinux.org/archlinux/packaging/packages/qt6-base/-/blob/4a0c2a8bb18bdc503580b992920cf34edf343a58/qt6-base-cflags.patch
 ---

--- a/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
@@ -1,7 +1,7 @@
 From 7117270cc6a3a7ab7f479b20690089234106b4e3 Mon Sep 17 00:00:00 2001
 From: Ruikai Liu <rickliu2000@outlook.com>
 Date: Thu, 6 Nov 2025 14:27:19 +0800
-Subject: [PATCH 2/5] FEDORA: qt3d: assimp: fix build with GCC >= 13
+Subject: [PATCH 2/6] FEDORA: qt3d: assimp: fix build with GCC >= 13
 
 Link: https://src.fedoraproject.org/rpms/qt6-qt3d/blob/072094f3e7e698321b92eafcb297111ba42eed15/f/qt3d-assimp-fix-build.patch
 ---

--- a/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
@@ -1,7 +1,7 @@
 From 275ded6ba66254cd737aee9223324f40254f1e1a Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Wed, 26 Jun 2024 22:16:10 +0800
-Subject: [PATCH 3/5] AOSCOS: qtbase: fallback to GLES if GL EGL context
+Subject: [PATCH 3/6] AOSCOS: qtbase: fallback to GLES if GL EGL context
  creation failed
 
 Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

--- a/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
+++ b/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
@@ -1,7 +1,7 @@
 From 83b74f7674af8c52adc934b47fc4e521ef4cde82 Mon Sep 17 00:00:00 2001
 From: Ruikai Liu <rickliu2000@outlook.com>
 Date: Fri, 7 Nov 2025 22:41:01 +0800
-Subject: [PATCH 4/5] AOSCOS: LOONGARCH64: qtwebengine: chromium: add LoongArch
+Subject: [PATCH 4/6] AOSCOS: LOONGARCH64: qtwebengine: chromium: add LoongArch
  support
 
 Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd31915301c156598af2eb3e4f53c/qt6-webengine/qt6-6.11.0.diff

--- a/runtime-desktop/qt-6/01-runtime/patches/0005-AOSCOS-qtdeclarative-fallback-to-QThreadStorage-for-.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0005-AOSCOS-qtdeclarative-fallback-to-QThreadStorage-for-.patch
@@ -1,7 +1,7 @@
 From eac157ff7417decb6a67deb060a36d71912a8e3f Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Tue, 11 Nov 2025 13:28:35 +0800
-Subject: [PATCH 5/5] AOSCOS: qtdeclarative: fallback to QThreadStorage for
+Subject: [PATCH 5/6] AOSCOS: qtdeclarative: fallback to QThreadStorage for
  loongson3
 
 ---

--- a/runtime-desktop/qt-6/01-runtime/patches/0006-Linux-accessibility-let-org.a11y.Status-win-over-XCB.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0006-Linux-accessibility-let-org.a11y.Status-win-over-XCB.patch
@@ -1,0 +1,56 @@
+From 75cfffbd641d4a7894aabe6200a67119309c2e6b Mon Sep 17 00:00:00 2001
+From: Matthew Aura <matthewaura075@gmail.com>
+Date: Sat, 18 Apr 2026 17:12:14 +0300
+Subject: [PATCH 6/6] Linux accessibility: let org.a11y.Status win over XCB
+ fallback
+
+Move the XCB fallback activation before the initial org.a11y.Status check so the status path can immediately disable the bridge when screen reader support is not enabled.
+
+Keep the explicit AT_SPI_BUS_ADDRESS override unchanged.
+
+Task-number: QTBUG-145881
+Pick-to: 6.11
+Change-Id: I3e2acdbf5a06bc91a98e267423df2d3169152c68
+---
+ .../gui/accessible/linux/dbusconnection.cpp    | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/qtbase/src/gui/accessible/linux/dbusconnection.cpp b/qtbase/src/gui/accessible/linux/dbusconnection.cpp
+index bf99a32f9a..d04d33529d 100644
+--- a/qtbase/src/gui/accessible/linux/dbusconnection.cpp
++++ b/qtbase/src/gui/accessible/linux/dbusconnection.cpp
+@@ -56,6 +56,15 @@ QAtSpiDBusConnection::QAtSpiDBusConnection(QObject *parent)
+     connect(dbusWatcher, &QDBusServiceWatcher::serviceRegistered,
+             this, &QAtSpiDBusConnection::checkEnabledState);
+ 
++    if (QGuiApplication::platformName().startsWith("xcb"_L1)) {
++        // In addition try if there is an xatom exposing the bus address, this allows applications run as root to work
++        QString address = getAddressFromXCB();
++        if (!address.isEmpty()) {
++            m_enabled = true;
++            connectA11yBus(address);
++        }
++    }
++
+     // If it is registered already, setup a11y right away
+     if (c.interface()->isServiceRegistered(A11Y_SERVICE))
+         checkEnabledState();
+@@ -66,15 +75,6 @@ QAtSpiDBusConnection::QAtSpiDBusConnection(QObject *parent)
+         if (interface_name == QLatin1StringView(OrgA11yStatusInterface::staticInterfaceName()))
+             checkEnabledState();
+     });
+-
+-    if (QGuiApplication::platformName().startsWith("xcb"_L1)) {
+-        // In addition try if there is an xatom exposing the bus address, this allows applications run as root to work
+-        QString address = getAddressFromXCB();
+-        if (!address.isEmpty()) {
+-            m_enabled = true;
+-            connectA11yBus(address);
+-        }
+-    }
+ }
+ 
+ QString QAtSpiDBusConnection::getAddressFromXCB()
+-- 
+2.52.0
+

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,5 +1,5 @@
 VER=6.11.0
-REL=1
+REL=2
 SRCS="https://download.qt.io/official_releases/qt/${VER%.*}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
 CHKSUMS="sha256::acf3b3db04c9e5d0820e8324b097320388954c297cee83d2bd698789234f68a4"
 CHKUPDATE="anitya::id=7927"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: fix false alarm of telegram-desktop on x11
    Track patches at AOSC-Tracking/qt-6 @ aosc/v6.11.0
    \(HEAD: 75cfffbd641d4a7894aabe6200a67119309c2e6b\).

Package(s) Affected
-------------------

- qt-6: 6.11.0-2
- qt-6-doc: 6.11.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6
```

Test Build(s) Done
------------------

