### PR TITLE
radare2: security update to 6.1.4

### DIFF
--- a/app-devel/radare2/spec
+++ b/app-devel/radare2/spec
@@ -1,4 +1,4 @@
-VER=6.0.7
+VER=6.1.4
 SRCS="git::commit=tags/$VER::https://github.com/radare/radare2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11009"

--- a/topics/radare2-6.1.4.toml
+++ b/topics/radare2-6.1.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Radare2 6.1.4"
+
+[caution]
+default = "Fixes 2 path traversal vulnerabilities (CVE-2026-6940, CVE-2026-6941, Severity: High) and an OS command injection vulnerability (CVE-2026-40517, Severity: High)"
+zh_CN = "修复 2 个路径遍历漏洞（漏洞编号 CVE-2026-6940 和 CVE-2026-6941，严重性：高）和一个操作系统命令注入漏洞（漏洞编号 CVE-2026-40517，严重性：高）"
+
+[packages-v2]
+"radare2" = "<6.1.4"


### PR DESCRIPTION
Topic Description
-----------------

- radare2: security update to 6.1.4
    Signed-off-by: stydxm <stydxm@outlook.com>
- lxc: security update to 7.0.0
    Fix CVE-2026-39402

Package(s) Affected
-------------------

- radare2: 6.1.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit radare2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
