### PR TITLE
32subsystem: adjust dependencies

### DIFF
--- a/groups/optenv32
+++ b/groups/optenv32
@@ -159,7 +159,6 @@ runtime-optenv32/glslang+32
 runtime-optenv32/gtk-2+32
 runtime-optenv32/libaio+32
 runtime-optenv32/libbsd+32
-runtime-optenv32/libcaca+32
 runtime-optenv32/libcroco+32
 runtime-optenv32/libdca+32
 runtime-optenv32/libdv+32

--- a/runtime-optenv32/32subsystem/autobuild/defines
+++ b/runtime-optenv32/32subsystem/autobuild/defines
@@ -10,7 +10,7 @@ freealut+32 freeglut+32 freetype+32 fribidi+32 game-music-emu+32 gcc+32
 gconf+32 gdbm+32 gdk-pixbuf+32 giflib+32 glew+32 glib+32 glibc+32 glslang+32
 glu+32 gmp+32 gnutls+32 gsm+32 gtk-2+32 gtk-3+32 harfbuzz+32 icu+32 imlib2+32
 json-c+32 krb5+32 lame+32 lcms2+32 libaio+32 libass+32 libasyncns+32
-libavc1394+32 libbluray+32 libbsd+32 libcaca+32 libcap+32 libcddb+32 libcdio+32
+libavc1394+32 libbluray+32 libbsd+32 libcap+32 libcddb+32 libcdio+32
 libdatrie+32 libdca+32 libdrm+32 libdv+32 libdvdcss+32 libdvdnav+32
 libdvdread+32 libepoxy+32 libexif+32 libffi+32 libgcrypt+32 libglvnd+32
 libgpg-error+32 libid3tag+32 libidn+32 libiec61883+32 libjpeg-turbo+32

--- a/runtime-optenv32/32subsystem/spec
+++ b/runtime-optenv32/32subsystem/spec
@@ -1,2 +1,2 @@
-VER=5
+VER=6
 DUMMYSRC=1


### PR DESCRIPTION
Topic Description
-----------------

- 32subsystem: adjust dependencies
    Signed-off-by: stydxm <stydxm@outlook.com>
- qgis: adjust dependencies
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- 32subsystem: 1:6

Security Update?
----------------

No

Build Order
-----------

```
#buildit 32subsystem
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
