### PR TITLE
zen-browser: update to 1.19.11~beta

### DIFF
--- a/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
+++ b/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
@@ -1,4 +1,4 @@
-From 2a5e63173159df2da87ea90013f1eea416e74471 Mon Sep 17 00:00:00 2001
+From a4663a3928ca841d394556989366462c6870e553 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:14:20 -0800
 Subject: [PATCH 1/7] AOSCOS: Disable LASX by default for libyuv

--- a/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
+++ b/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
@@ -1,4 +1,4 @@
-From e68372bf27b8307ded950b989c07fa59282c3eef Mon Sep 17 00:00:00 2001
+From 0073ace95598d0e255490958fe380f4bd354d756 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:17:48 -0800
 Subject: [PATCH 2/7] Enable GLES on riscv64

--- a/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
+++ b/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
@@ -1,4 +1,4 @@
-From 17cb7230711047b8f177db00608593fea1abc92c Mon Sep 17 00:00:00 2001
+From 57ced1fa29a01ee2627d6ee80e5dff878625030b Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:20:35 -0800
 Subject: [PATCH 3/7] Disable BROTLI_MODEL macro for some targets

--- a/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
+++ b/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
@@ -1,4 +1,4 @@
-From a429b8ec7b2c8f1d5ee9c8e6ae9a600c68bbd2d4 Mon Sep 17 00:00:00 2001
+From 9c2376a0af4e0aedb94fb51e11541e46bfd9515b Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:23:13 -0800
 Subject: [PATCH 4/7] AOSCOS: Fix unistd.h header inclusion in libwebrtc

--- a/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
+++ b/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
@@ -1,20 +1,20 @@
-From 8d38f4e2077bf2baf733a129c6a5fd92b13d47ee Mon Sep 17 00:00:00 2001
+From 60c1cc797ffc80f86df4182f64ce3589e95eb141 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 23:32:26 -0800
 Subject: [PATCH 5/7] AOSCOS: Update Google API keyfile path
 
 ---
- configs/common/mozconfig | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
+ configs/common/mozconfig | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/configs/common/mozconfig b/configs/common/mozconfig
-index 3d41bc83a..297b559a1 100644
+index 22b8e95c5..673f54d70 100644
 --- a/configs/common/mozconfig
 +++ b/configs/common/mozconfig
-@@ -36,8 +36,9 @@ if ! test "$SCCACHE_GHA_ENABLED" = "false"; then
+@@ -38,8 +38,9 @@ if test "$SCCACHE_GHA_ENABLED" = "true"; then
  fi
  
- # add safe browsing key if it exists on a file
+ # add API keys if it exists on a file
 -if test -f "$HOME/.zen-keys/safebrowsing.dat"; then
 -  ac_add_options --with-google-safebrowsing-api-keyfile="$HOME/.zen-keys/safebrowsing.dat"
 +if test -f "$SRCDIR/autobuild/google-api-key"; then
@@ -22,7 +22,16 @@ index 3d41bc83a..297b559a1 100644
 +  ac_add_options --with-google-safebrowsing-api-keyfile="$SRCDIR/autobuild/google-api-key"
  fi
  
- if test "$ZEN_RELEASE"; then
+ if test -f "$HOME/.zen-keys/mozilla.dat"; then
+@@ -93,7 +94,7 @@ if test "$ZEN_RELEASE"; then
+   ac_add_options --disable-crashreporter
+ 
+   # Experimental flag, enabled only on nightly for Firefox.
+-  # Should bring in some nice performance improvements, 
++  # Should bring in some nice performance improvements,
+   # but may cause stability issues.
+   ac_add_options --enable-replace-malloc
+ fi
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
+++ b/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
@@ -1,4 +1,4 @@
-From 7df0851541200d96169142abdb0a5ed829cc562f Mon Sep 17 00:00:00 2001
+From a64b5cf49849ee1aa43cff8e94ec6b121a8943f8 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <the@salted.fish>
 Date: Sat, 21 Feb 2026 20:28:31 -0500
 Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
@@ -8,7 +8,7 @@ Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/surfer.json b/surfer.json
-index 0d514c975..3b8a98daf 100644
+index 74a24c493..59207d938 100644
 --- a/surfer.json
 +++ b/surfer.json
 @@ -2,7 +2,7 @@
@@ -19,7 +19,7 @@ index 0d514c975..3b8a98daf 100644
 +  "binaryName": "zen-browser",
    "version": {
      "product": "firefox",
-     "version": "149.0.2",
+     "version": "150.0.1",
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
+++ b/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
@@ -1,4 +1,4 @@
-From 783d781278830682aa8678e78e7e02652d58efcb Mon Sep 17 00:00:00 2001
+From b49279ce980d98f9dd31c511b29758b621fb21ae Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 3 Feb 2026 05:56:14 -0500
 Subject: [PATCH 7/7] AOSCOS: Adjust mozconfig
@@ -10,12 +10,12 @@ Subject: [PATCH 7/7] AOSCOS: Adjust mozconfig
 
 Ref: aosc-os-abbs/app-web/firefox.
 ---
- configs/common/mozconfig | 11 +------
- configs/linux/mozconfig  | 64 +++++++++++++++++++++++-----------------
- 2 files changed, 38 insertions(+), 37 deletions(-)
+ configs/common/mozconfig | 10 +-----
+ configs/linux/mozconfig  | 69 +++++++++++++++++++++-------------------
+ 2 files changed, 37 insertions(+), 42 deletions(-)
 
 diff --git a/configs/common/mozconfig b/configs/common/mozconfig
-index 297b559a1..947f1593e 100644
+index 673f54d70..8ae8e5f49 100644
 --- a/configs/common/mozconfig
 +++ b/configs/common/mozconfig
 @@ -6,9 +6,6 @@
@@ -28,16 +28,16 @@ index 297b559a1..947f1593e 100644
  export MOZ_APP_BASENAME=Zen
  export MOZ_BRANDING_DIRECTORY=${brandingDir}
  export MOZ_OFFICIAL_BRANDING_DIRECTORY=${brandingDir}
-@@ -45,7 +42,7 @@ if test "$ZEN_RELEASE"; then
+@@ -54,7 +51,7 @@ fi
+ if test "$ZEN_RELEASE"; then
  
-   # TODO: Make this successful in builds
-   # ac_add_options --enable-clang-plugin
+   ac_add_options --enable-clang-plugin
 -  ac_add_options --enable-bootstrap=-sccache
 +  # ac_add_options --enable-bootstrap=-sccache
  
    ac_add_options --enable-optimize
  
-@@ -56,7 +53,6 @@ if test "$ZEN_RELEASE"; then
+@@ -65,7 +62,6 @@ if test "$ZEN_RELEASE"; then
    ac_add_options --disable-tests
  
    ac_add_options --enable-rust-simd
@@ -45,23 +45,22 @@ index 297b559a1..947f1593e 100644
  
    ac_add_options --disable-geckodriver
    ac_add_options --disable-rust-tests
-@@ -83,11 +79,6 @@ if test "$ZEN_RELEASE"; then
-   export MOZ_PACKAGE_JSSHELL=1
+@@ -93,10 +89,6 @@ if test "$ZEN_RELEASE"; then
  
    ac_add_options --disable-crashreporter
--
+ 
 -  # Experimental flag, enabled only on nightly for Firefox.
--  # Should bring in some nice performance improvements, 
+-  # Should bring in some nice performance improvements,
 -  # but may cause stability issues.
 -  ac_add_options --enable-replace-malloc
  fi
  
- ac_add_options --enable-unverified-updates
+ ac_add_options --enable-jxl
 diff --git a/configs/linux/mozconfig b/configs/linux/mozconfig
-index b15dcd399..ec024ff4b 100644
+index 9816e7580..2634d6e4a 100644
 --- a/configs/linux/mozconfig
 +++ b/configs/linux/mozconfig
-@@ -11,30 +11,40 @@ else
+@@ -11,36 +11,39 @@ else
      export CXX=clang++
  fi
  
@@ -72,8 +71,14 @@ index b15dcd399..ec024ff4b 100644
 -
 -        # Enable Profile Guided Optimization
 -        if ! test "$ZEN_GA_DISABLE_PGO"; then
--            export MOZ_PGO=1
--            ac_add_options MOZ_PGO=1
+-            if test "$ZEN_GA_GENERATE_PROFILE"; then
+-                mk_add_options "export MOZ_AUTOMATION_PACKAGE_GENERATED_SOURCES=0"
+-                ac_add_options --enable-profile-generate=cross
+-            else
+-                ac_add_options --enable-profile-use=cross
+-                ac_add_options --with-pgo-profile-path="$(echo ~)/artifact/merged.profdata"
+-                ac_add_options --with-pgo-jarlog="$(echo ~)/artifact/en-US.log"
+-            fi
 -        fi
 -    elif test "$SURFER_COMPAT" = "aarch64"; then
 -        ac_add_options --target=aarch64-linux-gnu
@@ -126,7 +131,6 @@ index b15dcd399..ec024ff4b 100644
 +# Features.
 +ac_add_options --enable-chrome-format=omni
 +ac_add_options --enable-js-shell
-+ac_add_options --enable-av1
 +ac_add_options --disable-tests
 +ac_add_options --disable-updater
 -- 

--- a/app-web/zen-browser/spec
+++ b/app-web/zen-browser/spec
@@ -1,4 +1,4 @@
-__VER="1.19.8"
+__VER="1.19.11"
 VER="${__VER}~beta"
 SRCS="git::commit=tags/${__VER}b;copy-repo=true::https://github.com/zen-browser/desktop"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- zen-browser: update to 1.19.11\~beta

Package(s) Affected
-------------------

- zen-browser: 1.19.11~beta

Security Update?
----------------

No

Build Order
-----------

```
#buildit zen-browser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
