### PR TITLE
quickshell: update to 0.3.0

### DIFF
--- a/runtime-common/cpptrace/autobuild/defines
+++ b/runtime-common/cpptrace/autobuild/defines
@@ -1,0 +1,13 @@
+PKGNAME=cpptrace
+PKGSEC=libs
+PKGDEP="gcc-runtime glibc libdwarf libunwind"
+PKGDES="Stacktrace library for C++11 and newer"
+BUILDDEP="pkg-config"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_SHARED_LIBS=ON'
+    '-DCPPTRACE_USE_EXTERNAL_LIBDWARF=ON'
+    '-DCPPTRACE_FIND_LIBDWARF_WITH_PKGCONFIG=ON'
+    '-DCPPTRACE_UNWIND_WITH_LIBUNWIND=ON'
+)

--- a/runtime-common/cpptrace/spec
+++ b/runtime-common/cpptrace/spec
@@ -1,0 +1,4 @@
+VER=1.0.4
+SRCS="git::commit=tags/v$VER::https://github.com/jeremy-rifkin/cpptrace.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378001"

--- a/runtime-desktop/quickshell/autobuild/defines
+++ b/runtime-desktop/quickshell/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=quickshell
 PKGSEC=libs
 PKGDES="Toolkit for making desktop shells"
-PKGDEP="gcc-runtime glibc jemalloc libdrm libxcb linux-pam mesa pipewire qt-6 wayland"
+PKGDEP="gcc-runtime glib glibc jemalloc libdrm libxcb linux-pam mesa pipewire qt-6 wayland polkit cpptrace"
 BUILDDEP="cli11 cmake ninja pkgconf spirv-tools wayland-protocols"
 PKGCONFL="noctalia-qs"
 

--- a/runtime-desktop/quickshell/spec
+++ b/runtime-desktop/quickshell/spec
@@ -1,5 +1,4 @@
-VER=0.2.1
+VER=0.3.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/quickshell-mirror/quickshell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378649"
-REL=3


### PR DESCRIPTION
Topic Description
-----------------

- cpptrace: new, 1.0.4
- quickshell: update to 0.3.0

Package(s) Affected
-------------------

- quickshell: 0.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cpptrace quickshell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
