### PR TITLE
uv: update to 0.11.8

### DIFF
--- a/lang-python/uv/autobuild/build
+++ b/lang-python/uv/autobuild/build
@@ -1,3 +1,8 @@
+if ab_match_arch loongarch64; then
+    abinfo "Syncing Python releases from loong64/versions ..."
+    python3 "$SRCDIR"/crates/uv-python/fetch-download-metadata.py
+fi
+
 abinfo "Building uv ..."
 export tripple="$(rustc --print host-tuple)"
 maturin build --locked --release --target "$tripple" --strip --compatibility linux

--- a/lang-python/uv/autobuild/defines
+++ b/lang-python/uv/autobuild/defines
@@ -1,6 +1,8 @@
 PKGNAME=uv
 PKGSEC=utils
 BUILDDEP="llvm rustc maturin"
+# httpx is required by uv's metadata-updating script for loongarch64
+BUILDDEP__loongarch64="$BUILDDEP httpx"
 PKGDEP="glibc gcc-runtime zlib bzip2"
 PKGDES="Python package and project manager"
 

--- a/lang-python/uv/autobuild/patches/0002-Override-download-metadata-source.patch.loongarch64
+++ b/lang-python/uv/autobuild/patches/0002-Override-download-metadata-source.patch.loongarch64
@@ -1,0 +1,15 @@
+Source: https://github.com/loong64/uv/blob/9f40378309f8d2c9191e4a96684d83a873e4d692/patch_loong64.patch#L12-L24
+
+diff --git a/crates/uv-python/fetch-download-metadata.py b/crates/uv-python/fetch-download-metadata.py
+index 13ddfb9..ebfbdea 100755
+--- a/crates/uv-python/fetch-download-metadata.py
++++ b/crates/uv-python/fetch-download-metadata.py
+@@ -191,7 +191,7 @@ class Finder:
+ class CPythonFinder(Finder):
+     implementation = ImplementationName.CPYTHON
+ 
+-    NDJSON_URL = "https://releases.astral.sh/github/versions/main/v1/python-build-standalone.ndjson"
++    NDJSON_URL = "https://github.com/loong64/versions/raw/refs/heads/main/v1/python-build-standalone.ndjson"
+ 
+     FLAVOR_PREFERENCES = [
+         "install_only_stripped",

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.11.7
+VER=0.11.8
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.11.8
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.11.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
