### PR TITLE
httpd: security update to 2.4.67

### DIFF
--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,5 +1,4 @@
-VER=2.4.66
-REL=1
+VER=2.4.67
 SRCS="tbl::https://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
-CHKSUMS="sha256::94d7ff2b42acbb828e870ba29e4cbad48e558a79c623ad3596e4116efcfea25a"
+CHKSUMS="sha256::66cd206637b0d5c446fa7dabe75fe03525da8fb55855876c46288cd88b136aa4"
 CHKUPDATE="anitya::id=1335"

--- a/topics/httpd-2.4.67.toml
+++ b/topics/httpd-2.4.67.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Apache HTTP Server (httpd) 2.4.67"
+zh_CN = "Apache HTTP 服务器 (httpd) 2.4.67"
+
+[caution]
+default = "Fixes 11 security vulnerabilities (4 of high severity, 5 of medium severity)"
+zh_CN = "修复 11 个安全漏洞（含 4 个高危漏洞和 5 个中危漏洞）"
+
+[packages-v2]
+"httpd" = "< 2.4.67"


### PR DESCRIPTION
Topic Description
-----------------

- httpd: security update to 2.4.67
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- httpd: 2.4.67

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
