### PR TITLE
loupe: bump REL due to libxml2 update

### DIFF
--- a/desktop-gnome/loupe/spec
+++ b/desktop-gnome/loupe/spec
@@ -1,4 +1,5 @@
 VER=49.2
+REL=1
 SRCS="https://download.gnome.org/sources/loupe/${VER%.*}/loupe-$VER.tar.xz"
 CHKSUMS="sha256::5853e75cceba7fa2bea01be273cd2f0a3061941e7bdfe3a008b233171067142c"
 CHKUPDATE="anitya::id=368849"


### PR DESCRIPTION
Topic Description
-----------------

- loupe: bump REL deu to libxml2 update

Package(s) Affected
-------------------

- loupe: 49.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit loupe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
