### PR TITLE
hugo: security update to 0.160.1

### DIFF
--- a/app-web/hugo/spec
+++ b/app-web/hugo/spec
@@ -1,5 +1,4 @@
-VER=0.158.0
-REL=1
+VER=0.160.1
 SRCS="git::commit=tags/v$VER::https://github.com/gohugoio/hugo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12959"

--- a/topics/hugo-0.160.1.toml
+++ b/topics/hugo-0.160.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Hugo 0.160.1"
+
+[caution]
+default = "Fixes a text escape vulnerability (CVE-2026-35166, Severity: Medium)"
+zh_CN = "修复一个文本转义漏洞（CVE-2026-35166，严重性：中）"
+
+[packages-v2]
+"hugo" = "< 0.160.1"


### PR DESCRIPTION
Topic Description
-----------------

- hugo: update to 0.160.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- hugo: 0.160.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hugo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
