### PR TITLE
pipewire: restore apparmor as PKGDEP

### DIFF
--- a/app-multimedia/pipewire/autobuild/defines
+++ b/app-multimedia/pipewire/autobuild/defines
@@ -1,11 +1,14 @@
 PKGNAME=pipewire
 PKGSEC=sound
 PKGDES="Server and user space API to deal with multimedia pipelines"
+# NOTE: AppArmor support is baked in, not fancy dlopen() imports.
+# NOTE: Without this Snap applications may not be able to play and record
+# audio.
 PKGDEP="alsa-lib bluez dbus ffmpeg gstreamer-1-0 gst-plugins-base-1-0 \
         libcanberra libfdk-aac libldac libfreeaptx libsndfile libusb libva \
         lilv ncurses readline rtkit sbc systemd v4l-utils vulkan \
         webrtc-audio-processing libcamera wireplumber x11-lib glib opus \
-        libebur128 fftw onnxruntime"
+        libebur128 fftw onnxruntime apparmor"
 PKGDEP__SNAPD="${PKGDEP} snapd-glib"
 PKGDEP__AMD64="${PKGDEP__SNAPD} libffado"
 PKGDEP__ARM64="${PKGDEP__SNAPD}"

--- a/app-multimedia/pipewire/spec
+++ b/app-multimedia/pipewire/spec
@@ -1,5 +1,5 @@
 VER=1.6.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/pipewire"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=57357"


### PR DESCRIPTION
Topic Description
-----------------

- pipewire: restore apparmor as PKGDEP
    Unlike systemd, the dependency to libapparmor.so.1 is baked in.

Package(s) Affected
-------------------

- pipewire: 1.6.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pipewire
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
