### PR TITLE
libcaca+32: update to 0.99.beta20

### DIFF
--- a/runtime-optenv32/libcaca+32/autobuild/defines
+++ b/runtime-optenv32/libcaca+32/autobuild/defines
@@ -1,4 +1,4 @@
-PKGNAME=libcaca
+PKGNAME=libcaca+32
 PKGSEC=libs
 PKGDES="Color ASCii Art libraries"
 PKGDEP="imlib2 ncurses"


### PR DESCRIPTION
Topic Description
-----------------

- libcaca+32: update to 0.99.beta20
    Signed-off-by: stydxm <stydxm@outlook.com>
- qgis: adjust dependencies
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libcaca+32: 0.99.beta20

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcaca+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
