### PR TITLE
libndp: update to 1.9

### DIFF
--- a/runtime-network/libndp/spec
+++ b/runtime-network/libndp/spec
@@ -1,5 +1,4 @@
-VER=1.7
-REL=1
+VER=1.9
 SRCS="tbl::http://libndp.org/files/libndp-$VER.tar.gz"
-CHKSUMS="sha256::2c480afbffb02792dbae3c13bbfb71d89f735562f2795cca0640ed3428b491b6"
+CHKSUMS="sha256::a8ab214e01dc3a9b615276905395637f391298c84d77651f0cbf0b1082dd2dd4"
 CHKUPDATE="anitya::id=14944"


### PR DESCRIPTION
Topic Description
-----------------

- libndp: update to 1.9
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- libndp: 1.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit libndp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
