### PR TITLE
Smartcard Survey 20260430

### DIFF
--- a/app-devices/pcsclite/autobuild/beyond
+++ b/app-devices/pcsclite/autobuild/beyond
@@ -1,1 +1,8 @@
-install -d "$PKGDIR"/usr/lib/pcsc/drivers
+abinfo "Creating PC/SC drivers directory ..."
+mkdir -pv "$PKGDIR"/usr/lib/pcsc/drivers
+
+abinfo "Merging /usr/share/doc/pcsc-lite to /usr/share/doc/pcsclite ..."
+mkdir -pv "$PKGDIR/usr/share/doc/pcsclite"
+mv -v "$PKGDIR/usr/share/doc/pcsc-lite/"* \
+	"$PKGDIR/usr/share/doc/pcsclite"
+rm -dv "$PKGDIR/usr/share/doc/pcsc-lite"

--- a/app-devices/pcsclite/autobuild/defines
+++ b/app-devices/pcsclite/autobuild/defines
@@ -1,44 +1,18 @@
 PKGNAME=pcsclite
 PKGSEC=libs
-PKGDEP="polkit python-3 systemd"
-PKGDEP__RETRO="systemd"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
-BUILDDEP__RETRO="python-3"
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGDES="PC/SC Architecture smartcard middleware library"
+PKGDEP="polkit systemd"
+PKGDEP__RETRO="systemd"
 
-AUTOTOOLS_AFTER="--enable-polkit \
-                 --enable-libudev \
-                 --enable-ipcdir=/var/run/pcscd \
-                 --enable-usbdropdir=/usr/lib/pcsc/drivers \
-                 --with-systemdsystemunitdir=/usr/lib/systemd/system \
-                 PYTHON=/usr/bin/python3"
-AUTOTOOLS_AFTER__RETRO="\
-                 --disable-polkit \
-                 --enable-libudev \
-                 --enable-ipcdir=/var/run/pcscd \
-                 --enable-usbdropdir=/usr/lib/pcsc/drivers \
-                 --with-systemdsystemunitdir=/usr/lib/systemd/system \
-                 PYTHON=/usr/bin/python3"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+ABTYPE=meson
+MESON_AFTER=(
+	'-Dlibudev=true'
+	'-Dlibusb=false'
+	'-Dlibsystemd=true'
+	'-Dsystemdunit=system'
+	'-Dpolkit=true'
+)
+MESON_AFTER__RETRO=(
+	"${MESON_AFTER[@]}"
+	'-Dpolkit=false'
+)

--- a/app-devices/pcsclite/spec
+++ b/app-devices/pcsclite/spec
@@ -1,5 +1,4 @@
-VER=1.9.9
-REL="3"
-SRCS="tbl::https://pcsclite.apdu.fr/files/pcsc-lite-$VER.tar.bz2"
-CHKSUMS="sha256::cbcc3b34c61f53291cecc0d831423c94d437b188eb2b97b7febc08de1c914e8a"
+VER=2.4.1
+SRCS="tbl::https://pcsclite.apdu.fr/files/pcsc-lite-$VER.tar.xz"
+CHKSUMS="sha256::afd3ba68c8000d2be048dc292df99a9812df9ad2efaf0a366eea22ac1faa19a7"
 CHKUPDATE="anitya::id=2611"

--- a/app-devices/yubico-pam/autobuild/defines
+++ b/app-devices/yubico-pam/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=yubico-pam
-PKGSEC=admin
-PKGDEP="json-c linux-pam yubico-c-client yubikey-personalization"
-BUILDDEP="asciidoc"
-PKGDES="Yubico YubiKey PAM modules"
-

--- a/app-devices/yubico-pam/spec
+++ b/app-devices/yubico-pam/spec
@@ -1,7 +1,0 @@
-VER=2.26
-REL=2
-SRCS="tbl::https://github.com/Yubico/yubico-pam/archive/$VER.tar.gz"
-CHKSUMS="sha256::5178fc083d12c9b26412adc80dab5d7ef463a689ef2e0143cb6f117732705dc7"
-SUBDIR="yubico-pam-$VER"
-
-CHKUPDATE="anitya::id=2588"

--- a/app-devices/yubico-piv-tool/autobuild/defines
+++ b/app-devices/yubico-piv-tool/autobuild/defines
@@ -1,7 +1,10 @@
 PKGNAME=yubico-piv-tool
 PKGSEC=admin
+PKGDES="Command line tool for the YubiKey PIV application"
 PKGDEP="pcsclite"
 BUILDDEP="help2man gengetopt check"
-PKGDES="Command line tool for the YubiKey PIV application"
 
-CMAKE_AFTER="-DCMAKE_SKIP_RPATH=OFF"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+	'-DCMAKE_SKIP_RPATH=OFF'
+)

--- a/app-devices/yubico-piv-tool/spec
+++ b/app-devices/yubico-piv-tool/spec
@@ -1,4 +1,4 @@
-VER=2.7.2
+VER=2.7.3
 SRCS="git::commit=tags/yubico-piv-tool-$VER::https://github.com/Yubico/yubico-piv-tool.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6998"

--- a/lang-python/pyscard/autobuild/defines
+++ b/lang-python/pyscard/autobuild/defines
@@ -4,7 +4,5 @@ PKGDEP="pcsclite python-3"
 BUILDDEP="swig setuptools-python3"
 PKGDES="Python module for smart card support"
 
-ABHOST=noarch
-
-ABTYPE=python
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/pyscard/autobuild/patches/0001-Revert-pyproject.toml-add-swig-in-build-system-requi.patch
+++ b/lang-python/pyscard/autobuild/patches/0001-Revert-pyproject.toml-add-swig-in-build-system-requi.patch
@@ -1,0 +1,25 @@
+From 2e0c8636cccbbcbebb9ee3be5c6b661a40153c3c Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Sat, 25 Apr 2026 21:27:59 -0400
+Subject: [PATCH] Revert "pyproject.toml: add "swig" in build-system requires"
+
+This reverts commit 84235c99657994a4bea774340a91704a92c13411.
+Use swig provided by the OS.
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 1922b9e..7e3cb88 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ["setuptools","swig"]
++requires = ["setuptools"]
+ build-backend = "setuptools.build_meta"
+ 
+ 
+-- 
+2.52.0
+

--- a/lang-python/pyscard/spec
+++ b/lang-python/pyscard/spec
@@ -1,5 +1,5 @@
 VER=2.3.1
+REL=2
 SRCS="pypi::version=$VER::pyscard"
 CHKSUMS="sha256::a24356f57a0a950740b6e54f51f819edd5296ee8892a6625b0da04724e9e6c13"
 CHKUPDATE="anitya::id=134670"
-REL="1"

--- a/runtime-devices/ccid/autobuild/beyond
+++ b/runtime-devices/ccid/autobuild/beyond
@@ -1,5 +1,6 @@
-mv "$PKGDIR"/usr/lib/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist "$PKGDIR"/etc/libccid_Info.plist
-ln -s /etc/libccid_Info.plist "$PKGDIR"/usr/lib/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist
-
-# Do not install udev rule that actually prevents anything to work.
-# install -Dm644 src/92_pcscd_ccid.rules "$PKGDIR"/usr/lib/udev/rules.d/92-pcscd-ccid.rules
+abinfo "Creating symlink for libccid_Info.plist..."
+mkdir -pv "${PKGDIR}/etc"
+mv -v "$PKGDIR"/usr/lib/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist \
+	"$PKGDIR"/etc/libccid_Info.plist
+ln -rsv "$PKGDIR"/etc/libccid_Info.plist \
+	"$PKGDIR"/usr/lib/pcsc/drivers/ifd-ccid.bundle/Contents/Info.plist

--- a/runtime-devices/ccid/autobuild/defines
+++ b/runtime-devices/ccid/autobuild/defines
@@ -3,5 +3,7 @@ PKGSEC=libs
 PKGDEP="libusb"
 PKGDES="A generic USB Chip/Smart Card Interface Devices driver"
 
-AUTOTOOLS_AFTER="--enable-twinserial --enable-serialconfdir=/etc/reader.conf.d \
-                 LEXLIB="
+ABTYPE=meson
+AUTOTOOLS_AFTER=(
+	'-Dserial=true'
+)

--- a/runtime-devices/ccid/spec
+++ b/runtime-devices/ccid/spec
@@ -1,5 +1,4 @@
-VER=1.5.1
-REL=1
-SRCS="tbl::https://ccid.apdu.fr/files/ccid-$VER.tar.bz2"
-CHKSUMS="sha256::e7a78c398ec0d617a4f98bac70d5b64f78689284dd0ae87d4692e2857f117377"
+VER=1.7.1
+SRCS="tbl::https://ccid.apdu.fr/files/ccid-$VER.tar.xz"
+CHKSUMS="sha256::32799ab16fe6e493c9452be3823f21810fbe80b884021a6f6f3fa69f26be5c86"
 CHKUPDATE="anitya::id=2612"

--- a/runtime-devices/yubico-c-client/autobuild/defines
+++ b/runtime-devices/yubico-c-client/autobuild/defines
@@ -1,5 +1,0 @@
-PKGNAME="yubico-c-client"
-PKGDES="Yubico YubiKey client C library"
-PKGDEP="yubico-c"
-BUILDDEP="help2man"
-PKGSEC=libs

--- a/runtime-devices/yubico-c-client/spec
+++ b/runtime-devices/yubico-c-client/spec
@@ -1,4 +1,0 @@
-VER=2.15
-SRCS="tbl::https://github.com/Yubico/yubico-c-client/archive/ykclient-$VER.tar.gz"
-CHKSUMS="sha256::3863f4fc2f3320c59fcbf57862bba48bcb716fddb886840bb0dd8db14d5ab7f0"
-CHKUPDATE="anitya::id=14843"

--- a/runtime-devices/yubico-c/autobuild/defines
+++ b/runtime-devices/yubico-c/autobuild/defines
@@ -1,5 +1,0 @@
-PKGNAME="yubico-c"
-PKGDES="Yubico YubiKey C library"
-PKGDEP="curl libusb"
-BUILDDEP="asciidoc"
-PKGSEC=libs

--- a/runtime-devices/yubico-c/spec
+++ b/runtime-devices/yubico-c/spec
@@ -1,4 +1,0 @@
-VER=1.13
-SRCS="tbl::https://github.com/Yubico/yubico-c/archive/libyubikey-$VER.tar.gz"
-CHKSUMS="sha256::dd046c83e67560206b0b3301ee8053922b516e3975b895804582eb8d7bdd1d79"
-CHKUPDATE="anitya::id=1802"


### PR DESCRIPTION
Topic Description
-----------------

- yubico-piv-tool: update to 2.7.3
- yubico-c: drop, orphaned
    EOL-ed by upstream.
    Ref: https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/
- yubico-c-client: drop, orphaned
    EOL-ed by upstream.
    Ref: https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/
- yubico-pam: drop, orphaned
    EOL-ed by upstream, use pam-u2f instead.
    Ref: https://www.yubico.com/support/terms-conditions/yubico-end-of-life-policy/eol-products/
- pyscard: bump REL, fix native library
    - Switch to ABTYPE=pep517.
    - Remove swig from dependencies in pyprojects.toml. That package is a binary
    distribution of swig and is not actually used.
    - Remove ABHOST=noarch. This package has a native library.
- ccid: update to 1.7.1
    - Switch to ABTYPE=meson.
- pcsclite: update to 2.4.1
    - Switch to ABTYPE=meson.

Package(s) Affected
-------------------

- ccid: 1.7.1
- pcsclite: 2.4.1
- pyscard: 2.3.1-2
- yubico-piv-tool: 2.7.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcsclite ccid pyscard yubico-piv-tool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
