### PR TITLE
renameutils: new, 0.12.0

### DIFF
--- a/app-utils/renameutils/autobuild/defines
+++ b/app-utils/renameutils/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=renameutils
+PKGSEC=utils
+PKGDEP="readline"
+PKGDES="Collection of utilities to rename files and directories"
+
+ABTYPE=autotools

--- a/app-utils/renameutils/autobuild/patches/renameutils-0.12.0-gcc15-fixes.patch
+++ b/app-utils/renameutils/autobuild/patches/renameutils-0.12.0-gcc15-fixes.patch
@@ -1,0 +1,268 @@
+# https://src.fedoraproject.org/rpms/renameutils/blob/rawhide/f/renameutils-0.12.0-install-typo.patch
+
+diff -u -Nr -U5 renameutils-0.12.0/src/common/error.c renameutils-0.12.0.gcc15-fixes/src/common/error.c
+--- renameutils-0.12.0/src/common/error.c	2009-08-16 12:51:56.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/error.c	2025-07-09 23:27:52.350052516 -0400
+@@ -73,15 +73,17 @@
+  * provided here.
+  */
+ void
+ free_error(void)
+ {
+-	struct MessageHeader *hdr;
++	struct MessageHeader *hdr, *nexthdr;
+ 
+-	for (hdr = message_header; hdr != NULL; hdr = hdr->old) {
++	for (hdr = message_header; hdr != NULL; ) {
+ 		free(hdr->message);
++		nexthdr = hdr->old;
+ 		free(hdr);
++		hdr = nexthdr;
+ 	}
+ 	if (error_message != NULL)
+ 		free(error_message);
+ }
+ 
+diff -u -Nr -U5 renameutils-0.12.0/src/common/hmap.c renameutils-0.12.0.gcc15-fixes/src/common/hmap.c
+--- renameutils-0.12.0/src/common/hmap.c	2009-08-16 12:52:30.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/hmap.c	2025-07-09 23:27:52.350478777 -0400
+@@ -361,11 +361,11 @@
+ 
+ /* It is allowed to remove the current entry from the iterator callback
+  * function. But no other entry.
+  */
+ void
+-hmap_foreach_value(HMap *map, void (*iterator)())
++hmap_foreach_value(HMap *map, void (*iterator)(void *))
+ {
+     uint32_t c;
+ 
+     for (c = 0; c < map->buckets_length; c++) {
+ 	HMapEntry *entry;
+@@ -376,11 +376,11 @@
+ 	}
+     }
+ }
+ 
+ void
+-hmap_foreach_key(HMap *map, void (*iterator)())
++hmap_foreach_key(HMap *map, void (*iterator)(void *))
+ {
+     uint32_t c;
+ 
+     for (c = 0; c < map->buckets_length; c++) {
+ 	HMapEntry *entry;
+diff -u -Nr -U5 renameutils-0.12.0/src/common/hmap.h renameutils-0.12.0.gcc15-fixes/src/common/hmap.h
+--- renameutils-0.12.0/src/common/hmap.h	2009-08-16 12:52:39.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/hmap.h	2025-07-09 23:28:41.025663316 -0400
+@@ -48,12 +48,12 @@
+ void *hmap_get(HMap *map, const void *key);
+ void *hmap_put(HMap *map, void *key, void *value);
+ bool hmap_contains_key(HMap *map, const void *key);
+ void *hmap_remove(HMap *map, const void *key);
+ void hmap_iterator(HMap *map, HMapIterator *it);
+-void hmap_foreach_key(HMap *map, void (*iterator)());
+-void hmap_foreach_value(HMap *map, void (*iterator)());
++void hmap_foreach_key(HMap *map, void (*iterator)(void*));
++void hmap_foreach_value(HMap *map, void (*iterator)(void*));
+ void hmap_clear(HMap *map);
+ size_t hmap_size(HMap *map);
+ void hmap_set_hash_fn(HMap *map, hash_fn_t hash);
+ void hmap_set_compare_fn(HMap *map, comparison_fn_t compare);
+ 
+diff -u -Nr -U5 renameutils-0.12.0/src/common/llist.c renameutils-0.12.0.gcc15-fixes/src/common/llist.c
+--- renameutils-0.12.0/src/common/llist.c	2009-08-16 12:53:33.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/llist.c	2025-07-09 23:27:52.350713871 -0400
+@@ -443,11 +443,11 @@
+ {
+ 	return list->size == 0;
+ }
+ 
+ void
+-llist_iterate(LList *list, void (*iterator_func)())
++llist_iterate(LList *list, void (*iterator_func)(void *))
+ {
+ 	LNode *entry;
+ 	for (entry = list->first; entry != NULL; entry = entry->next)
+ 		iterator_func(entry->data);
+ }
+diff -u -Nr -U5 renameutils-0.12.0/src/common/llist.h renameutils-0.12.0.gcc15-fixes/src/common/llist.h
+--- renameutils-0.12.0/src/common/llist.h	2009-08-16 12:53:43.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/llist.h	2025-07-09 23:28:13.829615270 -0400
+@@ -66,11 +66,11 @@
+ int32_t llist_last_index_of(LList *list, void *data);
+ LList *llist_clone(LList *list);
+ void **llist_to_array(LList *list);
+ void **llist_to_null_terminated_array(LList *list);
+ 
+-void llist_iterate(LList *list, void (*iterator_func)());
++void llist_iterate(LList *list, void (*iterator_func)(void*));
+ void llist_iterator(LList *list, LListIterator *it);
+ 
+ void llist_reverse(LList *list);
+ 
+ LNode *llist_get_first_node(LList *list);
+diff -u -Nr -U5 renameutils-0.12.0/src/common/tmap.c renameutils-0.12.0.gcc15-fixes/src/common/tmap.c
+--- renameutils-0.12.0/src/common/tmap.c	2009-08-16 12:54:32.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/tmap.c	2025-07-10 08:22:46.885703781 -0400
+@@ -505,38 +505,38 @@
+     return parent;
+ }
+ #endif
+ 
+ static void
+-tmap_foreach_nodes_key(TMapNode *node, void (*iterator)())
++tmap_foreach_nodes_key(TMapNode *node, void (*iterator)(void*))
+ {
+     if (node->left != &nil)
+     	tmap_foreach_nodes_key(node->left, iterator);
+     if (node->right != &nil)
+         tmap_foreach_nodes_key(node->right, iterator);
+     iterator(node->key);
+ }
+ 
+ static void
+-tmap_foreach_nodes_value(TMapNode *node, void (*iterator)())
++tmap_foreach_nodes_value(TMapNode *node, void (*iterator)(void*))
+ {
+     if (node->left != &nil)
+     	tmap_foreach_nodes_value(node->left, iterator);
+     if (node->right != &nil)
+         tmap_foreach_nodes_value(node->right, iterator);
+     iterator(node->value);
+ }
+ 
+ void
+-tmap_foreach_key(TMap *map, void (*iterator)())
++tmap_foreach_key(TMap *map, void (*iterator)(void*))
+ {
+     if (map->root != &nil)
+ 	tmap_foreach_nodes_key(map->root, iterator);
+ }
+ 
+ void
+-tmap_foreach_value(TMap *map, void (*iterator)())
++tmap_foreach_value(TMap *map, void (*iterator)(void*))
+ {
+     if (map->root != &nil)
+ 	tmap_foreach_nodes_value(map->root, iterator);
+ }
+ 
+diff -u -Nr -U5 renameutils-0.12.0/src/common/tmap.h renameutils-0.12.0.gcc15-fixes/src/common/tmap.h
+--- renameutils-0.12.0/src/common/tmap.h	2009-08-16 12:54:41.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/common/tmap.h	2025-07-10 08:22:46.919049364 -0400
+@@ -49,12 +49,12 @@
+ void *tmap_put(TMap *map, void *key, void *value);
+ void *tmap_remove(TMap *map, const void *key);
+ void tmap_iterator(TMap *map, TMapIterator *it); /* value iterator */
+ bool tmap_iterator_partial(TMap *map, TMapIterator *it, const void *match, comparison_fn_t comparator);
+ void tmap_clear(TMap *map);
+-void tmap_foreach_key(TMap *map, void (*iterator)());
+-void tmap_foreach_value(TMap *map, void (*iterator)());
++void tmap_foreach_key(TMap *map, void (*iterator)(void*));
++void tmap_foreach_value(TMap *map, void (*iterator)(void*));
+ 
+ #ifdef ENABLE_TMAP_TESTING
+ #include <stdio.h>
+ void tmap_dump(TMap *map, FILE *out);
+ bool tmap_verify(TMap *map);
+diff -u -Nr -U5 renameutils-0.12.0/src/list.c renameutils-0.12.0.gcc15-fixes/src/list.c
+--- renameutils-0.12.0/src/list.c	2012-04-18 09:45:30.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/list.c	2025-07-10 08:48:11.199020262 -0400
+@@ -164,18 +164,18 @@
+         }
+     }
+     hmap_free(map_files);
+     if (ferror(fh)) {
+         warn(_("%s: cannot read from file: %s\n"), quotearg(args[1]), errstr);
+-        llist_iterate(new_files, free_file_spec);
++        llist_iterate(new_files, free_file_spec_llist);
+         llist_free(new_files);
+         fclose(fh);
+         return;
+     }
+     fclose(fh);
+ 
+-    llist_iterate(work_files, free_file_spec);
++    llist_iterate(work_files, free_file_spec_llist);
+     llist_free(work_files);
+     work_files = new_files;
+ }
+ 
+ void
+@@ -368,11 +368,11 @@
+     llist_clear(edit_file_list);
+     if (plan != NULL) {
+         free_plan(plan);
+         plan = NULL;
+     }
+-    llist_iterate(work_files, free_file_spec);
++    llist_iterate(work_files, free_file_spec_llist);
+     llist_clear(work_files);
+ 
+     if (!process_ls_output(firstdir, work_files, ls_fd)) {
+ 	warn(_("cannot read `%s' output: %s"), ls_program, errstr);
+ 	clean_ls(ls_pid, ls_fd, &status);
+@@ -551,10 +551,17 @@
+     spec->next_spec = NULL;
+ 
+     return spec;
+ }
+ 
++/* Free the specified FileSpec, except through `llist_*` APIs.
++ */
++void free_file_spec_llist(void* file)
++{
++    free_file_spec((FileSpec*)file);
++}
++
+ /* Free the specified FileSpec.
+  */
+ void
+ free_file_spec(FileSpec *spec)
+ {
+diff -u -Nr -U5 renameutils-0.12.0/src/plan.c renameutils-0.12.0.gcc15-fixes/src/plan.c
+--- renameutils-0.12.0/src/plan.c	2011-07-10 18:03:54.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/plan.c	2025-07-10 08:48:32.068985024 -0400
+@@ -392,9 +392,9 @@
+ free_plan(ApplyPlan *plan)
+ {
+     llist_free(plan->ok);
+     llist_free(plan->error);
+     llist_free(plan->no_change);
+-    /*llist_iterate(plan->free_spec, free_file_spec);
++    /*llist_iterate(plan->free_spec, free_file_spec_llist);
+     llist_free(plan->free_spec);*/
+     free(plan);
+ }
+diff -u -Nr -U5 renameutils-0.12.0/src/qcmd.c renameutils-0.12.0.gcc15-fixes/src/qcmd.c
+--- renameutils-0.12.0/src/qcmd.c	2011-08-21 13:15:51.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/qcmd.c	2025-07-10 08:46:47.832161020 -0400
+@@ -261,11 +261,11 @@
+ 
+     if (plan != NULL)
+ 	free_plan(plan);
+ 
+     /*dump_spec_list(work_files);*/
+-    llist_iterate(work_files, free_file_spec);
++    llist_iterate(work_files, free_file_spec_llist);
+     llist_free(work_files);
+     free(all_options);
+     free(editor_program);
+     free(ls_program);
+     if (unlink(edit_filename) < 0)
+diff -u -Nr -U5 renameutils-0.12.0/src/qcmd.h renameutils-0.12.0.gcc15-fixes/src/qcmd.h
+--- renameutils-0.12.0/src/qcmd.h	2011-08-21 12:07:02.000000000 -0400
++++ renameutils-0.12.0.gcc15-fixes/src/qcmd.h	2025-07-10 08:47:46.641061730 -0400
+@@ -91,10 +91,11 @@
+ void list_command(char **args);
+ bool list_files(char **args);
+ void process_ls_option(int c);
+ struct option *append_ls_options(const struct option *options);
+ FileSpec *new_file_spec(void);
++void free_file_spec_llist(void* file);
+ void free_file_spec(FileSpec *spec);
+ void free_files(LList *files);
+ void display_ls_help(FILE *out);
+ bool cwd_to_work_directory();
+ bool cwd_from_work_directory();

--- a/app-utils/renameutils/autobuild/patches/renameutils-0.12.0-install-typo.patch
+++ b/app-utils/renameutils/autobuild/patches/renameutils-0.12.0-install-typo.patch
@@ -1,0 +1,34 @@
+# https://src.fedoraproject.org/rpms/renameutils/blob/rawhide/f/renameutils-0.12.0-install-typo.patch
+
+diff -u -r -U5 renameutils-0.12.0/src/Makefile.am renameutils-0.12.0.install-typo/src/Makefile.am
+--- renameutils-0.12.0/src/Makefile.am	2012-04-23 07:10:43.000000000 -0400
++++ renameutils-0.12.0.install-typo/src/Makefile.am	2013-06-11 00:02:04.715263195 -0400
+@@ -47,11 +47,11 @@
+ 	@[ -f qcp ] || (echo $(LN_S) qcmd qcp ; $(LN_S) qcmd qcp)
+ 	@[ -f imv ] || (echo $(LN_S) icmd imv ; $(LN_S) icmd imv)
+ 	@[ -f icp ] || (echo $(LN_S) icmd icp ; $(LN_S) icmd icp)
+ 
+ install-exec-local:
+-	$(mkdir_p) $(DESTDIR)($bindir)
++	$(mkdir_p) $(DESTDIR)$(bindir)
+ 	@[ -f $(DESTDIR)$(bindir)/qmv ] || (echo $(LN_S) qcmd $(DESTDIR)$(bindir)/qmv ; $(LN_S) qcmd $(DESTDIR)$(bindir)/qmv)
+ 	@[ -f $(DESTDIR)$(bindir)/qcp ] || (echo $(LN_S) qcmd $(DESTDIR)$(bindir)/qcp ; $(LN_S) qcmd $(DESTDIR)$(bindir)/qcp)
+ 	@[ -f $(DESTDIR)$(bindir)/imv ] || (echo $(LN_S) icmd $(DESTDIR)$(bindir)/imv ; $(LN_S) icmd $(DESTDIR)$(bindir)/imv)
+ 	@[ -f $(DESTDIR)$(bindir)/icp ] || (echo $(LN_S) icmd $(DESTDIR)$(bindir)/icp ; $(LN_S) icmd $(DESTDIR)$(bindir)/icp)
+ 
+diff -u -r -U5 renameutils-0.12.0/src/Makefile.in renameutils-0.12.0.install-typo/src/Makefile.in
+--- renameutils-0.12.0/src/Makefile.in	2012-04-23 07:24:10.000000000 -0400
++++ renameutils-0.12.0.install-typo/src/Makefile.in	2013-06-11 00:02:10.119249997 -0400
+@@ -1575,11 +1575,11 @@
+ 	@[ -f qcp ] || (echo $(LN_S) qcmd qcp ; $(LN_S) qcmd qcp)
+ 	@[ -f imv ] || (echo $(LN_S) icmd imv ; $(LN_S) icmd imv)
+ 	@[ -f icp ] || (echo $(LN_S) icmd icp ; $(LN_S) icmd icp)
+ 
+ install-exec-local:
+-	$(mkdir_p) $(DESTDIR)($bindir)
++	$(mkdir_p) $(DESTDIR)$(bindir)
+ 	@[ -f $(DESTDIR)$(bindir)/qmv ] || (echo $(LN_S) qcmd $(DESTDIR)$(bindir)/qmv ; $(LN_S) qcmd $(DESTDIR)$(bindir)/qmv)
+ 	@[ -f $(DESTDIR)$(bindir)/qcp ] || (echo $(LN_S) qcmd $(DESTDIR)$(bindir)/qcp ; $(LN_S) qcmd $(DESTDIR)$(bindir)/qcp)
+ 	@[ -f $(DESTDIR)$(bindir)/imv ] || (echo $(LN_S) icmd $(DESTDIR)$(bindir)/imv ; $(LN_S) icmd $(DESTDIR)$(bindir)/imv)
+ 	@[ -f $(DESTDIR)$(bindir)/icp ] || (echo $(LN_S) icmd $(DESTDIR)$(bindir)/icp ; $(LN_S) icmd $(DESTDIR)$(bindir)/icp)
+ 

--- a/app-utils/renameutils/spec
+++ b/app-utils/renameutils/spec
@@ -1,0 +1,4 @@
+VER=0.12.0
+SRCS="tbl::https://download.savannah.gnu.org/releases/renameutils/renameutils-$VER.tar.gz"
+CHKSUMS="sha256::cbd2f002027ccf5a923135c3f529c6d17fabbca7d85506a394ca37694a9eb4a3"
+CHKUPDATE="anitya::id=5711"


### PR DESCRIPTION
Topic Description
-----------------

- renameutils: new, 0.12.0

Package(s) Affected
-------------------

- renameutils: 0.12.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit renameutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
