### PR TITLE
showmethekey: update to 1.21.0

### DIFF
--- a/app-utils/showmethekey/spec
+++ b/app-utils/showmethekey/spec
@@ -1,4 +1,4 @@
-VER=1.20.0
+VER=1.21.0
 SRCS="git::commit=tags/v$VER::https://github.com/AlynxZhou/showmethekey"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=236314"


### PR DESCRIPTION
Topic Description
-----------------

- showmethekey: update to 1.21.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- showmethekey: 1.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit showmethekey
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
