### PR TITLE
deno: update to 2.7.14

### DIFF
--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From a06fec63128b2a23c471481dab4d271a8c7b9ef6 Mon Sep 17 00:00:00 2001
+From 5655e5ae6348f57709bb87b59061c7a56325acb8 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 4 Mar 2026 20:16:58 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
@@ -9,23 +9,23 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 3b7c5bccc..d16844c88 100644
+index 77a5e6474..06911ea73 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -11195,8 +11195,6 @@ dependencies = [
+@@ -11266,8 +11266,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "147.0.0"
+ version = "147.4.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "a98a7a54a2cbb941924658340efeff052840ab2dcb925c34260142ba85310023"
+-checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index d1878f148..2865d7de0 100644
+index 401fc3c0a..f4167b1ef 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -604,3 +604,6 @@ opt-level = 3
+@@ -610,3 +610,6 @@ opt-level = 3
  opt-level = 3
  [profile.release.package.twox-hash]
  opt-level = 3
@@ -33,5 +33,5 @@ index d1878f148..2865d7de0 100644
 +[patch.crates-io]
 +v8 = { path = '../rusty_v8' }
 -- 
-2.53.0
+2.54.0
 

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-loong64-support.patch.loongarch64_nosimd
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-loong64-support.patch.loongarch64_nosimd
@@ -1,1 +1,0 @@
-0002-AOSCOS-add-loong64-support.patch.loongarch64

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loongarch64
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loongarch64
@@ -1,8 +1,11 @@
-From 68381ca9186fbafb8b6403055f26d2690d539365 Mon Sep 17 00:00:00 2001
+From f30f47e6b225db90e8492586c540e5751154b178 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 20 Mar 2026 09:45:58 +0800
-Subject: [PATCH 2/2] AOSCOS: add loong64 support
+Subject: [PATCH 2/2] AOSCOS: add more architectures support
 
+After cranelift 0.117.1, it can support more unknown architectures.
+
+Ref: https://github.com/bytecodealliance/wasmtime/pull/10107
 ---
  Cargo.lock                             | 67 ++++++++++++++++----------
  Cargo.toml                             |  4 +-
@@ -10,10 +13,10 @@ Subject: [PATCH 2/2] AOSCOS: add loong64 support
  3 files changed, 46 insertions(+), 27 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index d16844c88..9554f7faa 100644
+index 06911ea73..72f0e8ced 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1308,37 +1308,53 @@ dependencies = [
+@@ -1321,37 +1321,53 @@ dependencies = [
  
  [[package]]
  name = "cranelift"
@@ -75,7 +78,7 @@ index d16844c88..9554f7faa 100644
   "cranelift-bforest",
   "cranelift-bitset",
   "cranelift-codegen-meta",
-@@ -1347,7 +1363,7 @@ dependencies = [
+@@ -1360,7 +1376,7 @@ dependencies = [
   "cranelift-entity",
   "cranelift-isle",
   "gimli",
@@ -84,7 +87,7 @@ index d16844c88..9554f7faa 100644
   "log",
   "regalloc2",
   "rustc-hash 2.1.1",
-@@ -1358,42 +1374,43 @@ dependencies = [
+@@ -1371,42 +1387,43 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen-meta"
@@ -138,7 +141,7 @@ index d16844c88..9554f7faa 100644
  dependencies = [
   "cranelift-codegen",
   "log",
-@@ -1403,15 +1420,15 @@ dependencies = [
+@@ -1416,15 +1433,15 @@ dependencies = [
  
  [[package]]
  name = "cranelift-isle"
@@ -158,7 +161,7 @@ index d16844c88..9554f7faa 100644
  dependencies = [
   "anyhow",
   "cranelift-codegen",
-@@ -1420,9 +1437,9 @@ dependencies = [
+@@ -1433,9 +1450,9 @@ dependencies = [
  
  [[package]]
  name = "cranelift-native"
@@ -171,10 +174,10 @@ index d16844c88..9554f7faa 100644
   "cranelift-codegen",
   "libc",
 diff --git a/Cargo.toml b/Cargo.toml
-index 2865d7de0..a44a66cdd 100644
+index f4167b1ef..51a2428ee 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -422,8 +422,8 @@ x25519-dalek = "2.0.0"
+@@ -428,8 +428,8 @@ x25519-dalek = "2.0.0"
  x509-parser = "0.15.0"
  
  # ffi
@@ -186,10 +189,10 @@ index 2865d7de0..a44a66cdd 100644
  libffi = "=5.1.0"
  libffi-sys = "=4.1.0"
 diff --git a/ext/node/polyfills/_process/process.ts b/ext/node/polyfills/_process/process.ts
-index 6dd071a90..5dfa47412 100644
+index 9aa922709..04c64bf6f 100644
 --- a/ext/node/polyfills/_process/process.ts
 +++ b/ext/node/polyfills/_process/process.ts
-@@ -37,6 +37,8 @@ export function arch(): string {
+@@ -41,6 +41,8 @@ export function arch(): string {
      return "arm64";
    } else if (build.arch == "riscv64gc") {
      return "riscv64";
@@ -199,5 +202,5 @@ index 6dd071a90..5dfa47412 100644
      throw new Error("unreachable");
    }
 -- 
-2.53.0
+2.54.0
 

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loongarch64_nosimd
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loongarch64_nosimd
@@ -1,0 +1,1 @@
+0002-AOSCOS-add-more-architectures-support.patch.loongarch64

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,21 +1,22 @@
-From 703913fd88c8f95823bf06bc925df2f2136e6725 Mon Sep 17 00:00:00 2001
+From 19b099baf17f611b7681ebda212bfa7ca471f388 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Thu, 29 Jan 2026 23:09:43 +0800
+Date: Wed, 29 Apr 2026 19:29:06 +0800
 Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup on arm64
 
 Because we have native linux arm64 CI :)
 ---
- build.rs | 16 ++++++++--------
- 1 file changed, 8 insertions(+), 8 deletions(-)
+ build.rs | 16 ----------------
+ 1 file changed, 16 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index 512c6ee..42bcd53 100644
+index b7a71b26..3cf8f023 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -357,14 +357,14 @@ fn build_v8(is_asan: bool) {
-     }
+@@ -379,22 +379,6 @@ fn build_v8(is_asan: bool) {
+   if needs_tls_define && !tls_define_injected {
+     gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
    }
-   // cross-compilation setup
+-  // cross-compilation setup
 -  if target_arch == "aarch64" {
 -    gn_args.push(r#"target_cpu="arm64""#.to_string());
 -    if target_os == "linux" {
@@ -24,17 +25,16 @@ index 512c6ee..42bcd53 100644
 -      maybe_install_sysroot("amd64");
 -    }
 -  }
-+  //if target_arch == "aarch64" {
-+  //  gn_args.push(r#"target_cpu="arm64""#.to_string());
-+  //  if target_os == "linux" {
-+  //    gn_args.push("use_sysroot=true".to_string());
-+  //    maybe_install_sysroot("arm64");
-+  //    maybe_install_sysroot("amd64");
-+  //  }
-+  //}
-   if target_arch == "arm" {
-     gn_args.push(r#"target_cpu="arm""#.to_string());
-     gn_args.push(r#"v8_target_cpu="arm""#.to_string());
+-  if target_arch == "arm" {
+-    gn_args.push(r#"target_cpu="arm""#.to_string());
+-    gn_args.push(r#"v8_target_cpu="arm""#.to_string());
+-    gn_args.push("use_sysroot=true".to_string());
+-    maybe_install_sysroot("i386");
+-    maybe_install_sysroot("arm");
+-  }
+ 
+   let target_triple = env::var("TARGET").unwrap();
+   // check if the target triple describes a non-native environment
 -- 
-2.53.0
+2.54.0
 

--- a/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,4 +1,4 @@
-From e6ec6e15dce4650a6daee885fa4de9c69ad78b08 Mon Sep 17 00:00:00 2001
+From cba75642b38a0dd58a73fba1f60c8b92770f48c2 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
 Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
@@ -11,7 +11,7 @@ Correct the builtins path accordingly.
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index e05032c..6709252 100644
+index e05032c0..67092527 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
 @@ -185,22 +185,23 @@ template("clang_lib") {
@@ -56,5 +56,5 @@ index e05032c..6709252 100644
        libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
      }
 -- 
-2.53.0
+2.54.0
 

--- a/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,4 +1,4 @@
-From 0d8db76403b3c726b89b0a17624b80585ca73d22 Mon Sep 17 00:00:00 2001
+From 307723a74fc208fe64c0cbfb3a0348f9885cfc50 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sun, 29 Mar 2026 18:50:37 +0800
 Subject: [PATCH 5/5] AOSCOS: drop unknown argument
@@ -8,7 +8,7 @@ Subject: [PATCH 5/5] AOSCOS: drop unknown argument
  1 file changed, 19 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index ff8022f..9721cdd 100644
+index ff8022f0..9721cdd9 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
 @@ -625,13 +625,6 @@ config("compiler") {
@@ -45,5 +45,5 @@ index ff8022f..9721cdd 100644
    }
  }
 -- 
-2.53.0
+2.54.0
 

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.7.10
+VER=2.7.14
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=147.0.0
+RUSTY_V8_VER=147.4.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::4a9bc3b8afe6402f6aea241b8bd1547b7c268966465917ec1a1fe8b295a5d739 \
+CHKSUMS="sha256::617bc7247da4c8b031e3f155e10bfcb085ddd8f51625a73318dfd02fa5e939d0 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.7.14

Package(s) Affected
-------------------

- deno: 2.7.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
