### PR TITLE
mariadb: update to 12.3.1

### DIFF
--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,5 +1,4 @@
-VER=12.1.2
-REL=1
+VER=12.3.1
 SRCS="git::commit=tags/mariadb-$VER;copy-repo=true::https://github.com/MariaDB/server"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1887"

--- a/topics/mariadb-12.3.1.toml
+++ b/topics/mariadb-12.3.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "MariaDB 12.3.1"
+
+[caution]
+default = "Fixes a Heap-based Buffer Overflow vulnerability (CVE-2026-32710, Severity: Critical) and a Memory Allocation with Excessive Size Value vulnerability (CVE-2026-35549, Severity: Medium)"
+zh_CN = "修复一个堆缓冲区溢出漏洞（CVE-2026-32710，严重性：严重）和一个未经控制的内存分配漏洞（CVE-2026-35549，严重性：中）"
+
+[packages-v2]
+"mariadb" = "< 12.3.1"


### PR DESCRIPTION
Topic Description
-----------------

- mariadb: update to 12.3.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- mariadb: 12.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mariadb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
