### PR TITLE
btop: update to 1.4.7

### DIFF
--- a/app-utils/btop/autobuild/defines
+++ b/app-utils/btop/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=btop
 PKGSEC=utils
-PKGDES="A terminal system resource and status monitor"
+PKGDES="Terminal system resource and status monitor"
 PKGDEP="gcc-runtime"
+
+ABTYPE=self

--- a/app-utils/btop/spec
+++ b/app-utils/btop/spec
@@ -1,4 +1,4 @@
-VER=1.4.6
+VER=1.4.7
 SRCS="git::commit=tags/v$VER::https://github.com/aristocratos/btop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=253331"


### PR DESCRIPTION
Topic Description
-----------------

- btop: update to 1.4.7
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- btop: 1.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit btop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
