### PR TITLE
exiv2: security update to 0.28.8

### DIFF
--- a/runtime-imaging/exiv2/spec
+++ b/runtime-imaging/exiv2/spec
@@ -1,5 +1,4 @@
-VER=0.28.7
-REL=1
+VER=0.28.8
 SRCS="git::commit=tags/v${VER}::https://github.com/Exiv2/exiv2"
 CHKSUMS=SKIP
 CHKUPDATE="anitya::id=769"

--- a/topics/exiv2-0.28.8.toml
+++ b/topics/exiv2-0.28.8.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Exiv2 0.28.8"
+
+[caution]
+default = "Fixes 2 out-of-bounds read vulnerability (CVE-2026-25884, CVE-2026-27596, Severity: High), and an integer overflow vulnerability (CVE-2026-27631, Severity: Medium)"
+zh_CN = "修复了两个越界读取漏洞（CVE-2026-25884、CVE-2026-27596，严重性：高），以及一个整数溢出漏洞（CVE-2026-27631，严重性：中等）"
+
+[packages-v2]
+"exiv2" = "< 0.28.8"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add exiv2-0.28.8.toml
- Model: Deepseek V4 Pro
- Platform: Deepseek 开放平台
- Agent platform: Claude Code
- Prompt:
写对于CVE-2026-25884、CVE-2026-27596、CVE-2026-27631的topic，参考 @topics/expat-2.7.4.toml 的格式，列出每个漏洞内容和等级
- exiv2: security update to 0.28.8

Package(s) Affected
-------------------

- exiv2: 0.28.8

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit exiv2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
