### PR TITLE
llama.cpp-8953 + ggml 0.10.0

### DIFF
--- a/runtime-creativity/llama.cpp/spec
+++ b/runtime-creativity/llama.cpp/spec
@@ -1,5 +1,5 @@
-VER=8642
+VER=8953
 # The build system uses git tags to determine version number
-SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggerganov/llama.cpp.git"
+SRCS="git::commit=tags/b${VER};copy-repo=true::https://github.com/ggml-org/llama.cpp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328681"

--- a/runtime-scientific/ggml/autobuild/defines
+++ b/runtime-scientific/ggml/autobuild/defines
@@ -2,7 +2,10 @@ PKGNAME=ggml
 PKGSEC=libs
 PKGDEP="gcc-runtime glibc vulkan-loader libcl openblas"
 PKGDES="Tensor library for machine learning"
-BUILDDEP="vulkan-headers glslang shaderc opencl-registry-api openblas lapack"
+BUILDDEP="vulkan-headers spirv-headers glslang shaderc \
+          opencl-registry-api openblas lapack"
+BUILDDEP__AMD64="${BUILDDEP} cuda"
+BUILDDEP__ARM64="${BUILDDEP} cuda"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
@@ -21,11 +24,13 @@ CMAKE_AFTER=(
 CMAKE_AFTER__AMD64=(
     "${CMAKE_AFTER[@]}"
     '-DGGML_CPU_ALL_VARIANTS=ON'
+    '-DGGML_CUDA=ON'
 )
 
 CMAKE_AFTER__ARM64=(
     "${CMAKE_AFTER[@]}"
     '-DGGML_CPU_ALL_VARIANTS=ON'
+    '-DGGML_CUDA=ON'
 )
 
 CMAKE_AFTER__LOONGARCH64=(

--- a/runtime-scientific/ggml/autobuild/prepare
+++ b/runtime-scientific/ggml/autobuild/prepare
@@ -1,0 +1,4 @@
+if ab_match_arch amd64 || ab_match_arch arm64; then
+	abinfo "Making cuda available..."
+	source /etc/profile.d/cuda.sh
+fi

--- a/runtime-scientific/ggml/spec
+++ b/runtime-scientific/ggml/spec
@@ -1,4 +1,4 @@
-VER=0.9.11
+VER=0.10.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ggml-org/ggml"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383765"


### PR DESCRIPTION
Topic Description
-----------------

- llama.cpp: 8953
- ggml: 0.10.0, cuda support

Package(s) Affected
-------------------

- ggml: 0.10.0
- llama.cpp: 8953

Security Update?
----------------

No

Build Order
-----------

```
#buildit ggml llama.cpp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
