### PR TITLE
COSMIC 1.0.13 Survey

### DIFF
--- a/desktop-cosmic/cosmic-app-library/spec
+++ b/desktop-cosmic/cosmic-app-library/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-applibrary.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377102"

--- a/desktop-cosmic/cosmic-applets/spec
+++ b/desktop-cosmic/cosmic-applets/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-applets.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377113"

--- a/desktop-cosmic/cosmic-bg/spec
+++ b/desktop-cosmic/cosmic-bg/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-bg.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377115"

--- a/desktop-cosmic/cosmic-comp/spec
+++ b/desktop-cosmic/cosmic-comp/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-comp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377116"

--- a/desktop-cosmic/cosmic-edit/spec
+++ b/desktop-cosmic/cosmic-edit/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-edit.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377117"

--- a/desktop-cosmic/cosmic-files/spec
+++ b/desktop-cosmic/cosmic-files/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-files.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377118"

--- a/desktop-cosmic/cosmic-greeter/spec
+++ b/desktop-cosmic/cosmic-greeter/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-greeter.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377119"

--- a/desktop-cosmic/cosmic-icons/spec
+++ b/desktop-cosmic/cosmic-icons/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER::https://github.com/pop-os/cosmic-icons.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377120"

--- a/desktop-cosmic/cosmic-idle/spec
+++ b/desktop-cosmic/cosmic-idle/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-idle.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377121"

--- a/desktop-cosmic/cosmic-initial-setup/spec
+++ b/desktop-cosmic/cosmic-initial-setup/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-initial-setup.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383659"

--- a/desktop-cosmic/cosmic-launcher/spec
+++ b/desktop-cosmic/cosmic-launcher/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-launcher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377122"

--- a/desktop-cosmic/cosmic-notifications/spec
+++ b/desktop-cosmic/cosmic-notifications/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-notifications.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377123"

--- a/desktop-cosmic/cosmic-osd/spec
+++ b/desktop-cosmic/cosmic-osd/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-osd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377124"

--- a/desktop-cosmic/cosmic-panel/spec
+++ b/desktop-cosmic/cosmic-panel/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-panel.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377125"

--- a/desktop-cosmic/cosmic-player/spec
+++ b/desktop-cosmic/cosmic-player/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-player.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377126"

--- a/desktop-cosmic/cosmic-randr/spec
+++ b/desktop-cosmic/cosmic-randr/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-randr.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377127"

--- a/desktop-cosmic/cosmic-screenshot/spec
+++ b/desktop-cosmic/cosmic-screenshot/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-screenshot.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377128"

--- a/desktop-cosmic/cosmic-session/spec
+++ b/desktop-cosmic/cosmic-session/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-session.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377129"

--- a/desktop-cosmic/cosmic-settings-daemon/spec
+++ b/desktop-cosmic/cosmic-settings-daemon/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-settings-daemon.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377131"

--- a/desktop-cosmic/cosmic-settings/spec
+++ b/desktop-cosmic/cosmic-settings/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-settings.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377130"

--- a/desktop-cosmic/cosmic-store/autobuild/defines
+++ b/desktop-cosmic/cosmic-store/autobuild/defines
@@ -6,3 +6,7 @@ PKGDES="App store for the COSMIC Desktop Environment"
 
 ABTYPE=rust
 USECLANG=1
+
+# FIXME: 
+# ld.lld: error: undefined symbol: aws_lc_0_40_0_EVP_parse_private_key
+NOLTO=1

--- a/desktop-cosmic/cosmic-store/spec
+++ b/desktop-cosmic/cosmic-store/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-store.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377132"

--- a/desktop-cosmic/cosmic-term/spec
+++ b/desktop-cosmic/cosmic-term/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-term.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377133"

--- a/desktop-cosmic/cosmic-wallpapers/spec
+++ b/desktop-cosmic/cosmic-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-wallpapers.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=382459"

--- a/desktop-cosmic/cosmic-workspaces/spec
+++ b/desktop-cosmic/cosmic-workspaces/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/cosmic-workspaces-epoch.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383658"

--- a/desktop-cosmic/pop-launcher/spec
+++ b/desktop-cosmic/pop-launcher/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/launcher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377135"

--- a/desktop-cosmic/xdg-desktop-portal-cosmic/spec
+++ b/desktop-cosmic/xdg-desktop-portal-cosmic/spec
@@ -1,4 +1,4 @@
-VER=1.0.8
+VER=1.0.13
 SRCS="git::commit=tags/epoch-$VER;copy-repo=true::https://github.com/pop-os/xdg-desktop-portal-cosmic.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377137"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal-cosmic: update to 1.0.13
- pop-launcher: update to 1.0.13
- cosmic-workspaces: update to 1.0.13
- cosmic-term: update to 1.0.13
- cosmic-wallpapers: update to 1.0.13
- cosmic-store: update to 1.0.13
- cosmic-settings-daemon: update to 1.0.13
- cosmic-settings: update to 1.0.13
- cosmic-session: update to 1.0.13
- cosmic-screenshot: update to 1.0.13

... and 16 more commits

Package(s) Affected
-------------------

- cosmic-app-library: 1.0.13
- cosmic-applets: 1.0.13
- cosmic-bg: 1.0.13
- cosmic-comp: 1.0.13
- cosmic-edit: 1.0.13
- cosmic-files: 1.0.13
- cosmic-greeter: 1.0.13
- cosmic-icons: 1.0.13
- cosmic-idle: 1.0.13
- cosmic-initial-setup: 1.0.13
- cosmic-launcher: 1.0.13
- cosmic-notifications: 1.0.13
- cosmic-osd: 1.0.13
- cosmic-panel: 1.0.13
- cosmic-player: 1.0.13
- cosmic-randr: 1.0.13
- cosmic-screenshot: 1.0.13
- cosmic-session: 1.0.13
- cosmic-settings: 1.0.13
- cosmic-settings-daemon: 1.0.13
- cosmic-store: 1.0.13
- cosmic-term: 1.0.13
- cosmic-wallpapers: 1.0.13
- cosmic-workspaces: 1.0.13
- pop-launcher: 1.0.13
- xdg-desktop-portal-cosmic: 1.0.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit groups/cosmic
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
