### PR TITLE
caddy: update to 2.11.3

### DIFF
--- a/app-web/caddy/spec
+++ b/app-web/caddy/spec
@@ -1,8 +1,7 @@
-VER=2.11.2
-REL=1
+VER=2.11.3
 SRCS="tbl::https://github.com/caddyserver/caddy/releases/download/v${VER}/caddy_${VER}_buildable-artifact.tar.gz \
       git::commit=tags/v$VER;rename=dist::https://github.com/caddyserver/dist.git"
-CHKSUMS="sha256::2fabd8281230e6ea3de2000acc0685e5e64e9310e458498e03612d874008070b \
+CHKSUMS="sha256::13e921d1a4db2740fe80df7c47a3dd9bf6cde7ea302684d836c6352706ce3f6a \
          SKIP"
 CHKUPDATE="anitya::id=15601"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- caddy: update to 2.11.3
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- caddy: 2.11.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit caddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
