### PR TITLE
btrfs-progs: update to 6.19.1

### DIFF
--- a/app-admin/btrfs-progs/autobuild/defines
+++ b/app-admin/btrfs-progs/autobuild/defines
@@ -2,40 +2,33 @@ PKGNAME=btrfs-progs
 PKGSEC=admin
 PKGDEP="glibc e2fsprogs lzo systemd reiserfsprogs util-linux zlib zstd"
 BUILDDEP="asciidoc xmlto sphinx"
-BUILDDEP__RETRO=""
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
-
 PKGDES="Btrfs filesystem utilities"
 
-ABMK="prefix=$PKGDIR/usr"
+ABTYPE=autotools
+# FIXME: make: *** No targets specified and no makefile found.  Stop.
 ABSHADOW=0
-
-AUTOTOOLS_AFTER="--enable-largefile \
-                 --enable-backtrace \
-                 --enable-documentation \
-                 --enable-programs \
-                 --enable-shared \
-                 --disable-static \
-                 --enable-convert \
-                 --enable-zoned \
-                 --enable-zstd \
-                 --enable-libudev \
-                 --enable-python \
-                 --disable-experimental \
-                 --enable-lzo \
-                 --with-convert=ext2,reiserfs \
-                 --with-crypto=builtin \
-                 PYTHON=/usr/bin/python3"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-backtrace \
-                 --disable-documentation \
-                 --disable-libudev \
-                 --disable-python"
+AUTOTOOLS_AFTER=(
+    '--enable-largefile'
+    '--enable-backtrace'
+    '--enable-documentation'
+    '--enable-programs'
+    '--enable-shared'
+    '--disable-static'
+    '--enable-convert'
+    '--enable-zoned'
+    '--enable-zstd'
+    '--enable-libudev'
+    '--enable-python'
+    '--disable-experimental'
+    '--enable-lzo'
+    '--with-convert=ext2,reiserfs'
+    '--with-crypto=builtin'
+    'PYTHON=/usr/bin/python3'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-documentation'
+    '--disable-backtrace'
+    '--disable-libudev'
+    '--disable-python'
+)

--- a/app-admin/btrfs-progs/spec
+++ b/app-admin/btrfs-progs/spec
@@ -1,4 +1,4 @@
-VER=6.19
+VER=6.19.1
 SRCS="https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v$VER.tar.xz"
-CHKSUMS="sha256::ad6b791a60eb563d3314bc18e3c47f6b053a032639488b5b09b9d5e7921de6b6"
+CHKSUMS="sha256::bb27e1ec54e7c3c0b7b2e596f853a73c07a3d72f21bc94042073c24dbf045796"
 CHKUPDATE="anitya::id=227"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-progs: update to 6.19.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- btrfs-progs: 6.19.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-progs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
