### PR TITLE
cinnamon: update to 6.6.8


### DIFF
--- a/desktop-cinnamon/cinnamon-settings-daemon/spec
+++ b/desktop-cinnamon/cinnamon-settings-daemon/spec
@@ -1,4 +1,4 @@
-VER=6.6.3
+VER=6.6.4
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/cinnamon-settings-daemon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6389"

--- a/desktop-cinnamon/cinnamon/spec
+++ b/desktop-cinnamon/cinnamon/spec
@@ -1,5 +1,4 @@
-VER=6.6.7
-REL=1
+VER=6.6.8
 SRCS="git::commit=tags/$VER::https://github.com/linuxmint/Cinnamon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6265"


### PR DESCRIPTION
Topic Description
-----------------

- cinnamon-settings-daemon: update to 6.6.4
- cinnamon: update to 6.6.8
- Revert "timezonemap: drop, orphaned"
    This reverts commit d1f4b00fb1a107a09ee235a7ff0a49d6cd99e75b.

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit timezonemap cinnamon cinnamon-settings-daemon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
