### PR TITLE
ujson: security update to 5.12.0

### DIFF
--- a/lang-python/ujson/autobuild/defines
+++ b/lang-python/ujson/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=ujson
 PKGSEC=python
 PKGDEP="double-conversion gcc-runtime glibc python-3"
 BUILDDEP="setuptools setuptools-scm"
-PKGDES="Ultra fast JSON encoder and decoder for Python"
+PKGDES="JSON encoder and decoder for Python"
 
 ABTYPE=pep517

--- a/lang-python/ujson/spec
+++ b/lang-python/ujson/spec
@@ -1,5 +1,4 @@
-VER=5.11.0
+VER=5.12.0
 SRCS="pypi::version=$VER::ujson"
-CHKSUMS="sha256::e204ae6f909f099ba6b6b942131cee359ddda2b6e4ea39c12eb8b991fe2010e0"
+CHKSUMS="sha256::14b2e1eb528d77bc0f4c5bd1a7ebc05e02b5b41beefb7e8567c9675b8b13bcf4"
 CHKUPDATE="anitya::id=124429"
-REL="1"

--- a/topics/ujson-5.12.0.toml
+++ b/topics/ujson-5.12.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "ujson 5.12.0"
+
+[caution]
+default = "Fixes a DoS vulnerability caused by memory leaks (CVE-2026-32874, Severity: High) and an Integer Overflow vulnerability (CVE-2026-32875, Severity: High)"
+zh_CN = "修复一个内存泄漏导致的拒绝服务漏洞（漏洞编号 CVE-2026-32874，严重性：高）和一个整数溢出漏洞（漏洞编号 CVE-2026-32875，严重性：高）"
+
+[packages-v2]
+"ujson" = "< 5.12.0"


### PR DESCRIPTION
Topic Description
-----------------

- ujson: security update to 5.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- ujson: 5.12.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit ujson
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
