### PR TITLE
tzdata: update to 2026b

### DIFF
--- a/runtime-data/tzdata/spec
+++ b/runtime-data/tzdata/spec
@@ -1,5 +1,4 @@
-VER=2026a
-REL=1
+VER=2026b
 SRCS="https://data.iana.org/time-zones/releases/tzdata$VER.tar.gz"
-CHKSUMS="sha256::77b541725937bb53bd92bd484c0b43bec8545e2d3431ee01f04ef8f2203ba2b7"
+CHKSUMS="sha256::114543d9f19a6bfeb5bca43686aea173d38755a3db1f2eec112647ae92c6f544"
 CHKUPDATE="anitya::id=5021"


### PR DESCRIPTION
Topic Description
-----------------

- tzdata: update to 2026b
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- tzdata: 2026b

Security Update?
----------------

No

Build Order
-----------

```
#buildit tzdata
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
