### PR TITLE
uriparser: security update to 1.0.2

### DIFF
--- a/runtime-web/uriparser/spec
+++ b/runtime-web/uriparser/spec
@@ -1,4 +1,4 @@
-VER=1.0.1
+VER=1.0.2
 SRCS="git::commit=tags/uriparser-$VER::https://github.com/uriparser/uriparser"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10160"

--- a/topics/uriparser-1.0.2.toml
+++ b/topics/uriparser-1.0.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "uriparser 1.0.2"
+
+[caution]
+default = "Fixes a numeric truncation vulnerability (CVE-2026-44927, Severity: Low) and a Always-Incorrect Control Flow Implementation vulnerability (CVE-2026-44928, Severity: Low)"
+zh_CN = "修复一个数值截断漏洞（CVE-2026-44927，严重性：低）和一个控制流实现错误漏洞（CVE-2026-44928，严重性：低）"
+
+[packages-v2]
+"uriparser" = "< 1.0.2"


### PR DESCRIPTION
Topic Description
-----------------

- uriparser: security update to 1.0.2

Package(s) Affected
-------------------

- uriparser: 1.0.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit uriparser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
