### PR TITLE
shadow: update to 4.19.4

### DIFF
--- a/app-admin/shadow/autobuild/defines
+++ b/app-admin/shadow/autobuild/defines
@@ -1,59 +1,43 @@
 PKGNAME=shadow
 PKGDES="Utilities for managing accounts and shadow password files"
 PKGSEC=admin
-
-RECONF=0
-
 # bash is required for postinst
 PKGDEP="acl bash linux-pam attr"
 PKGDEP__RETRO="acl bash linux-pam"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
-
 BUILDDEP="itstool docbook-xsl"
 BUILDDEP_RETRO=""
 
+ABTYPE=autotools
 # Note: --disable-man will not install the manpages, since they are not generated.
-AUTOTOOLS_AFTER="--enable-largefile \
-                 --enable-shadowgrp \
-                 --enable-man \
-                 --enable-account-tools-setuid \
-                 --enable-subordinate-ids \
-                 --enable-nls \
-                 --disable-rpath \
-                 --without-audit \
-                 --with-libpam \
-                 --with-btrfs \
-                 --without-selinux \
-                 --with-acl \
-                 --with-attr \
-                 --without-skey \
-                 --without-tcb \
-                 --with-sha-crypt \
-                 --without-bcrypt \
-                 --without-yescrypt \
-                 --with-nscd \
-                 --with-sssd \
-                 --with-group-name-max-length=32 \
-                 --with-su \
-                 --without-libbsd \
-                 --with-fcaps=no"
-AUTOTOOLS_AFTER__RETRO=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-man"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+    '--enable-largefile'
+    '--enable-shadowgrp'
+    '--enable-man'
+    '--enable-account-tools-setuid'
+    '--enable-subordinate-ids'
+    '--enable-nls'
+    '--disable-rpath'
+    '--without-audit'
+    '--with-libpam'
+    '--with-btrfs'
+    '--without-selinux'
+    '--with-acl'
+    '--with-attr'
+    '--without-skey'
+    '--without-tcb'
+    '--with-sha-crypt'
+    '--without-bcrypt'
+    '--without-yescrypt'
+    '--with-nscd'
+    '--with-sssd'
+    '--with-group-name-max-length=32'
+    '--with-su'
+    '--without-libbsd'
+    '--with-fcaps=no'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-man'
+)
 
 PKGESS=1

--- a/app-admin/shadow/autobuild/defines.stage2
+++ b/app-admin/shadow/autobuild/defines.stage2
@@ -1,32 +1,34 @@
 PKGNAME=shadow
 PKGDES="Utilities for managing accounts and shadow password files"
 PKGSEC=admin
-RECONF=0
 PKGDEP="acl bash linux-pam attr"
 
-AUTOTOOLS_AFTER="--enable-largefile \
-                 --enable-shadowgrp \
-                 --disable-man \
-                 --enable-account-tools-setuid \
-                 --enable-subordinate-ids \
-                 --enable-nls \
-                 --disable-rpath \
-                 --without-audit \
-                 --with-libpam \
-                 --with-btrfs \
-                 --without-selinux \
-                 --with-acl \
-                 --with-attr \
-                 --without-skey \
-                 --without-tcb \
-                 --with-sha-crypt \
-                 --without-bcrypt \
-                 --without-yescrypt \
-                 --with-nscd \
-                 --with-sssd \
-                 --with-group-name-max-length=32 \
-                 --with-su \
-                 --without-libbsd \
-                 --with-fcaps=no"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--enable-largefile'
+    '--enable-shadowgrp'
+    '--disable-man'
+    '--enable-account-tools-setuid'
+    '--enable-subordinate-ids'
+    '--enable-nls'
+    '--disable-rpath'
+    '--without-audit'
+    '--with-libpam'
+    '--with-btrfs'
+    '--without-selinux'
+    '--with-acl'
+    '--with-attr'
+    '--without-skey'
+    '--without-tcb'
+    '--with-sha-crypt'
+    '--without-bcrypt'
+    '--without-yescrypt'
+    '--with-nscd'
+    '--with-sssd'
+    '--with-group-name-max-length=32'
+    '--with-su'
+    '--without-libbsd'
+    '--with-fcaps=no'
+)
 
 PKGESS=1

--- a/app-admin/shadow/autobuild/patches/0001-login.defs-Adapt-to-AOSC-configuration.patch
+++ b/app-admin/shadow/autobuild/patches/0001-login.defs-Adapt-to-AOSC-configuration.patch
@@ -1,4 +1,4 @@
-From 964a317ef6fc3eb92ac6d2b99604c2b6e89c5047 Mon Sep 17 00:00:00 2001
+From bd8daa4712fa7521e88d814ec1a57c650b3bc27b Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Mon, 30 Dec 2024 22:12:24 +0800
 Subject: [PATCH] login.defs: Adapt to AOSC configuration
@@ -13,7 +13,7 @@ Subject: [PATCH] login.defs: Adapt to AOSC configuration
  1 file changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/etc/login.defs b/etc/login.defs
-index 33622c29..48073d7e 100644
+index 966724c7..56efc8d4 100644
 --- a/etc/login.defs
 +++ b/etc/login.defs
 @@ -86,8 +86,7 @@ CONSOLE		/etc/securetty
@@ -85,7 +85,7 @@ index 33622c29..48073d7e 100644
  # Extra per user group ids
  SUB_GID_MIN		   100000
 @@ -329,7 +329,7 @@ CHFN_RESTRICT		rwh
- # Note: If you use PAM, it is recommended to use a value consistent with
+ # Note: if you use PAM, it is recommended to use a value consistent with
  # the PAM modules configuration.
  #
 -#ENCRYPT_METHOD DES
@@ -94,5 +94,5 @@ index 33622c29..48073d7e 100644
  #
  # Only works if ENCRYPT_METHOD is set to SHA256 or SHA512.
 -- 
-2.47.1
+2.54.0
 

--- a/app-admin/shadow/autobuild/prepare
+++ b/app-admin/shadow/autobuild/prepare
@@ -1,3 +1,0 @@
-abinfo "Do not build and ship the groups command, which is in coreutils ..."
-sed -i 's/groups$(EXEEXT) //' src/Makefile.in
-find man -name Makefile.in -exec sed -i 's/groups\.1 / /' {} \;

--- a/app-admin/shadow/spec
+++ b/app-admin/shadow/spec
@@ -1,5 +1,4 @@
-VER=4.17.2
-REL=3
+VER=4.19.4
 SRCS="tbl::https://github.com/shadow-maint/shadow/releases/download/$VER/shadow-$VER.tar.xz"
-CHKSUMS="sha256::a21cf0d34bffc4314cede01cff258689174fab30ca494ae8f45784d3d56c9849"
+CHKSUMS="sha256::ce57a313e315a0a7cb04a8f50cc20753e994e487bbe9b78a2a824ca75cb486c0"
 CHKUPDATE="anitya::id=4802"


### PR DESCRIPTION
Topic Description
-----------------

- shadow: update to 4.19.4
    - Drop unused prepare script.
    - Adjust defines script.
    - Tracking patches at AOSC-Tracking/shadow @ aosc/4.19.4 \(HEAD: bd8daa4712fa7521e88d814ec1a57c650b3bc27b\)

Package(s) Affected
-------------------

- shadow: 4.19.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadow
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
