### PR TITLE
lxml: security update to 6.1.0

### DIFF
--- a/lang-python/lxml/spec
+++ b/lang-python/lxml/spec
@@ -1,5 +1,4 @@
-VER=6.0.2
-REL=3
+VER=6.1.0
 SRCS="git::commit=tags/lxml-$VER::https://github.com/lxml/lxml"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3914"

--- a/topics/lxml-6.1.0.toml
+++ b/topics/lxml-6.1.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "lxml 6.1.0"
+
+[caution]
+default = "Fixes an Improper Restriction of XML External Entity Reference vulnerability (CVE-2026-41066, Severity: High)"
+zh_CN = "修复一个 XML 外部实体引用的不恰当限制漏洞（CVE-2026-41066，严重性：高）"
+
+[packages-v2]
+"lxml" = "< 6.1.0"


### PR DESCRIPTION
Topic Description
-----------------

- lxml: security update to 6.1.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- lxml: 6.1.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit lxml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
