### PR TITLE
libexif: security update to 0.6.26

### DIFF
--- a/runtime-imaging/libexif/autobuild/defines
+++ b/runtime-imaging/libexif/autobuild/defines
@@ -1,7 +1,4 @@
 PKGNAME=libexif
-PKGDES="A library for parsing, editing, and saving EXIF data"
+PKGDES="Library for parsing, editing, and saving EXIF data"
 PKGDEP="glibc"
 PKGSEC=libs
-
-
-

--- a/runtime-imaging/libexif/spec
+++ b/runtime-imaging/libexif/spec
@@ -1,4 +1,4 @@
-VER=0.6.22
-SRCS="tbl::https://github.com/libexif/libexif/releases/download/libexif-${VER//./_}-release/libexif-$VER.tar.xz"
-CHKSUMS="sha256::5048f1c8fc509cc636c2f97f4b40c293338b6041a5652082d5ee2cf54b530c56"
+VER=0.6.26
+SRCS="git::version=v$VER::https://github.com/libexif/libexif"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1607"

--- a/runtime-optenv32/libexif+32/autobuild/defines
+++ b/runtime-optenv32/libexif+32/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=libexif+32
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 glibc+32"
 BUILDDEP="devel-base+32"
-PKGDES="A library for parsing, editing, and saving EXIF data (32-bit x86 runtime)"
+PKGDES="Library for parsing, editing, and saving EXIF data (32-bit x86 runtime)"
 
 ABHOST=optenv32

--- a/runtime-optenv32/libexif+32/spec
+++ b/runtime-optenv32/libexif+32/spec
@@ -1,5 +1,4 @@
-VER=0.6.22
-REL=1
-SRCS="tbl::https://github.com/libexif/libexif/releases/download/libexif-${VER//./_}-release/libexif-$VER.tar.xz"
-CHKSUMS="sha256::5048f1c8fc509cc636c2f97f4b40c293338b6041a5652082d5ee2cf54b530c56"
+VER=0.6.26
+SRCS="git::version=v$VER::https://github.com/libexif/libexif"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1607"

--- a/topics/libexif-0.6.26.toml
+++ b/topics/libexif-0.6.26.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libexif 0.6.26"
+
+[caution]
+default = "Fixes 2 integer underflow vulnerability (CVE-2026-32775, CVE-2026-40386, Severity: High) and an integer overflow vulnerability (CVE-2026-40385, Severity: High)"
+zh_CN = "修复两个整数下溢漏洞（CVE-2026-32775、CVE-2026-40386，严重性：高）和一个整数溢出漏洞（CVE-2026-40385，严重性：高）"
+
+[packages-v2]
+"libexif" = "< 0.6.26"
+"libexif+32" = "< 0.6.26"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add libexif-0.6.26.toml
- libexif+32: security update to 0.6.26
- libexif: security update to 0.6.26

Package(s) Affected
-------------------

- libexif: 0.6.26

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libexif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
