### PR TITLE
topics(vim-*): fix typesetting for zh_CN TUMs

### DIFF
--- a/topics/vim-9.2.0280.toml
+++ b/topics/vim-9.2.0280.toml
@@ -5,7 +5,7 @@ default = "Vim 9.2.0280"
 
 [caution]
 default = "Fixes a Improper Limitation of a Pathname to a Restricted Directory (Path Traversal) vulnerability (CVE-2026-35177, Severity: Low)"
-zh_CN = "修复一个对路径名的限制不恰当（路径遍历）漏洞（漏洞编号CVE-2026-35177，严重性：低）"
+zh_CN = "修复一个对路径名的限制不恰当（路径遍历）漏洞（漏洞编号 CVE-2026-35177，严重性：低）"
 
 [packages-v2]
 "vim" = "< 9.2.0280"

--- a/topics/vim-9.2.0437.toml
+++ b/topics/vim-9.2.0437.toml
@@ -5,7 +5,7 @@ default = "Vim 9.2.0437"
 
 [caution]
 default = "Fixes a OS Command Injection vulnerability (CVE-2026-44656, Severity: Medium)"
-zh_CN = "修复一个系统命令注入漏洞（漏洞编号CVE-2026-44656，严重性：中）"
+zh_CN = "修复一个系统命令注入漏洞（漏洞编号 CVE-2026-44656，严重性：中）"
 
 [packages-v2]
 "vim" = "< 9.2.0437"

--- a/topics/vim-9.2.0478.toml
+++ b/topics/vim-9.2.0478.toml
@@ -5,7 +5,7 @@ default = "Vim 9.2.0478"
 
 [caution]
 default = "Fixes a Heap Buffer Overflow vulnerability (CVE-2026-45130, Severity: Medium)"
-zh_CN = "修复一个堆缓冲区溢出漏洞（漏洞编号CVE-2026-45130，严重性：中）"
+zh_CN = "修复一个堆缓冲区溢出漏洞（漏洞编号 CVE-2026-45130，严重性：中）"
 
 [packages-v2]
 "vim" = "< 9.2.0478"


### PR DESCRIPTION
Topic Description
-----------------

- topics\(vim-\*\): fix typesetting for zh_CN TUMs

Package(s) Affected
-------------------

- gvim: 9.2.0478
- vim: 9.2.0478

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
