### PR TITLE
libxml2 rework Survey

### DIFF
--- a/desktop-cinnamon/timezonemap/autobuild/defines
+++ b/desktop-cinnamon/timezonemap/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=timezonemap
+PKGSEC=libs
+PKGDEP="gtk-3 json-glib librsvg libsoup"
+BUILDDEP="gnome-common gobject-introspection"
+PKGDES="Timezone map widget for GTK+ 3"

--- a/desktop-cinnamon/timezonemap/spec
+++ b/desktop-cinnamon/timezonemap/spec
@@ -1,0 +1,4 @@
+VER=0.4.6
+SRCS="tbl::http://deb.debian.org/debian/pool/main/libt/libtimezonemap/libtimezonemap_$VER.orig.tar.gz"
+CHKSUMS="sha256::0d634cc2476d8f57d1ee1864bd4f442180ae4bf040a9ae4bf73b66bbd85d7195"
+CHKUPDATE="anitya::id=230550"

--- a/desktop-gnome/devhelp/autobuild/defines
+++ b/desktop-gnome/devhelp/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=devhelp
+PKGSEC=gnome
+PKGDEP="amtk gtk-3 hicolor-icon-theme python-3 webkit2gtk"
+BUILDDEP="intltool itstool"
+PKGDES="API documentation browser for GNOME"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dflatpak_build=false'
+    '-Dgtk_doc=false'
+    '-Dplugin_emacs=true'
+    '-Dplugin_gedit=true'
+    '-Dplugin_vim=true'
+)

--- a/desktop-gnome/devhelp/autobuild/patches/0001-build-Fix-i18n.merge_file-use-with-Meson-0.61.patch
+++ b/desktop-gnome/devhelp/autobuild/patches/0001-build-Fix-i18n.merge_file-use-with-Meson-0.61.patch
@@ -1,0 +1,35 @@
+From 281bade14c1925cf9e7329fa8e9cf2d82512c66f Mon Sep 17 00:00:00 2001
+From: Emmanuele Bassi <ebassi@gnome.org>
+Date: Mon, 24 Jan 2022 23:39:24 +0000
+Subject: [PATCH] build: Fix i18n.merge_file() use with Meson 0.61
+
+The function never took positional arguments.
+
+Fixes: #59
+---
+ data/meson.build | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/data/meson.build b/data/meson.build
+index c6aeffb4..0bc531a2 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -19,7 +19,6 @@ appdata_conf = configuration_data()
+ appdata_conf.set('application_id', APPLICATION_ID)
+ appdata = APPLICATION_ID + '.appdata.xml'
+ appdata_file = I18N.merge_file(
+-  appdata,
+   input: configure_file(
+     input: 'org.gnome.Devhelp.appdata.xml.in.in',
+     output: APPLICATION_ID + '.appdata.xml.in',
+@@ -45,7 +44,6 @@ desktop_conf = configuration_data()
+ desktop_conf.set('application_id', APPLICATION_ID)
+ desktop = APPLICATION_ID + '.desktop'
+ desktop_file = I18N.merge_file(
+-  desktop,
+   type: 'desktop',
+   input: configure_file(
+     input: 'org.gnome.Devhelp.desktop.in.in',
+-- 
+2.36.0
+

--- a/desktop-gnome/devhelp/autobuild/patches/0002-Remove-incorrect-arg-for-i18n.merge_file.patch
+++ b/desktop-gnome/devhelp/autobuild/patches/0002-Remove-incorrect-arg-for-i18n.merge_file.patch
@@ -1,0 +1,27 @@
+From 03b9b6b55ab1e1376b314ac7f99693512e42d80b Mon Sep 17 00:00:00 2001
+From: r-value <i@rvalue.moe>
+Date: Wed, 17 Nov 2021 18:02:20 +0800
+Subject: [PATCH] Remove incorrect arg for i18n.merge_file
+
+`i18n.merge_file` has been ignoring positional arguments and
+explicitly rejects with error "ERROR: Function does not take
+positional arguments" since meson 0.60.0
+---
+ plugins/gedit-plugin/meson.build | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/plugins/gedit-plugin/meson.build b/plugins/gedit-plugin/meson.build
+index 4f779886..877a01ff 100644
+--- a/plugins/gedit-plugin/meson.build
++++ b/plugins/gedit-plugin/meson.build
+@@ -7,7 +7,6 @@ install_data(
+ 
+ plugin_info_file = 'devhelp.plugin'
+ I18N.merge_file(
+-  plugin_info_file,
+   type: 'desktop',
+   input: plugin_info_file + '.desktop.in',
+   output: plugin_info_file,
+-- 
+2.36.0
+

--- a/desktop-gnome/devhelp/spec
+++ b/desktop-gnome/devhelp/spec
@@ -1,0 +1,5 @@
+VER=41.2
+SRCS="https://download.gnome.org/sources/devhelp/${VER:0:2}/devhelp-${VER/\~/.}.tar.xz"
+CHKSUMS="sha256::ecaa90b0f4daa8fb2030f6dc690bf533ff99a773437fe0e18acfe82d997f60d2"
+CHKUPDATE="anitya::id=13119"
+REL="1"

--- a/groups/webkit2gtk-rebuilds
+++ b/groups/webkit2gtk-rebuilds
@@ -1,4 +1,5 @@
 desktop-gnome/gnome-online-accounts
+desktop-gnome/devhelp
 desktop-gnome/evolution-data-server
 desktop-gnome/evolution
 desktop-gnome/glade


### PR DESCRIPTION
Topic Description
-----------------

- Revert "devhelp: drop"
    This reverts commit d9cfcbc57f47b41fa896d1465d7d8f9e5aafb29a.
- Revert "timezonemap: drop, orphaned"
    This reverts commit d1f4b00fb1a107a09ee235a7ff0a49d6cd99e75b.

Package(s) Affected
-------------------

- devhelp: 41.2-1
- timezonemap: 0.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit timezonemap devhelp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
