### PR TITLE
cairosvg: security update to 2.9.0

### DIFF
--- a/app-imaging/cairosvg/spec
+++ b/app-imaging/cairosvg/spec
@@ -1,5 +1,4 @@
-VER=2.8.2
-SRCS="tbl::https://github.com/Kozea/CairoSVG/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::c292f3111c8cc4e5dc80aac9d4a36098ecb3ec9cf3238a6269da03f567c98b8c"
+VER=2.9.0
+SRCS="pypi::version=$VER::CairoSVG"
+CHKSUMS="sha256::1debb00cd2da11350d8b6f5ceb739f1b539196d71d5cf5eb7363dbd1bfbc8dc5"
 CHKUPDATE="anitya::id=3789"
-REL="1"

--- a/topics/cairosvg-2.9.0.toml
+++ b/topics/cairosvg-2.9.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "CairoSVG 2.9.0"
+
+[caution]
+default = "Fixes an Uncontrolled Recursion vulnerability (CVE-2026-31899, Severity: High)"
+zh_CN = "修复一个未经控制的递归漏洞（CVE-2026-31899，严重性：高）"
+
+[packages-v2]
+"cairosvg" = "< 2.9.0"


### PR DESCRIPTION
Topic Description
-----------------

- cairosvg: security update to 2.9.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- cairosvg: 2.9.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit cairosvg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
