### PR TITLE
dunst: update to 1.13.2

### DIFF
--- a/app-utils/dunst/spec
+++ b/app-utils/dunst/spec
@@ -1,4 +1,4 @@
-VER=1.13.1
+VER=1.13.2
 SRCS="git::commit=tags/v${VER}::https://github.com/dunst-project/dunst"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12188"


### PR DESCRIPTION
Topic Description
-----------------

- dunst: update to 1.13.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- dunst: 1.13.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit dunst
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
