### PR TITLE
libjxl: security update to 0.11.2

### DIFF
--- a/runtime-imaging/libjxl/spec
+++ b/runtime-imaging/libjxl/spec
@@ -1,5 +1,4 @@
-VER=0.11.1
-REL="3"
+VER=0.11.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/libjxl/libjxl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232764"

--- a/topics/libjxl-0.11.2.toml
+++ b/topics/libjxl-0.11.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libjxl 0.11.2"
+
+[caution]
+default = "Fixes an use of uninitialized resource vulnerability (CVE-2025-12474, Severity: Medium) and an allocation of resources without limits or throttling vulnerability (CVE-2026-1837, Severity: High)"
+zh_CN = "修复一个使用未初始化资源的漏洞（CVE-2025-12474，严重性：中）和一个无限资源分配漏洞（CVE-2026-1837，严重性：高）"
+
+[packages-v2]
+"libjxl" = "< 0.11.2"


### PR DESCRIPTION
Topic Description
-----------------

- libjxl: security update to 0.11.2
- Model: Deepseek V4 Flash
- Platform: Deepseek 开放平台
- Agent platform: Claude Code
- Prompt: 更新libjxl，写CVE-2025-12474和CVE-2026-1837的TUM

Package(s) Affected
-------------------

- libjxl: 0.11.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libjxl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
