### PR TITLE
codex: update to 0.130.0

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From aa27219b956994fef02aee14b06bcf54a330505b Mon Sep 17 00:00:00 2001
+From 55240ec15d26fc0b6196e16c480cb0ca63dd9590 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 31 Mar 2026 15:36:13 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
@@ -9,10 +9,10 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 2bd379252a..9812a58ed9 100644
+index 10b5cc2351..9a75aa6f9e 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -13341,8 +13341,6 @@ dependencies = [
+@@ -13603,8 +13603,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "146.4.0"
@@ -22,10 +22,10 @@ index 2bd379252a..9812a58ed9 100644
   "bindgen",
   "bitflags 2.10.0",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index ba7b113183..10b6731f50 100644
+index c1258e83a1..133a6b4743 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -481,5 +481,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -516,5 +516,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
@@ -1,15 +1,15 @@
-From afdb3b50a0203e5129f3e1d416461a0a2939f79e Mon Sep 17 00:00:00 2001
+From 1bd4f0450b43560fb9ea15cec50a6a6ba4e75a6c Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Wed, 29 Apr 2026 20:02:25 +0800
+Date: Mon, 11 May 2026 14:42:19 +0800
 Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
 
 https://github.com/openai/codex/issues/14065
 ---
- codex-rs/Cargo.lock | 204 ++++++++++++++++++++++----------------------
- 1 file changed, 102 insertions(+), 102 deletions(-)
+ codex-rs/Cargo.lock | 228 ++++++++++++++++++++++----------------------
+ 1 file changed, 114 insertions(+), 114 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 9812a58ed9..dfbdd4f844 100644
+index 9a75aa6f9e..7902126c3a 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -402,7 +402,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
@@ -17,696 +17,804 @@ index 9812a58ed9..dfbdd4f844 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1750,7 +1750,7 @@ dependencies = [
+@@ -1778,7 +1778,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-agent-graph-store"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "async-trait",
+  "codex-protocol",
+@@ -1793,7 +1793,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-identity"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1768,7 +1768,7 @@ dependencies = [
+@@ -1812,7 +1812,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1788,7 +1788,7 @@ dependencies = [
+@@ -1832,7 +1832,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1797,7 +1797,7 @@ dependencies = [
+@@ -1841,7 +1841,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1831,7 +1831,7 @@ dependencies = [
+@@ -1875,7 +1875,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -1912,7 +1912,7 @@ dependencies = [
+@@ -1956,7 +1956,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -1936,7 +1936,7 @@ dependencies = [
+@@ -1981,7 +1981,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1963,7 +1963,7 @@ dependencies = [
+@@ -2008,7 +2008,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -1984,7 +1984,7 @@ dependencies = [
+@@ -2029,7 +2029,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-app-server-transport"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "axum",
+@@ -2068,7 +2068,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2003,7 +2003,7 @@ dependencies = [
+@@ -2087,7 +2087,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -2020,7 +2020,7 @@ dependencies = [
+@@ -2104,7 +2104,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-trait",
   "pretty_assertions",
-@@ -2030,7 +2030,7 @@ dependencies = [
+@@ -2114,7 +2114,7 @@ dependencies = [
  
  [[package]]
  name = "codex-aws-auth"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "aws-config",
   "aws-credential-types",
-@@ -2045,7 +2045,7 @@ dependencies = [
+@@ -2129,7 +2129,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -2062,7 +2062,7 @@ dependencies = [
+@@ -2146,7 +2146,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "serde",
   "serde_json",
-@@ -2071,7 +2071,7 @@ dependencies = [
+@@ -2155,7 +2155,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-builtin-mcps"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "codex-memories-mcp",
+@@ -2166,7 +2166,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-bwrap"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "cc",
+  "libc",
+@@ -2175,7 +2175,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2092,7 +2092,7 @@ dependencies = [
+@@ -2198,7 +2198,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2150,7 +2150,7 @@ dependencies = [
+@@ -2255,7 +2255,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-trait",
   "bytes",
-@@ -2180,7 +2180,7 @@ dependencies = [
+@@ -2286,7 +2286,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-requirements"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-trait",
   "base64 0.22.1",
-@@ -2205,7 +2205,7 @@ dependencies = [
+@@ -2311,7 +2311,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2237,7 +2237,7 @@ dependencies = [
+@@ -2343,7 +2343,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2252,7 +2252,7 @@ dependencies = [
+@@ -2358,7 +2358,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-trait",
   "chrono",
-@@ -2262,7 +2262,7 @@ dependencies = [
+@@ -2368,7 +2368,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-channel",
   "async-trait",
-@@ -2279,11 +2279,11 @@ dependencies = [
+@@ -2385,11 +2385,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2323,7 +2323,7 @@ dependencies = [
+@@ -2435,7 +2435,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2335,7 +2335,7 @@ dependencies = [
+@@ -2447,7 +2447,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2457,7 +2457,7 @@ dependencies = [
+@@ -2567,7 +2567,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-core-api"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "codex-analytics",
+  "codex-app-server-protocol",
+@@ -2585,7 +2585,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-plugins"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2491,7 +2491,7 @@ dependencies = [
+@@ -2623,7 +2623,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-skills"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-analytics",
-@@ -2522,7 +2522,7 @@ dependencies = [
+@@ -2654,7 +2654,7 @@ dependencies = [
  
  [[package]]
  name = "codex-debug-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2534,7 +2534,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-device-key"
--version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "async-trait",
-  "base64 0.22.1",
-@@ -2550,7 +2550,7 @@ dependencies = [
+@@ -2666,7 +2666,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2594,7 +2594,7 @@ dependencies = [
+@@ -2711,7 +2711,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2628,7 +2628,7 @@ dependencies = [
+@@ -2748,7 +2748,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2645,7 +2645,7 @@ dependencies = [
+@@ -2765,7 +2765,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy-legacy"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "allocative",
   "anyhow",
-@@ -2665,7 +2665,7 @@ dependencies = [
+@@ -2785,7 +2785,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2674,7 +2674,7 @@ dependencies = [
+@@ -2794,7 +2794,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-external-agent-migration"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "codex-hooks",
+  "pretty_assertions",
+@@ -2806,7 +2806,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-external-agent-sessions"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "chrono",
+  "codex-app-server-protocol",
+@@ -2820,7 +2820,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -2687,7 +2687,7 @@ dependencies = [
+@@ -2833,7 +2833,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-login",
-@@ -2700,7 +2700,7 @@ dependencies = [
+@@ -2846,7 +2846,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2716,7 +2716,7 @@ dependencies = [
+@@ -2862,7 +2862,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-file-system"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "async-trait",
+  "codex-protocol",
+@@ -2872,7 +2872,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
-  "assert_matches",
-@@ -2741,7 +2741,7 @@ dependencies = [
+  "chrono",
+@@ -2896,7 +2896,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2760,7 +2760,7 @@ dependencies = [
+@@ -2919,7 +2919,7 @@ dependencies = [
  
  [[package]]
  name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-utils-home-dir",
   "pretty_assertions",
-@@ -2769,7 +2769,7 @@ dependencies = [
+@@ -2928,7 +2928,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "keyring",
   "tracing",
-@@ -2777,7 +2777,7 @@ dependencies = [
+@@ -2936,7 +2936,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
-  "cc",
   "clap",
-@@ -2801,7 +2801,7 @@ dependencies = [
+  "codex-core",
+@@ -2959,7 +2959,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -2815,7 +2815,7 @@ dependencies = [
+@@ -2973,7 +2973,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "anyhow",
-  "async-trait",
-@@ -2856,7 +2856,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-mcp"
--version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "anyhow",
-  "async-channel",
-@@ -2889,7 +2889,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-mcp-server"
--version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "anyhow",
-  "codex-arg0",
-@@ -2922,7 +2922,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-model-provider"
--version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "async-trait",
-  "codex-agent-identity",
-@@ -2946,7 +2946,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-model-provider-info"
--version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "codex-api",
-  "codex-app-server-protocol",
-@@ -2963,7 +2963,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-models-manager"
--version = "0.0.0"
-+version = "0.125.0"
- dependencies = [
-  "async-trait",
-  "chrono",
-@@ -2984,7 +2984,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-network-proxy"
--version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
 @@ -3015,7 +3015,7 @@ dependencies = [
  
  [[package]]
+ name = "codex-mcp"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "async-channel",
+@@ -3048,7 +3048,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-mcp-server"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "codex-arg0",
+@@ -3079,7 +3079,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-memories-mcp"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "codex-utils-absolute-path",
+@@ -3096,7 +3096,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-memories-read"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "codex-protocol",
+  "codex-shell-command",
+@@ -3110,7 +3110,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-memories-write"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "chrono",
+@@ -3145,7 +3145,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-message-history"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "codex-config",
+  "pretty_assertions",
+@@ -3158,7 +3158,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-model-provider"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "async-trait",
+  "codex-agent-identity",
+@@ -3182,7 +3182,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-model-provider-info"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "codex-api",
+  "codex-app-server-protocol",
+@@ -3199,7 +3199,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-models-manager"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "async-trait",
+  "chrono",
+@@ -3220,7 +3220,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-network-proxy"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "async-trait",
+@@ -3251,7 +3251,7 @@ dependencies = [
+ 
+ [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -3034,7 +3034,7 @@ dependencies = [
+@@ -3270,7 +3270,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -3066,7 +3066,7 @@ dependencies = [
+@@ -3302,7 +3302,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
+  "codex-config",
   "codex-utils-absolute-path",
-  "codex-utils-plugins",
-@@ -3075,7 +3075,7 @@ dependencies = [
+@@ -3312,7 +3312,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -3083,7 +3083,7 @@ dependencies = [
+@@ -3320,7 +3320,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -3123,7 +3123,7 @@ dependencies = [
+@@ -3361,7 +3361,7 @@ dependencies = [
  
  [[package]]
  name = "codex-realtime-webrtc"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "libwebrtc",
   "thiserror 2.0.18",
-@@ -3132,7 +3132,7 @@ dependencies = [
+@@ -3370,7 +3370,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3143,7 +3143,7 @@ dependencies = [
+@@ -3381,7 +3381,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3160,7 +3160,7 @@ dependencies = [
+@@ -3398,7 +3398,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -3197,7 +3197,7 @@ dependencies = [
+@@ -3435,7 +3435,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3222,7 +3222,7 @@ dependencies = [
+@@ -3460,7 +3460,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout-trace"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-code-mode",
-@@ -3237,7 +3237,7 @@ dependencies = [
+@@ -3475,7 +3475,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3258,7 +3258,7 @@ dependencies = [
+@@ -3496,7 +3496,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "age",
   "anyhow",
-@@ -3279,7 +3279,7 @@ dependencies = [
+@@ -3517,7 +3517,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3299,7 +3299,7 @@ dependencies = [
+@@ -3537,7 +3537,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3320,7 +3320,7 @@ dependencies = [
+@@ -3558,7 +3558,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-utils-absolute-path",
   "include_dir",
-@@ -3329,7 +3329,7 @@ dependencies = [
+@@ -3567,7 +3567,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3352,7 +3352,7 @@ dependencies = [
+@@ -3590,7 +3590,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-uds",
-@@ -3364,7 +3364,7 @@ dependencies = [
+@@ -3602,7 +3602,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -3372,7 +3372,7 @@ dependencies = [
+@@ -3610,7 +3610,7 @@ dependencies = [
  
  [[package]]
  name = "codex-test-binary-support"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-arg0",
   "tempfile",
-@@ -3380,7 +3380,7 @@ dependencies = [
+@@ -3618,7 +3618,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-thread-manager-sample"
+-version = "0.0.0"
++version = "0.130.0"
+ dependencies = [
+  "anyhow",
+  "clap",
+@@ -3629,7 +3629,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-store"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-trait",
   "chrono",
-@@ -3405,7 +3405,7 @@ dependencies = [
+@@ -3649,7 +3649,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-code-mode",
-@@ -3422,7 +3422,7 @@ dependencies = [
+@@ -3666,7 +3666,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "arboard",
-@@ -3527,7 +3527,7 @@ dependencies = [
+@@ -3773,7 +3773,7 @@ dependencies = [
  
  [[package]]
  name = "codex-uds"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "async-io",
   "pretty_assertions",
-@@ -3539,7 +3539,7 @@ dependencies = [
+@@ -3785,7 +3785,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "dirs",
   "dunce",
-@@ -3553,14 +3553,14 @@ dependencies = [
+@@ -3799,14 +3799,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-protocol",
  ]
@@ -714,125 +822,125 @@ index 9812a58ed9..dfbdd4f844 100644
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "lru 0.16.3",
   "sha1",
-@@ -3569,7 +3569,7 @@ dependencies = [
+@@ -3815,7 +3815,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -3578,7 +3578,7 @@ dependencies = [
+@@ -3824,7 +3824,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -3589,15 +3589,15 @@ dependencies = [
+@@ -3835,15 +3835,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dirs",
-@@ -3607,7 +3607,7 @@ dependencies = [
+@@ -3853,7 +3853,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -3619,7 +3619,7 @@ dependencies = [
+@@ -3865,7 +3865,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -3628,7 +3628,7 @@ dependencies = [
+@@ -3874,7 +3874,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -3638,7 +3638,7 @@ dependencies = [
+@@ -3884,7 +3884,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -3647,7 +3647,7 @@ dependencies = [
+@@ -3893,7 +3893,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -3657,7 +3657,7 @@ dependencies = [
+@@ -3903,7 +3903,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-exec-server",
   "codex-login",
-@@ -3670,7 +3670,7 @@ dependencies = [
+@@ -3916,7 +3916,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -3686,7 +3686,7 @@ dependencies = [
+@@ -3932,7 +3932,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "assert_matches",
   "async-trait",
-@@ -3697,14 +3697,14 @@ dependencies = [
+@@ -3943,14 +3943,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "rustls",
  ]
@@ -840,25 +948,25 @@ index 9812a58ed9..dfbdd4f844 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -3715,7 +3715,7 @@ dependencies = [
+@@ -3961,7 +3961,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -3725,14 +3725,14 @@ dependencies = [
+@@ -3971,14 +3971,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -866,16 +974,16 @@ index 9812a58ed9..dfbdd4f844 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -3740,14 +3740,14 @@ dependencies = [
+@@ -3988,14 +3988,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -883,34 +991,34 @@ index 9812a58ed9..dfbdd4f844 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -3755,7 +3755,7 @@ dependencies = [
+@@ -4003,7 +4003,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4005,7 +4005,7 @@ dependencies = [
+@@ -4254,7 +4254,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -8184,7 +8184,7 @@ dependencies = [
+@@ -8436,7 +8436,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.125.0"
++version = "0.130.0"
  dependencies = [
   "anyhow",
   "codex-login",

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.125.0
+VER=0.130.0
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=146.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.130.0

Package(s) Affected
-------------------

- codex: 0.130.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
