### PR TITLE
htop: update to 3.5.1

### DIFF
--- a/app-admin/htop/autobuild/defines
+++ b/app-admin/htop/autobuild/defines
@@ -1,28 +1,23 @@
 PKGNAME=htop
 PKGSEC=utils
 PKGDEP="libcap libnl libunwind lsof lm-sensors ncurses strace"
-# FIXME: libunwind is not available for riscv64.
-PKGDEP__RISCV64="${PKGDEP/libunwind/}"
-PKGDES="A top-like interactive process viewer"
+PKGDES="Top-like interactive process viewer"
 
-# Note: --disable-pcp, PCP - Performance Co-Pilot.
-AUTOTOOLS_AFTER="--disable-pcp \
-                 --enable-unicode \
-                 --enable-affinity \
-                 --enable-unwind \
-                 --enable-openvz \
-                 --enable-vserver \
-                 --enable-ancient-vserver \
-                 --enable-capabilities \
-                 --enable-delayacct \
-                 --enable-sensors \
-                 --disable-werror \
-                 --disable-debug"
-# FIXME: libunwind is not available for riscv64.
-AUTOTOOLS_AFTER__RISCV64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-unwind"
-
-ABSHADOW=0
+ABTYPE=autotools
+# NOTE: Disable PCP version htop, we are building the plain htop binary
+AUTOTOOLS_AFTER=(
+    '--disable-pcp'
+    '--enable-unicode'
+    '--enable-affinity'
+    '--enable-backtrace=unwind-ptrace'
+    '--enable-openvz'
+    '--enable-vserver'
+    '--enable-ancient-vserver'
+    '--enable-capabilities'
+    '--enable-delayacct'
+    '--enable-sensors'
+    '--disable-werror'
+    '--disable-debug'
+)
 
 PKGEPOCH=1

--- a/app-admin/htop/spec
+++ b/app-admin/htop/spec
@@ -1,4 +1,4 @@
-VER=3.4.1
+VER=3.5.1
 SRCS="tbl::https://github.com/htop-dev/htop/releases/download/$VER/htop-$VER.tar.xz"
-CHKSUMS="sha256::904f7d4580fc11cffc7e0f06895a4789e0c1c054435752c151e812fead9f6220"
+CHKSUMS="sha256::526cecd62870aa8d14d2a79a35ea197e4e2b5317d275b567cee0574b2ddb2e9a"
 CHKUPDATE="anitya::id=1332"


### PR DESCRIPTION
Topic Description
-----------------

- htop: update to 3.5.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- htop: 1:3.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit htop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
