### PR TITLE
vscode: update to 1.119.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.118.1
+VER=1.119.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::ace6f418c2b034a33629784fb75b74c4dfe9a7edf84eba3b88540f74595c65a1"
-CHKSUMS__ARM64="sha256::03a08f166a604ef6783fb96ecc8495a6bb236232dd2fb87c2d7555ee7f7901e4"
+CHKSUMS__AMD64="sha256::39be7a2c3f95bd933a8c804d12aa22a8053328b7cd04384e6af40e971c38e18b"
+CHKSUMS__ARM64="sha256::cd9a8885090484aa02bcb0cb4ce65b59bd5414aeaa8d3398fb3b66c958939f8b"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.119.0
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- vscode: 1.119.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
