### PR TITLE
systemd: enable apparmor-aware support

### DIFF
--- a/app-admin/systemd/autobuild/defines
+++ b/app-admin/systemd/autobuild/defines
@@ -21,7 +21,7 @@ PKGDEP__M68K="${PKGDEP__RETRO}"
 PKGDEP__POWERPC="${PKGDEP__RETRO}"
 PKGDEP__PPC64="${PKGDEP__RETRO}"
 BUILDDEP="gobject-introspection gperf gtk-doc intltool jinja2 llvm lxml \
-          pyelftools libxkbcommon"
+          pyelftools libxkbcommon apparmor"
 BUILDDEP__RETRO="docbook-xsl gperf intltool jinja2 libxslt"
 BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
 BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
@@ -143,7 +143,7 @@ MESON_AFTER=(
     '-Dntp-servers=aoscos.pool.ntp.org'
     '-Dseccomp=enabled'
     '-Dselinux=disabled'
-    '-Dapparmor=disabled'
+    '-Dapparmor=enabled'
     '-Dsmack=false'
     '-Dpolkit=enabled'
     '-Dima=false'

--- a/app-admin/systemd/spec
+++ b/app-admin/systemd/spec
@@ -1,7 +1,7 @@
 VER=259
 
 # Use this for stable/main branch releases.
-REL=4
+REL=5
 SRCS="git::commit=tags/v$VER::https://github.com/systemd/systemd.git"
 
 # Use this for RC releases.


### PR DESCRIPTION
Topic Description
-----------------

- systemd: enable apparmor-aware support
    This will introduce build-time dependency to apparmor, but the
    libapparmor library is dlopen'd at runtime.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- systemd: 1:259-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
