### PR TITLE
libxml2: rework - wave 3

### DIFF
--- a/app-admin/flatpak/spec
+++ b/app-admin/flatpak/spec
@@ -1,4 +1,5 @@
 VER=1.17.7
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak.git \
       file::rename=flathub.flatpakrepo::https://flathub.org/repo/flathub.flatpakrepo"
 CHKSUMS="SKIP \

--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=1_4_3
 VER=${UPSTREAM_VER//_/.}
-REL=3
+REL=4
 SRCS="git::commit=tags/INKSCAPE_${UPSTREAM_VER}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"

--- a/runtime-common/libxml2/autobuild/defines
+++ b/runtime-common/libxml2/autobuild/defines
@@ -22,7 +22,7 @@ PKGBREAK="0ad<=0.28.0-1 afdko<=4.0.3 akonadi<=23.08.5 appstream<=1.1.2 \
           dvdauthor<=0.7.2-4 ebook-tools<=0.2.2-4 emacs<=30.2-2 \
           eom<=1:1.28.1-1 epiphany<=49.2 evolution<=3.58.3 \
           evolution-data-server<=3.58.3 evolution-ews<=3.58.3 \
-          fcitx<=4.2.9.9-1 ffmpeg<=7.1.3-1 flatpak<=1.17.5-1 \
+          fcitx<=4.2.9.9-1 ffmpeg<=7.1.3-1 flatpak<=1.17.7 \
           flatpak-builder<=1.4.7 flickcurl<=1.26-4 font-manager<=0.9.4-1 \
           fontforge<=20251009-3 foomatic-db-engine<=4.0.13 gconf<=3.2.6-9 \
           gdal<=3.12.1-3 geany-plugins<=2.1-2 gettext<=1:1.0-2 \
@@ -36,7 +36,7 @@ PKGBREAK="0ad<=0.28.0-1 afdko<=4.0.3 akonadi<=23.08.5 appstream<=1.1.2 \
           hivex<=1.3.24-2 hotdoc<=0.17.4-1 html5-parser<=0.4.12-1 \
           httpd<=2.4.67 hwloc<=2.10.0 icecast<=2.4.4-3 \
           imagemagick<=6.9.13+37-2 imagemagick+7<=7.1.1+32-2 \
-          inkscape<=1.4.3-1 intel-oneapi-basekit<=2025.3.2 \
+          inkscape<=1.4.3-3 intel-oneapi-basekit<=2025.3.2 \
           kbibtex-trinity<=14.1.5 kdoctools<=5.115.0 khelpcenter<=23.08.5-2 \
           kio<=5.115.0 kitinerary<=23.08.5-7 kodi<=21.3-2 \
           koffice-trinity<=14.1.5-2 kopete<=23.08.5 ktouch<=23.08.5 \
@@ -61,7 +61,7 @@ PKGBREAK="0ad<=0.28.0-1 afdko<=4.0.3 akonadi<=23.08.5 appstream<=1.1.2 \
           mate-applets<=1:1.28.1 mate-calc<=1.28.0-1 \
           mate-control-center<=1.28.1 mate-media<=1.28.1 \
           mate-notification-daemon<=1:1.28.5 mate-system-monitor<=1:1.28.1 \
-          mlt<=7.36.1 msitools<=0.106 netcf<=0.2.8-5 netpbm<=10.86.48-1 \
+          mlt<=7.38.0 msitools<=0.106 netcf<=0.2.8-5 netpbm<=10.86.48-1 \
           networkmanager-openconnect<=1.2.10-1 nfs-utils<=2.8.4-1 \
           nghttp2<=1.65.0-1 nokogiri<=1.18.10 oath-toolkit<=2.6.13 \
           obconf<=2.0.4-6 obconf-qt<=0.16.4 open-vm-tools<=13.0.5-1 \

--- a/runtime-common/libxml2/spec
+++ b/runtime-common/libxml2/spec
@@ -1,5 +1,5 @@
 VER=2.15.1
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/GNOME/libxml2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1783"

--- a/runtime-multimedia/mlt/spec
+++ b/runtime-multimedia/mlt/spec
@@ -1,4 +1,5 @@
 VER=7.38.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/mlt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11007"

--- a/runtime-multimedia/mlt/spec
+++ b/runtime-multimedia/mlt/spec
@@ -1,5 +1,5 @@
 VER=7.38.0
 REL=1
-SRCS="git::commit=tags/v$VER::https://github.com/mltframework/mlt"
-CHKSUMS="SKIP"
+SRCS="tbl::https://github.com/mltframework/mlt/releases/download/v$VER/mlt-$VER.tar.gz"
+CHKSUMS="sha256::b8f0a23c89e9250edc5038d745537c382367bf2ad3dad5d5c7cd13b0fe1c4144"
 CHKUPDATE="anitya::id=11007"


### PR DESCRIPTION
Topic Description
-----------------

- libxml2: update PKGBREAK
- mlt: rebuild \(again\) for libxml2 2.15.1
- flatpak: rebuild \(again\) for libxml2 2.15.1
- inkscape: rebuild \(again\) for libxml2 2.15.1

Package(s) Affected
-------------------

- flatpak: 1.17.7-1
- inkscape: 1.4.3-4
- libxml2: 2.15.1-2
- mlt: 7.38.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit inkscape flatpak mlt libxml2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
