### PR TITLE
libvncserver: security update to 0.9.15

### DIFF
--- a/runtime-network/libvncserver/spec
+++ b/runtime-network/libvncserver/spec
@@ -1,5 +1,4 @@
-VER=0.9.13
-REL=1
-SRCS="tbl::https://github.com/LibVNC/libvncserver/archive/LibVNCServer-$VER.tar.gz"
-CHKSUMS='sha256::0ae5bb9175dc0a602fe85c1cf591ac47ee5247b87f2bf164c16b05f87cbfa81a'
+VER=0.9.15
+SRCS="git::commit=tags/LibVNCServer-$VER::https://github.com/LibVNC/libvncserver"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1756"

--- a/topics/libvncserver-0.9.15.toml
+++ b/topics/libvncserver-0.9.15.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "LibVNCServer 0.9.15"
+
+[caution]
+default = "Fixes a memory leak vulnerability (CVE-2020-29260, Severity: High), a heap out-of-bounds read vulnerability (CVE-2026-32853, Severity: High), and a NULL pointer dereference vulnerability (CVE-2026-32854, Severity: High)"
+zh_CN = "修复了一个内存泄漏漏洞（CVE-2020-29260，严重性：高）、一个堆越界读取漏洞（CVE-2026-32853，严重性：高），以及一个空指针解引用漏洞（CVE-2026-32854，严重性：高）"
+
+[packages-v2]
+"libvncserver" = "< 0.9.15"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add libvncserver-0.9.15.toml
- libvncserver: security update to 0.9.15

Package(s) Affected
-------------------

- libvncserver: 0.9.15

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libvncserver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
