### PR TITLE
mosdns: update to 5.3.4

### DIFF
--- a/app-network/mosdns/spec
+++ b/app-network/mosdns/spec
@@ -1,5 +1,4 @@
-VER=5.3.3
-REL=5
+VER=5.3.4
 SRCS="git::commit=tags/v$VER::https://github.com/IrineSistiana/mosdns.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377076"


### PR DESCRIPTION
Topic Description
-----------------

- mosdns: update to 5.3.4
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- mosdns: 5.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mosdns
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
