### PR TITLE
ipython: update to 9.13.0

### DIFF
--- a/lang-python/ipython/autobuild/defines
+++ b/lang-python/ipython/autobuild/defines
@@ -1,11 +1,8 @@
 PKGNAME=ipython
 PKGSEC=python
-PKGDES="An enhanced Interactive Python shell"
-# FIXME: typing-extensions is required for Python < 3.12 and exceptiongroups is
-# required for Python < 3.11
+PKGDES="Interactive Python shell"
 PKGDEP="asttokens decorator executing jedi pexpect prompt-toolkit pure-eval \
-        pygments sqlite stack-data traitlets typing-extensions exceptiongroup \
-        matplotlib-inline"
+        pygments sqlite stack-data traitlets matplotlib-inline"
 PKGREC="pickleshare"
 
 ABHOST=noarch

--- a/lang-python/ipython/spec
+++ b/lang-python/ipython/spec
@@ -1,5 +1,4 @@
-VER=8.32.0
+VER=9.13.0
 SRCS="tbl::https://pypi.io/packages/source/i/ipython/ipython-$VER.tar.gz"
-CHKSUMS="sha256::be2c91895b0b9ea7ba49d33b23e2040c352b33eb6a519cca7ce6e0c743444251"
+CHKSUMS="sha256::7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967"
 CHKUPDATE="anitya::id=1399"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- ipython: update to 9.13.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ipython: 9.13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
