### PR TITLE
gnutls: security update to 3.8.13

### DIFF
--- a/runtime-cryptography/gnutls/spec
+++ b/runtime-cryptography/gnutls/spec
@@ -1,4 +1,4 @@
-VER=3.8.12
+VER=3.8.13
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
-CHKSUMS="sha256::a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51"
+CHKSUMS="sha256::ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e"
 CHKUPDATE="anitya::id=1221"

--- a/runtime-optenv32/gnutls+32/spec
+++ b/runtime-optenv32/gnutls+32/spec
@@ -1,4 +1,4 @@
-VER=3.8.12
+VER=3.8.13
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnutls/v${VER:0:3}/gnutls-$VER.tar.xz"
-CHKSUMS="sha256::a7b341421bfd459acf7a374ca4af3b9e06608dcd7bd792b2bf470bea012b8e51"
+CHKSUMS="sha256::ffed8ec1bf09c2426d4f14aae377de4753b53e537d685e604e99a8b16ca9c97e"
 CHKUPDATE="anitya::id=1221"

--- a/topics/gnutls-3.8.13.toml
+++ b/topics/gnutls-3.8.13.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "gnutls 3.8.13"
+
+[caution]
+default = "Fixes 12 security vulnerabilities (including 5 of high severity and 5 of medium severity)"
+zh_CN = "修复 12 处安全漏洞（含 5 个高危漏洞及 5 个中危漏洞）"
+
+[packages-v2]
+"gnutls" = "< 3.8.13"
+"gnutls+32" = "< 3.8.13"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add gnutls-3.8.13.toml
    Signed-off-by: stydxm <stydxm@outlook.com>
- gnutls+32: security update to 3.8.13
- gnutls: security update to 3.8.13

Package(s) Affected
-------------------

- gnutls: 3.8.13

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit gnutls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
