### PR TITLE
mda-lv2: new, 1.2.10

### DIFF
--- a/app-multimedia/mda-lv2/autobuild/defines
+++ b/app-multimedia/mda-lv2/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=mda-lv2
+PKGDES="Paul Kellett's MDA plugins as LV2 plugins"
+PKGSEC=sound
+PKGDEP="gcc-runtime"
+BUILDDEP="lv2"
+ABTYPE=meson

--- a/app-multimedia/mda-lv2/spec
+++ b/app-multimedia/mda-lv2/spec
@@ -1,0 +1,4 @@
+VER=1.2.10
+SRCS="tbl::https://download.drobilla.net/mda-lv2-${VER}.tar.xz"
+CHKSUMS="sha256::aeea5986a596dd953e2997421a25e45923928c6286c4c8c36e5ef63ca1c2a75a"
+CHKUPDATE="anitya::id=242899"


### PR DESCRIPTION
Topic Description
-----------------

- mda-lv2: new, 1.2.10
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- mda-lv2: 1.2.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit mda-lv2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
