### PR TITLE
cups-filters: re-enable universal filter

### DIFF
--- a/runtime-doc/cups-filters/autobuild/defines
+++ b/runtime-doc/cups-filters/autobuild/defines
@@ -12,7 +12,7 @@ AUTOTOOLS_AFTER=(
 	'--enable-poppler'
 	'--enable-driverless'
 	'--enable-foomatic'
-	'--disable-universal-cups-filter'
+	'--enable-universal-cups-filter'
 	'--enable-individual-cups-filters'
 	'--disable-rpath'
 	'--disable-mutool'

--- a/runtime-doc/cups-filters/spec
+++ b/runtime-doc/cups-filters/spec
@@ -1,5 +1,6 @@
 VER=2.0.1+git20260309
 __COMMIT="1255e2071294ee2c4633e1fd73472c0f61babee3"
+REL=1
 SRCS="git::commit=${__COMMIT}::https://github.com/OpenPrinting/cups-filters"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5541"


### PR DESCRIPTION
Topic Description
-----------------

- cups-filters: re-enable universal filter
    This filter is still used by some non-built-in printer drivers.

Package(s) Affected
-------------------

- cups-filters: 2.0.1+git20260309-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cups-filters
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
