### PR TITLE
ppsspp: Fix Jit_WeightsU16Skin in VertexDecoderLoongArch64.cpp

### DIFF
--- a/app-games/ppsspp/autobuild/patches/0002-Fix-Jit_WeightsU16Skin-in-VertexDecoderLoongArch64-cpp.patch
+++ b/app-games/ppsspp/autobuild/patches/0002-Fix-Jit_WeightsU16Skin-in-VertexDecoderLoongArch64-cpp.patch
@@ -1,0 +1,29 @@
+From d1bf797e1b824b43df9adfc3382dece10de0e8ec Mon Sep 17 00:00:00 2001
+From: Lin Runze <lrzlin@163.com>
+Date: Sat, 25 Apr 2026 16:33:06 +0800
+Subject: [PATCH] loongarch: Fix Jit_WeightsU16Skin in
+ VertexDecoderLoongArch64.cpp
+
+---
+ GPU/Common/VertexDecoderLoongArch64.cpp | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/GPU/Common/VertexDecoderLoongArch64.cpp b/GPU/Common/VertexDecoderLoongArch64.cpp
+index dbb1a68933e5..a80780292db4 100644
+--- a/GPU/Common/VertexDecoderLoongArch64.cpp
++++ b/GPU/Common/VertexDecoderLoongArch64.cpp
+@@ -506,11 +506,11 @@ void VertexDecoderJitCache::Jit_WeightsU16Skin() {
+ 
+ 	if (dec_->nweights > 4) {
+ 		switch (dec_->nweights) {
+-		case 5: LD_HU(scratchReg, srcReg, 0); break;
+-	    case 6: LD_WU(scratchReg, srcReg, 0); break;
++		case 5: LD_HU(scratchReg, srcReg, 8); break;
++		case 6: LD_WU(scratchReg, srcReg, 8); break;
+ 		case 7:
+ 		case 8:
+-			LD_D(scratchReg, srcReg, 0);
++			LD_D(scratchReg, srcReg, 8);
+ 			break;
+ 		}
+ 		VINSGR2VR_D(lsxScratchReg, scratchReg, 0);

--- a/app-games/ppsspp/spec
+++ b/app-games/ppsspp/spec
@@ -1,5 +1,5 @@
 VER=1.20.1
-REL=2
+REL=3
 SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/hrydgard/ppsspp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12295"


### PR DESCRIPTION
Topic Description
-----------------

- ppsspp: Fix Jit_WeightsU16Skin in VertexDecoderLoongArch64.cpp

Package(s) Affected
-------------------

- ppsspp: 1.20.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ppsspp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
