### PR TITLE
qutebrowser: update to 3.7.0+pdfjs5.7.284

### DIFF
--- a/app-web/qutebrowser/spec
+++ b/app-web/qutebrowser/spec
@@ -1,12 +1,11 @@
-UPSTREAM_VER=3.6.3
+UPSTREAM_VER=3.7.0
 # NOTE: Find the latest pdf.js version in
 # https://github.com/mozilla/pdf.js/releases
-PDFJS_VER=5.4.449
+PDFJS_VER=5.7.284
 VER=${UPSTREAM_VER}+pdfjs${PDFJS_VER}
 SRCS="tbl::https://github.com/qutebrowser/qutebrowser/releases/download/v$UPSTREAM_VER/qutebrowser-$UPSTREAM_VER.tar.gz \
       file::rename=pdfjs.zip::https://github.com/mozilla/pdf.js/releases/download/v$PDFJS_VER/pdfjs-$PDFJS_VER-dist.zip"
-CHKSUMS="sha256::6dbe2889e61ebd63003ae40b319e1e81f306e924e8316c6795ae4884021c2faf \
-         sha256::8afd631c5f062d2ef160e1fb362d4ccce9ae8157f246b6da91a95a257326e34d"
+CHKSUMS="sha256::c7f95884ea5e6675e584025bea55cff950c47d749aff7f415f68da03fcce0f92 \
+         sha256::6d1b81252d76358df5831567d7d551f40ebae0cd8e0a554694bc4df0d3db8715"
 SUBDIR="qutebrowser-$UPSTREAM_VER"
 CHKUPDATE="anitya::id=9759"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- qutebrowser: update to 3.7.0+pdfjs5.4.449
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- qutebrowser: 3.7.0+pdfjs5.4.449

Security Update?
----------------

No

Build Order
-----------

```
#buildit qutebrowser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
