### PR TITLE
virtualenv: update to 21.3.1

### DIFF
--- a/lang-python/python-discovery/autobuild/defines
+++ b/lang-python/python-discovery/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=python-discovery
+PKGDES="Python library to discover installed Python interpreters"
+PKGSEC=python
+PKGDEP="python-3 py-filelock platformdirs"
+BUILDDEP="python-build python-installer wheel tomli hatch-vcs hatchling setuptools-scm"
+
+ABHOST=noarch
+ABTYPE=pep517
+NOPYTHON2="1"

--- a/lang-python/python-discovery/spec
+++ b/lang-python/python-discovery/spec
@@ -1,0 +1,4 @@
+VER=1.3.0
+SRCS="pypi::version=$VER::python-discovery"
+CHKSUMS="sha256::d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0"
+CHKUPDATE="anitya::id=388662"

--- a/lang-python/virtualenv/autobuild/defines
+++ b/lang-python/virtualenv/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=virtualenv
 PKGSEC=python
-PKGDEP="python-3 py-filelock distlib platformdirs"
+PKGDEP="python-3 py-filelock distlib platformdirs python-discovery"
 BUILDDEP="python-build python-installer wheel tomli hatch-vcs hatchling setuptools-scm"
 PKGDES="Tool to create isolated Python environments"
 

--- a/lang-python/virtualenv/spec
+++ b/lang-python/virtualenv/spec
@@ -1,4 +1,4 @@
-VER=21.0.0
+VER=21.3.1
 SRCS="pypi::version=$VER::virtualenv"
-CHKSUMS="sha256::e8efe4271b4a5efe7a4dce9d60a05fd11859406c0d6aa8464f4cf451bc132889"
+CHKSUMS="sha256::c2305bc1fddeec40699b8370d13f8d431b0701f00ce895061ce493aeded4426b"
 CHKUPDATE="anitya::id=6904"


### PR DESCRIPTION
Topic Description
-----------------

- virtualenv: update to 21.3.1
    - Added python-discovery dependency introduced in 21.0.0 version.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- python-discovery: new, 1.3.0
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- python-discovery: 1.3.0
- virtualenv: 21.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-discovery virtualenv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
