### PR TITLE
intel-compute-runtime: update to 26.18.38308.1

### DIFF
--- a/app-devel/intel-graphics-compiler/autobuild/prepare
+++ b/app-devel/intel-graphics-compiler/autobuild/prepare
@@ -15,7 +15,9 @@ ab_apply_patches "$SRCDIR"/autobuild/patches/*-llvm-*.patch."${CROSS:-$ARCH}"
 
 for file in "${SRCDIR}"/../opencl-clang/patches/clang/*.patch
 do
-    patch -p1 -t -s -N -i "$file"
+    # FIXME: opencl-clang's LLVM 16 patch queue may drift slightly from pinned LLVM 16.0.6.
+    # Relax context matching to avoid rejecting valid hunks with stale surrounding lines.
+    git apply -C0 --ignore-whitespace "$file"
 done
 rm -v "${SRCDIR}"/../opencl-clang/patches/clang/*.patch
 for file in "${SRCDIR}"/external/llvm/releases/16.0.0/patches_external/*.patch

--- a/app-devel/intel-graphics-compiler/spec
+++ b/app-devel/intel-graphics-compiler/spec
@@ -1,17 +1,18 @@
-VER=2.30.1
+VER=2.34.4
 LLVM_VER=16.0.6
-OPENCL_CLANG_VER=16.0.8
-SPIRV_LLVM_TRANSLATOR_VER=16.0.22
-VS_INTRINSICS_VER=0.24.3
-SPIRV_TOOLS_VER=1.4.341.0
+OPENCL_CLANG_VER=16.0.11
+SPIRV_LLVM_TRANSLATOR_VER=16.0.23
+VS_INTRINSICS_VER=0.25.0
+SPIRV_TOOLS_COMMIT=28a883ba4c67f58a9540fb0651c647bb02883622
+SPIRV_HEADERS_COMMIT=9268f3057354a2cb65991ba5f38b16d81e803692
 
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/intel/intel-graphics-compiler.git \
       tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-"${LLVM_VER}"/llvm-project-"${LLVM_VER}".src.tar.xz \
       git::commit=tags/v$OPENCL_CLANG_VER;rename=opencl-clang;copy-repo=true::https://github.com/intel/opencl-clang.git \
       git::commit=tags/v$SPIRV_LLVM_TRANSLATOR_VER;rename=SPIRV-LLVM-Translator-IGC;copy-repo=true::https://github.com/KhronosGroup/SPIRV-LLVM-Translator.git \
       git::commit=tags/v$VS_INTRINSICS_VER;rename=vc-intrinsics::https://github.com/intel/vc-intrinsics.git \
-      git::commit=tags/vulkan-sdk-$SPIRV_TOOLS_VER;rename=SPIRV-Tools::https://github.com/KhronosGroup/SPIRV-Tools.git \
-      git::commit=tags/vulkan-sdk-$SPIRV_TOOLS_VER;rename=SPIRV-Headers::https://github.com/KhronosGroup/SPIRV-Headers.git"
+      git::commit=$SPIRV_TOOLS_COMMIT;rename=SPIRV-Tools::https://github.com/KhronosGroup/SPIRV-Tools.git \
+      git::commit=$SPIRV_HEADERS_COMMIT;rename=SPIRV-Headers::https://github.com/KhronosGroup/SPIRV-Headers.git"
 CHKSUMS="SKIP \
          sha256::ce5e71081d17ce9e86d7cbcfa28c4b04b9300f8fb7e78422b1feb6bc52c3028e \
          SKIP \

--- a/runtime-devices/igsc/spec
+++ b/runtime-devices/igsc/spec
@@ -1,4 +1,4 @@
-VER=1.0.2
+VER=1.2.0
 SRCS="git::commit=tags/V$VER::https://github.com/intel/igsc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229526"

--- a/runtime-devices/metee/spec
+++ b/runtime-devices/metee/spec
@@ -1,4 +1,4 @@
-VER=6.2.1
+VER=6.2.3
 SRCS="git::commit=tags/$VER::https://github.com/intel/metee.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230452"

--- a/runtime-scientific/intel-compute-runtime/spec
+++ b/runtime-scientific/intel-compute-runtime/spec
@@ -1,4 +1,4 @@
-VER=26.09.37435.1
+VER=26.18.38308.1
 SRCS="git::commit=tags/$VER::https://github.com/intel/compute-runtime.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=229527"


### PR DESCRIPTION
Topic Description
-----------------

- intel-compute-runtime: update to 26.18.38308.1
- intel-graphics-compiler: update to 2.34.4
- igsc: update to 1.2.0
- metee: update to 6.2.3

Package(s) Affected
-------------------

- igsc: 1.2.0
- intel-compute-runtime: 26.18.38308.1
- intel-graphics-compiler: 2.34.4
- metee: 6.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit metee igsc intel-graphics-compiler intel-compute-runtime
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
