### PR TITLE
lcms2: security update to 2.19

### DIFF
--- a/runtime-imaging/lcms2/spec
+++ b/runtime-imaging/lcms2/spec
@@ -1,4 +1,4 @@
-VER=2.18
+VER=2.19
 SRCS="tbl::https://downloads.sourceforge.net/lcms/lcms2-$VER.tar.gz"
-CHKSUMS="sha256::ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347"
+CHKSUMS="sha256::49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216"
 CHKUPDATE="anitya::id=9815"

--- a/runtime-optenv32/lcms2+32/spec
+++ b/runtime-optenv32/lcms2+32/spec
@@ -1,4 +1,4 @@
-VER=2.18
+VER=2.19
 SRCS="tbl::https://downloads.sourceforge.net/lcms/lcms2-$VER.tar.gz"
-CHKSUMS="sha256::ee67be3566f459362c1ee094fde2c159d33fa0390aa4ed5f5af676f9e5004347"
+CHKSUMS="sha256::49e7e134e4299733dd0eda434fa468997a28ab3d33fa397c642b03644f552216"
 CHKUPDATE="anitya::id=9815"

--- a/topics/lcms2-2.19.toml
+++ b/topics/lcms2-2.19.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Little CMS 2.19"
+
+[caution]
+default = "Fixes an integer overflow vulnerability (CVE-2026-41254, Severity: High)"
+zh_CN = "修复了一个整数溢出漏洞（CVE-2026-41254，严重性：高）"
+
+[packages-v2]
+"lcms2" = "< 2.19"
+"lcms2+32" = "< 2.19"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add lcms2-2.19.toml
- lcms2+32: security update to 2.19
- lcms2: security update to 2.19

Package(s) Affected
-------------------

- lcms2: 2.19

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit lcms2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
