### PR TITLE
matugen: update to 4.1.0

### DIFF
--- a/app-utils/matugen/spec
+++ b/app-utils/matugen/spec
@@ -1,5 +1,4 @@
-VER=3.1.0
-REL=1
+VER=4.1.0
 SRCS="git::commit=tags/v$VER::https://github.com/InioX/matugen"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=340788"


### PR DESCRIPTION
Topic Description
-----------------

- matugen: update to 4.1.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- matugen: 4.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit matugen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
