### PR TITLE
expat: update to 2.8.0

### DIFF
--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,4 @@
-VER=2.7.5
+VER=2.8.0
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/runtime-optenv32/expat+32/spec
+++ b/runtime-optenv32/expat+32/spec
@@ -1,4 +1,4 @@
-VER=2.7.5
+VER=2.8.0
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/topics/expat-2.8.0.toml
+++ b/topics/expat-2.8.0.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Expat 2.8.0"
+
+[caution]
+default = "Fixes a hash flooding vulnerability (CVE-2026-41080, Severity: High)"
+zh_CN = "修复一个哈希洪水漏洞（CVE-2026-41080，严重性：高）"
+
+[packages-v2]
+"expat" = "< 2.8.0"
+"expat+32" = "< 2.8.0"


### PR DESCRIPTION
Topic Description
-----------------

- expat: update to 2.8.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- expat: 2.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
