### PR TITLE
lxc: security update to 7.0.0

### DIFF
--- a/app-admin/lxc/spec
+++ b/app-admin/lxc/spec
@@ -1,4 +1,4 @@
-VER=6.0.6
+VER=7.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/lxc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1860"

--- a/topics/lxc-7.0.0.toml
+++ b/topics/lxc-7.0.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "LXC 7.0.0"
+
+[caution]
+default = "Fixes a network configuration permission vulnerability in lxc-user-nic when used with OVS - CVE-2026-39402 (Severity: Low)"
+zh_CN = "修复一个 lxc-user-nic 与 OVS 配合使用时存在的网络配置权限漏洞, 漏洞编号 CVE-2026-39402 (严重性: 低)"
+
+[packages-v2]
+"lxc" = "< 7.0.0"


### PR DESCRIPTION
Topic Description
-----------------

- lxc: security update to 7.0.0
    Fix CVE-2026-39402

Package(s) Affected
-------------------

- lxc: 7.0.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit lxc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
