### PR TITLE
libmicrohttpd: update to 1.0.5

### DIFF
--- a/runtime-web/libmicrohttpd/spec
+++ b/runtime-web/libmicrohttpd/spec
@@ -1,4 +1,4 @@
-VER=1.0.3
+VER=1.0.5
 SRCS="tbl::https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-$VER.tar.gz"
-CHKSUMS="sha256::7816b57aae199cf5c3645e8770e1be5f0a4dfafbcb24b3772173dc4ee634126a"
+CHKSUMS="sha256::b46d00f58efa6f497b97d2e782c4ee66301d412ddd855dd3068518b3a2cd3ea2"
 CHKUPDATE="anitya::id=1658"


### PR DESCRIPTION
Topic Description
-----------------

- libmicrohttpd: update to 1.0.5
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libmicrohttpd: 1.0.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmicrohttpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
