### PR TITLE
libcaca+32: set ABHOST=optenv32

### DIFF
--- a/runtime-optenv32/libcaca+32/autobuild/defines
+++ b/runtime-optenv32/libcaca+32/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libcaca+32
 PKGSEC=libs
 PKGDES="Color ASCii Art libraries"
-PKGDEP="imlib2 ncurses"
+PKGDEP="imlib2+32 ncurses+32 pango+32"
 
 ABTYPE=autotools
 AUTOTOOLS_AFTER=(
@@ -15,3 +15,5 @@ AUTOTOOLS_AFTER=(
     "--disable-doc"
 )
 NOLTO=1
+
+ABHOST=optenv32

--- a/runtime-optenv32/libcaca+32/spec
+++ b/runtime-optenv32/libcaca+32/spec
@@ -1,4 +1,5 @@
 VER=0.99.beta20
+REL=1
 EPOCH=1
 SRCS="git::commit=tags/v$VER::https://github.com/cacalabs/libcaca"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- libcaca+32: set ABHOST=optenv32
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libcaca+32: 0.99.beta20-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcaca+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
