### PR TITLE
libde265: security update to 1.0.18

### DIFF
--- a/runtime-multimedia/libde265/autobuild/defines
+++ b/runtime-multimedia/libde265/autobuild/defines
@@ -4,9 +4,9 @@ PKGDEP="gcc-runtime"
 BUILDDEP="gdk-pixbuf qt-5"
 PKGSEC=libs
 
-ABTYPE=autotools
-ABSHADOW=0
+ABTYPE=cmakeninja
 # encoder is disabled by default from 1.0.10. Enabling it here.
-AUTOTOOLS_AFTER=(
-    '--enable-encoder'
+CMAKE_AFTER=(
+    '-DENABLE_ENCODER=ON'
+    '-DENABLE_SHERLOCK265=ON'
 )

--- a/runtime-multimedia/libde265/autobuild/defines.stage2
+++ b/runtime-multimedia/libde265/autobuild/defines.stage2
@@ -4,8 +4,8 @@ PKGDEP="gcc-runtime"
 BUILDDEP="gdk-pixbuf"
 PKGSEC=libs
 
-ABTYPE=autotools
+ABTYPE=cmakeninja
 # Note: sherlock265 requires Qt.
-AUTOTOOLS_AFTER=(
-    "--disable-sherlock265"
+CMAKE_AFTER=(
+    '-DENABLE_SHERLOCK265=OFF'
 )

--- a/runtime-multimedia/libde265/spec
+++ b/runtime-multimedia/libde265/spec
@@ -1,4 +1,4 @@
-VER=1.0.16
+VER=1.0.18
 SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libde265"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11239"

--- a/topics/libde265-1.0.18.toml
+++ b/topics/libde265-1.0.18.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libde265 1.0.18"
+
+[caution]
+default = "Fixes a buffer overflow vulnerability (CVE-2025-61147, Severity: Medium), a NULL pointer dereference vulnerability (CVE-2026-33164, Severity: High), and an out-of-bounds write vulnerability (CVE-2026-33165, Severity: Medium)"
+zh_CN = "修复一个缓冲区溢出漏洞（CVE-2025-61147，严重性：中）、一个空指针解引用漏洞（CVE-2026-33164，严重性：高）和一个越界写入漏洞（CVE-2026-33165，严重性：中）"
+
+[packages-v2]
+"libde265" = "< 1.0.18"


### PR DESCRIPTION
Topic Description
-----------------

- libde265: security update to 1.0.18
    - Model: Deepseek V4 Flash
    - Platform: Deepseek 开放平台
    - Agent platform: Claude Code
    - Prompt: 更新libde265，写CVE-2025-61147、CVE-2026-33164、CVE-2026-33165的TUM

Package(s) Affected
-------------------

- libde265: 1.0.18

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libde265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
