### PR TITLE
iosevka-fonts: update to 34.4.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=34.1.0
+VER=34.4.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::a8cbe150856aef9b58ec8dd8a6cbc29b9b7db34d6ed466ba57347cd1d3537efe \
-         sha256::bec2efb67ad877c140f3a645ce2969841022db055d5a8376a6f73dacea9bb5e1 \
-         sha256::70ac43efcb702ded3929e124f4aa4c06745023af697709f433693b3433b5d5cc \
-         sha256::5d259fa989af4d96d369ac6cedb7a74da908dc7e8d23b5d7aa69bf60159224ba \
-         sha256::c2d9f83fd539a3ca77e5d6a98bbc9f8911c06b1b403fd6f9ca394a2a23716f97 \
-         sha256::6afb572265667567fcc3ede85171a595149ca4e60cc3b4bd98976ec4dbdbb826 \
-         sha256::bda8738e4b1969dc67f92afe0feacfc03909c18b1a1e9a63b00a3d13b0188449 \
-         sha256::4cd9e1e2281559f1ae4063ecb48c1c463d8d7856bb6eaaa1bbc4b31f35bf9e20 \
-         sha256::1c629f0479bca9d8632573462c6e7f68564cc3a7898d16579e0cd1ab4fb06fd6 \
-         sha256::6b76a00801125c35bfb98391080331b6a189e207e842c4a7c1e96a03acaed1a3 \
-         sha256::128ca84fc59a6e483cdf4eea1db899ae3ab064c019769d7ca4e257453d289382 \
-         sha256::034f04772d73139a3d0c9181fd395add3856c4006bb2eafcd9b1f5a587af3469 \
-         sha256::bbacc3d9fa70e0e63e48c77a0f44c88bf391a54f404593cfc3ee774d818e69f9 \
-         sha256::f9623e38d8fc87121e5858e4cab930c6e67d741c9ef2694df6200c16111e1360 \
-         sha256::85fc9d6ccac45d6195a53f3a8ea71ba9eb9cbda3a67f1fa00e1051ffc109fc81 \
-         sha256::7c92403bdc3ba66e579b18f97cdf307b0529a46bec1dc5228d35372b32598764 \
-         sha256::f9f4395ddae67043ef76dad69a65bdecab1af42873b2ff32598b6cb78461bf21 \
-         sha256::7415ba8fb8e585425ddedb832e70d9b3613ae63a31907ddfdae3fd62c10239e5 \
-         sha256::82c607e807a8b95c06afc71c13d4cc83832705fcbfa97a4097cc35c84897f026 \
-         sha256::2e0a5e12d1e7684d2ed2e10f738c51a19c6d1cb2afa439a94cb4273f27adcbec \
-         sha256::ace9472b5bbca362fac68daf55f625beea925e3f422c08a56e238d79ae001376 \
-         sha256::9e05b708d3bb6e0616fee6d873ec079d6f40a92928eb66b78f3671947de55330 \
-         sha256::50562b5edf20aa3820840b71c091b8f7afc50de5c299b1dd9ddde94989c98484 \
-         sha256::b0876305da64c7efd265f93d9d053c87a580cb50cda6b4da3f80b6317fb7a598 \
+CHKSUMS="sha256::24f7c8e6f874037aa51d6e9d2970755417cff5a845750e650251230d513b4b27 \
+         sha256::a2e8ebb91a8072a6f408f868062f4290096b56e07b495698df9f75656e5129a0 \
+         sha256::2a327d52965f432d9490bbf1ceb1c526caadcb330265b2b15004c1c43186c1b8 \
+         sha256::c3ce3b0eeae1a6a0ee8929a764d29b87830a8bab201dd2e47e9a68392bc8e3bb \
+         sha256::03f7a3e4794185d2452040bd29f007a427c331212d5690bda02d8506c13368ad \
+         sha256::48e6b36349034aef6eb1a365b7c47cd69cc0963baa4acffc34c97d3cd0c45b57 \
+         sha256::fe8d1b209c7860d8829e437ca8efe79f4e27ed4b82d64f183100776262ee0bd5 \
+         sha256::f9c41b85120e44037d6054749c3bde8bb668e129412da47a6654891300d399e5 \
+         sha256::342cb10ec0a119d9f963ba2e3fd35f736810f9d7011ac004c69e4a87aa51118b \
+         sha256::41748b88afb71741815c2c5cf46f540655225c7722842333ac8a4de70cd75370 \
+         sha256::f3b3583dd5402c482df84e9903df8dcb1550cb7341122971d7969a369d1aceaf \
+         sha256::546d25ef5f4a84d3179b02ed4279bdab8c4f313b1d21bb6870f322051db946ff \
+         sha256::ea8ab22db7da9721f4862830eedd9c40c6073b663e517d484c87a151d8cca6ee \
+         sha256::bda7f59de661509b68b18f7034e5cab38b6d349af72a7c755f673800c8c89fc7 \
+         sha256::4af303a6ff66af2e8716c0b858a947e99e8a897eb77ba4df44b17e1d01bd3c41 \
+         sha256::7482e6c3179a4bff1928ca5e4cc77ddd92f29fe256a906b34c84ec3a84729ad0 \
+         sha256::ddea34c8f0c9d9379afb4ba276620186e7143668f0f8f15c080bdf0aba83a979 \
+         sha256::fbb6e34e8e6636e54abfa77327b1685a3099d4a353589662a94fd104c7e96903 \
+         sha256::f97e64e9385f4b694a9b3c690856c753b1b2ee1084cf5746c78ed364a0359ec0 \
+         sha256::ca6fdf14ae0d375234fdc2922016fb6ac1e6cccbdd1d938e043da8e151f3101e \
+         sha256::6a6c23a1d3567e0ec2958f29bf15df8e01fc61b7d5e6f5e286589c7f79be89c2 \
+         sha256::2ecb83ed22cf7026788aad54e097dffab50c49fa2b34beacade6b9a8433a2ad5 \
+         sha256::3fcdcf84fb46acd4fe506116ace15106bbf1e5aeb254b989f8d77309767bccc2 \
+         sha256::77e35e36dac373bc24ffa532a73efcffae01124575876b2baeed659f6a705a0c \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.4.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
