### PR TITLE
rsync: update to 3.4.2

### DIFF
--- a/app-network/rsync/spec
+++ b/app-network/rsync/spec
@@ -1,4 +1,4 @@
-VER=3.4.1
+VER=3.4.2
 SRCS="tbl::https://download.samba.org/pub/rsync/rsync-$VER.tar.gz"
-CHKSUMS="sha256::2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52"
+CHKSUMS="sha256::ff10aa2c151cd4b2dbbe6135126dbc854046113d2dfb49572a348233267eb315"
 CHKUPDATE="anitya::id=4217"

--- a/topics/rsync-3.4.2.toml
+++ b/topics/rsync-3.4.2.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "rsync 3.4.2"
+
+[caution]
+default = "Fixes a use-after-free vulnerability - CVE-2026-41035 (Severity: High)."
+zh_CN = "修复一个释放后使用 (use-after-free) 漏洞，漏洞编号 CVE-2026-41035（严重性：高）"
+zh_TW = "修復一个释放后使用 (use-after-free) 漏洞，漏洞編號 CVE-2026-41035（嚴重性：高）"
+
+[packages-v2]
+"rsync" = "< 3.4.2"


### PR DESCRIPTION
Topic Description
-----------------

- rsync: update to 3.4.2
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- rsync: 3.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
