### PR TITLE
libusb: update to 1.0.30

### DIFF
--- a/runtime-devices/libusb/spec
+++ b/runtime-devices/libusb/spec
@@ -1,4 +1,4 @@
-VER=1.0.29
+VER=1.0.30
 SRCS="tbl::https://github.com/libusb/libusb/releases/download/v$VER/libusb-$VER.tar.bz2"
-CHKSUMS="sha256::5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
+CHKSUMS="sha256::fea36f34f9156400209595e300840767ab1a385ede1dc7ee893015aea9c6dbaf"
 CHKUPDATE="anitya::id=1749"

--- a/runtime-optenv32/libusb+32/autobuild/defines
+++ b/runtime-optenv32/libusb+32/autobuild/defines
@@ -5,3 +5,4 @@ BUILDDEP="devel-base+32"
 PKGDES="A library providing USB device access and manipulation support (32-bit x86 runtime)"
 
 ABHOST=optenv32
+ABTYPE=autotools

--- a/runtime-optenv32/libusb+32/spec
+++ b/runtime-optenv32/libusb+32/spec
@@ -1,4 +1,4 @@
-VER=1.0.29
+VER=1.0.30
 SRCS="tbl::https://github.com/libusb/libusb/releases/download/v$VER/libusb-$VER.tar.bz2"
-CHKSUMS="sha256::5977fc950f8d1395ccea9bd48c06b3f808fd3c2c961b44b0c2e6e29fc3a70a85"
+CHKSUMS="sha256::fea36f34f9156400209595e300840767ab1a385ede1dc7ee893015aea9c6dbaf"
 CHKUPDATE="anitya::id=1749"


### PR DESCRIPTION
Topic Description
-----------------

- libusb: update to 1.0.30
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- libusb: 1.0.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit libusb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
