### PR TITLE
libcava: update to 0.10.7

### DIFF
--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,4 +1,5 @@
 VER=0.15.0
+REL=1
 # NOTE: the sole submodule is the AUR package repository
 SRCS="git::commit=tags/$VER;submodule=false::https://github.com/Alexays/Waybar.git"
 CHKSUMS="SKIP"

--- a/runtime-multimedia/libcava/spec
+++ b/runtime-multimedia/libcava/spec
@@ -1,5 +1,4 @@
-VER=0.10.6
-REL=1
+VER=0.10.7
 SRCS="git::commit=tags/$VER::https://github.com/LukashonakV/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372377"


### PR DESCRIPTION
Topic Description
-----------------

- libcava: update to 0.10.7
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libcava: 0.10.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcava waybar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
