### PR TITLE
niri: add loongarch64_nosimd support

### DIFF
--- a/desktop-wm/niri/autobuild/defines
+++ b/desktop-wm/niri/autobuild/defines
@@ -9,4 +9,3 @@ BUILDDEP="rustc llvm"
 PKGDES="Scrollable-tiling Wayland compositor"
 USECLANG=1
 ABTYPE=rust
-FAIL_ARCH="(loongarch64_nosimd)"

--- a/desktop-wm/niri/spec
+++ b/desktop-wm/niri/spec
@@ -1,4 +1,5 @@
 VER=26.04
+REL=1
 # Note: copy-repo is required for the build system to detect commit hash
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/YaLTeR/niri.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- niri: add loongarch64_nosimd support

Package(s) Affected
-------------------

- niri: 26.04

Security Update?
----------------

No

Build Order
-----------

```
#buildit niri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
