### PR TITLE
luanti: update to 5.16.1

### DIFF
--- a/app-games/luanti/spec
+++ b/app-games/luanti/spec
@@ -1,4 +1,4 @@
-VER=5.15.1
+VER=5.16.1
 SRCS="git::commit=tags/$VER::https://github.com/luanti-org/luanti.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1978"


### PR DESCRIPTION
Topic Description
-----------------

- luanti: update to 5.16.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- luanti: 5.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit luanti
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
