### PR TITLE
ndisc6: new, 1.0.8

### DIFF
--- a/app-network/ndisc6/autobuild/defines
+++ b/app-network/ndisc6/autobuild/defines
@@ -1,0 +1,4 @@
+PKGNAME=ndisc6
+PKGSEC=net
+PKGDEP="glibc"
+PKGDES="Tools to diagnose IPv6 networking"

--- a/app-network/ndisc6/spec
+++ b/app-network/ndisc6/spec
@@ -1,0 +1,4 @@
+VER=1.0.8
+SRCS="tbl::https://www.remlab.net/files/ndisc6/ndisc6-${VER}.tar.bz2"
+CHKSUMS="sha256::1f2fb2dc1172770aa5a09d39738a44d8b753cc5e2e25e306ca78682f9fea0b4f"
+CHKUPDATE="anitya::id=21531"


### PR DESCRIPTION
Topic Description
-----------------

- ndisc6: new, 1.0.8

Package(s) Affected
-------------------

- ndisc6: 1.0.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit ndisc6
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
