### PR TITLE
lxcfs: update to 7.0.0

### DIFF
--- a/app-admin/lxcfs/autobuild/overrides/usr/lib/systemd/system/lxcfs.service
+++ b/app-admin/lxcfs/autobuild/overrides/usr/lib/systemd/system/lxcfs.service
@@ -7,7 +7,7 @@ Before=lxc.service
 ExecStart=/usr/bin/lxcfs -f -s -o allow_other /var/lib/lxcfs
 KillMode=process
 Restart=on-failure
-ExecStopPost=-/bin/fusermount -u /var/lib/lxcfs
+ExecStopPost=-/bin/fusermount3 -u /var/lib/lxcfs
 
 [Install]
 WantedBy=multi-user.target

--- a/app-admin/lxcfs/spec
+++ b/app-admin/lxcfs/spec
@@ -1,4 +1,4 @@
-VER=6.0.6
+VER=7.0.0
 SRCS="tbl::https://linuxcontainers.org/downloads/lxcfs/lxcfs-v$VER.tar.gz"
-CHKSUMS="sha256::386339ba4cde289b0f6df4fe7a614caa1e45dd91bc0200b4aff6c51bf9d5ef9e"
+CHKSUMS="sha256::89a5ac0e98cfae6aad26d00e0e977affe810865ebccd4c4cf9422f980ade5624"
 CHKUPDATE="anitya::id=17098"


### PR DESCRIPTION
Topic Description
-----------------

- lxcfs: update to 7.0.0

Package(s) Affected
-------------------

- lxcfs: 7.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit lxcfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
