### PR TITLE
libglibutil: update to 1.0.81

### DIFF
--- a/runtime-common/libglibutil/spec
+++ b/runtime-common/libglibutil/spec
@@ -1,4 +1,4 @@
-VER=1.0.80
+VER=1.0.81
 SRCS="git::commit=tags/$VER::https://github.com/sailfishos/libglibutil"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279493"


### PR DESCRIPTION
Topic Description
-----------------

- libglibutil: update to 1.0.81
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libglibutil: 1.0.81

Security Update?
----------------

No

Build Order
-----------

```
#buildit libglibutil
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
