### PR TITLE
lrzip: update to 0.660

### DIFF
--- a/app-utils/lrzip/autobuild/beyond
+++ b/app-utils/lrzip/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Dropping extra documentation..."
+rm -rv "$PKGDIR"/usr/share/doc

--- a/app-utils/lrzip/autobuild/defines
+++ b/app-utils/lrzip/autobuild/defines
@@ -28,7 +28,6 @@ AUTOTOOLS_AFTER=(
 	"--enable-largefile"
 	"--disable-asm"
 	"--disable-static-bin"
-	"--disable-doc"
 )
 AUTOTOOLS_AFTER__AMD64=(
 	"${AUTOTOOLS_AFTER[@]}"

--- a/app-utils/lrzip/spec
+++ b/app-utils/lrzip/spec
@@ -1,5 +1,4 @@
-VER=0.651
-REL=1
+VER=0.660
 SRCS="tbl::https://github.com/ckolivas/lrzip/archive/v$VER.tar.gz"
-CHKSUMS="sha256::f4c84de778a059123040681fd47c17565fcc4fec0ccc68fcf32d97fad16cd892"
+CHKSUMS="sha256::fd2cb18fc166e565a23f3415306d71a0f9151e0f1d7016d9a2c7eb038cd3c159"
 CHKUPDATE="anitya::id=1842"

--- a/topics/lrzip-0.660.toml
+++ b/topics/lrzip-0.660.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "lrzip 0.660"
+
+[caution]
+default = "Fixes denial of service vulnerabilities (CVE-2022-33067, CVE-2023-39741, Severity: Medium), a use-after-free vulnerability (CVE-2025-15570, Severity: High), and a null pointer dereference vulnerability (CVE-2025-15571, Severity: Medium)"
+zh_CN = "修复拒绝服务漏洞（CVE-2022-33067、CVE-2023-39741，严重性：中）、一个释放后使用漏洞（CVE-2025-15570，严重性：高）和一个空指针解引用漏洞（CVE-2025-15571，严重性：中）"
+
+[packages-v2]
+"lrzip" = "< 0.660"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add lrzip-0.660.toml
    This commit is authored with assistance from LLM:
    - Model: Deepseek V4 Pro
    - Platform: Deepseek 开放平台
    - Agent platform: Claude Code
    - Prompt:
    参照 @topics/libpcap-1.10.6.toml 写一个TUM，完善对漏洞的描述，name中使用项目实际名字而非包名
    用同样的格式把CVE-2022-33067和CVE-2023-39741也写进去，按cve号排序，对同类漏洞合并
    核查这些漏洞的Severity是否正确
    Signed-off-by: stydxm <stydxm@outlook.com>
- lrzip: update to 0.660
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- lrzip: 0.660

Security Update?
----------------

No

Build Order
-----------

```
#buildit lrzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
