### PR TITLE
crun: security update to 1.27.1

### DIFF
--- a/app-admin/crun/spec
+++ b/app-admin/crun/spec
@@ -1,5 +1,4 @@
-VER=1.26
+VER=1.27.1
 SRCS="https://github.com/containers/crun/releases/download/$VER/crun-$VER.tar.zst"
-CHKSUMS="sha256::8218cf0f59c6cf2931b4ba8d19dbab1efc1557cbb94662903d17d6787442244d"
+CHKSUMS="sha256::a1b9829c1de814719df65e2ba3922eb56249c5939a50be769f91e948193cac55"
 CHKUPDATE="anitya::id=96792"
-REL="1"

--- a/topics/crun-1.27.1.toml
+++ b/topics/crun-1.27.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "crun 1.27.1"
+
+[caution]
+default = "Fixes a privilege escalation vulnerability (CVE-2026-30892, Severity: High)"
+zh_CN = "修复一个提权漏洞（CVE-2026-30892，严重性：高）"
+
+[packages-v2]
+"crun" = "< 1.27.1"


### PR DESCRIPTION
Topic Description
-----------------

- crun: security update to 1.27.1

Package(s) Affected
-------------------

- crun: 1.27.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit crun
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
