### PR TITLE
pip: update to 26.1

### DIFF
--- a/lang-python/pip/spec
+++ b/lang-python/pip/spec
@@ -1,4 +1,4 @@
-VER=26.0.1
+VER=26.1
 SRCS="git::commit=tags/$VER::https://github.com/pypa/pip"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6529"


### PR DESCRIPTION
Topic Description
-----------------

- pip: update to 26.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- pip: 26.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
