### PR TITLE
coturn: update to 4.10.0

### DIFF
--- a/app-network/coturn/spec
+++ b/app-network/coturn/spec
@@ -1,4 +1,4 @@
-VER=4.9.0
+VER=4.10.0
 SRCS="git::commit=tags/$VER::https://github.com/coturn/coturn.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=105341"

--- a/topics/coturn-4.10.0.toml
+++ b/topics/coturn-4.10.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "coturn 4.10.0"
+
+[caution]
+default = "Fixes an Incorrect Type Conversion or Cast vulnerability (CVE-2026-40613, Severity: High)"
+zh_CN = "修复一个不正确的类型转换漏洞（CVE-2026-40613，严重性：高）"
+
+[packages-v2]
+"coturn" = "< 4.10.0"


### PR DESCRIPTION
Topic Description
-----------------

- coturn: update to 4.10.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- coturn: 4.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit coturn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
