### PR TITLE
noctalia-shell: update to 4.7.7

### DIFF
--- a/runtime-desktop/noctalia-shell/spec
+++ b/runtime-desktop/noctalia-shell/spec
@@ -1,4 +1,4 @@
-VER=4.7.6
+VER=4.7.7
 SRCS="git::commit=tags/v$VER::https://github.com/noctalia-dev/noctalia-shell.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388552"


### PR DESCRIPTION
Topic Description
-----------------

- noctalia-shell: update to 4.7.7
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- noctalia-shell: 4.7.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit noctalia-shell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
