### PR TITLE
codex: update to 0.125.0

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From 84391a0deda3ffc75a680e48ff94a0a4f61e4d29 Mon Sep 17 00:00:00 2001
+From aa27219b956994fef02aee14b06bcf54a330505b Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 31 Mar 2026 15:36:13 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
@@ -9,10 +9,10 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 4d173d203..4323055b1 100644
+index 2bd379252a..9812a58ed9 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -11390,8 +11390,6 @@ dependencies = [
+@@ -13341,8 +13341,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "146.4.0"
@@ -22,10 +22,10 @@ index 4d173d203..4323055b1 100644
   "bindgen",
   "bitflags 2.10.0",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index 4f5800755..98518a370 100644
+index ba7b113183..10b6731f50 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -435,5 +435,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -481,5 +481,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  
@@ -34,5 +34,5 @@ index 4f5800755..98518a370 100644
  [patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
  tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
 -- 
-2.53.0
+2.54.0
 

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
@@ -1,15 +1,15 @@
-From cfb80b8eba2b266d97ede6c88b346c129b6d41eb Mon Sep 17 00:00:00 2001
+From afdb3b50a0203e5129f3e1d416461a0a2939f79e Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Mon, 13 Apr 2026 10:58:37 +0800
+Date: Wed, 29 Apr 2026 20:02:25 +0800
 Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
 
 https://github.com/openai/codex/issues/14065
 ---
- codex-rs/Cargo.lock | 186 ++++++++++++++++++++++----------------------
- 1 file changed, 93 insertions(+), 93 deletions(-)
+ codex-rs/Cargo.lock | 204 ++++++++++++++++++++++----------------------
+ 1 file changed, 102 insertions(+), 102 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 4323055b1..147ce19fe 100644
+index 9812a58ed9..dfbdd4f844 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -402,7 +402,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
@@ -17,615 +17,696 @@ index 4323055b1..147ce19fe 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1368,7 +1368,7 @@ dependencies = [
+@@ -1750,7 +1750,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-agent-identity"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "anyhow",
+  "base64 0.22.1",
+@@ -1768,7 +1768,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1386,7 +1386,7 @@ dependencies = [
+@@ -1788,7 +1788,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1395,7 +1395,7 @@ dependencies = [
+@@ -1797,7 +1797,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1428,7 +1428,7 @@ dependencies = [
+@@ -1831,7 +1831,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -1500,7 +1500,7 @@ dependencies = [
+@@ -1912,7 +1912,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -1523,7 +1523,7 @@ dependencies = [
+@@ -1936,7 +1936,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1551,7 +1551,7 @@ dependencies = [
+@@ -1963,7 +1963,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1572,7 +1572,7 @@ dependencies = [
+@@ -1984,7 +1984,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -1591,7 +1591,7 @@ dependencies = [
+@@ -2003,7 +2003,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -1608,7 +1608,7 @@ dependencies = [
+@@ -2020,7 +2020,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "async-trait",
   "pretty_assertions",
-@@ -1618,7 +1618,7 @@ dependencies = [
+@@ -2030,7 +2030,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-aws-auth"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "aws-config",
+  "aws-credential-types",
+@@ -2045,7 +2045,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
-  "codex-backend-openapi-models",
-@@ -1633,7 +1633,7 @@ dependencies = [
+  "codex-api",
+@@ -2062,7 +2062,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "serde",
   "serde_json",
-@@ -1642,7 +1642,7 @@ dependencies = [
+@@ -2071,7 +2071,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1662,7 +1662,7 @@ dependencies = [
+@@ -2092,7 +2092,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -1714,7 +1714,7 @@ dependencies = [
+@@ -2150,7 +2150,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "async-trait",
   "bytes",
-@@ -1744,7 +1744,7 @@ dependencies = [
+@@ -2180,7 +2180,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-requirements"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "async-trait",
   "base64 0.22.1",
-@@ -1769,7 +1769,7 @@ dependencies = [
+@@ -2205,7 +2205,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -1801,7 +1801,7 @@ dependencies = [
+@@ -2237,7 +2237,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -1815,7 +1815,7 @@ dependencies = [
+@@ -2252,7 +2252,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "async-trait",
   "chrono",
-@@ -1825,7 +1825,7 @@ dependencies = [
+@@ -2262,7 +2262,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
+  "async-channel",
   "async-trait",
-  "pretty_assertions",
-@@ -1839,11 +1839,11 @@ dependencies = [
+@@ -2279,11 +2279,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
-  "codex-app-server-protocol",
-@@ -1874,7 +1874,7 @@ dependencies = [
+  "async-trait",
+@@ -2323,7 +2323,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -1886,7 +1886,7 @@ dependencies = [
+@@ -2335,7 +2335,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2006,7 +2006,7 @@ dependencies = [
+@@ -2457,7 +2457,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-core-plugins"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "anyhow",
+  "chrono",
+@@ -2491,7 +2491,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-skills"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "codex-analytics",
-@@ -2035,7 +2035,7 @@ dependencies = [
+@@ -2522,7 +2522,7 @@ dependencies = [
  
  [[package]]
  name = "codex-debug-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2047,7 +2047,7 @@ dependencies = [
+@@ -2534,7 +2534,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-device-key"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "async-trait",
+  "base64 0.22.1",
+@@ -2550,7 +2550,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2091,7 +2091,7 @@ dependencies = [
+@@ -2594,7 +2594,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2118,7 +2118,7 @@ dependencies = [
+@@ -2628,7 +2628,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2135,7 +2135,7 @@ dependencies = [
+@@ -2645,7 +2645,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy-legacy"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "allocative",
   "anyhow",
-@@ -2155,7 +2155,7 @@ dependencies = [
+@@ -2665,7 +2665,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2164,7 +2164,7 @@ dependencies = [
+@@ -2674,7 +2674,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -2177,7 +2177,7 @@ dependencies = [
+@@ -2687,7 +2687,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "codex-login",
-@@ -2190,7 +2190,7 @@ dependencies = [
+@@ -2700,7 +2700,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2206,7 +2206,7 @@ dependencies = [
+@@ -2716,7 +2716,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
+  "anyhow",
   "assert_matches",
-  "codex-utils-absolute-path",
-@@ -2225,7 +2225,7 @@ dependencies = [
+@@ -2741,7 +2741,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2243,7 +2243,7 @@ dependencies = [
+@@ -2760,7 +2760,7 @@ dependencies = [
  
  [[package]]
- name = "codex-instructions"
+ name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
-  "codex-protocol",
+  "codex-utils-home-dir",
   "pretty_assertions",
-@@ -2252,7 +2252,7 @@ dependencies = [
+@@ -2769,7 +2769,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "keyring",
   "tracing",
-@@ -2260,7 +2260,7 @@ dependencies = [
+@@ -2777,7 +2777,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "cc",
   "clap",
-@@ -2283,7 +2283,7 @@ dependencies = [
+@@ -2801,7 +2801,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -2297,7 +2297,7 @@ dependencies = [
+@@ -2815,7 +2815,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2338,7 +2338,7 @@ dependencies = [
+@@ -2856,7 +2856,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-channel",
-@@ -2367,7 +2367,7 @@ dependencies = [
+@@ -2889,7 +2889,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "codex-arg0",
-@@ -2399,7 +2399,7 @@ dependencies = [
+@@ -2922,7 +2922,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-model-provider"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "async-trait",
+  "codex-agent-identity",
+@@ -2946,7 +2946,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider-info"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-api",
   "codex-app-server-protocol",
-@@ -2416,7 +2416,7 @@ dependencies = [
+@@ -2963,7 +2963,7 @@ dependencies = [
  
  [[package]]
  name = "codex-models-manager"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
-  "base64 0.22.1",
+  "async-trait",
   "chrono",
-@@ -2447,7 +2447,7 @@ dependencies = [
+@@ -2984,7 +2984,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2478,7 +2478,7 @@ dependencies = [
+@@ -3015,7 +3015,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -2497,7 +2497,7 @@ dependencies = [
+@@ -3034,7 +3034,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -2529,7 +2529,7 @@ dependencies = [
+@@ -3066,7 +3066,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-utils-absolute-path",
   "codex-utils-plugins",
-@@ -2538,7 +2538,7 @@ dependencies = [
+@@ -3075,7 +3075,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -2546,7 +2546,7 @@ dependencies = [
+@@ -3083,7 +3083,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -2586,7 +2586,7 @@ dependencies = [
+@@ -3123,7 +3123,7 @@ dependencies = [
  
  [[package]]
  name = "codex-realtime-webrtc"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "libwebrtc",
   "thiserror 2.0.18",
-@@ -2595,7 +2595,7 @@ dependencies = [
+@@ -3132,7 +3132,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -2606,7 +2606,7 @@ dependencies = [
+@@ -3143,7 +3143,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2623,7 +2623,7 @@ dependencies = [
+@@ -3160,7 +3160,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2657,7 +2657,7 @@ dependencies = [
+@@ -3197,7 +3197,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2682,7 +2682,7 @@ dependencies = [
+@@ -3222,7 +3222,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-rollout-trace"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "anyhow",
+  "codex-code-mode",
+@@ -3237,7 +3237,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
-  "codex-network-proxy",
-  "codex-protocol",
-@@ -2699,7 +2699,7 @@ dependencies = [
+  "anyhow",
+  "async-trait",
+@@ -3258,7 +3258,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "age",
   "anyhow",
-@@ -2720,7 +2720,7 @@ dependencies = [
+@@ -3279,7 +3279,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -2740,7 +2740,7 @@ dependencies = [
+@@ -3299,7 +3299,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2761,7 +2761,7 @@ dependencies = [
+@@ -3320,7 +3320,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-utils-absolute-path",
   "include_dir",
-@@ -2770,7 +2770,7 @@ dependencies = [
+@@ -3329,7 +3329,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2793,7 +2793,7 @@ dependencies = [
+@@ -3352,7 +3352,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
-  "codex-utils-cargo-bin",
-@@ -2804,7 +2804,7 @@ dependencies = [
+  "codex-uds",
+@@ -3364,7 +3364,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -2812,7 +2812,7 @@ dependencies = [
+@@ -3372,7 +3372,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-test-binary-support"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "codex-arg0",
+  "tempfile",
+@@ -3380,7 +3380,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-thread-store"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "async-trait",
+  "chrono",
+@@ -3405,7 +3405,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-code-mode",
-@@ -2829,7 +2829,7 @@ dependencies = [
+@@ -3422,7 +3422,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "arboard",
-@@ -2928,7 +2928,7 @@ dependencies = [
+@@ -3527,7 +3527,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-uds"
+-version = "0.0.0"
++version = "0.125.0"
+ dependencies = [
+  "async-io",
+  "pretty_assertions",
+@@ -3539,7 +3539,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "dirs",
   "dunce",
-@@ -2942,14 +2942,14 @@ dependencies = [
+@@ -3553,14 +3553,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-protocol",
  ]
@@ -633,125 +714,125 @@ index 4323055b1..147ce19fe 100644
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "lru 0.16.3",
   "sha1",
-@@ -2958,7 +2958,7 @@ dependencies = [
+@@ -3569,7 +3569,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -2967,7 +2967,7 @@ dependencies = [
+@@ -3578,7 +3578,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -2978,15 +2978,15 @@ dependencies = [
+@@ -3589,15 +3589,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
+  "codex-utils-absolute-path",
   "dirs",
-  "pretty_assertions",
-@@ -2995,7 +2995,7 @@ dependencies = [
+@@ -3607,7 +3607,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -3007,7 +3007,7 @@ dependencies = [
+@@ -3619,7 +3619,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -3016,7 +3016,7 @@ dependencies = [
+@@ -3628,7 +3628,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -3026,7 +3026,7 @@ dependencies = [
+@@ -3638,7 +3638,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -3035,7 +3035,7 @@ dependencies = [
+@@ -3647,7 +3647,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -3045,7 +3045,7 @@ dependencies = [
+@@ -3657,7 +3657,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
+  "codex-exec-server",
   "codex-login",
-  "serde",
-@@ -3055,7 +3055,7 @@ dependencies = [
+@@ -3670,7 +3670,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -3071,7 +3071,7 @@ dependencies = [
+@@ -3686,7 +3686,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "assert_matches",
   "async-trait",
-@@ -3082,14 +3082,14 @@ dependencies = [
+@@ -3697,14 +3697,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "rustls",
  ]
@@ -759,25 +840,25 @@ index 4323055b1..147ce19fe 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -3100,7 +3100,7 @@ dependencies = [
+@@ -3715,7 +3715,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -3110,14 +3110,14 @@ dependencies = [
+@@ -3725,14 +3725,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -785,16 +866,16 @@ index 4323055b1..147ce19fe 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -3125,14 +3125,14 @@ dependencies = [
+@@ -3740,14 +3740,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -802,37 +883,37 @@ index 4323055b1..147ce19fe 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -3140,7 +3140,7 @@ dependencies = [
+@@ -3755,7 +3755,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3360,7 +3360,7 @@ dependencies = [
+@@ -4005,7 +4005,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -6396,7 +6396,7 @@ checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
+@@ -8184,7 +8184,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.120.0"
++version = "0.125.0"
  dependencies = [
   "anyhow",
   "codex-login",
 -- 
-2.53.0
+2.54.0
 

--- a/app-utils/codex/autobuild/prepare
+++ b/app-utils/codex/autobuild/prepare
@@ -23,3 +23,11 @@ export NINJA="/usr/bin/ninja"
 export PYTHON="/usr/bin/python3"
 export CLANG_BASE_PATH="/usr"
 export V8_FROM_SOURCE=1
+
+# FIXME:
+# [...]/codex/codex-rs/linux-sandbox/../vendor/bubblewrap/bind-mount.c:398:(.text.bind_mount+0x7c): relocation truncated to fit: R_LARCH_B26 against symbol `mount@@GLIBC_2.36' defined in .text section in /usr/lib/libc.so.6
+# /usr/bin/ld: [...]/codex/codex-rs/target/release/deps/rustceh2GWY/libcodex_linux_sandbox-fc6385a7043f333c.rlib(2b80fc795abff254-bind-mount.o): relocation R_LARCH_B26 overflow 0xfffffffff7646140 
+if ab_match_arch loongarch64 || \
+   ab_match_arch loongarch64_nosimd; then
+    export RUSTFLAGS="${RUSTFLAGS} -Ccode-model=medium"
+fi

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.120.0
+VER=0.125.0
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=146.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.125.0

Package(s) Affected
-------------------

- codex: 0.125.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
