### PR TITLE
matplotlib: update to 3.10.9

### DIFF
--- a/lang-python/matplotlib/autobuild/patches/0003-AOSCOS-Relax-meson-python-version-requirement.patch
+++ b/lang-python/matplotlib/autobuild/patches/0003-AOSCOS-Relax-meson-python-version-requirement.patch
@@ -19,23 +19,23 @@ diff --git a/pyproject.toml b/pyproject.toml
 index e6d1abaf530b..76755eec2574 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
-@@ -47,7 +47,7 @@ requires-python = ">=3.10"
+@@ -48,7 +48,7 @@
  [project.optional-dependencies]
  # Should be a copy of the build dependencies below.
  dev = [
 -    "meson-python>=0.13.1,<0.17.0",
 +    "meson-python>=0.13.1",
      "pybind11>=2.13.2,!=2.13.3",
-     "setuptools_scm>=7",
+     "setuptools_scm>=7,<10",
      # Not required by us but setuptools_scm without a version, cso _if_
-@@ -71,7 +71,7 @@ dev = [
+@@ -72,7 +72,7 @@
  build-backend = "mesonpy"
  # Also keep in sync with optional dependencies above.
  requires = [
 -    "meson-python>=0.13.1,<0.17.0",
 +    "meson-python>=0.13.1",
      "pybind11>=2.13.2,!=2.13.3",
-     "setuptools_scm>=7",
+     "setuptools_scm>=7,<10",
  ]
 -- 
 2.49.0

--- a/lang-python/matplotlib/spec
+++ b/lang-python/matplotlib/spec
@@ -1,5 +1,4 @@
-VER=3.10.3
+VER=3.10.9
 SRCS="tbl::https://pypi.io/packages/source/m/matplotlib/matplotlib-$VER.tar.gz"
-CHKSUMS="sha256::2f82d2c5bb7ae93aaaa4cd42aca65d76ce6376f83304fa3a630b569aca274df0"
+CHKSUMS="sha256::fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358"
 CHKUPDATE="anitya::id=3919"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- matplotlib: update to 3.10.9
    Co-authored-by: Chen \(@jiegec\) <c@jia.je>

Package(s) Affected
-------------------

- matplotlib: 3.10.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit matplotlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
