### PR TITLE
mitmproxy: security update to 12.2.2

### DIFF
--- a/app-network/mitmproxy/spec
+++ b/app-network/mitmproxy/spec
@@ -1,5 +1,5 @@
-UPSTREAM_VER=12.2.1
-MITMPROXY_RS_VER=0.12.8
+UPSTREAM_VER=12.2.2
+MITMPROXY_RS_VER=0.12.9
 VER=${UPSTREAM_VER}+rs$MITMPROXY_RS_VER
 SRCS="git::commit=tags/v$UPSTREAM_VER;rename=mitmproxy::https://github.com/mitmproxy/mitmproxy \
       git::commit=tags/v$MITMPROXY_RS_VER;rename=mitmproxy_rs::https://github.com/mitmproxy/mitmproxy_rs"
@@ -7,4 +7,3 @@ CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=13889"
 SUBDIR=.
-REL="1"

--- a/topics/mitmproxy-12.2.2.toml
+++ b/topics/mitmproxy-12.2.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "mitmproxy 12.2.2"
+
+[caution]
+default = "Fixes an LDAP injection vulnerability (CVE-2026-40606, Severity: Medium)"
+zh_CN = "修复一个 LDAP 注入漏洞（CVE-2026-40606，严重性：中）"
+
+[packages-v2]
+"mitmproxy" = "< 12.2.2+rs0.12.9"


### PR DESCRIPTION
Topic Description
-----------------

- mitmproxy: security update to 12.2.2

Package(s) Affected
-------------------

- mitmproxy: 12.2.2+rs0.12.9

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit mitmproxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
