### PR TITLE
alacritty: update to 0.17.0

### DIFF
--- a/app-utils/alacritty/autobuild/defines
+++ b/app-utils/alacritty/autobuild/defines
@@ -2,15 +2,9 @@ PKGNAME=alacritty
 PKGSEC="utils"
 PKGDEP="freetype fontconfig xclip x11-lib"
 BUILDDEP="rustc llvm cargo cmake fontconfig ncurses desktop-file-utils scdoc"
-BUILDDEP__LOONGSON3="${BUILDDEP/llvm/}"
-PKGDES="A cross-platform, GPU-accelerated terminal emulator"
+PKGDES="GPU-accelerated terminal emulator"
 PKGBREAK="ncurses<=6.2-2"
 PKGREP="ncurses<=6.2-2"
 
+ABTYPE=rust
 USECLANG=1
-NOLTO__LOONGSON3=1
-USECLANG__LOONGSON3=0
-ABSPLITDBG=0
-
-# FIXME: Disable LTO on loongarch64 before LLVM 18 update
-NOLTO__LOONGARCH64=1

--- a/app-utils/alacritty/spec
+++ b/app-utils/alacritty/spec
@@ -1,4 +1,4 @@
-VER=0.16.1
+VER=0.17.0
 SRCS="git::commit=tags/v$VER::https://github.com/alacritty/alacritty"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141678"


### PR DESCRIPTION
Topic Description
-----------------

- alacritty: update to 0.17.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- alacritty: 0.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit alacritty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
