### PR TITLE
zxing-cpp: update to 3.0.2

### DIFF
--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,6 @@
 VER=26.2.4.1
-SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://git.libreoffice.org/core"
+REL=1
+SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://github.com/LibreOffice/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"
 ENVREQ="total_mem=60 total_mem_per_core=2"

--- a/app-utils/zxing-cpp/autobuild/build
+++ b/app-utils/zxing-cpp/autobuild/build
@@ -1,10 +1,11 @@
-abinfo "Building and zxing-cpp ..."
-export CMAKE_AFTER=""
+abinfo "Building zxing-cpp ..."
 build_cmakeninja_configure
 build_cmakeninja_build
+
+abinfo "Installing zxing-cpp ..."
 build_cmakeninja_install
 
-abinfo "Building python package"
+abinfo "Building python package ..."
 python3 \
 	-m build \
 	--no-isolation \

--- a/app-utils/zxing-cpp/autobuild/defines
+++ b/app-utils/zxing-cpp/autobuild/defines
@@ -4,8 +4,14 @@ PKGDEP="gcc-runtime python-3"
 PKGDES="Command-line tool and library for decoding QRCode"
 BUILDDEP="setuptools-python3 pybind11"
 
-PKGBREAK="python-zxing-cpp<=2.3.0-1"
+PKGBREAK="python-zxing-cpp<=2.3.0-1 gstreamer<=1.28.1-6 libreoffice<=26.2.4.1 \
+          kitinerary<=23.08.5-8 prison5<=5.115.0-2"
 PKGREP="python-zxing-cpp<=2.3.0-1"
 
 ABTYPE=self
 PKGEPOCH=1
+
+# Note: Enable both the new and old Writer APIs for compatibility.
+CMAKE_AFTER=(
+    "-DZXING_WRITERS=BOTH"
+)

--- a/app-utils/zxing-cpp/autobuild/patches/0001-Skip-broken-build-requirements-check-for-python-wrap.patch
+++ b/app-utils/zxing-cpp/autobuild/patches/0001-Skip-broken-build-requirements-check-for-python-wrap.patch
@@ -1,26 +1,25 @@
-From 8f843c65acc771b172920fe16c5245d5b7cf340d Mon Sep 17 00:00:00 2001
+From 87a85a0ffa1a0cfd6ee9ab1e6b310e083f6b234f Mon Sep 17 00:00:00 2001
 From: MutsukiC <mutsuki@aosc.io>
-Date: Thu, 23 Apr 2026 09:28:14 +0800
+Date: Sat, 9 May 2026 13:45:59 +0800
 Subject: [PATCH] Skip broken build requirements check for python wrapper
 
 ---
- wrappers/python/pyproject.toml | 3 ---
- 1 file changed, 3 deletions(-)
+ wrappers/python/pyproject.toml | 2 --
+ 1 file changed, 2 deletions(-)
 
 diff --git a/wrappers/python/pyproject.toml b/wrappers/python/pyproject.toml
-index 16484fe3..f6c16894 100644
+index 7c3aa927..866f6d10 100644
 --- a/wrappers/python/pyproject.toml
 +++ b/wrappers/python/pyproject.toml
-@@ -1,9 +1,6 @@
- [build-system]
- requires = [
-     "setuptools>=42",
--    "setuptools_scm",
+@@ -3,8 +3,6 @@ requires = [
+     "setuptools>=77",
+ #    "setuptools-scm>=8",
      "wheel",
--    "cmake>=3.15",
+-    "cmake>=3.18",
 -    "pybind11[global]",
  ]
  build-backend = "setuptools.build_meta"
+ 
 -- 
 2.52.0
 

--- a/app-utils/zxing-cpp/spec
+++ b/app-utils/zxing-cpp/spec
@@ -1,5 +1,4 @@
-VER=2.3.0
-SRCS="git::commit=tags/v$VER::https://github.com/nu-book/zxing-cpp"
+VER=3.0.2
+SRCS="git::commit=tags/v$VER::https://github.com/zxing-cpp/zxing-cpp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=101246"
-REL=2

--- a/desktop-kde/kitinerary/autobuild/patches/0001-Compile-with-newer-poppler.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0001-Compile-with-newer-poppler.patch
@@ -1,7 +1,7 @@
-From ccb01a841fff3f88852fa151e99fe6f41ebf8fbb Mon Sep 17 00:00:00 2001
+From 8c93caf14054bc8a361bd368456993d2cd23e72e Mon Sep 17 00:00:00 2001
 From: Albert Astals Cid <aacid@kde.org>
 Date: Sun, 21 Apr 2024 11:14:42 +0200
-Subject: [PATCH 1/3] Compile with newer poppler
+Subject: [PATCH 1/5] Compile with newer poppler
 
 And remove ancient poppler ifdefs
 ---
@@ -270,5 +270,5 @@ index 79e5233b..78c05af6 100644
              qpp.moveTo(subpath->getX(0), subpath->getY(0));
              for (auto j = 1;j < subpath->getNumPoints();) {
 -- 
-2.48.1
+2.52.0
 

--- a/desktop-kde/kitinerary/autobuild/patches/0002-Fix-compilation-against-Poppler-25.01.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0002-Fix-compilation-against-Poppler-25.01.patch
@@ -1,7 +1,7 @@
-From f14c0e630ae0af777aa3fd5fed0746c3d811b9d3 Mon Sep 17 00:00:00 2001
+From 8d83f1ce4136068c2a83a2566411d745dc8ab8b4 Mon Sep 17 00:00:00 2001
 From: Volker Krause <vkrause@kde.org>
 Date: Sat, 21 Dec 2024 16:44:37 +0100
-Subject: [PATCH 2/3] Fix compilation against Poppler 25.01
+Subject: [PATCH 2/5] Fix compilation against Poppler 25.01
 
 ---
  src/lib/pdf/pdfdocument.cpp | 12 +++++++++++-
@@ -42,5 +42,5 @@ index 98e0758d..64c840f9 100644
  
  int PdfPage::imageCount() const
 -- 
-2.48.1
+2.52.0
 

--- a/desktop-kde/kitinerary/autobuild/patches/0003-Adapt-to-Poppler-25.02-API-changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0003-Adapt-to-Poppler-25.02-API-changes.patch
@@ -1,7 +1,7 @@
-From f31d0940c5b7deec57b78993cb5ade25bb6f2445 Mon Sep 17 00:00:00 2001
+From 96003bf4efb7e3b134a9dadbf42e34a844b49775 Mon Sep 17 00:00:00 2001
 From: Volker Krause <vkrause@kde.org>
 Date: Tue, 21 Jan 2025 18:57:10 +0100
-Subject: [PATCH 3/3] Adapt to Poppler 25.02 API changes
+Subject: [PATCH 3/5] Adapt to Poppler 25.02 API changes
 
 ---
  src/lib/pdf/pdfdocument.cpp | 5 +++++
@@ -27,5 +27,5 @@ index 64c840f9..20f77095 100644
  
      return QString::fromUtf8(s->c_str());
 -- 
-2.48.1
+2.52.0
 

--- a/desktop-kde/kitinerary/autobuild/patches/0004-Adapt-ZXing-3.0-API-Changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0004-Adapt-ZXing-3.0-API-Changes.patch
@@ -1,0 +1,90 @@
+From 1e9a2e1fc0f37b1f549f21636ca40bc0ec3b72f5 Mon Sep 17 00:00:00 2001
+From: MutsukiC <mutsuki@aosc.io>
+Date: Sat, 16 May 2026 13:06:04 +0800
+Subject: [PATCH 4/5] Adapt ZXing 3.0 API Changes
+
+Backported these upstream changes:
+- Port away from deprecated ZXing API
+- Adapt to ZXing 3.0 BarcodeFormats API change
+---
+ src/lib/barcodedecoder.cpp | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/src/lib/barcodedecoder.cpp b/src/lib/barcodedecoder.cpp
+index 2892665b..ac2058d3 100644
+--- a/src/lib/barcodedecoder.cpp
++++ b/src/lib/barcodedecoder.cpp
+@@ -152,9 +152,9 @@ struct {
+ #endif
+ };
+ 
+-static auto typeToFormats(BarcodeDecoder::BarcodeTypes types)
++static ZXing::BarcodeFormats typeToFormats(BarcodeDecoder::BarcodeTypes types)
+ {
+-#if ZXING_VERSION >= QT_VERSION_CHECK(1, 1, 0)
++#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+     ZXing::BarcodeFormats formats;
+ #else
+     std::vector<ZXing::BarcodeFormat> formats;
+@@ -162,7 +162,7 @@ static auto typeToFormats(BarcodeDecoder::BarcodeTypes types)
+ 
+     for (auto i : zxing_format_map) {
+         if (types & i.type) {
+-#if ZXING_VERSION >= QT_VERSION_CHECK(1, 1, 0)
++#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+             formats |= i.zxingType;
+ #else
+             formats.push_back(i.zxingType);
+@@ -189,7 +189,11 @@ static ZXing::ImageFormat zxingImageFormat(QImage::Format format)
+         case QImage::Format_ARGB32:
+         case QImage::Format_RGB32:
+ #if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
+-            return ZXing::ImageFormat::BGRX;
++#if ZXING_VERSION >= QT_VERSION_CHECK(2, 3, 0)
++            return ZXing::ImageFormat::RGBA;
++#else
++            return ZXing::ImageFormat::RGBX;
++#endif
+ #else
+             return ZXing::ImageFormat::XRGB;
+ #endif
+@@ -197,7 +201,11 @@ static ZXing::ImageFormat zxingImageFormat(QImage::Format format)
+             return ZXing::ImageFormat::RGB;
+         case QImage::Format_RGBX8888:
+         case QImage::Format_RGBA8888:
++#if ZXING_VERSION >= QT_VERSION_CHECK(2, 3, 0)
++            return ZXing::ImageFormat::RGBA;
++#else
+             return ZXing::ImageFormat::RGBX;
++#endif
+         case QImage::Format_Grayscale8:
+             return ZXing::ImageFormat::Lum;
+         default:
+@@ -205,8 +213,11 @@ static ZXing::ImageFormat zxingImageFormat(QImage::Format format)
+     }
+     Q_UNREACHABLE();
+ }
+-
++#if ZXING_VERSION >= QT_VERSION_CHECK(3, 0, 0)
++static ZXing::Barcode zxingReadBarcode(const QImage &img, const ZXing::ReaderOptions &hints)
++#else
+ static ZXing::Result zxingReadBarcode(const QImage &img, const ZXing::DecodeHints &hints)
++#endif
+ {
+     return ZXing::ReadBarcode({img.bits(), img.width(), img.height(), zxingImageFormat(img.format()), static_cast<int>(img.bytesPerLine())}, hints);
+ }
+@@ -214,7 +225,11 @@ static ZXing::Result zxingReadBarcode(const QImage &img, const ZXing::DecodeHint
+ 
+ void BarcodeDecoder::decodeZxing(const QImage &img, BarcodeDecoder::BarcodeTypes format, BarcodeDecoder::Result &result) const
+ {
++#if ZXING_VERSION >= QT_VERSION_CHECK(3, 0, 0)
++    ZXing::ReaderOptions hints;
++#else
+     ZXing::DecodeHints hints;
++#endif
+ #if ZXING_VERSION >= QT_VERSION_CHECK(1, 1, 0)
+     hints.setFormats(typeToFormats(format));
+ #else
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0005-Namespace-ZXING_-macros.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0005-Namespace-ZXING_-macros.patch
@@ -1,0 +1,220 @@
+From d3ee6e4630f0f7d76099cb1c12a339074d3f2992 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Sat, 16 May 2026 13:10:58 +0800
+Subject: [PATCH 5/5] Namespace ZXING_* macros
+
+Avoids clashing with those from ZXing itself, especially when we have to
+modify them like for the detection of the upcoming ZXing 3.0.
+---
+ src/lib/barcodedecoder.cpp        | 24 ++++++++++++------------
+ src/lib/config-kitinerary.h.cmake | 16 ++++++++--------
+ src/lib/extractorcapabilities.cpp |  2 +-
+ src/lib/qimagepurebinarizer.cpp   |  4 ++--
+ src/lib/qimagepurebinarizer_p.h   |  6 +++---
+ 5 files changed, 26 insertions(+), 26 deletions(-)
+
+diff --git a/src/lib/barcodedecoder.cpp b/src/lib/barcodedecoder.cpp
+index ac2058d3..a49d7034 100644
+--- a/src/lib/barcodedecoder.cpp
++++ b/src/lib/barcodedecoder.cpp
+@@ -15,7 +15,7 @@
+ #include <QString>
+ 
+ #define ZX_USE_UTF8 1
+-#if ZXING_USE_READBARCODE
++#if KZXING_USE_READBARCODE
+ #include <ZXing/ReadBarcode.h>
+ #else
+ #include <ZXing/DecodeHints.h>
+@@ -133,7 +133,7 @@ struct {
+     BarcodeDecoder::BarcodeType type;
+     ZXing::BarcodeFormat zxingType;
+ } static constexpr const zxing_format_map[] = {
+-#if ZXING_VERSION > QT_VERSION_CHECK(1, 1, 1)
++#if KZXING_VERSION > QT_VERSION_CHECK(1, 1, 1)
+     { BarcodeDecoder::Aztec, ZXing::BarcodeFormat::Aztec },
+     { BarcodeDecoder::QRCode, ZXing::BarcodeFormat::QRCode },
+     { BarcodeDecoder::PDF417, ZXing::BarcodeFormat::PDF417 },
+@@ -154,7 +154,7 @@ struct {
+ 
+ static ZXing::BarcodeFormats typeToFormats(BarcodeDecoder::BarcodeTypes types)
+ {
+-#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+     ZXing::BarcodeFormats formats;
+ #else
+     std::vector<ZXing::BarcodeFormat> formats;
+@@ -162,7 +162,7 @@ static ZXing::BarcodeFormats typeToFormats(BarcodeDecoder::BarcodeTypes types)
+ 
+     for (auto i : zxing_format_map) {
+         if (types & i.type) {
+-#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+             formats |= i.zxingType;
+ #else
+             formats.push_back(i.zxingType);
+@@ -182,14 +182,14 @@ BarcodeDecoder::BarcodeType formatToType(ZXing::BarcodeFormat format)
+     return BarcodeDecoder::None;
+ }
+ 
+-#if ZXING_USE_READBARCODE
++#if KZXING_USE_READBARCODE
+ static ZXing::ImageFormat zxingImageFormat(QImage::Format format)
+ {
+     switch (format) {
+         case QImage::Format_ARGB32:
+         case QImage::Format_RGB32:
+ #if Q_BYTE_ORDER == Q_LITTLE_ENDIAN
+-#if ZXING_VERSION >= QT_VERSION_CHECK(2, 3, 0)
++#if KZXING_VERSION >= QT_VERSION_CHECK(2, 3, 0)
+             return ZXing::ImageFormat::RGBA;
+ #else
+             return ZXing::ImageFormat::RGBX;
+@@ -201,7 +201,7 @@ static ZXing::ImageFormat zxingImageFormat(QImage::Format format)
+             return ZXing::ImageFormat::RGB;
+         case QImage::Format_RGBX8888:
+         case QImage::Format_RGBA8888:
+-#if ZXING_VERSION >= QT_VERSION_CHECK(2, 3, 0)
++#if KZXING_VERSION >= QT_VERSION_CHECK(2, 3, 0)
+             return ZXing::ImageFormat::RGBA;
+ #else
+             return ZXing::ImageFormat::RGBX;
+@@ -213,7 +213,7 @@ static ZXing::ImageFormat zxingImageFormat(QImage::Format format)
+     }
+     Q_UNREACHABLE();
+ }
+-#if ZXING_VERSION >= QT_VERSION_CHECK(3, 0, 0)
++#if KZXING_VERSION >= QT_VERSION_CHECK(3, 0, 0)
+ static ZXing::Barcode zxingReadBarcode(const QImage &img, const ZXing::ReaderOptions &hints)
+ #else
+ static ZXing::Result zxingReadBarcode(const QImage &img, const ZXing::DecodeHints &hints)
+@@ -225,18 +225,18 @@ static ZXing::Result zxingReadBarcode(const QImage &img, const ZXing::DecodeHint
+ 
+ void BarcodeDecoder::decodeZxing(const QImage &img, BarcodeDecoder::BarcodeTypes format, BarcodeDecoder::Result &result) const
+ {
+-#if ZXING_VERSION >= QT_VERSION_CHECK(3, 0, 0)
++#if KZXING_VERSION >= QT_VERSION_CHECK(3, 0, 0)
+     ZXing::ReaderOptions hints;
+ #else
+     ZXing::DecodeHints hints;
+ #endif
+-#if ZXING_VERSION >= QT_VERSION_CHECK(1, 1, 0)
++#if KZXING_VERSION >= QT_VERSION_CHECK(1, 1, 0)
+     hints.setFormats(typeToFormats(format));
+ #else
+     hints.setPossibleFormats(typeToFormats(format));
+ #endif
+ 
+-#if ZXING_USE_READBARCODE
++#if KZXING_USE_READBARCODE
+     hints.setBinarizer(ZXing::Binarizer::FixedThreshold);
+     hints.setIsPure((format & BarcodeDecoder::IgnoreAspectRatio) == 0);
+ 
+@@ -250,7 +250,7 @@ void BarcodeDecoder::decodeZxing(const QImage &img, BarcodeDecoder::BarcodeTypes
+ #endif
+ 
+     if (res.isValid()) {
+-#if ZXING_VERSION >= QT_VERSION_CHECK(1, 4, 0)
++#if KZXING_VERSION >= QT_VERSION_CHECK(1, 4, 0)
+         // detect content type
+         std::string zxUtf8Text;
+         if (res.contentType() == ZXing::ContentType::Text) {
+diff --git a/src/lib/config-kitinerary.h.cmake b/src/lib/config-kitinerary.h.cmake
+index 0a7a621d..dd709902 100644
+--- a/src/lib/config-kitinerary.h.cmake
++++ b/src/lib/config-kitinerary.h.cmake
+@@ -14,20 +14,20 @@
+ #define KPOPPLER_VERSION_PATCH @POPPLER_VERSION_PATCH@
+ #define KPOPPLER_VERSION ((@POPPLER_VERSION_MAJOR@<<16)|(@POPPLER_VERSION_MINOR@<<8)|(@POPPLER_VERSION_PATCH@))
+ 
+-#define ZXING_VERSION_STRING "@ZXing_VERSION@"
+-#define ZXING_VERSION_MAJOR @ZXing_VERSION_MAJOR@
+-#define ZXING_VERSION_MINOR @ZXing_VERSION_MINOR@
+-#define ZXING_VERSION_PATCH @ZXing_VERSION_PATCH@
+-#define ZXING_VERSION ((@ZXing_VERSION_MAJOR@<<16)|(@ZXing_VERSION_MINOR@<<8)|(@ZXing_VERSION_PATCH@))
++#define KZXING_VERSION_STRING "@ZXing_VERSION@"
++#define KZXING_VERSION_MAJOR @ZXing_VERSION_MAJOR@
++#define KZXING_VERSION_MINOR @ZXing_VERSION_MINOR@
++#define KZXING_VERSION_PATCH @ZXing_VERSION_PATCH@
++#define KZXING_VERSION ((@ZXing_VERSION_MAJOR@<<16)|(@ZXing_VERSION_MINOR@<<8)|(@ZXing_VERSION_PATCH@))
+ 
+ // QT_VERSION_CHECK isn't available in here for the below check
+ #define K_VERSION_CHECK(major, minor, patch) ((major<<16)|(minor<<8)|(patch))
+ 
+ // this might compile with older versions too, but it only actually works post 1.1.1
+-#if ZXING_VERSION > K_VERSION_CHECK(1, 1, 1)
+-    #define ZXING_USE_READBARCODE 1
++#if KZXING_VERSION > K_VERSION_CHECK(1, 1, 1)
++    #define KZXING_USE_READBARCODE 1
+ #else
+-    #define ZXING_USE_READBARCODE 0
++    #define KZXING_USE_READBARCODE 0
+ #endif
+ 
+ #cmakedefine01 HAVE_LIBXML2
+diff --git a/src/lib/extractorcapabilities.cpp b/src/lib/extractorcapabilities.cpp
+index 845c925c..867cd846 100644
+--- a/src/lib/extractorcapabilities.cpp
++++ b/src/lib/extractorcapabilities.cpp
+@@ -35,7 +35,7 @@ QString ExtractorCapabilities::capabilitiesString()
+ 
+         "iCal support        : kcal (" KCALENDARCORE_VERSION_STRING ")\n"
+ 
+-        "Barcode decoder     : ZXing (" ZXING_VERSION_STRING ")\n"
++        "Barcode decoder     : ZXing (" KZXING_VERSION_STRING ")\n"
+ 
+         "Phone number decoder: "
+ #if HAVE_PHONENUMBER
+diff --git a/src/lib/qimagepurebinarizer.cpp b/src/lib/qimagepurebinarizer.cpp
+index a5863009..a632a8af 100644
+--- a/src/lib/qimagepurebinarizer.cpp
++++ b/src/lib/qimagepurebinarizer.cpp
+@@ -5,7 +5,7 @@
+ */
+ 
+ #include "qimagepurebinarizer_p.h"
+-#if !ZXING_USE_READBARCODE
++#if !KZXING_USE_READBARCODE
+ 
+ #include <ZXing/BitArray.h>
+ 
+@@ -59,7 +59,7 @@ bool QImagePureBinarizer::getBlackRow(int y, ZXing::BitArray &row) const
+     return true;
+ }
+ 
+-#if ZXING_VERSION >= QT_VERSION_CHECK(1, 1, 1)
++#if KZXING_VERSION >= QT_VERSION_CHECK(1, 1, 1)
+ bool QImagePureBinarizer::getPatternRow(int y, ZXing::PatternRow& res) const
+ {
+     res.clear();
+diff --git a/src/lib/qimagepurebinarizer_p.h b/src/lib/qimagepurebinarizer_p.h
+index 255a9c1c..7cead76c 100644
+--- a/src/lib/qimagepurebinarizer_p.h
++++ b/src/lib/qimagepurebinarizer_p.h
+@@ -7,7 +7,7 @@
+ #pragma once
+ 
+ #include "config-kitinerary.h"
+-#if !ZXING_USE_READBARCODE
++#if !KZXING_USE_READBARCODE
+ 
+ #include <QImage>
+ 
+@@ -31,12 +31,12 @@ public:
+     bool isPureBarcode() const override;
+ 
+     bool getBlackRow(int y, ZXing::BitArray &row) const
+-#if ZXING_VERSION < QT_VERSION_CHECK(1, 1, 1)
++#if KZXING_VERSION < QT_VERSION_CHECK(1, 1, 1)
+     // no longer present in later versions of 1.1.1...
+     override
+ #endif
+     ;
+-#if ZXING_VERSION >= QT_VERSION_CHECK(1, 1, 1)
++#if KZXING_VERSION >= QT_VERSION_CHECK(1, 1, 1)
+     bool getPatternRow(int y, ZXing::PatternRow& res) const override;
+ #endif
+     std::shared_ptr<const ZXing::BitMatrix> getBlackMatrix() const override;
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=8
+REL=9
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-kde/prison5/autobuild/patches/0001-Actually-search-for-ZXing-3.patch
+++ b/desktop-kde/prison5/autobuild/patches/0001-Actually-search-for-ZXing-3.patch
@@ -1,0 +1,35 @@
+From de4b07119fc004121fae604a9cb323cde8b07fc0 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Tue, 3 Feb 2026 17:54:18 +0100
+Subject: [PATCH 1/3] Actually search for ZXing 3
+
+Now that the version number has been bumped upstream we need to explicitly
+allow for 3.0 as well.
+---
+ CMakeLists.txt | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b375dda..14f111f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -43,10 +43,12 @@ find_package(Dmtx)
+ set_package_properties(Dmtx PROPERTIES
+     PURPOSE "Required for generation of Data Matrix barcodes."
+     TYPE RECOMMENDED)
+-find_package(ZXing 2.0)
+-if (NOT TARGET ZXing::ZXing)
+-  find_package(ZXing 1.2.0)
+-endif()
++foreach(ver 3.0 2.0 1.2.0)
++    find_package(ZXing ${ver} CONFIG QUIET)
++    if (TARGET ZXing::ZXing)
++        break()
++    endif()
++endforeach()
+ set_package_properties(ZXing PROPERTIES
+     PURPOSE "Required for generation of PDF417 barcodes and for scanning of barcodes from live video feed."
+     TYPE RECOMMENDED)
+-- 
+2.52.0
+

--- a/desktop-kde/prison5/autobuild/patches/0002-Adapt-to-ZXing-3.0-API-change.patch
+++ b/desktop-kde/prison5/autobuild/patches/0002-Adapt-to-ZXing-3.0-API-change.patch
@@ -1,0 +1,87 @@
+From 55c152801e621e0c5e203c4d7c2b8491059c84df Mon Sep 17 00:00:00 2001
+From: MutsukiC <mutsuki@kmi.moe>
+Date: Sun, 17 May 2026 10:33:39 +0800
+Subject: [PATCH 2/3] Adapt to ZXing 3.0 API change
+
+Backport upstream changes
+---
+ src/scanner/format.cpp             |  9 +++++++++
+ src/scanner/videoscannerworker.cpp | 21 +++++++++++++++------
+ 2 files changed, 24 insertions(+), 6 deletions(-)
+
+diff --git a/src/scanner/format.cpp b/src/scanner/format.cpp
+index d1278f1..b7e8914 100644
+--- a/src/scanner/format.cpp
++++ b/src/scanner/format.cpp
+@@ -34,10 +34,19 @@ static constexpr const format_map_t format_map[] = {
+ 
+ ZXing::BarcodeFormats Format::toZXing(Format::BarcodeFormats formats)
+ {
++#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+     ZXing::BarcodeFormats f;
++#else
++    std::vector<ZXing::BarcodeFormat> f;
++#endif
++
+     for (auto m : format_map) {
+         if (m.format & formats) {
++#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+             f |= m.zxFormat;
++#else
++            f.push_back(m.zxFormat);
++#endif
+         }
+     }
+     return f;
+diff --git a/src/scanner/videoscannerworker.cpp b/src/scanner/videoscannerworker.cpp
+index 2b2537c..3fa3464 100644
+--- a/src/scanner/videoscannerworker.cpp
++++ b/src/scanner/videoscannerworker.cpp
+@@ -15,7 +15,6 @@
+ 
+ #define ZX_USE_UTF8 1
+ #include <ZXing/ReadBarcode.h>
+-#include <ZXing/TextUtfEncoding.h>
+ 
+ using namespace Prison;
+ 
+@@ -27,13 +26,23 @@ VideoScannerWorker::VideoScannerWorker(QObject *parent)
+ 
+ void VideoScannerWorker::slotScanFrame(VideoScannerFrame frame)
+ {
+-#if ZXING_VERSION < QT_VERSION_CHECK(1, 4, 0)
+-    ZXing::Result zxRes(ZXing::DecodeStatus::FormatError);
+-#else
++#if ZXING_VERSION < QT_VERSION_CHECK(2, 3, 0)
+     ZXing::Result zxRes;
++#else
++    ZXing::Barcode zxRes;
+ #endif
++#if ZXING_VERSION < QT_VERSION_CHECK(2, 3, 0)
+     ZXing::DecodeHints hints;
+-    hints.setFormats(frame.formats() == Format::NoFormat ? ZXing::BarcodeFormats::all() : Format::toZXing(frame.formats()));
++#else
++    ZXing::ReaderOptions hints;
++#endif
++    if (frame.formats() != Format::NoFormat) {
++    hints.setFormats(Format::toZXing(frame.formats()));
++#if KZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
++} else {
++    hints.setFormats(ZXing::BarcodeFormats::all());
++#endif
++    }
+ 
+     frame.map();
+ 
+@@ -124,7 +133,7 @@ void VideoScannerWorker::slotScanFrame(VideoScannerFrame frame)
+             return c < 0x20 && c != 0x0a && c != 0x0d;
+         });
+         if (hasWideChars || !hasControlChars) {
+-            res->content = QString::fromStdString(ZXing::TextUtfEncoding::ToUtf8(zxRes.text()));
++            res->content = QString::fromStdString(zxRes.text());
+         } else {
+             QByteArray b;
+             b.resize(zxRes.text().size());
+-- 
+2.52.0
+

--- a/desktop-kde/prison5/autobuild/patches/0003-Consistently-namespace-ZXing-version-defines.patch
+++ b/desktop-kde/prison5/autobuild/patches/0003-Consistently-namespace-ZXing-version-defines.patch
@@ -1,0 +1,92 @@
+From 592308130579176f485e1bcd8128666e19f12297 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Sun, 17 May 2026 10:38:57 +0800
+Subject: [PATCH 3/3] Consistently namespace ZXing version defines Avoids
+ clashing with the defines in newer ZXing versions.
+
+Also, simplify the format hint ifdefs a bit.
+---
+ src/scanner/config-prison-scanner.h.in | 8 ++++----
+ src/scanner/format.cpp                 | 5 +++--
+ src/scanner/videoscannerworker.cpp     | 6 +++---
+ 3 files changed, 10 insertions(+), 9 deletions(-)
+
+diff --git a/src/scanner/config-prison-scanner.h.in b/src/scanner/config-prison-scanner.h.in
+index fe3855e..447221e 100644
+--- a/src/scanner/config-prison-scanner.h.in
++++ b/src/scanner/config-prison-scanner.h.in
+@@ -6,9 +6,9 @@
+ #ifndef CONFIG_PRISON_SCANNER_H
+ #define CONFIG_PRISON_SCANNER_H
+ 
+-#define ZXING_VERSION_MAJOR @ZXing_VERSION_MAJOR@
+-#define ZXING_VERSION_MINOR @ZXing_VERSION_MINOR@
+-#define ZXING_VERSION_PATCH @ZXing_VERSION_PATCH@
+-#define ZXING_VERSION ((@ZXing_VERSION_MAJOR@<<16)|(@ZXing_VERSION_MINOR@<<8)|(@ZXing_VERSION_PATCH@))
++#define KZXING_VERSION_MAJOR @ZXing_VERSION_MAJOR@
++#define KZXING_VERSION_MINOR @ZXing_VERSION_MINOR@
++#define KZXING_VERSION_PATCH @ZXing_VERSION_PATCH@
++#define KZXING_VERSION ((@ZXing_VERSION_MAJOR@<<16)|(@ZXing_VERSION_MINOR@<<8)|(@ZXing_VERSION_PATCH@))
+ 
+ #endif // CONFIG_PRISON_SCANNER_H
+diff --git a/src/scanner/format.cpp b/src/scanner/format.cpp
+index b7e8914..8536a88 100644
+--- a/src/scanner/format.cpp
++++ b/src/scanner/format.cpp
+@@ -4,6 +4,7 @@
+ */
+ 
+ #include "format_p.h"
++#include "config-prison-scanner.h"
+ 
+ using namespace Prison;
+ 
+@@ -34,7 +35,7 @@ static constexpr const format_map_t format_map[] = {
+ 
+ ZXing::BarcodeFormats Format::toZXing(Format::BarcodeFormats formats)
+ {
+-#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+     ZXing::BarcodeFormats f;
+ #else
+     std::vector<ZXing::BarcodeFormat> f;
+@@ -42,7 +43,7 @@ ZXing::BarcodeFormats Format::toZXing(Format::BarcodeFormats formats)
+ 
+     for (auto m : format_map) {
+         if (m.format & formats) {
+-#if ZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(3, 0, 0)
+             f |= m.zxFormat;
+ #else
+             f.push_back(m.zxFormat);
+diff --git a/src/scanner/videoscannerworker.cpp b/src/scanner/videoscannerworker.cpp
+index 3fa3464..41b70ac 100644
+--- a/src/scanner/videoscannerworker.cpp
++++ b/src/scanner/videoscannerworker.cpp
+@@ -26,12 +26,12 @@ VideoScannerWorker::VideoScannerWorker(QObject *parent)
+ 
+ void VideoScannerWorker::slotScanFrame(VideoScannerFrame frame)
+ {
+-#if ZXING_VERSION < QT_VERSION_CHECK(2, 3, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(2, 3, 0)
+     ZXing::Result zxRes;
+ #else
+     ZXing::Barcode zxRes;
+ #endif
+-#if ZXING_VERSION < QT_VERSION_CHECK(2, 3, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(2, 3, 0)
+     ZXing::DecodeHints hints;
+ #else
+     ZXing::ReaderOptions hints;
+@@ -124,7 +124,7 @@ void VideoScannerWorker::slotScanFrame(VideoScannerFrame frame)
+     if (zxRes.isValid()) {
+         auto res = ScanResultPrivate::get(scanResult);
+ 
+-#if ZXING_VERSION < QT_VERSION_CHECK(1, 4, 0)
++#if KZXING_VERSION < QT_VERSION_CHECK(1, 4, 0)
+         // distinguish between binary and text content
+         const auto hasWideChars = std::any_of(zxRes.text().begin(), zxRes.text().end(), [](auto c) {
+             return c > 255;
+-- 
+2.52.0
+

--- a/desktop-kde/prison5/spec
+++ b/desktop-kde/prison5/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=2
+REL=3
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/prison-$VER.tar.xz"
 CHKSUMS="sha256::8964fc90ba2b3643d62cee9d01c46f4824670ed8c1bcd12ac3b129cebe4273de"
 CHKUPDATE="anitya::id=8762"

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.28.1
-REL=6
+REL=7
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- kitinerary: bump REL due to zxing-cpp update
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- prison5: bump REL due to zxing-cpp update
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- libreoffice: bump REL due to zxing-cpp update
    - Use GitHub mirror as SRCS due to massive git traffic
    without remote filter=blob:none support
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- gstreamer: bump REL due to zxing-cpp update
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- zxing-cpp: update to 3.0.2
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- gstreamer: 1.28.1-4
- kitinerary: 23.08.5-9
- libreoffice: 26.2.0.3-3
- prison5: 1:5.115.0-3
- zxing-cpp: 1:3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit zxing-cpp:-pkgbreak gstreamer prison5 kitinerary libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
