### PR TITLE
wl-clipboard: update to 2.3.0

### DIFF
--- a/app-utils/wl-clipboard/spec
+++ b/app-utils/wl-clipboard/spec
@@ -1,4 +1,4 @@
-VER=2.2.1
+VER=2.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/bugaevc/wl-clipboard"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=49082"


### PR DESCRIPTION
Topic Description
-----------------

- wl-clipboard: update to 2.3.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wl-clipboard: 2.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wl-clipboard
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
