### PR TITLE
git-cliff: update to 2.13.1

### DIFF
--- a/app-vcs/git-cliff/spec
+++ b/app-vcs/git-cliff/spec
@@ -1,4 +1,4 @@
-VER=2.12.0
+VER=2.13.1
 SRCS="git::commit=tags/v$VER::https://github.com/orhun/git-cliff"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368021"


### PR DESCRIPTION
Topic Description
-----------------

- git-cliff: update to 2.13.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- git-cliff: 2.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit git-cliff
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
