### PR TITLE
fcitx5-pinyin-moegirl: update to 20260511

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260412
+VER=20260511
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::62c759539e9d074a35a55ed2246d7f48c85284ca199a2489e778d2b1ba61f609 \
-         sha256::a88164683762bc4eed3909a4d13a4d07cc28bf989acde817ede263301fa515ed \
+CHKSUMS="sha256::1fd499464c19259f4b3038b27d75d99bccc2ab71370a36d208178f8dfd693dde \
+         sha256::aedaf0b8f36f87492ba1b4c33f7a13ac0b30623f402c26484eb7ee756e445df7 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260511

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260511
- rime-pinyin-moegirl: 20260511

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
