### PR TITLE
wine: update to 11.9+gecko2.47.4+mono11.1.0

### DIFF
--- a/app-emulation/wine/autobuild/build
+++ b/app-emulation/wine/autobuild/build
@@ -1,15 +1,8 @@
 abinfo "Applying Wine Staging patches ..."
 ln -sv "$SRCDIR" \
     "$SRCDIR"/../wine-staging/patches/wine
-# FIXME: ../dlls/dcomp/tests/dcomp.c:56:2: error: "Unsupported architecture"
-# Link: https://bugs.winehq.org/show_bug.cgi?id=59665
-if ab_match_arch arm64; then
-    "$SRCDIR"/../wine-staging/staging/patchinstall.py \
-        DESTDIR="$SRCDIR" --all -W dcomp-DCompositionCreateDevice2
-else
-    "$SRCDIR"/../wine-staging/staging/patchinstall.py \
-        DESTDIR="$SRCDIR" --all
-fi
+"$SRCDIR"/../wine-staging/staging/patchinstall.py \
+    DESTDIR="$SRCDIR" --all
 
 abinfo "Preparing to build Wine runtime ..."
 mkdir -pv "$SRCDIR"/wine

--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -95,12 +95,14 @@ AUTOTOOLS_AFTER__AMD64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-archs=x86_64,i386'
 )
-# FIXME: ../dlls/dcomp/tests/dcomp.c:56:2: error: "Unsupported architecture"
-# Link: https://bugs.winehq.org/show_bug.cgi?id=59665
+# FIXME: disabling winsqlite3 and sqlite3 due to 
+# error: call to undeclared library function '_ReadWriteBarrier' with type 'void (void)';
+# Link: https://bugs.winehq.org/show_bug.cgi?id=59769
 AUTOTOOLS_AFTER__ARM64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-archs=arm64ec,aarch64,x86_64,i386'
-    '--disable-dcomp'
+    '--disable-winsqlite3'
+    '--disable-sqlite3'
 )
 AUTOTOOLS_AFTER__I486=(
     "${AUTOTOOLS_AFTER[@]}"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=11.1.0
-UPSTREAM_VER=11.8
+UPSTREAM_VER=11.9
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::53aa85995d4b97f0116a1c56b8a6a1417730ef59a277819d2d3d31364ea556b0 \
+CHKSUMS="sha256::e39cc18db287358a2436f8af498bedc7e444d55eb99ef545b60e778bb4ea0f6f \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 11.9+gecko2.47.4+mono11.1.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wine: 3:11.9+gecko2.47.4+mono11.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
