### PR TITLE
Easyeffects survey 20260430

### DIFF
--- a/app-multimedia/easyeffects/autobuild/defines
+++ b/app-multimedia/easyeffects/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="pipewire zita-convolver tbb rnnoise libportal pipewire gtk-4 \
         libadwaita libsigc++-3.0 lilv lv2 libbs2b libsndfile fftw \
         libsamplerate libebur128 soundtouch speex nlohmann-json fmt gsl \
         gtk-update-icon-cache"
-PKGRECOM="calf lsp-plugins"
+PKGRECOM="calf lsp-plugins zam-plugins mda-lv2"
 BUILDDEP="appstream-glib itstool ladspa-sdk desktop-file-utils"
 
 ABTYPE=meson

--- a/app-multimedia/easyeffects/spec
+++ b/app-multimedia/easyeffects/spec
@@ -1,5 +1,5 @@
 VER=7.2.5
-REL=2
+REL=3
 SRCS="git::commit=tags/v${VER}::https://github.com/wwmm/easyeffects.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242876"

--- a/app-multimedia/mda-lv2/autobuild/defines
+++ b/app-multimedia/mda-lv2/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=mda-lv2
+PKGDES="Paul Kellett's MDA plugins as LV2 plugins"
+PKGSEC=sound
+PKGDEP="gcc-runtime"
+BUILDDEP="lv2"
+ABTYPE=meson

--- a/app-multimedia/mda-lv2/spec
+++ b/app-multimedia/mda-lv2/spec
@@ -1,0 +1,4 @@
+VER=1.2.10
+SRCS="tbl::https://download.drobilla.net/mda-lv2-${VER}.tar.xz"
+CHKSUMS="sha256::aeea5986a596dd953e2997421a25e45923928c6286c4c8c36e5ef63ca1c2a75a"
+CHKUPDATE="anitya::id=242899"

--- a/app-multimedia/zam-plugins/autobuild/build
+++ b/app-multimedia/zam-plugins/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building ..."
+make PREFIX=/usr SKIP_STRIPPING=true $ABMK
+
+abinfo "Installing ..."
+make PREFIX=/usr DESTDIR="$PKGDIR" SKIP_STRIPPING=true $ABMK install

--- a/app-multimedia/zam-plugins/autobuild/defines
+++ b/app-multimedia/zam-plugins/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=zam-plugins
+PKGDES="Collection of LV2/LADSPA/VST/JACK plugins for audio processing"
+PKGSEC=sound
+PKGDEP="alsa-lib jack liblo pulseaudio sdl2 libglvnd x11-lib"
+
+ABTYPE=self

--- a/app-multimedia/zam-plugins/spec
+++ b/app-multimedia/zam-plugins/spec
@@ -1,0 +1,4 @@
+VER=4.5
+SRCS="git::commit=tags/${VER}::https://github.com/zamaudio/zam-plugins.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=17580"


### PR DESCRIPTION
Topic Description
-----------------

- easyeffects: add two plugin packages to PKGRECOM
    These two packages provide some plugins shown in the EasyEffects GUI.
    The version of this package is kept because newer versions require KF6.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- zam-plugins: new, 4.5
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- mda-lv2: new, 1.2.10
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- easyeffects: 7.2.5-3
- mda-lv2: 1.2.10
- zam-plugins: 4.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit mda-lv2 zam-plugins easyeffects
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
