### PR TITLE
libwebp+32: update to 1.6.0

### DIFF
--- a/runtime-optenv32/libwebp+32/spec
+++ b/runtime-optenv32/libwebp+32/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
-REL=1
+VER=1.6.0
 SRCS="tbl::http://downloads.webmproject.org/releases/webp/libwebp-$VER.tar.gz"
-CHKSUMS="sha256::b3779627c2dfd31e3d8c4485962c2efe17785ef975e2be5c8c0c9e6cd3c4ef66"
+CHKSUMS="sha256::e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564"
 CHKUPDATE="anitya::id=1761"

--- a/topics/libwebp-1.6.0.toml
+++ b/topics/libwebp-1.6.0.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "WebP Codec (libwebp) 1.6.0"
+
+[caution]
+default = "Fixes a Out-of-Bounds write vulnerability (CVE-2023-4863, Severity: High)"
+zh_CN = "修复一个越界写入漏洞（CVE-2023-4863，严重性：高）"
+
+[packages-v2]
+"libwebp" = "< 1.6.0"
+"libwebp+32" = "< 1.6.0"


### PR DESCRIPTION
Topic Description
-----------------

- libwebp+32: update to 1.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libwebp+32: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libwebp+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
