### PR TITLE
topics: add CVE-2026-43500 for linux-kernel-6.18.27

### DIFF
--- a/topics/linux-kernel-6.18.27.toml
+++ b/topics/linux-kernel-6.18.27.toml
@@ -5,8 +5,8 @@ default = "Linux Kernel 6.18.27"
 zh_CN = "Linux 内核，版本 6.18.27"
 
 [caution]
-default = "Fixes a series of Local Privilege Escalation vulnerability, codenamed \"Dirty Frag\" - CVE-2026-43284 (severity: High)"
-zh_CN = "修复代号为 \"Dirty Frag\" 的系列本地提权漏洞（CVE-2026-43284，严重性：高）"
+default = "Fixes a series of Local Privilege Escalation vulnerability, codenamed \"Dirty Frag\" - CVE-2026-43284 and CVE-2026-43500 (severity: High)"
+zh_CN = "修复代号为 \"Dirty Frag\" 的系列本地提权漏洞（CVE-2026-43284 及 CVE-2026-43500，严重性：高）"
 
 [packages-v2]
 "linux+kernel" = "< 3:6.18.27"

--- a/topics/linux-kernel-asahi-6.18.27.toml
+++ b/topics/linux-kernel-asahi-6.18.27.toml
@@ -5,8 +5,8 @@ default = "Linux Kernel (Apple silicon) 6.18.27"
 zh_CN = "Linux 内核 (Apple silicon)，版本 6.18.27"
 
 [caution]
-default = "Fixes a series of Local Privilege Escalation vulnerability, codenamed \"Dirty Frag\" - CVE-2026-43284 (severity: High)"
-zh_CN = "修复代号为 \"Dirty Frag\" 的系列本地提权漏洞（CVE-2026-43284，严重性：高）"
+default = "Fixes a series of Local Privilege Escalation vulnerability, codenamed \"Dirty Frag\" - CVE-2026-43284 and CVE-2026-43500 (severity: High)"
+zh_CN = "修复代号为 \"Dirty Frag\" 的系列本地提权漏洞（CVE-2026-43284 及 CVE-2026-43500，严重性：高）"
 
 [packages-v2]
 "linux+kernel+asahi" = "< 3:6.18.27"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add CVE-2026-43500 for linux-kernel-6.18.27

Package(s) Affected
-------------------



Security Update?
----------------

Yes

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
