### PR TITLE
nghttp2: security update to 1.69.0

### DIFF
--- a/runtime-web/nghttp2/spec
+++ b/runtime-web/nghttp2/spec
@@ -1,5 +1,4 @@
-VER=1.65.0
-REL=2
+VER=1.69.0
 SRCS="tbl::https://github.com/nghttp2/nghttp2/releases/download/v$VER/nghttp2-$VER.tar.xz"
-CHKSUMS="sha256::f1b9df5f02e9942b31247e3d415483553bc4ac501c87aa39340b6d19c92a9331"
+CHKSUMS="sha256::1fb324b6ec2c56f6bde0658f4139ffd8209fa9e77ce98fd7a5f63af8d0e508ad"
 CHKUPDATE="anitya::id=8651"

--- a/topics/nghttp2-1.69.0.toml
+++ b/topics/nghttp2-1.69.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "nghttp2 1.69.0"
+
+[caution]
+default = "Fixes a Reachable Assertion vulnerability (CVE-2026-27135, Severity: High)"
+zh_CN = "修复一个可达断言漏洞（CVE-2026-27135，严重性：高）"
+
+[packages-v2]
+"nghttp2" = "< 1.69.0"


### PR DESCRIPTION
Topic Description
-----------------

- nghttp2: security update to 1.69.0

Package(s) Affected
-------------------

- nghttp2: 1.69.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit nghttp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
