### PR TITLE
afpfs-ng: fix build

### DIFF
--- a/runtime-network/afpfs-ng/autobuild/prepare
+++ b/runtime-network/afpfs-ng/autobuild/prepare
@@ -1,2 +1,10 @@
 abinfo "Appending -fcommon to fix build with GCC >= 10 ..."
 export CFLAGS="${CFLAGS} -fcommon"
+
+# FIXME: 
+# unicode.c:1068:1: error: number of arguments doesn't match prototype
+# other several same errors
+# unicode.c:1227:19: error: too many arguments to function 'mbCharLen'; expected 0, have 1
+# and several errors for other functions
+abinfo "Defining NeedFunctionPrototypes for unicode headers ..."
+export CPPFLAGS="${CPPFLAGS} -DNeedFunctionPrototypes=1"

--- a/runtime-network/afpfs-ng/spec
+++ b/runtime-network/afpfs-ng/spec
@@ -1,5 +1,5 @@
 VER=0.8.1
-REL=5
+REL=6
 SRCS="tbl::https://downloads.sourceforge.net/sourceforge/afpfs-ng/afpfs-ng-$VER.tar.bz2"
 CHKSUMS="sha256::688560de1cde57ab8d9e0ef7dc6436dbf0267fe8884f9014e50ff92b297b01a8"
 CHKUPDATE="anitya::id=28"


### PR DESCRIPTION
Topic Description
-----------------

- afpfs-ng: fix build
    This commit is authored with assistance from LLM:
    - Model: GPT-5.4
    - Platform: Packy Code
    - Agent platform: Codex
    - Prompt: 我在编译afpfs-ng的时候遇到了报错，你可以在工作目录里用ciel build看一下具体内容，然后尝试解决，如果需要的话可以添加patch
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit afpfs-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
