### PR TITLE
libgcrypt: update to 1.12.2

### DIFF
--- a/runtime-cryptography/libgcrypt/01-shared/defines
+++ b/runtime-cryptography/libgcrypt/01-shared/defines
@@ -2,8 +2,12 @@ PKGNAME=libgcrypt
 PKGDES="General purpose cryptographic library based on the code from GnuPG"
 PKGDEP="libgpg-error"
 PKGSEC=libs
-AUTOTOOLS_AFTER="\
-    --disable-padlock-support \
-    --without-capabilities --enable-static"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--disable-padlock-support'
+    '--without-capabilities'
+    '--enable-static'
+)
 
-NOLTO=1
+# FIXME: lto1: fatal error: target specific builtin not available 
+NOLTO__RISCV64=1

--- a/runtime-cryptography/libgcrypt/02-static/defines
+++ b/runtime-cryptography/libgcrypt/02-static/defines
@@ -3,11 +3,15 @@ PKGDES="General purpose cryptographic library based on the code from GnuPG (stat
 PKGDEP="libgcrypt"
 PKGSEC=libs
 
-AUTOTOOLS_AFTER="--disable-padlock-support --without-capabilities \
-                 --disable-shared --enable-static"
+ABTYPE=self
+AUTOTOOLS_AFTER=(
+    '--disable-padlock-support'
+    '--without-capabilities'
+    '--disable-shared'
+    '--enable-static'
+)
 NOSTATIC=no
 AB_FLAGS_SPECS=0
 AB_FLAGS_PIC=1
-NOLTO=1
 
 ABSPLITDBG=0

--- a/runtime-cryptography/libgcrypt/spec
+++ b/runtime-cryptography/libgcrypt/spec
@@ -1,4 +1,4 @@
-VER=1.11.2
+VER=1.12.2
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$VER.tar.bz2"
-CHKSUMS="sha256::6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac"
+CHKSUMS="sha256::7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e"
 CHKUPDATE="anitya::id=1623"

--- a/runtime-optenv32/libgcrypt+32/spec
+++ b/runtime-optenv32/libgcrypt+32/spec
@@ -1,4 +1,4 @@
-VER=1.11.0
+VER=1.12.2
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-$VER.tar.bz2"
-CHKSUMS="sha256::09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c"
+CHKSUMS="sha256::7ce33c2492221a0436f96a8500215e9f3e3dcb5fd26a757cd415e7a843babd5e"
 CHKUPDATE="anitya::id=1623"

--- a/topics/libgcrypt-1.12.2.toml
+++ b/topics/libgcrypt-1.12.2.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Libgcrypt 1.12.2"
+
+[caution]
+default = "Fixes an Out-of-bounds Write vulnerability (CVE-2026-41989, Severity: Medium)"
+zh_CN = "修复一个越界写入漏洞（CVE-2026-41989，严重性：中）"
+
+[packages-v2]
+"libgcrypt" = "< 1.12.2"
+"libgcrypt+32" = "< 1.12.2"


### PR DESCRIPTION
Topic Description
-----------------

- libgcrypt: update to 1.12.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libgcrypt: 1.12.2
- libgcrypt-static: 1.12.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgcrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
