### PR TITLE
oma: update to 1.26.0

### DIFF
--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.25.2
+VER=1.26.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.26.0.toml
+++ b/topics/oma-1.26.0.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.26"
+zh_CN = "小熊猫包管理 (oma) 1.26"
+
+[caution]
+default = "Improves HTTP download performance and compatibility, and introduces automatic cleaning after system updates and package installation"
+zh_CN = "改善 HTTP 下载性能和兼容性并引入了软件包更新和安装后的自动清理功能"
+
+[packages-v2]
+"oma" = "< 1.26.0"


### PR DESCRIPTION
Topic Description
-----------------

- oma: update to 1.26.0

Package(s) Affected
-------------------

- oma: 1.26.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`



