### PR TITLE
nvidia: add arguments to fix issues of resume

### DIFF
--- a/runtime-display/nvidia-open/autobuild/overrides/usr/lib/modprobe.d/nvidia.conf
+++ b/runtime-display/nvidia-open/autobuild/overrides/usr/lib/modprobe.d/nvidia.conf
@@ -1,3 +1,11 @@
 blacklist nouveau
 blacklist nova_core
 blacklist nova_drm
+
+# By default the NVIDIA Linux drivers save and restore only essential
+# video memory allocations on system suspend and resume.
+# This will cause problems with Wayland.
+# Set these arguments to save and restore all video memory contents.
+options nvidia \
+        NVreg_UseKernelSuspendNotifiers=1 \
+        NVreg_TemporaryFilePath=/var/tmp

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,5 +1,5 @@
 VER=595.58.03
-REL=1
+REL=2
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/03-kernel/overrides/usr/lib/modprobe.d/nvidia.conf
+++ b/runtime-display/nvidia/03-kernel/overrides/usr/lib/modprobe.d/nvidia.conf
@@ -1,3 +1,11 @@
 blacklist nouveau
 blacklist nova_core
 blacklist nova_drm
+
+# By default the NVIDIA Linux drivers save and restore only essential
+# video memory allocations on system suspend and resume.
+# This will cause problems with Wayland.
+# Set these arguments to save and restore all video memory contents.
+options nvidia \
+        NVreg_UseKernelSuspendNotifiers=1 \
+        NVreg_TemporaryFilePath=/var/tmp

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,4 +1,5 @@
 VER=595.58.03
+REL=1
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
 CHKSUMS__AMD64="sha256::8c0d4f967b7932c4ab5714272aee8103392b0a702c92afa555176d36205829f9"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia-open: add arguments to fix issues of resume
- Add module arguments to save and restore all video memory contents.
- Fix problems when resume from suspend with Wayland.
- nvidia: add arguments to fix issues of resume
- Add module arguments to save and restore all video memory contents.
- Fix problems when resume from suspend with Wayland.

Package(s) Affected
-------------------

- nvidia: 595.58.03-1
- nvidia-firmware: 595.58.03-1
- nvidia-open: 595.58.03-2
- nvidia-utils: 595.58.03-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
