### PR TITLE
dart-sdk: update to 3.11.6

### DIFF
--- a/lang-dart/dart-sdk/spec
+++ b/lang-dart/dart-sdk/spec
@@ -1,4 +1,4 @@
-VER=3.11.3
+VER=3.11.6
 ### Note: Pinned commit for depot_tools since it does not have release tags
 SRCS="git::rename=sdk;commit=tags/$VER;copy-repo=true::https://github.com/dart-lang/sdk.git \
       git::rename=sdk/depot_tools;commit=679386aca8b1aa9037f21d1a590e3424cd4bde5d::https://chromium.googlesource.com/chromium/tools/depot_tools.git"


### PR DESCRIPTION
Topic Description
-----------------

- dart-sdk: update to 3.11.6
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- dart-sdk: 3.11.6
- dartaotruntime: 3.11.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit dart-sdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
