### PR TITLE
podman: security update to 5.8.2+vsock0.8.8

### DIFF
--- a/app-containers/podman/spec
+++ b/app-containers/podman/spec
@@ -1,9 +1,8 @@
-UPSTREAM_VER=5.7.0
-REL=4
+UPSTREAM_VER=5.8.2
 # Find gvisor-tap-vsock version at:
 #
 # https://github.com/containers/podman/blob/v$PKGVER/contrib/pkginstaller/Makefile
-GVISOR_TAP_VSOCK_VER=0.8.7
+GVISOR_TAP_VSOCK_VER=0.8.8
 VER=${UPSTREAM_VER}+vsock${GVISOR_TAP_VSOCK_VER}
 SRCS="git::commit=v${UPSTREAM_VER};rename=podman-${UPSTREAM_VER}::https://github.com/containers/podman \
       git::commit=tags/v${GVISOR_TAP_VSOCK_VER};rename=gvisor-tap-vsock::https://github.com/containers/gvisor-tap-vsock"

--- a/topics/podman-5.8.2.toml
+++ b/topics/podman-5.8.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Podman 5.8.2"
+
+[caution]
+default = "Fixes an OS Command Injection vulnerability (CVE-2026-33414, Severity: High)"
+zh_CN = "修复一个系统命令注入漏洞（漏洞编号 CVE-2026-33414，严重性：高）"
+
+[packages-v2]
+"podman" = "< 5.8.2+vsock0.8.8"


### PR DESCRIPTION
Topic Description
-----------------

- podman: security update to 5.8.2+vsock0.8.8

Package(s) Affected
-------------------

- podman: 5.8.2+vsock0.8.8

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit podman
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
