### PR TITLE
opensc: security update to 0.27.1

### DIFF
--- a/app-devices/opensc/spec
+++ b/app-devices/opensc/spec
@@ -1,4 +1,4 @@
-VER=0.26.1
+VER=0.27.1
 SRCS="git::commit=tags/$VER::https://github.com/OpenSC/OpenSC"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2559"

--- a/topics/opensc-0.27.1.toml
+++ b/topics/opensc-0.27.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "OpenSC 0.27.1"
+
+[caution]
+default = "Fixes 5 security vulnerabilities (including 5 of medium severity)"
+zh_CN = "修复 5 个安全漏洞（含 5 个中危漏洞）"
+
+[packages-v2]
+"opensc" = "< 0.27.1"


### PR DESCRIPTION
Topic Description
-----------------

- opensc: security update to 0.27.1

Package(s) Affected
-------------------

- opensc: 0.27.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit opensc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
