### PR TITLE
libtpms: security update to 0.10.2

### DIFF
--- a/runtime-devices/libtpms/spec
+++ b/runtime-devices/libtpms/spec
@@ -1,4 +1,4 @@
-VER=0.10.1
+VER=0.10.2
 SRCS="git::commit=tags/v$VER::https://github.com/stefanberger/libtpms"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=116460"

--- a/topics/libtpms-0.10.2.toml
+++ b/topics/libtpms-0.10.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libtpms 0.10.2"
+
+[caution]
+default = "Fixes an Use of a Broken or Risky Cryptographic Algorithm vulnerability (CVE-2026-21444, Severity: Medium)"
+zh_CN = "修复一个使用了已损坏或存在风险的加密算法导致的漏洞（CVE-2026-21444，严重性：中）"
+
+[packages-v2]
+"libtpms" = "< 0.10.2"


### PR DESCRIPTION
Topic Description
-----------------

- libtpms: update to 0.10.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libtpms: 0.10.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtpms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
