### PR TITLE
qt-6: update to 6.11.1


### DIFF
--- a/app-admin/btrfs-assistant/spec
+++ b/app-admin/btrfs-assistant/spec
@@ -2,4 +2,4 @@ VER=2.2
 SRCS="git::commit=tags/$VER::https://gitlab.com/btrfs-assistant/btrfs-assistant.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=254195"
-REL=3
+REL=4

--- a/app-creativity/shotcut/spec
+++ b/app-creativity/shotcut/spec
@@ -2,3 +2,4 @@ VER=26.4.30
 SRCS="git::commit=tags/v$VER::https://github.com/mltframework/shotcut"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20347"
+REL=1

--- a/app-devel/cutter/spec
+++ b/app-devel/cutter/spec
@@ -2,4 +2,4 @@ VER=2.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/rizinorg/cutter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141382"
-REL=5
+REL=6

--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,5 +1,5 @@
 VER=18.0.0
-REL=4
+REL=5
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
 CHKSUMS="sha256::c773b74114d1fbca66c81b8fb799892827e7e1542491ed459aaad279e0253973"
 CHKUPDATE="anitya::id=4136"

--- a/app-devel/rz-ghidra/spec
+++ b/app-devel/rz-ghidra/spec
@@ -2,4 +2,4 @@ VER=0.8.0
 SRCS="git::commit=tags/v$VER::https://github.com/rizinorg/rz-ghidra"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376621"
-REL=3
+REL=4

--- a/app-devices/libopenrazer/spec
+++ b/app-devices/libopenrazer/spec
@@ -2,4 +2,4 @@ VER=0.4.0
 SRCS="git::commit=tags/v${VER}::https://github.com/z3ntu/libopenrazer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369594"
-REL=3
+REL=4

--- a/app-devices/razergenie/spec
+++ b/app-devices/razergenie/spec
@@ -2,4 +2,4 @@ VER=1.3.0
 SRCS="tbl::https://github.com/z3ntu/RazerGenie/releases/download/v$VER/RazerGenie-$VER.tar.xz"
 CHKSUMS="sha256::20fbbdfb11c9b815e74a3b666362f3e680a830b6bc116950c7f45930e6b2b2f0"
 CHKUPDATE="anitya::id=21290"
-REL=3
+REL=4

--- a/app-doc/calibre/spec
+++ b/app-doc/calibre/spec
@@ -3,3 +3,4 @@ REL=1
 SRCS="tbl::https://download.calibre-ebook.com/$VER/calibre-$VER.tar.xz"
 CHKSUMS="sha256::16611f951386748e834819423e0938935755e402301ef07aa58f84f48b694201"
 CHKUPDATE="anitya::id=6141"
+REL=1

--- a/app-doc/lyx/spec
+++ b/app-doc/lyx/spec
@@ -2,3 +2,4 @@ VER=2.5.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/LyX-org/lyx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1864"
+REL=1

--- a/app-doc/texstudio/spec
+++ b/app-doc/texstudio/spec
@@ -2,4 +2,4 @@ VER=4.8.6
 SRCS="git::commit=tags/$VER::https://github.com/texstudio-org/texstudio"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6239"
-REL=3
+REL=4

--- a/app-games/melonds/spec
+++ b/app-games/melonds/spec
@@ -2,4 +2,4 @@ VER=1.1
 SRCS="git::commit=tags/$VER::https://github.com/melonDS-emu/melonDS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227658"
-REL=1
+REL=2

--- a/app-i18n/fcitx-qt5/spec
+++ b/app-i18n/fcitx-qt5/spec
@@ -1,5 +1,5 @@
 VER=1.2.7
-REL=11
+REL=12
 SRCS="tbl::https://download.fcitx-im.org/fcitx-qt5/fcitx-qt5-$VER.tar.xz"
 CHKSUMS="sha256::951fcf8f1db23ed22ad91094eb4c6c906f92005a3643b52f666bd8a331163147"
 CHKUPDATE="anitya::id=6513"

--- a/app-i18n/fcitx5-kkc/spec
+++ b/app-i18n/fcitx5-kkc/spec
@@ -2,4 +2,4 @@ VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-kkc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138241"
-REL=1
+REL=2

--- a/app-i18n/fcitx5-qt/spec
+++ b/app-i18n/fcitx5-qt/spec
@@ -1,5 +1,5 @@
 VER=5.1.11
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-qt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138234"

--- a/app-i18n/fcitx5-skk/spec
+++ b/app-i18n/fcitx5-skk/spec
@@ -2,4 +2,4 @@ VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-skk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138240"
-REL=1
+REL=2

--- a/app-i18n/fcitx5-unikey/spec
+++ b/app-i18n/fcitx5-unikey/spec
@@ -2,4 +2,4 @@ VER=5.1.8
 SRCS="git::commit=tags/$VER::https://github.com/fcitx/fcitx5-unikey"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180082"
-REL=1
+REL=2

--- a/app-multimedia/mkvtoolnix/spec
+++ b/app-multimedia/mkvtoolnix/spec
@@ -1,5 +1,5 @@
 VER=91.0
-REL=6
+REL=7
 SRCS="tbl::https://www.bunkus.org/videotools/mkvtoolnix/sources/mkvtoolnix-$VER.tar.xz"
 CHKSUMS="sha256::451320ee90a041cf85b42dbb4683316bf288d2382c54cdd8cd33b1e0258a3bb3"
 CHKUPDATE="anitya::id=1991"

--- a/app-multimedia/qpwgraph/spec
+++ b/app-multimedia/qpwgraph/spec
@@ -2,3 +2,4 @@ VER=1.0.1
 SRCS="git::commit=tags/v${VER}::https://gitlab.freedesktop.org/rncbc/qpwgraph.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242723"
+REL=1

--- a/app-multimedia/strawberry/spec
+++ b/app-multimedia/strawberry/spec
@@ -1,5 +1,5 @@
 VER=1.2.14
-REL=3
+REL=4
 SRCS="git::commit=tags/$VER::https://github.com/strawberrymusicplayer/strawberry"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19048"

--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,4 +1,5 @@
 VER=4.6.6
+REL=1
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
 CHKSUMS="sha256::27e7ff780cd68a7466082be82ca26c06a002e74a71646ef3a6e4683e444c1a86"
 CHKUPDATE="anitya::id=5137"

--- a/app-scientific/geant4/spec
+++ b/app-scientific/geant4/spec
@@ -2,4 +2,4 @@ VER=11.3.2
 SRCS="tbl::https://geant4-data.web.cern.ch/releases/geant4-v$VER.tar.gz"
 CHKSUMS="sha256::892aedd7425262a50ac3d3c7117d81c0c0da4b408c6880dbaf5478b9301e488c"
 CHKUPDATE="anitya::id=375805"
-REL=5
+REL=6

--- a/app-scientific/octave/spec
+++ b/app-scientific/octave/spec
@@ -2,3 +2,4 @@ VER=11.1.0
 SRCS="tbl::https://ftp.gnu.org/gnu/octave/octave-$VER.tar.lz"
 CHKSUMS="sha256::fb48e9bb9e3e7c6a4755cc90789ecfe54a00f5c59089cf6d50bb32d964bc1abf"
 CHKUPDATE="anitya::id=2528"
+REL=1

--- a/app-scientific/vtk/spec
+++ b/app-scientific/vtk/spec
@@ -1,5 +1,5 @@
 VER=9.5.2
-REL=6
+REL=7
 SRCS="git::commit=tags/v${VER}::https://gitlab.kitware.com/vtk/vtk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15084"

--- a/app-utils/aosc-media-writer/spec
+++ b/app-utils/aosc-media-writer/spec
@@ -2,4 +2,4 @@ VER=0.4.4
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/MediaWriter"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371926"
-REL=1
+REL=2

--- a/app-utils/deskflow/spec
+++ b/app-utils/deskflow/spec
@@ -2,4 +2,4 @@ VER=1.26.0
 SRCS="git::commit=tags/v$VER::https://github.com/deskflow/deskflow.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375452"
-REL=1
+REL=2

--- a/app-utils/flameshot/spec
+++ b/app-utils/flameshot/spec
@@ -1,5 +1,5 @@
 VER=12.1.0
-REL=4
+REL=5
 SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
 CHKSUMS="sha256::c82c05d554e7a6d810aca8417ca12b21e4f74864455ab4ac94602668f85ac22a"
 CHKUPDATE="anitya::id=16948"

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,5 +1,5 @@
 VER=1.3.2
-REL=6
+REL=7
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
 CHKSUMS="sha256::8e986ed88561b4da6e9efe0c54fa4ca8923035c99264df0b0464497c5fb94e9e"
 CHKUPDATE="anitya::id=3643"

--- a/app-utils/qt6ct/spec
+++ b/app-utils/qt6ct/spec
@@ -2,4 +2,4 @@ VER=0.11
 SRCS="git::commit=tags/${VER}::https://www.opencode.net/trialuser/qt6ct.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=288166"
-REL=2
+REL=3

--- a/app-virtualization/virtualbox/spec
+++ b/app-virtualization/virtualbox/spec
@@ -1,5 +1,5 @@
 VER=7.2.4
-REL=4
+REL=5
 # Note: Sometimes Oracle seems to release fix-up tarballs.
 UBUNTU_VBOX_VER="170995~Ubuntu~plucky"
 SRCS="tbl::https://download.virtualbox.org/virtualbox/${VER%%[a-z]*}/VirtualBox-${VER}.tar.bz2 \

--- a/app-web/proton-bridge/spec
+++ b/app-web/proton-bridge/spec
@@ -1,5 +1,5 @@
 VER=3.21.2
-REL=9
+REL=10
 SRCS="git::copy-repo=true;submodule=false;commit=tags/v$VER::https://github.com/ProtonMail/proton-bridge"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231962"

--- a/app-web/qbittorrent/spec
+++ b/app-web/qbittorrent/spec
@@ -2,3 +2,4 @@ VER=5.2.0
 SRCS="git::commit=tags/release-$VER::https://github.com/qbittorrent/qBittorrent"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6111"
+REL=1

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=2
+REL=3
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=e0943d068ce90b5010f1aea946e6901e25b43bf6

--- a/desktop-displaymanagers/lightdm/spec
+++ b/desktop-displaymanagers/lightdm/spec
@@ -1,5 +1,5 @@
 VER=1.32.0
-REL=4
+REL=5
 SRCS="git::commit=tags/$VER::https://github.com/canonical/lightdm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1813"

--- a/groups/qt5-rebuilds
+++ b/groups/qt5-rebuilds
@@ -1,6 +1,5 @@
 app-i18n/fcitx-qt5
 app-i18n/fcitx5-qt
 app-creativity/lmms
-app-web/telegram-desktop
 desktop-kde/layer-shell-qt
 runtime-desktop/qtstyleplugins

--- a/groups/qt6-rebuilds
+++ b/groups/qt6-rebuilds
@@ -63,3 +63,4 @@ virtualbox
 wireshark
 obs-studio
 quickshell
+telegram-desktop

--- a/lang-python/pyqt6-sip/spec
+++ b/lang-python/pyqt6-sip/spec
@@ -2,3 +2,4 @@ VER=13.11.1
 SRCS="pypi::version=$VER::pyqt6_sip"
 CHKSUMS="sha256::869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be"
 CHKUPDATE="anitya::id=149588"
+REL=1

--- a/lang-python/pyqt6-webengine/spec
+++ b/lang-python/pyqt6-webengine/spec
@@ -2,3 +2,4 @@ VER=6.11.0
 SRCS="pypi::version=$VER::PyQt6_WebEngine"
 CHKSUMS="sha256::15cf49efbbbd4c6bc87653b2c4ae80d6049f800e31620b336734ae2e37cbedae"
 CHKUPDATE="anitya::id=258848"
+REL=1

--- a/lang-python/pyqt6/spec
+++ b/lang-python/pyqt6/spec
@@ -2,3 +2,4 @@ VER=6.11.0
 SRCS="pypi::version=$VER::pyqt6"
 CHKSUMS="sha256::45dd60aa69976de1918b5ced6b4e7b6a25abd2a919ecef5fd5826ecc76718889"
 CHKUPDATE="anitya::id=149589"
+REL=1

--- a/lang-python/pyside6/spec
+++ b/lang-python/pyside6/spec
@@ -1,5 +1,5 @@
 VER=6.10.2
-REL=2
+REL=3
 SRCS="tbl::https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-$VER-src/pyside-setup-everywhere-src-$VER.tar.xz"
 CHKSUMS="sha256::05eec38bb71bffff8860786e3c0766cc4b86affc72439bd246c54889bdcb7400"
 CHKUPDATE="anitya::id=148812"

--- a/runtime-common/quazip/spec
+++ b/runtime-common/quazip/spec
@@ -2,4 +2,4 @@ VER=1.5
 SRCS="git::commit=tags/v$VER::https://github.com/stachenov/quazip"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4141"
-REL=3
+REL=4

--- a/runtime-cryptography/gpgme/spec
+++ b/runtime-cryptography/gpgme/spec
@@ -1,5 +1,5 @@
 VER=2.0.1
-REL=1
+REL=2
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-$VER.tar.bz2"
 CHKSUMS="sha256::821ab0695c842eab51752a81980c92b0410c7eadd04103f791d5d2a526784966"
 CHKUPDATE="anitya::id=1239"

--- a/runtime-desktop/kdsingleapplication/spec
+++ b/runtime-desktop/kdsingleapplication/spec
@@ -2,4 +2,4 @@ VER=1.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/KDAB/KDSingleApplication"
 CHKSUMS="SKIP"
 CHKUPDATE="antiya::id=370439"
-REL=3
+REL=4

--- a/runtime-desktop/libdbusmenu-qt/spec
+++ b/runtime-desktop/libdbusmenu-qt/spec
@@ -1,5 +1,5 @@
 VER=0.9.3+16.04.20160218
-REL=10
+REL=11
 SRCS="tbl::http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbusmenu-qt/libdbusmenu-qt_$VER.orig.tar.gz"
 CHKSUMS="sha256::a8e6358a31c44ccdf1bfc46c95a77a6bfc7fc1f536aadb913ed4f4405c570cf6"
 CHKUPDATE="html::url=http://archive.ubuntu.com/ubuntu/pool/main/libd/libdbusmenu-qt/;pattern=libdbusmenu-qt_(.+?).orig.tar.gz"

--- a/runtime-desktop/libportal/spec
+++ b/runtime-desktop/libportal/spec
@@ -2,4 +2,4 @@ VER=0.9.1
 SRCS="tbl::https://github.com/flatpak/libportal/releases/download/$VER/libportal-$VER.tar.xz"
 CHKSUMS="sha256::de801ee349ed3c255a9af3c01b1a401fab5b3fc1c35eb2fd7dfb35d4b8194d7f"
 CHKUPDATE="anitya::id=230124"
-REL=1
+REL=2

--- a/runtime-desktop/qt-6/01-runtime/beyond
+++ b/runtime-desktop/qt-6/01-runtime/beyond
@@ -3,6 +3,7 @@ mkdir -pv "$PKGDIR"/usr/bin
 for b in "$PKGDIR"/usr/lib/qt6/bin/*; do
     ln -sv ../lib/qt6/bin/"$(basename "$b")" "$PKGDIR"/usr/bin/"$(basename "$b")"-qt6
 done
+ln -sv ../lib/qt6/bin/qmake6 "$PKGDIR"/usr/bin/qmake6
 
 abinfo "Copying xcb private headers ..."
 install -dv -m755 "$PKGDIR"/usr/include/qt6xcb-private/{gl_integrations,nativepainting}

--- a/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0001-ARCHLINUX-qtbase-respect-system-compiler-linker-flag.patch
@@ -1,4 +1,4 @@
-From 6b7a1f914371a4ce610d1098357ad236a161367b Mon Sep 17 00:00:00 2001
+From fb4519a7b3c056798d05090b7797d6a4b8e09cf4 Mon Sep 17 00:00:00 2001
 From: Ruikai Liu <rickliu2000@outlook.com>
 Date: Thu, 6 Nov 2025 14:22:16 +0800
 Subject: [PATCH 1/6] ARCHLINUX: qtbase: respect system compiler/linker flags

--- a/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0002-FEDORA-qt3d-assimp-fix-build-with-GCC-13.patch
@@ -1,4 +1,4 @@
-From 7117270cc6a3a7ab7f479b20690089234106b4e3 Mon Sep 17 00:00:00 2001
+From 33a3157a62ce9e2dbd643e590f6230d3f5663ff2 Mon Sep 17 00:00:00 2001
 From: Ruikai Liu <rickliu2000@outlook.com>
 Date: Thu, 6 Nov 2025 14:27:19 +0800
 Subject: [PATCH 2/6] FEDORA: qt3d: assimp: fix build with GCC >= 13

--- a/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0003-AOSCOS-qtbase-fallback-to-GLES-if-GL-EGL-context-cre.patch
@@ -1,4 +1,4 @@
-From 275ded6ba66254cd737aee9223324f40254f1e1a Mon Sep 17 00:00:00 2001
+From b5d3fdc45109d044ca9cc863c04b4e910b67f369 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <uwu@icenowy.me>
 Date: Wed, 26 Jun 2024 22:16:10 +0800
 Subject: [PATCH 3/6] AOSCOS: qtbase: fallback to GLES if GL EGL context

--- a/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
+++ b/runtime-desktop/qt-6/01-runtime/patches/0004-AOSCOS-LOONGARCH64-qtwebengine-chromium-add-LoongArc.patch.loongarch64
@@ -1,27 +1,27 @@
-From 83b74f7674af8c52adc934b47fc4e521ef4cde82 Mon Sep 17 00:00:00 2001
-From: Ruikai Liu <rickliu2000@outlook.com>
-Date: Fri, 7 Nov 2025 22:41:01 +0800
+From ceda3284d086e6e3d7cd1aa8984810eb9f88c7f7 Mon Sep 17 00:00:00 2001
+From: Ruikai Liu <rickliu2000@foxmail.com>
+Date: Thu, 21 May 2026 14:24:59 +0800
 Subject: [PATCH 4/6] AOSCOS: LOONGARCH64: qtwebengine: chromium: add LoongArch
  support
 
-Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd31915301c156598af2eb3e4f53c/qt6-webengine/qt6-6.11.0.diff
+Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/2facd2a4bfb9ebe606e7810f405bc2426c4ffe53/qt6-webengine/qt6-6.11.1.diff
 ---
+ .../plugins/Q3DViewer/q3dviewer_de.ts         |    6 +
+ .../plugins/Q3DViewer/q3dviewer_en.ts         |    6 +
  qtwebengine/cmake/QtToolchainHelpers.cmake    |    2 +
  .../3rdparty/chromium/base/system/sys_info.cc |    2 +
+ .../chromium/build/config/compiler/BUILD.gn   |    2 +-
  .../chromium/build/config/loongarch64.gni     |    2 +-
- .../runtime/chrome_runtime_api_delegate.cc    |    2 +
- .../embedder_support/user_agent_utils.cc      |    2 +
+ .../build/toolchain/gcc_toolchain.gni         |    6 +
  .../metrics/debug/metrics_internals_utils.cc  |    2 +
  .../components/variations/proto/study.proto   |    2 +
- .../extensions/common/api/runtime.json        |    4 +-
- .../gpu/config/software_rendering_list.json   |   12 +
  .../3rdparty/chromium/sandbox/features.gni    |    2 +-
  .../linux/bpf_dsl/linux_syscall_ranges.h      |    7 +
  .../sandbox/linux/bpf_dsl/seccomp_macros.h    |   41 +
  .../seccomp-bpf-helpers/baseline_policy.cc    |    4 +-
  .../seccomp-bpf-helpers/sigsys_handlers.cc    |    2 +
- .../syscall_parameters_restrictions.cc        |    9 +-
- .../linux/seccomp-bpf-helpers/syscall_sets.cc |   62 +-
+ .../syscall_parameters_restrictions.cc        |    7 +-
+ .../linux/seccomp-bpf-helpers/syscall_sets.cc |   60 +-
  .../linux/seccomp-bpf-helpers/syscall_sets.h  |    6 +-
  .../sandbox/linux/seccomp-bpf/syscall.cc      |   35 +-
  .../sandbox/linux/services/credentials.cc     |    2 +-
@@ -30,23 +30,25 @@ Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd3191530
  .../linux/syscall_broker/broker_client.cc     |   15 +
  .../linux/syscall_broker/broker_client.h      |    3 +
  .../linux/syscall_broker/broker_command.h     |    1 +
- .../syscall_broker/broker_file_permission.h   |    1 +
  .../linux/syscall_broker/broker_host.cc       |   18 +-
  .../linux/syscall_broker/broker_process.cc    |   21 +-
  .../syscall_broker/syscall_dispatcher.cc      |   15 +
  .../linux/syscall_broker/syscall_dispatcher.h |    3 +
  .../linux/system_headers/linux_seccomp.h      |    8 +
  .../linux/system_headers/linux_signal.h       |    2 +-
- .../sandbox/linux/system_headers/linux_stat.h |   44 +-
+ .../sandbox/linux/system_headers/linux_stat.h |   46 +-
  .../linux/system_headers/linux_syscalls.h     |    4 +
- .../system_headers/loong64_linux_syscalls.h   | 1194 +++
+ .../system_headers/loong64_linux_syscalls.h   | 1194 +++++++++
  .../policy/linux/bpf_audio_policy_linux.cc    |    1 +
  .../policy/linux/bpf_broker_policy_linux.cc   |    6 +
  .../linux/bpf_cros_amd_gpu_policy_linux.cc    |    2 +-
  .../policy/linux/bpf_gpu_policy_linux.cc      |    2 +-
  .../policy/linux/bpf_network_policy_linux.cc  |    2 +-
  .../linux/bpf_screen_ai_policy_linux.cc       |    2 +-
- .../sandbox/policy/linux/sandbox_linux.cc     |   13 +
+ .../sandbox/policy/linux/sandbox_linux.cc     |   10 +
+ .../src/3rdparty/chromium/skia/BUILD.gn       |    4 +-
+ .../blink/renderer/platform/BUILD.gn          |    2 +-
+ .../blink/renderer/platform/audio/delay.cc    |    4 +-
  .../loongarch64/webgl_image_conversion_lsx.h  |   88 +-
  .../boringssl/src/include/openssl/target.h    |    2 +
  .../crashpad/minidump/minidump_context.h      |   50 +
@@ -74,10 +76,9 @@ Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd3191530
  .../crashpad/util/linux/thread_info.h         |   20 +-
  .../util/misc/capture_context_linux.S         |   45 +
  .../util/net/http_transport_libcurl.cc        |    2 +
- .../dav1d/config/linux/loong64/config.h       |   45 +
  .../src/scripts/build/rollup.config.mjs       |    2 +-
- .../config/Chrome/linux/loong64/config.h      |  802 ++
- .../Chrome/linux/loong64/config_components.h  | 2274 +++++
+ .../config/Chrome/linux/loong64/config.h      |  766 ++++++
+ .../Chrome/linux/loong64/config_components.h  | 2188 +++++++++++++++++
  .../linux/loong64/libavcodec/bsf_list.c       |    2 +
  .../linux/loong64/libavcodec/codec_list.c     |   17 +
  .../linux/loong64/libavcodec/parser_list.c    |    9 +
@@ -85,41 +86,29 @@ Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd3191530
  .../linux/loong64/libavformat/muxer_list.c    |    2 +
  .../linux/loong64/libavformat/protocol_list.c |    2 +
  .../Chrome/linux/loong64/libavutil/avconfig.h |    6 +
- .../linux/loong64/libavutil/ffversion.h       |    5 +
- .../config/Chromium/linux/loong64/config.h    | 1574 ++++
- .../linux/loong64/config_components.h         | 4492 ++++++++++
- .../linux/loong64/libavcodec/bsf_list.c       |    4 +
- .../linux/loong64/libavcodec/codec_list.c     |   30 +
- .../linux/loong64/libavcodec/parser_list.c    |   14 +
- .../linux/loong64/libavformat/demuxer_list.c  |   16 +
- .../linux/loong64/libavformat/muxer_list.c    |    4 +
- .../linux/loong64/libavformat/protocol_list.c |    4 +
- .../linux/loong64/libavutil/avconfig.h        |   12 +
- .../linux/loong64/libavutil/ffversion.h       |   10 +
- .../chromium/third_party/ffmpeg/config.h      |  802 ++
- .../third_party/ffmpeg/config_components.h    | 2274 +++++
- .../third_party/ffmpeg/doc/config.texi        | 3057 +++++++
+ .../config/Chromium/linux/loong64/config.h    |  765 ++++++
+ .../linux/loong64/config_components.h         | 2188 +++++++++++++++++
+ .../linux/loong64/libavcodec/bsf_list.c       |    2 +
+ .../linux/loong64/libavcodec/codec_list.c     |   15 +
+ .../linux/loong64/libavcodec/parser_list.c    |    7 +
+ .../linux/loong64/libavformat/demuxer_list.c  |    8 +
+ .../linux/loong64/libavformat/muxer_list.c    |    2 +
+ .../linux/loong64/libavformat/protocol_list.c |    2 +
+ .../linux/loong64/libavutil/avconfig.h        |    6 +
  .../third_party/ffmpeg/ffmpeg_generated.gni   |   14 +
- .../third_party/ffmpeg/libavcodec/bsf_list.c  |    2 +
- .../ffmpeg/libavcodec/codec_list.c            |   17 +
- .../ffmpeg/libavcodec/parser_list.c           |    9 +
- .../ffmpeg/libavdevice/indev_list.c           |    2 +
- .../ffmpeg/libavdevice/outdev_list.c          |    2 +
- .../ffmpeg/libavfilter/filter_list.c          |    6 +
- .../ffmpeg/libavformat/demuxer_list.c         |    9 +
- .../ffmpeg/libavformat/muxer_list.c           |    2 +
- .../ffmpeg/libavformat/protocol_list.c        |    2 +
- .../third_party/ffmpeg/libavutil/avconfig.h   |    6 +
+ .../chromium/third_party/skia/gn/core.gni     |    6 +-
+ .../skia/include/private/base/SkFeatures.h    |    4 +-
+ .../skia/src/core/SkBitmapProcState_opts.cpp  |    5 -
+ .../skia/src/core/SkBlitRow_opts.cpp          |    5 -
+ .../skia/src/core/SkSwizzler_opts.cpp         |    5 -
  .../skia/src/opts/SkOpts_SetTarget.h          |    3 +-
  .../swiftshader/src/Reactor/BUILD.gn          |    6 +-
- .../chromium/third_party/xnnpack/BUILD.gn     | 7417 +++++++++++++++++
- .../third_party/xnnpack/bazelroot/BUILD       |   13 +
- .../third_party/xnnpack/generate_build_gn.py  |    7 +-
- .../xnnpack/src/src/xnnpack/common.h          |    6 +
- .../xnnpack/src/src/xnnpack/hardware-config.h |    3 +
- 111 files changed, 25099 insertions(+), 109 deletions(-)
+ .../swiftshader/src/Vulkan/BUILD.gn           |    1 +
+ .../third_party/llvm-10.0/BUILD.gn            |    2 +
+ 99 files changed, 8136 insertions(+), 131 deletions(-)
+ create mode 100644 qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_de.ts
+ create mode 100644 qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_en.ts
  create mode 100644 qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/loong64_linux_syscalls.h
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/dav1d/config/linux/loong64/config.h
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
@@ -129,7 +118,6 @@ Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd3191530
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
@@ -139,23 +127,33 @@ Link: https://github.com/AOSC-Dev/chromium-loongarch64/blob/26b4a953036bd3191530
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
  create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config.h
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config_components.h
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/doc/config.texi
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/bsf_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/codec_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/parser_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/indev_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/outdev_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavfilter/filter_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/demuxer_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/muxer_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/protocol_list.c
- create mode 100644 qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavutil/avconfig.h
 
+diff --git a/qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_de.ts b/qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_de.ts
+new file mode 100644
+index 0000000000..1b056fa53b
+--- /dev/null
++++ b/qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_de.ts
+@@ -0,0 +1,6 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++Run the update_translations CMake target to populate the source strings in this file.
++-->
++<!DOCTYPE TS>
++<TS version="2.1" language="de" sourcelanguage="en"/>
+diff --git a/qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_en.ts b/qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_en.ts
+new file mode 100644
+index 0000000000..42edc32782
+--- /dev/null
++++ b/qtdoc/examples/demos/documentviewer/plugins/Q3DViewer/q3dviewer_en.ts
+@@ -0,0 +1,6 @@
++<?xml version="1.0" encoding="utf-8"?>
++<!--
++Run the update_translations CMake target to populate the source strings in this file.
++-->
++<!DOCTYPE TS>
++<TS version="2.1" language="en" sourcelanguage="en"/>
 diff --git a/qtwebengine/cmake/QtToolchainHelpers.cmake b/qtwebengine/cmake/QtToolchainHelpers.cmake
-index 2518830485..ba538a6ceb 100644
+index aca1fab4af..043df1fdb5 100644
 --- a/qtwebengine/cmake/QtToolchainHelpers.cmake
 +++ b/qtwebengine/cmake/QtToolchainHelpers.cmake
 @@ -55,6 +55,8 @@ function(get_gn_arch result arch)
@@ -180,6 +178,19 @@ index 000604bcb8..8b08fcc46c 100644
  #else
    return std::string();
  #endif
+diff --git a/qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn b/qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn
+index 45d5edc377..de0c6c3688 100644
+--- a/qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/build/config/compiler/BUILD.gn
+@@ -765,7 +765,7 @@ config("compiler") {
+     if (is_linux && use_lld && !llvm_android_mainline && current_cpu != "arm" &&
+         current_cpu != "s390x" &&
+         default_toolchain != "//build/toolchain/cros:target") {
+-      cflags += [ "-Wa,--crel,--allow-experimental-crel" ]
++      # cflags += [ "-Wa,--crel,--allow-experimental-crel" ]
+     }
+   }
+ 
 diff --git a/qtwebengine/src/3rdparty/chromium/build/config/loongarch64.gni b/qtwebengine/src/3rdparty/chromium/build/config/loongarch64.gni
 index 9a95ec9151..a9dc9d28db 100644
 --- a/qtwebengine/src/3rdparty/chromium/build/config/loongarch64.gni
@@ -193,32 +204,23 @@ index 9a95ec9151..a9dc9d28db 100644
      loongarch64_use_lasx = false
    }
  }
-diff --git a/qtwebengine/src/3rdparty/chromium/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc b/qtwebengine/src/3rdparty/chromium/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
-index 62140c0073..146fb8f0fa 100644
---- a/qtwebengine/src/3rdparty/chromium/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
-+++ b/qtwebengine/src/3rdparty/chromium/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
-@@ -376,6 +376,8 @@ bool ChromeRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
-     info->arch = extensions::api::runtime::PlatformArch::kMips;
-   } else if (strcmp(arch, "mips64el") == 0) {
-     info->arch = extensions::api::runtime::PlatformArch::kMips64;
-+  } else if (strcmp(arch, "loongarch64") == 0) {
-+    info->arch = extensions::api::runtime::PlatformArch::kLoongarch64;
-   } else if (strcmp(arch, "riscv64") == 0) {
-     info->arch = extensions::api::runtime::PlatformArch::kRiscv64;
-   } else {
-diff --git a/qtwebengine/src/3rdparty/chromium/components/embedder_support/user_agent_utils.cc b/qtwebengine/src/3rdparty/chromium/components/embedder_support/user_agent_utils.cc
-index 8c44d2265b..fe7883e165 100644
---- a/qtwebengine/src/3rdparty/chromium/components/embedder_support/user_agent_utils.cc
-+++ b/qtwebengine/src/3rdparty/chromium/components/embedder_support/user_agent_utils.cc
-@@ -805,6 +805,8 @@ std::string GetCpuArchitecture() {
-               cpu_info.substr(2, 2) == "86") ||
-              base::StartsWith(cpu_info, "x86")) {
-     return "x86";
-+  } else if (base::StartsWith(cpu_info, "loong")) {
-+    return "loongarch";
-   }
- #elif BUILDFLAG(IS_FUCHSIA)
-   std::string cpu_arch = base::SysInfo::ProcessCPUArchitecture();
+diff --git a/qtwebengine/src/3rdparty/chromium/build/toolchain/gcc_toolchain.gni b/qtwebengine/src/3rdparty/chromium/build/toolchain/gcc_toolchain.gni
+index 23da92d843..63ff80e3ba 100644
+--- a/qtwebengine/src/3rdparty/chromium/build/toolchain/gcc_toolchain.gni
++++ b/qtwebengine/src/3rdparty/chromium/build/toolchain/gcc_toolchain.gni
+@@ -329,6 +329,12 @@ template("single_gcc_toolchain") {
+       extra_ldflags = ""
+     }
+ 
++    if (current_cpu == "loong64") {
++      extra_cflags += " -mcmodel=medium"
++      extra_cxxflags += " -mcmodel=medium"
++      extra_ldflags += " -mno-relax"
++    }
++
+     if (system_headers_in_deps) {
+       md = "-MD"
+     } else {
 diff --git a/qtwebengine/src/3rdparty/chromium/components/metrics/debug/metrics_internals_utils.cc b/qtwebengine/src/3rdparty/chromium/components/metrics/debug/metrics_internals_utils.cc
 index b63ffa6dfa..f2dc230772 100644
 --- a/qtwebengine/src/3rdparty/chromium/components/metrics/debug/metrics_internals_utils.cc
@@ -245,51 +247,6 @@ index 0c642d82c7..f20e3d2611 100644
    }
  
    // Enum to pass as optional bool.
-diff --git a/qtwebengine/src/3rdparty/chromium/extensions/common/api/runtime.json b/qtwebengine/src/3rdparty/chromium/extensions/common/api/runtime.json
-index cf6fe1558e..4ebb1a8c88 100644
---- a/qtwebengine/src/3rdparty/chromium/extensions/common/api/runtime.json
-+++ b/qtwebengine/src/3rdparty/chromium/extensions/common/api/runtime.json
-@@ -99,6 +99,7 @@
-             {"name": "x86-64", "description": "Specifies the processer architecture as x86-64."},
-             {"name": "mips", "description": "Specifies the processer architecture as mips."},
-             {"name": "mips64", "description": "Specifies the processer architecture as mips64."},
-+	    {"name": "loongarch64", "description": "Specifies the processer architecture as loongarch64."},
-             {"name": "riscv64", "description": "Specifies the processer architecture as riscv64."}
-          ],
-         "description": "The machine's processor architecture."
-@@ -112,7 +113,8 @@
-           {"name": "x86-32", "description": "Specifies the native client architecture as x86-32."},
-           {"name": "x86-64", "description": "Specifies the native client architecture as x86-64."},
-           {"name": "mips", "description": "Specifies the native client architecture as mips."},
--          {"name": "mips64", "description": "Specifies the native client architecture as mips64."}
-+          {"name": "mips64", "description": "Specifies the native client architecture as mips64."},
-+          {"name": "loongarch64", "description": "Specifies the native client architecture as loongarch64."}
-         ]
-       },
-       {
-diff --git a/qtwebengine/src/3rdparty/chromium/gpu/config/software_rendering_list.json b/qtwebengine/src/3rdparty/chromium/gpu/config/software_rendering_list.json
-index 8e6ae3b39a..bcfe5dfcf6 100644
---- a/qtwebengine/src/3rdparty/chromium/gpu/config/software_rendering_list.json
-+++ b/qtwebengine/src/3rdparty/chromium/gpu/config/software_rendering_list.json
-@@ -1475,6 +1475,18 @@
-       "features": [
-         "direct_rendering_display_compositor"
-       ]
-+    },
-+    {
-+      "id": 186,
-+      "description": "Corrupted webpage rendering on Loongson LG100/110 graphics with 2D acceleration enabled",
-+      "os": {
-+        "type" : "linux"
-+      },
-+      "vendor_id": "0x0014",
-+      "device_id": [ "0x7a36" ],
-+      "features": [
-+        "accelerated_2d_canvas"
-+      ]
-     }
-   ]
- }
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni
 index 8c5db2c6fa..32a49bea45 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni
@@ -420,7 +377,7 @@ index 424f755250..6cf19f4514 100644
    CrashSIGSYS_Handler(args, fs_denied_errno);
  
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
-index 40101b5140..da5686cfee 100644
+index 40101b5140..ac320fce6e 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
 @@ -44,7 +44,7 @@
@@ -428,7 +385,7 @@ index 40101b5140..da5686cfee 100644
  
  #if BUILDFLAG(IS_LINUX) && !defined(__arm__) && !defined(__aarch64__) && \
 -    !defined(PTRACE_GET_THREAD_AREA)
-+    !defined(PTRACE_GET_THREAD_AREA) && !defined(__loongarch__)
++    !defined(__loongarch__) && !defined(PTRACE_GET_THREAD_AREA)
  // Also include asm/ptrace-abi.h since ptrace.h in older libc (for instance
  // the one in Ubuntu 16.04 LTS) is missing PTRACE_GET_THREAD_AREA.
  // asm/ptrace-abi.h doesn't exist on arm32 and PTRACE_GET_THREAD_AREA isn't
@@ -445,17 +402,8 @@ index 40101b5140..da5686cfee 100644
  #endif
  #if defined(__arm__)
                   PTRACE_GETVFPREGS,
-@@ -530,7 +533,7 @@ SANDBOX_EXPORT bpf_dsl::ResultExpr RestrictSockSendFlags(int sysno) {
-       break;
- #endif
- #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
--    defined(__mips__) || defined(__aarch64__)
-+    defined(__mips__) || defined(__aarch64__) || defined(__loongarch__)
-     case __NR_sendto:  // Could specify destination.
-       argIndex = 3;
-       break;
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
-index f3b9561aaf..909299e692 100644
+index f3b9561aaf..9af328ea2a 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
 @@ -103,7 +103,7 @@ bool SyscallSets::IsUmask(int sysno) {
@@ -576,15 +524,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_accept:
      case __NR_accept4:
      case __NR_bind:
-@@ -548,13 +554,15 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
-     case __NR_mlock:
-     case __NR_munlock:
-     case __NR_munmap:
-+#if !defined(__loongarch__)
-     case __NR_mseal:
-+#endif
-       return true;
-     case __NR_madvise:
+@@ -554,7 +560,7 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
      case __NR_mincore:
      case __NR_mlockall:
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -593,7 +533,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_mmap:
  #endif
  #if defined(__i386__) || defined(__arm__) || \
-@@ -587,7 +595,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+@@ -587,7 +593,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
      case __NR__llseek:
  #endif
@@ -602,7 +542,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_poll:
  #endif
      case __NR_ppoll:
-@@ -608,7 +616,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+@@ -608,7 +614,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      case __NR_recv:
  #endif
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -611,7 +551,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_recvfrom:  // Could specify source.
      case __NR_recvmsg:   // Could specify source.
  #endif
-@@ -639,7 +647,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
+@@ -639,7 +645,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      case __NR_send:
  #endif
  #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
@@ -620,7 +560,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_sendmsg:  // Could specify destination.
      case __NR_sendto:   // Could specify destination.
  #endif
-@@ -656,7 +664,7 @@ bool SyscallSets::IsSockSendOneMsg(int sysno) {
+@@ -656,7 +662,7 @@ bool SyscallSets::IsSockSendOneMsg(int sysno) {
      case __NR_send:
  #endif
  #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
@@ -629,7 +569,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_sendmsg:  // Could specify destination.
      case __NR_sendto:   // Could specify destination.
  #endif
-@@ -690,7 +698,7 @@ bool SyscallSets::IsSeccomp(int sysno) {
+@@ -690,7 +696,7 @@ bool SyscallSets::IsSeccomp(int sysno) {
  bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
    switch (sysno) {
      case __NR_sched_yield:
@@ -638,7 +578,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_pause:
  #endif
      case __NR_nanosleep:
-@@ -774,7 +782,7 @@ bool SyscallSets::IsNuma(int sysno) {
+@@ -774,7 +780,7 @@ bool SyscallSets::IsNuma(int sysno) {
      case __NR_getcpu:
      case __NR_mbind:
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -647,7 +587,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_migrate_pages:
  #endif
      case __NR_move_pages:
-@@ -822,7 +830,9 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
+@@ -822,7 +828,9 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
      case __NR_getrusage:
      case __NR_personality:  // Can change its personality as well.
      case __NR_prlimit64:    // Like setrlimit / getrlimit.
@@ -657,7 +597,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_times:
        return true;
      default:
-@@ -844,7 +854,7 @@ bool SyscallSets::IsDebug(int sysno) {
+@@ -844,7 +852,7 @@ bool SyscallSets::IsDebug(int sysno) {
  
  bool SyscallSets::IsGlobalSystemStatus(int sysno) {
    switch (sysno) {
@@ -666,7 +606,7 @@ index f3b9561aaf..909299e692 100644
      case __NR__sysctl:
      case __NR_sysfs:
  #endif
-@@ -862,7 +872,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
+@@ -862,7 +870,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
  
  bool SyscallSets::IsEventFd(int sysno) {
    switch (sysno) {
@@ -675,7 +615,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_eventfd:
  #endif
      case __NR_eventfd2:
-@@ -914,7 +924,7 @@ bool SyscallSets::IsKeyManagement(int sysno) {
+@@ -914,7 +922,7 @@ bool SyscallSets::IsKeyManagement(int sysno) {
  }
  
  #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
@@ -684,7 +624,7 @@ index f3b9561aaf..909299e692 100644
  bool SyscallSets::IsSystemVSemaphores(int sysno) {
    switch (sysno) {
      case __NR_semctl:
-@@ -934,7 +944,7 @@ bool SyscallSets::IsSystemVSemaphores(int sysno) {
+@@ -934,7 +942,7 @@ bool SyscallSets::IsSystemVSemaphores(int sysno) {
  
  #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
      defined(__aarch64__) ||                                         \
@@ -693,7 +633,7 @@ index f3b9561aaf..909299e692 100644
  // These give a lot of ambient authority and bypass the setuid sandbox.
  bool SyscallSets::IsSystemVSharedMemory(int sysno) {
    switch (sysno) {
-@@ -950,7 +960,7 @@ bool SyscallSets::IsSystemVSharedMemory(int sysno) {
+@@ -950,7 +958,7 @@ bool SyscallSets::IsSystemVSharedMemory(int sysno) {
  #endif
  
  #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
@@ -702,7 +642,7 @@ index f3b9561aaf..909299e692 100644
  bool SyscallSets::IsSystemVMessageQueue(int sysno) {
    switch (sysno) {
      case __NR_msgctl:
-@@ -981,7 +991,7 @@ bool SyscallSets::IsSystemVIpc(int sysno) {
+@@ -981,7 +989,7 @@ bool SyscallSets::IsSystemVIpc(int sysno) {
  
  bool SyscallSets::IsAnySystemV(int sysno) {
  #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
@@ -711,7 +651,7 @@ index f3b9561aaf..909299e692 100644
    return IsSystemVMessageQueue(sysno) || IsSystemVSemaphores(sysno) ||
           IsSystemVSharedMemory(sysno);
  #elif defined(__i386__) || \
-@@ -1018,7 +1028,7 @@ bool SyscallSets::IsAdvancedScheduler(int sysno) {
+@@ -1018,7 +1026,7 @@ bool SyscallSets::IsAdvancedScheduler(int sysno) {
  bool SyscallSets::IsInotify(int sysno) {
    switch (sysno) {
      case __NR_inotify_add_watch:
@@ -720,7 +660,7 @@ index f3b9561aaf..909299e692 100644
      case __NR_inotify_init:
  #endif
      case __NR_inotify_init1:
-@@ -1153,7 +1163,7 @@ bool SyscallSets::IsMisc(int sysno) {
+@@ -1153,7 +1161,7 @@ bool SyscallSets::IsMisc(int sysno) {
  #if defined(__x86_64__)
      case __NR_tuxcall:
  #endif
@@ -990,18 +930,6 @@ index d44c42fe2b..5fd22d8186 100644
    COMMAND_UNLINK,
    COMMAND_INOTIFY_ADD_WATCH,
  
-diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_file_permission.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_file_permission.h
-index 0b9fb9c04e..4202dc1889 100644
---- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_file_permission.h
-+++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_file_permission.h
-@@ -5,6 +5,7 @@
- #ifndef SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
- #define SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
- 
-+#include <cstdint>
- #include <bitset>
- #include <cstdint>
- #include <string>
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc
 index bf1339b061..ca5793ecc0 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/broker_host.cc
@@ -1116,7 +1044,7 @@ index 9845f87509..ae8448b047 100644
        return !fast_check || policy_->allowed_command_set.test(COMMAND_UNLINK);
  #endif
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc
-index 2c019f92b8..59d3e60923 100644
+index 2c019f92b8..e7b4ac840e 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/syscall_broker/syscall_dispatcher.cc
 @@ -27,6 +27,8 @@ int SyscallDispatcher::DefaultStatForTesting(const char* pathname,
@@ -1124,7 +1052,7 @@ index 2c019f92b8..59d3e60923 100644
  #if defined(__NR_fstatat64)
    return Stat64(pathname, follow_links, sb);
 +#elif defined(__NR_statx)
-+  return Statx(pathname, follow_links, sb);
++  return Statx(pathname, follow_links ? 0 : AT_SYMLINK_NOFOLLOW, sb);
  #elif defined(__NR_newfstatat)
    return Stat(pathname, follow_links, sb);
  #endif
@@ -1202,7 +1130,7 @@ index 69ccaf1081..0d29396a6c 100644
  #define LINUX_SIGHUP 1
  #define LINUX_SIGINT 2
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h
-index 3aae8cbced..7b4ca05e6b 100644
+index 3aae8cbced..c5293cfeb8 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/linux/system_headers/linux_stat.h
 @@ -150,7 +150,7 @@ struct kernel_stat {
@@ -1214,10 +1142,11 @@ index 3aae8cbced..7b4ca05e6b 100644
  struct kernel_stat {
    unsigned long st_dev;
    unsigned long st_ino;
-@@ -175,6 +175,40 @@ struct kernel_stat {
+@@ -175,6 +175,42 @@ struct kernel_stat {
  };
  #endif
  
++#if defined(__loongarch__)
 +// from linux include/uapi/linux/stat.h
 +struct kernel_statx_timestamp {
 +  long tv_sec;
@@ -1251,11 +1180,12 @@ index 3aae8cbced..7b4ca05e6b 100644
 +  unsigned int stx_dio_offset_align;
 +  unsigned long __spare3[12];
 +};
++#endif
 +
  #if !defined(AT_EMPTY_PATH)
  #define AT_EMPTY_PATH 0x1000
  #endif
-@@ -207,8 +241,14 @@ using default_stat_struct = struct kernel_stat;
+@@ -207,8 +243,14 @@ using default_stat_struct = struct kernel_stat;
  #define __NR_fstatat_default __NR_newfstatat
  #define __NR_fstat_default __NR_fstat
  
@@ -2567,7 +2497,7 @@ index 03b9aadeff..ecbcec86ab 100644
                Allow())
            // Sending ENOSYS tells the Futex backend to use another approach if
 diff --git a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc
-index 449273b196..4d72237d99 100644
+index 449273b196..46d160b3bf 100644
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/policy/linux/sandbox_linux.cc
 @@ -581,6 +581,7 @@ bpf_dsl::ResultExpr SandboxLinux::HandleViaBroker(int sysno) const {
@@ -2578,7 +2508,7 @@ index 449273b196..4d72237d99 100644
    if (sysno == __NR_fstatat_default) {
      // This may be an fstatat(fd, "", stat_buf, AT_EMPTY_PATH), which should be
      // rewritten as fstat(fd, stat_buf). This should be consistent with how the
-@@ -591,6 +592,18 @@ bpf_dsl::ResultExpr SandboxLinux::HandleViaBroker(int sysno) const {
+@@ -591,6 +592,15 @@ bpf_dsl::ResultExpr SandboxLinux::HandleViaBroker(int sysno) const {
      return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
                         RewriteFstatatSIGSYS(BPFBasePolicy::GetFSDeniedErrno()))
          .Else(handle_via_broker);
@@ -2586,9 +2516,6 @@ index 449273b196..4d72237d99 100644
 +  if (sysno == __NR_statx) {
 +    // This may be a statx(fd, "", AT_EMPTY_PATH, mask, statx_buf), and we allow it.
 +    // Otherwise, we expect a statx(AT_FDCWD, path, flags, mask, statx_buf).
-+    // However, it is possible to pass a non-empty path even when AT_EMPTY_PATH
-+    // is set. But there are currently no easy way to validate the argument in
-+    // seccomp bpf.
 +    const bpf_dsl::Arg<int> flags(2);
 +    return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
 +                       bpf_dsl::Allow())
@@ -2597,6 +2524,56 @@ index 449273b196..4d72237d99 100644
    } else {
      return handle_via_broker;
    }
+diff --git a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn
+index 48edd7108d..f6e2febed3 100644
+--- a/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/skia/BUILD.gn
+@@ -164,7 +164,7 @@ config("skia_config") {
+   if (current_cpu == "loong64") {
+     cflags = [
+       "-mlsx",
+-      "-flax-vector-conversions=all",
++      "-flax-vector-conversions",
+     ]
+   }
+ }
+@@ -793,7 +793,7 @@ if (current_cpu == "loong64") {
+     sources = skia_opts.lasx_sources
+     cflags = [
+       "-mlasx",
+-      "-flax-vector-conversions=all",
++      "-flax-vector-conversions",
+     ]
+     visibility = [ ":skia_opts" ]
+   }
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/BUILD.gn
+index 18bd204cbc..097e9e741e 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/BUILD.gn
+@@ -1684,7 +1684,7 @@ jumbo_component("platform") {
+   if (current_cpu == "loong64") {
+     cflags = [
+       "-mlsx",
+-      "-flax-vector-conversions=all",
++      "-flax-vector-conversions",
+     ]
+   }
+ 
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/audio/delay.cc b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/audio/delay.cc
+index b031acfd8e..5191143610 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/audio/delay.cc
++++ b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/audio/delay.cc
+@@ -107,8 +107,8 @@ double Delay::DelayTime(float sample_rate) {
+ #if !(defined(ARCH_CPU_X86_FAMILY) || defined(CPU_ARM_NEON))
+ // Default scalar versions if simd/neon are not available.
+ std::tuple<size_t, size_t> Delay::ProcessARateVector(
+-    float* destination,
+-    uint32_t frames_to_process) const {
++    base::span<float> destination,
++    size_t frames_to_process) const {
+   // We don't have a vectorized version, so just do nothing and return the 0 to
+   // indicate no frames processed and return the current write_index_.
+   return std::make_tuple(0, write_index_);
 diff --git a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h b/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
 index 114f3c112e..1e2096f651 100644
 --- a/qtwebengine/src/3rdparty/chromium/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
@@ -3624,57 +3601,6 @@ index df63a77296..1f7d652441 100644
  #else
  #error Port
  #endif
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/dav1d/config/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/dav1d/config/linux/loong64/config.h
-new file mode 100644
-index 0000000000..44c60eb528
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/dav1d/config/linux/loong64/config.h
-@@ -0,0 +1,45 @@
-+/*
-+ * Autogenerated by the Meson build system.
-+ * Do not edit, your changes will be lost.
-+ */
-+
-+#pragma once
-+
-+#define ARCH_AARCH64 0
-+
-+#define ARCH_ARM 0
-+
-+#define ARCH_PPC64LE 0
-+
-+#define ARCH_X86 0
-+
-+#define ARCH_X86_32 0
-+
-+#define ARCH_X86_64 0
-+
-+#define CONFIG_16BPC 1
-+
-+#define CONFIG_8BPC 1
-+
-+// #define CONFIG_LOG 1 -- Logging is controlled by Chromium
-+
-+#define ENDIANNESS_BIG 0
-+
-+#define HAVE_ASM 0
-+
-+#define HAVE_C11_GENERIC 1
-+
-+#define HAVE_CLOCK_GETTIME 1
-+
-+#define HAVE_DLSYM 1
-+
-+#define HAVE_POSIX_MEMALIGN 1
-+
-+// #define HAVE_PTHREAD_GETAFFINITY_NP 1 -- Controlled by Chomium
-+
-+// #define HAVE_PTHREAD_SETAFFINITY_NP 1 -- Controlled by Chomium
-+
-+#define HAVE_UNISTD_H 1
-+
-+#define TRIM_DSP_FUNCTIONS 1
-+
 diff --git a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs
 index b85411dc71..ac54145c3b 100644
 --- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs
@@ -3690,4015 +3616,26 @@ index b85411dc71..ac54145c3b 100644
        resolveId(source, importer) {
 diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
 new file mode 100644
-index 0000000000..3fd73dcf72
+index 0000000000..b9968e487b
 --- /dev/null
 +++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
-@@ -0,0 +1,802 @@
+@@ -0,0 +1,766 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_H
 +#define FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\"-O2\\\"' --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264' --disable-iamf"
++#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --enable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\"-O2\\\\\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'"
 +#define FFMPEG_LICENSE "LGPL version 2.1 or later"
-+#define CONFIG_THIS_YEAR 2025
-+#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
-+#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 20.1.5 (https://github.com/llvm/llvm-project 7b09d7b446383b71b63d429b21ee45ba389c5134)"
-+#define OS_NAME linux
-+#define EXTERN_PREFIX ""
-+#define EXTERN_ASM 
-+#define BUILDSUF ""
-+#define SLIBSUF ".so"
-+#define SWS_MAX_FILTER_SIZE 256
-+#define ARCH_AARCH64 0
-+#define ARCH_ARM 0
-+#define ARCH_IA64 0
-+#define ARCH_LOONGARCH 1
-+#define ARCH_LOONGARCH32 0
-+#define ARCH_LOONGARCH64 1
-+#define ARCH_M68K 0
-+#define ARCH_MIPS 0
-+#define ARCH_MIPS64 0
-+#define ARCH_PARISC 0
-+#define ARCH_PPC 0
-+#define ARCH_PPC64 0
-+#define ARCH_RISCV 0
-+#define ARCH_S390 0
-+#define ARCH_SPARC 0
-+#define ARCH_SPARC64 0
-+#define ARCH_TILEGX 0
-+#define ARCH_TILEPRO 0
-+#define ARCH_WASM 0
-+#define ARCH_X86 0
-+#define ARCH_X86_32 0
-+#define ARCH_X86_64 0
-+#define HAVE_ARMV5TE 0
-+#define HAVE_ARMV6 0
-+#define HAVE_ARMV6T2 0
-+#define HAVE_ARMV8 0
-+#define HAVE_DOTPROD 0
-+#define HAVE_I8MM 0
-+#define HAVE_NEON 0
-+#define HAVE_VFP 0
-+#define HAVE_VFPV3 0
-+#define HAVE_SETEND 0
-+#define HAVE_SVE 0
-+#define HAVE_SVE2 0
-+#define HAVE_ALTIVEC 0
-+#define HAVE_DCBZL 0
-+#define HAVE_LDBRX 0
-+#define HAVE_POWER8 0
-+#define HAVE_PPC4XX 0
-+#define HAVE_VEC_XL 0
-+#define HAVE_VSX 0
-+#define HAVE_RV 0
-+#define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
-+#define HAVE_RV_ZVBB 0
-+#define HAVE_SIMD128 0
-+#define HAVE_AESNI 0
-+#define HAVE_AMD3DNOW 0
-+#define HAVE_AMD3DNOWEXT 0
-+#define HAVE_AVX 0
-+#define HAVE_AVX2 0
-+#define HAVE_AVX512 0
-+#define HAVE_AVX512ICL 0
-+#define HAVE_FMA3 0
-+#define HAVE_FMA4 0
-+#define HAVE_MMX 0
-+#define HAVE_MMXEXT 0
-+#define HAVE_SSE 0
-+#define HAVE_SSE2 0
-+#define HAVE_SSE3 0
-+#define HAVE_SSE4 0
-+#define HAVE_SSE42 0
-+#define HAVE_SSSE3 0
-+#define HAVE_XOP 0
-+#define HAVE_I686 0
-+#define HAVE_MIPSFPU 0
-+#define HAVE_MIPS32R2 0
-+#define HAVE_MIPS32R5 0
-+#define HAVE_MIPS64R2 0
-+#define HAVE_MIPS32R6 0
-+#define HAVE_MIPS64R6 0
-+#define HAVE_MIPSDSP 0
-+#define HAVE_MIPSDSPR2 0
-+#define HAVE_MSA 0
-+#define HAVE_LOONGSON2 0
-+#define HAVE_LOONGSON3 0
-+#define HAVE_MMI 0
-+#define HAVE_LSX 0
-+#define HAVE_LASX 0
-+#define HAVE_ARMV5TE_EXTERNAL 0
-+#define HAVE_ARMV6_EXTERNAL 0
-+#define HAVE_ARMV6T2_EXTERNAL 0
-+#define HAVE_ARMV8_EXTERNAL 0
-+#define HAVE_DOTPROD_EXTERNAL 0
-+#define HAVE_I8MM_EXTERNAL 0
-+#define HAVE_NEON_EXTERNAL 0
-+#define HAVE_VFP_EXTERNAL 0
-+#define HAVE_VFPV3_EXTERNAL 0
-+#define HAVE_SETEND_EXTERNAL 0
-+#define HAVE_SVE_EXTERNAL 0
-+#define HAVE_SVE2_EXTERNAL 0
-+#define HAVE_ALTIVEC_EXTERNAL 0
-+#define HAVE_DCBZL_EXTERNAL 0
-+#define HAVE_LDBRX_EXTERNAL 0
-+#define HAVE_POWER8_EXTERNAL 0
-+#define HAVE_PPC4XX_EXTERNAL 0
-+#define HAVE_VEC_XL_EXTERNAL 0
-+#define HAVE_VSX_EXTERNAL 0
-+#define HAVE_RV_EXTERNAL 0
-+#define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
-+#define HAVE_RV_ZVBB_EXTERNAL 0
-+#define HAVE_SIMD128_EXTERNAL 0
-+#define HAVE_AESNI_EXTERNAL 0
-+#define HAVE_AMD3DNOW_EXTERNAL 0
-+#define HAVE_AMD3DNOWEXT_EXTERNAL 0
-+#define HAVE_AVX_EXTERNAL 0
-+#define HAVE_AVX2_EXTERNAL 0
-+#define HAVE_AVX512_EXTERNAL 0
-+#define HAVE_AVX512ICL_EXTERNAL 0
-+#define HAVE_FMA3_EXTERNAL 0
-+#define HAVE_FMA4_EXTERNAL 0
-+#define HAVE_MMX_EXTERNAL 0
-+#define HAVE_MMXEXT_EXTERNAL 0
-+#define HAVE_SSE_EXTERNAL 0
-+#define HAVE_SSE2_EXTERNAL 0
-+#define HAVE_SSE3_EXTERNAL 0
-+#define HAVE_SSE4_EXTERNAL 0
-+#define HAVE_SSE42_EXTERNAL 0
-+#define HAVE_SSSE3_EXTERNAL 0
-+#define HAVE_XOP_EXTERNAL 0
-+#define HAVE_I686_EXTERNAL 0
-+#define HAVE_MIPSFPU_EXTERNAL 0
-+#define HAVE_MIPS32R2_EXTERNAL 0
-+#define HAVE_MIPS32R5_EXTERNAL 0
-+#define HAVE_MIPS64R2_EXTERNAL 0
-+#define HAVE_MIPS32R6_EXTERNAL 0
-+#define HAVE_MIPS64R6_EXTERNAL 0
-+#define HAVE_MIPSDSP_EXTERNAL 0
-+#define HAVE_MIPSDSPR2_EXTERNAL 0
-+#define HAVE_MSA_EXTERNAL 0
-+#define HAVE_LOONGSON2_EXTERNAL 0
-+#define HAVE_LOONGSON3_EXTERNAL 0
-+#define HAVE_MMI_EXTERNAL 0
-+#define HAVE_LSX_EXTERNAL 0
-+#define HAVE_LASX_EXTERNAL 0
-+#define HAVE_ARMV5TE_INLINE 0
-+#define HAVE_ARMV6_INLINE 0
-+#define HAVE_ARMV6T2_INLINE 0
-+#define HAVE_ARMV8_INLINE 0
-+#define HAVE_DOTPROD_INLINE 0
-+#define HAVE_I8MM_INLINE 0
-+#define HAVE_NEON_INLINE 0
-+#define HAVE_VFP_INLINE 0
-+#define HAVE_VFPV3_INLINE 0
-+#define HAVE_SETEND_INLINE 0
-+#define HAVE_SVE_INLINE 0
-+#define HAVE_SVE2_INLINE 0
-+#define HAVE_ALTIVEC_INLINE 0
-+#define HAVE_DCBZL_INLINE 0
-+#define HAVE_LDBRX_INLINE 0
-+#define HAVE_POWER8_INLINE 0
-+#define HAVE_PPC4XX_INLINE 0
-+#define HAVE_VEC_XL_INLINE 0
-+#define HAVE_VSX_INLINE 0
-+#define HAVE_RV_INLINE 0
-+#define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
-+#define HAVE_RV_ZVBB_INLINE 0
-+#define HAVE_SIMD128_INLINE 0
-+#define HAVE_AESNI_INLINE 0
-+#define HAVE_AMD3DNOW_INLINE 0
-+#define HAVE_AMD3DNOWEXT_INLINE 0
-+#define HAVE_AVX_INLINE 0
-+#define HAVE_AVX2_INLINE 0
-+#define HAVE_AVX512_INLINE 0
-+#define HAVE_AVX512ICL_INLINE 0
-+#define HAVE_FMA3_INLINE 0
-+#define HAVE_FMA4_INLINE 0
-+#define HAVE_MMX_INLINE 0
-+#define HAVE_MMXEXT_INLINE 0
-+#define HAVE_SSE_INLINE 0
-+#define HAVE_SSE2_INLINE 0
-+#define HAVE_SSE3_INLINE 0
-+#define HAVE_SSE4_INLINE 0
-+#define HAVE_SSE42_INLINE 0
-+#define HAVE_SSSE3_INLINE 0
-+#define HAVE_XOP_INLINE 0
-+#define HAVE_I686_INLINE 0
-+#define HAVE_MIPSFPU_INLINE 0
-+#define HAVE_MIPS32R2_INLINE 0
-+#define HAVE_MIPS32R5_INLINE 0
-+#define HAVE_MIPS64R2_INLINE 0
-+#define HAVE_MIPS32R6_INLINE 0
-+#define HAVE_MIPS64R6_INLINE 0
-+#define HAVE_MIPSDSP_INLINE 0
-+#define HAVE_MIPSDSPR2_INLINE 0
-+#define HAVE_MSA_INLINE 0
-+#define HAVE_LOONGSON2_INLINE 0
-+#define HAVE_LOONGSON3_INLINE 0
-+#define HAVE_MMI_INLINE 0
-+#define HAVE_LSX_INLINE 0
-+#define HAVE_LASX_INLINE 0
-+#define HAVE_ALIGNED_STACK 0
-+#define HAVE_FAST_64BIT 1
-+#define HAVE_FAST_CLZ 1
-+#define HAVE_FAST_CMOV 0
-+#define HAVE_FAST_FLOAT16 0
-+#define HAVE_SIMD_ALIGN_16 0
-+#define HAVE_SIMD_ALIGN_32 1
-+#define HAVE_SIMD_ALIGN_64 0
-+#define HAVE_MEMORYBARRIER 0
-+#define HAVE_MM_EMPTY 0
-+#define HAVE_RDTSC 0
-+#define HAVE_SEM_TIMEDWAIT 1
-+#define HAVE_INLINE_ASM 1
-+#define HAVE_SYMVER 0
-+#define HAVE_X86ASM 0
-+#define HAVE_BIGENDIAN 0
-+#define HAVE_FAST_UNALIGNED 1
-+#define HAVE_ARPA_INET_H 0
-+#define HAVE_ASM_HWPROBE_H 0
-+#define HAVE_ASM_TYPES_H 1
-+#define HAVE_CDIO_PARANOIA_H 0
-+#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
-+#define HAVE_CUDA_H 0
-+#define HAVE_DISPATCH_DISPATCH_H 0
-+#define HAVE_DIRECT_H 0
-+#define HAVE_DIRENT_H 1
-+#define HAVE_DXGIDEBUG_H 0
-+#define HAVE_DXVA_H 0
-+#define HAVE_ES2_GL_H 0
-+#define HAVE_GSM_H 0
-+#define HAVE_IO_H 0
-+#define HAVE_LINUX_DMA_BUF_H 0
-+#define HAVE_LINUX_PERF_EVENT_H 1
-+#define HAVE_MALLOC_H 1
-+#define HAVE_OPENCV2_CORE_CORE_C_H 0
-+#define HAVE_POLL_H 1
-+#define HAVE_PTHREAD_NP_H 0
-+#define HAVE_SYS_HWPROBE_H 0
-+#define HAVE_SYS_PARAM_H 1
-+#define HAVE_SYS_RESOURCE_H 1
-+#define HAVE_SYS_SELECT_H 1
-+#define HAVE_SYS_SOUNDCARD_H 1
-+#define HAVE_SYS_TIME_H 1
-+#define HAVE_SYS_UN_H 1
-+#define HAVE_SYS_VIDEOIO_H 0
-+#define HAVE_TERMIOS_H 1
-+#define HAVE_UDPLITE_H 0
-+#define HAVE_UNISTD_H 1
-+#define HAVE_VALGRIND_VALGRIND_H 0
-+#define HAVE_WINDOWS_H 0
-+#define HAVE_WINSOCK2_H 0
-+#define HAVE_INTRINSICS_NEON 0
-+#define HAVE_INTRINSICS_SSE2 0
-+#define HAVE_ATANF 1
-+#define HAVE_ATAN2F 1
-+#define HAVE_CBRT 1
-+#define HAVE_CBRTF 1
-+#define HAVE_COPYSIGN 1
-+#define HAVE_COSF 1
-+#define HAVE_ERF 1
-+#define HAVE_EXP2 1
-+#define HAVE_EXP2F 1
-+#define HAVE_EXPF 1
-+#define HAVE_HYPOT 1
-+#define HAVE_ISFINITE 1
-+#define HAVE_ISINF 1
-+#define HAVE_ISNAN 1
-+#define HAVE_LDEXPF 1
-+#define HAVE_LLRINT 1
-+#define HAVE_LLRINTF 1
-+#define HAVE_LOG2 1
-+#define HAVE_LOG2F 1
-+#define HAVE_LOG10F 1
-+#define HAVE_LRINT 1
-+#define HAVE_LRINTF 1
-+#define HAVE_POWF 1
-+#define HAVE_RINT 1
-+#define HAVE_ROUND 1
-+#define HAVE_ROUNDF 1
-+#define HAVE_SINF 1
-+#define HAVE_TRUNC 1
-+#define HAVE_TRUNCF 1
-+#define HAVE_DOS_PATHS 0
-+#define HAVE_LIBC_MSVCRT 0
-+#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
-+#define HAVE_SECTION_DATA_REL_RO 1
-+#define HAVE_THREADS 1
-+#define HAVE_UWP 0
-+#define HAVE_WINRT 0
-+#define HAVE_ACCESS 1
-+#define HAVE_ALIGNED_MALLOC 0
-+#define HAVE_ARC4RANDOM_BUF 0
-+#define HAVE_CLOCK_GETTIME 1
-+#define HAVE_CLOSESOCKET 0
-+#define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
-+#define HAVE_FCNTL 1
-+#define HAVE_GETADDRINFO 0
-+#define HAVE_GETAUXVAL 1
-+#define HAVE_GETENV 1
-+#define HAVE_GETHRTIME 0
-+#define HAVE_GETOPT 1
-+#define HAVE_GETMODULEHANDLE 0
-+#define HAVE_GETPROCESSAFFINITYMASK 0
-+#define HAVE_GETPROCESSMEMORYINFO 0
-+#define HAVE_GETPROCESSTIMES 0
-+#define HAVE_GETRUSAGE 1
-+#define HAVE_GETSTDHANDLE 0
-+#define HAVE_GETSYSTEMTIMEASFILETIME 0
-+#define HAVE_GETTIMEOFDAY 1
-+#define HAVE_GLOB 1
-+#define HAVE_GLXGETPROCADDRESS 0
-+#define HAVE_GMTIME_R 1
-+#define HAVE_INET_ATON 0
-+#define HAVE_ISATTY 1
-+#define HAVE_KBHIT 0
-+#define HAVE_LOCALTIME_R 1
-+#define HAVE_LSTAT 1
-+#define HAVE_LZO1X_999_COMPRESS 0
-+#define HAVE_MACH_ABSOLUTE_TIME 0
-+#define HAVE_MAPVIEWOFFILE 0
-+#define HAVE_MEMALIGN 1
-+#define HAVE_MKSTEMP 1
-+#define HAVE_MMAP 1
-+#define HAVE_MPROTECT 1
-+#define HAVE_NANOSLEEP 1
-+#define HAVE_PEEKNAMEDPIPE 0
-+#define HAVE_POSIX_MEMALIGN 1
-+#define HAVE_PRCTL 1
-+#define HAVE_PTHREAD_CANCEL 1
-+#define HAVE_PTHREAD_SET_NAME_NP 0
-+#define HAVE_PTHREAD_SETNAME_NP 0
-+#define HAVE_SCHED_GETAFFINITY 1
-+#define HAVE_SECITEMIMPORT 0
-+#define HAVE_SETCONSOLETEXTATTRIBUTE 0
-+#define HAVE_SETCONSOLECTRLHANDLER 0
-+#define HAVE_SETDLLDIRECTORY 0
-+#define HAVE_SETMODE 0
-+#define HAVE_SETRLIMIT 1
-+#define HAVE_SLEEP 0
-+#define HAVE_STRERROR_R 1
-+#define HAVE_SYSCONF 1
-+#define HAVE_SYSCTL 0
-+#define HAVE_SYSCTLBYNAME 0
-+#define HAVE_TEMPNAM 1
-+#define HAVE_USLEEP 1
-+#define HAVE_UTGETOSTYPEFROMSTRING 0
-+#define HAVE_VIRTUALALLOC 0
-+#define HAVE_WGLGETPROCADDRESS 0
-+#define HAVE_BCRYPT 0
-+#define HAVE_VAAPI_DRM 0
-+#define HAVE_VAAPI_X11 0
-+#define HAVE_VAAPI_WIN32 0
-+#define HAVE_VDPAU_X11 0
-+#define HAVE_PTHREADS 1
-+#define HAVE_OS2THREADS 0
-+#define HAVE_W32THREADS 0
-+#define HAVE_AS_ARCH_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_SVE_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_SVE2_DIRECTIVE 0
-+#define HAVE_AS_DN_DIRECTIVE 0
-+#define HAVE_AS_FPU_DIRECTIVE 0
-+#define HAVE_AS_FUNC 0
-+#define HAVE_AS_OBJECT_ARCH 0
-+#define HAVE_ASM_MOD_Q 0
-+#define HAVE_BLOCKS_EXTENSION 0
-+#define HAVE_EBP_AVAILABLE 0
-+#define HAVE_EBX_AVAILABLE 0
-+#define HAVE_GNU_AS 0
-+#define HAVE_GNU_WINDRES 0
-+#define HAVE_IBM_ASM 0
-+#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
-+#define HAVE_INLINE_ASM_LABELS 1
-+#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
-+#define HAVE_PRAGMA_DEPRECATED 1
-+#define HAVE_RSYNC_CONTIMEOUT 1
-+#define HAVE_SYMVER_ASM_LABEL 1
-+#define HAVE_SYMVER_GNU_ASM 1
-+#define HAVE_VFP_ARGS 0
-+#define HAVE_XFORM_ASM 0
-+#define HAVE_XMM_CLOBBERS 0
-+#define HAVE_DPI_AWARENESS_CONTEXT 0
-+#define HAVE_IDXGIOUTPUT5 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
-+#define HAVE_KCMVIDEOCODECTYPE_VP9 0
-+#define HAVE_KCMVIDEOCODECTYPE_AV1 0
-+#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
-+#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
-+#define HAVE_KVTQPMODULATIONLEVEL_DEFAULT 0
-+#define HAVE_SECPKGCONTEXT_KEYINGMATERIALINFO 0
-+#define HAVE_SOCKLEN_T 0
-+#define HAVE_STRUCT_ADDRINFO 0
-+#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
-+#define HAVE_STRUCT_IP_MREQ_SOURCE 0
-+#define HAVE_STRUCT_IPV6_MREQ 0
-+#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
-+#define HAVE_STRUCT_POLLFD 0
-+#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
-+#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
-+#define HAVE_STRUCT_SOCKADDR_IN6 0
-+#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
-+#define HAVE_STRUCT_SOCKADDR_STORAGE 0
-+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
-+#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 1
-+#define HAVE_STRUCT_MFXCONFIGINTERFACE 0
-+#define HAVE_GZIP 1
-+#define HAVE_IOCTL_POSIX 0
-+#define HAVE_LIBDRM_GETFB2 0
-+#define HAVE_MAKEINFO 0
-+#define HAVE_MAKEINFO_HTML 0
-+#define HAVE_OPENCL_D3D11 0
-+#define HAVE_OPENCL_DRM_ARM 0
-+#define HAVE_OPENCL_DRM_BEIGNET 0
-+#define HAVE_OPENCL_DXVA2 0
-+#define HAVE_OPENCL_VAAPI_BEIGNET 0
-+#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
-+#define HAVE_OPENCL_VIDEOTOOLBOX 0
-+#define HAVE_PERL 1
-+#define HAVE_POD2MAN 1
-+#define HAVE_TEXI2HTML 0
-+#define HAVE_XMLLINT 0
-+#define HAVE_ZLIB_GZIP 0
-+#define HAVE_OPENVINO2 0
-+#define CONFIG_DOC 0
-+#define CONFIG_HTMLPAGES 0
-+#define CONFIG_MANPAGES 0
-+#define CONFIG_PODPAGES 0
-+#define CONFIG_TXTPAGES 0
-+#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
-+#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
-+#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
-+#define CONFIG_DECODE_AUDIO_EXAMPLE 1
-+#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
-+#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
-+#define CONFIG_DECODE_VIDEO_EXAMPLE 1
-+#define CONFIG_DEMUX_DECODE_EXAMPLE 1
-+#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
-+#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
-+#define CONFIG_EXTRACT_MVS_EXAMPLE 1
-+#define CONFIG_FILTER_AUDIO_EXAMPLE 0
-+#define CONFIG_HW_DECODE_EXAMPLE 1
-+#define CONFIG_MUX_EXAMPLE 0
-+#define CONFIG_QSV_DECODE_EXAMPLE 0
-+#define CONFIG_REMUX_EXAMPLE 1
-+#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
-+#define CONFIG_SCALE_VIDEO_EXAMPLE 0
-+#define CONFIG_SHOW_METADATA_EXAMPLE 1
-+#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
-+#define CONFIG_TRANSCODE_EXAMPLE 0
-+#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
-+#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
-+#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
-+#define CONFIG_AVISYNTH 0
-+#define CONFIG_FREI0R 0
-+#define CONFIG_LIBCDIO 0
-+#define CONFIG_LIBDAVS2 0
-+#define CONFIG_LIBDVDNAV 0
-+#define CONFIG_LIBDVDREAD 0
-+#define CONFIG_LIBRUBBERBAND 0
-+#define CONFIG_LIBVIDSTAB 0
-+#define CONFIG_LIBX264 0
-+#define CONFIG_LIBX265 0
-+#define CONFIG_LIBXAVS 0
-+#define CONFIG_LIBXAVS2 0
-+#define CONFIG_LIBXVID 0
-+#define CONFIG_DECKLINK 0
-+#define CONFIG_LIBFDK_AAC 0
-+#define CONFIG_LIBTLS 0
-+#define CONFIG_GMP 0
-+#define CONFIG_LIBARIBB24 0
-+#define CONFIG_LIBLENSFUN 0
-+#define CONFIG_LIBOPENCORE_AMRNB 0
-+#define CONFIG_LIBOPENCORE_AMRWB 0
-+#define CONFIG_LIBVO_AMRWBENC 0
-+#define CONFIG_MBEDTLS 0
-+#define CONFIG_RKMPP 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_CHROMAPRINT 0
-+#define CONFIG_GCRYPT 0
-+#define CONFIG_GNUTLS 0
-+#define CONFIG_JNI 0
-+#define CONFIG_LADSPA 0
-+#define CONFIG_LCMS2 0
-+#define CONFIG_LIBAOM 0
-+#define CONFIG_LIBARIBCAPTION 0
-+#define CONFIG_LIBASS 0
-+#define CONFIG_LIBBLURAY 0
-+#define CONFIG_LIBBS2B 0
-+#define CONFIG_LIBCACA 0
-+#define CONFIG_LIBCELT 0
-+#define CONFIG_LIBCODEC2 0
-+#define CONFIG_LIBDAV1D 0
-+#define CONFIG_LIBDC1394 0
-+#define CONFIG_LIBFLITE 0
-+#define CONFIG_LIBFONTCONFIG 0
-+#define CONFIG_LIBFREETYPE 0
-+#define CONFIG_LIBFRIBIDI 0
-+#define CONFIG_LIBHARFBUZZ 0
-+#define CONFIG_LIBGLSLANG 0
-+#define CONFIG_LIBGME 0
-+#define CONFIG_LIBGSM 0
-+#define CONFIG_LIBIEC61883 0
-+#define CONFIG_LIBILBC 0
-+#define CONFIG_LIBJACK 0
-+#define CONFIG_LIBJXL 0
-+#define CONFIG_LIBKLVANC 0
-+#define CONFIG_LIBKVAZAAR 0
-+#define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
-+#define CONFIG_LIBMODPLUG 0
-+#define CONFIG_LIBMP3LAME 0
-+#define CONFIG_LIBMYSOFA 0
-+#define CONFIG_LIBOAPV 0
-+#define CONFIG_LIBOPENCV 0
-+#define CONFIG_LIBOPENH264 0
-+#define CONFIG_LIBOPENJPEG 0
-+#define CONFIG_LIBOPENMPT 0
-+#define CONFIG_LIBOPENVINO 0
-+#define CONFIG_LIBOPUS 1
-+#define CONFIG_LIBPLACEBO 0
-+#define CONFIG_LIBPULSE 0
-+#define CONFIG_LIBQRENCODE 0
-+#define CONFIG_LIBQUIRC 0
-+#define CONFIG_LIBRABBITMQ 0
-+#define CONFIG_LIBRAV1E 0
-+#define CONFIG_LIBRIST 0
-+#define CONFIG_LIBRSVG 0
-+#define CONFIG_LIBRTMP 0
-+#define CONFIG_LIBSHADERC 0
-+#define CONFIG_LIBSHINE 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_LIBSNAPPY 0
-+#define CONFIG_LIBSOXR 0
-+#define CONFIG_LIBSPEEX 0
-+#define CONFIG_LIBSRT 0
-+#define CONFIG_LIBSSH 0
-+#define CONFIG_LIBSVTAV1 0
-+#define CONFIG_LIBTENSORFLOW 0
-+#define CONFIG_LIBTESSERACT 0
-+#define CONFIG_LIBTHEORA 0
-+#define CONFIG_LIBTORCH 0
-+#define CONFIG_LIBTWOLAME 0
-+#define CONFIG_LIBUAVS3D 0
-+#define CONFIG_LIBV4L2 0
-+#define CONFIG_LIBVMAF 0
-+#define CONFIG_LIBVORBIS 0
-+#define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
-+#define CONFIG_LIBWEBP 0
-+#define CONFIG_LIBXEVD 0
-+#define CONFIG_LIBXEVE 0
-+#define CONFIG_LIBXML2 0
-+#define CONFIG_LIBZIMG 0
-+#define CONFIG_LIBZMQ 0
-+#define CONFIG_LIBZVBI 0
-+#define CONFIG_LV2 0
-+#define CONFIG_MEDIACODEC 0
-+#define CONFIG_OHCODEC 0
-+#define CONFIG_OPENAL 0
-+#define CONFIG_OPENGL 0
-+#define CONFIG_OPENSSL 0
-+#define CONFIG_POCKETSPHINX 0
-+#define CONFIG_VAPOURSYNTH 0
-+#define CONFIG_VULKAN_STATIC 0
-+#define CONFIG_WHISPER 0
-+#define CONFIG_ALSA 0
-+#define CONFIG_APPKIT 0
-+#define CONFIG_AVFOUNDATION 0
-+#define CONFIG_BZLIB 0
-+#define CONFIG_COREIMAGE 0
-+#define CONFIG_ICONV 0
-+#define CONFIG_LIBXCB 0
-+#define CONFIG_LIBXCB_SHM 0
-+#define CONFIG_LIBXCB_SHAPE 0
-+#define CONFIG_LIBXCB_XFIXES 0
-+#define CONFIG_LZMA 0
-+#define CONFIG_MEDIAFOUNDATION 0
-+#define CONFIG_METAL 0
-+#define CONFIG_SCHANNEL 0
-+#define CONFIG_SDL2 0
-+#define CONFIG_SECURETRANSPORT 0
-+#define CONFIG_SNDIO 0
-+#define CONFIG_XLIB 0
-+#define CONFIG_ZLIB 0
-+#define CONFIG_CUDA_NVCC 0
-+#define CONFIG_CUDA_SDK 0
-+#define CONFIG_LIBNPP 0
-+#define CONFIG_LIBMFX 0
-+#define CONFIG_LIBVPL 0
-+#define CONFIG_MMAL 0
-+#define CONFIG_OMX 0
-+#define CONFIG_OPENCL 0
-+#define CONFIG_AMF 0
-+#define CONFIG_AUDIOTOOLBOX 0
-+#define CONFIG_CUDA 0
-+#define CONFIG_CUDA_LLVM 0
-+#define CONFIG_CUVID 0
-+#define CONFIG_D3D11VA 0
-+#define CONFIG_D3D12VA 0
-+#define CONFIG_DXVA2 0
-+#define CONFIG_FFNVCODEC 0
-+#define CONFIG_LIBDRM 0
-+#define CONFIG_NVDEC 0
-+#define CONFIG_NVENC 0
-+#define CONFIG_VAAPI 0
-+#define CONFIG_VDPAU 0
-+#define CONFIG_VIDEOTOOLBOX 0
-+#define CONFIG_VULKAN 0
-+#define CONFIG_V4L2_M2M 0
-+#define CONFIG_FTRAPV 0
-+#define CONFIG_GRAY 0
-+#define CONFIG_HARDCODED_TABLES 0
-+#define CONFIG_OMX_RPI 0
-+#define CONFIG_RUNTIME_CPUDETECT 1
-+#define CONFIG_SAFE_BITSTREAM_READER 1
-+#define CONFIG_SHARED 0
-+#define CONFIG_SMALL 0
-+#define CONFIG_STATIC 1
-+#define CONFIG_SWSCALE_ALPHA 1
-+#define CONFIG_GPL 0
-+#define CONFIG_NONFREE 0
-+#define CONFIG_VERSION3 0
-+#define CONFIG_AVDEVICE 0
-+#define CONFIG_AVFILTER 0
-+#define CONFIG_SWSCALE 0
-+#define CONFIG_AVFORMAT 1
-+#define CONFIG_AVCODEC 1
-+#define CONFIG_SWRESAMPLE 0
-+#define CONFIG_AVUTIL 1
-+#define CONFIG_FFPLAY 0
-+#define CONFIG_FFPROBE 0
-+#define CONFIG_FFMPEG 0
-+#define CONFIG_DWT 0
-+#define CONFIG_ERROR_RESILIENCE 0
-+#define CONFIG_FAAN 0
-+#define CONFIG_FAST_UNALIGNED 1
-+#define CONFIG_IAMF 0
-+#define CONFIG_LSP 0
-+#define CONFIG_PIXELUTILS 0
-+#define CONFIG_NETWORK 0
-+#define CONFIG_AUTODETECT 0
-+#define CONFIG_FONTCONFIG 0
-+#define CONFIG_LARGE_TESTS 1
-+#define CONFIG_LINUX_PERF 0
-+#define CONFIG_MACOS_KPERF 0
-+#define CONFIG_MEMORY_POISONING 0
-+#define CONFIG_NEON_CLOBBER_TEST 0
-+#define CONFIG_OSSFUZZ 0
-+#define CONFIG_PIC 1
-+#define CONFIG_PTX_COMPRESSION 0
-+#define CONFIG_RESOURCE_COMPRESSION 0
-+#define CONFIG_THUMB 0
-+#define CONFIG_VALGRIND_BACKTRACE 0
-+#define CONFIG_XMM_CLOBBER_TEST 0
-+#define CONFIG_BSFS 0
-+#define CONFIG_DECODERS 1
-+#define CONFIG_ENCODERS 0
-+#define CONFIG_HWACCELS 0
-+#define CONFIG_PARSERS 1
-+#define CONFIG_INDEVS 0
-+#define CONFIG_OUTDEVS 0
-+#define CONFIG_FILTERS 0
-+#define CONFIG_DEMUXERS 1
-+#define CONFIG_MUXERS 0
-+#define CONFIG_PROTOCOLS 0
-+#define CONFIG_AANDCTTABLES 0
-+#define CONFIG_AC3DSP 0
-+#define CONFIG_ADTS_HEADER 1
-+#define CONFIG_ATSC_A53 1
-+#define CONFIG_AUDIO_FRAME_QUEUE 0
-+#define CONFIG_AUDIODSP 0
-+#define CONFIG_BLOCKDSP 0
-+#define CONFIG_BSWAPDSP 0
-+#define CONFIG_CABAC 1
-+#define CONFIG_CBS 0
-+#define CONFIG_CBS_APV 0
-+#define CONFIG_CBS_AV1 0
-+#define CONFIG_CBS_H264 0
-+#define CONFIG_CBS_H265 0
-+#define CONFIG_CBS_H266 0
-+#define CONFIG_CBS_JPEG 0
-+#define CONFIG_CBS_MPEG2 0
-+#define CONFIG_CBS_VP8 0
-+#define CONFIG_CBS_VP9 0
-+#define CONFIG_CELP_MATH 0
-+#define CONFIG_D3D12VA_ENCODE 0
-+#define CONFIG_DEFLATE_WRAPPER 0
-+#define CONFIG_DIRAC_PARSE 1
-+#define CONFIG_DNN 0
-+#define CONFIG_DOVI_RPUDEC 0
-+#define CONFIG_DOVI_RPUENC 0
-+#define CONFIG_DVPROFILE 0
-+#define CONFIG_EVCPARSE 0
-+#define CONFIG_EXIF 0
-+#define CONFIG_FAANDCT 0
-+#define CONFIG_FAANIDCT 0
-+#define CONFIG_FDCTDSP 0
-+#define CONFIG_FMTCONVERT 0
-+#define CONFIG_FRAME_THREAD_ENCODER 0
-+#define CONFIG_G722DSP 0
-+#define CONFIG_GOLOMB 1
-+#define CONFIG_GPLV3 0
-+#define CONFIG_H263DSP 0
-+#define CONFIG_H264CHROMA 1
-+#define CONFIG_H264DSP 1
-+#define CONFIG_H264PARSE 1
-+#define CONFIG_H264PRED 1
-+#define CONFIG_H264QPEL 1
-+#define CONFIG_H264_SEI 1
-+#define CONFIG_HEVCPARSE 0
-+#define CONFIG_HEVC_SEI 0
-+#define CONFIG_HPELDSP 0
-+#define CONFIG_HUFFMAN 0
-+#define CONFIG_HUFFYUVDSP 0
-+#define CONFIG_HUFFYUVENCDSP 0
-+#define CONFIG_IAMFDEC 0
-+#define CONFIG_IAMFENC 0
-+#define CONFIG_IDCTDSP 0
-+#define CONFIG_INFLATE_WRAPPER 0
-+#define CONFIG_INTRAX8 0
-+#define CONFIG_ISO_MEDIA 1
-+#define CONFIG_ISO_WRITER 0
-+#define CONFIG_IVIDSP 0
-+#define CONFIG_JPEGTABLES 0
-+#define CONFIG_LGPLV3 0
-+#define CONFIG_LIBX262 0
-+#define CONFIG_LIBX264_HDR10 0
-+#define CONFIG_LLAUDDSP 0
-+#define CONFIG_LLVIDDSP 0
-+#define CONFIG_LLVIDENCDSP 0
-+#define CONFIG_LPC 0
-+#define CONFIG_LZF 0
-+#define CONFIG_ME_CMP 0
-+#define CONFIG_MPEG_ER 0
-+#define CONFIG_MPEGAUDIO 1
-+#define CONFIG_MPEGAUDIODSP 1
-+#define CONFIG_MPEGAUDIOHEADER 1
-+#define CONFIG_MPEG4AUDIO 1
-+#define CONFIG_MPEGVIDEO 0
-+#define CONFIG_MPEGVIDEODEC 0
-+#define CONFIG_MPEGVIDEOENC 0
-+#define CONFIG_MPEGVIDEOENCDSP 0
-+#define CONFIG_MSMPEG4DEC 0
-+#define CONFIG_MSMPEG4ENC 0
-+#define CONFIG_MSS34DSP 0
-+#define CONFIG_PIXBLOCKDSP 0
-+#define CONFIG_QPELDSP 0
-+#define CONFIG_QSV 0
-+#define CONFIG_QSVDEC 0
-+#define CONFIG_QSVENC 0
-+#define CONFIG_QSVVPP 0
-+#define CONFIG_RANGECODER 0
-+#define CONFIG_RIFFDEC 1
-+#define CONFIG_RIFFENC 0
-+#define CONFIG_RTPDEC 0
-+#define CONFIG_RTPENC_CHAIN 0
-+#define CONFIG_RV34DSP 0
-+#define CONFIG_SCENE_SAD 0
-+#define CONFIG_SINEWIN 1
-+#define CONFIG_SMPTE_436M 0
-+#define CONFIG_SNAPPY 0
-+#define CONFIG_SRTP 0
-+#define CONFIG_STARTCODE 1
-+#define CONFIG_TEXTUREDSP 0
-+#define CONFIG_TEXTUREDSPENC 0
-+#define CONFIG_TPELDSP 0
-+#define CONFIG_VAAPI_1 0
-+#define CONFIG_VAAPI_ENCODE 0
-+#define CONFIG_VULKAN_1_4 0
-+#define CONFIG_VC1DSP 0
-+#define CONFIG_VIDEODSP 1
-+#define CONFIG_VP3DSP 0
-+#define CONFIG_VP56DSP 0
-+#define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
-+#define CONFIG_VVC_SEI 0
-+#define CONFIG_WMA_FREQS 0
-+#define CONFIG_WMV2DSP 0
-+#endif /* FFMPEG_CONFIG_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
-new file mode 100644
-index 0000000000..6dd25c4177
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
-@@ -0,0 +1,2274 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_COMPONENTS_H
-+#define FFMPEG_CONFIG_COMPONENTS_H
-+#define CONFIG_AAC_ADTSTOASC_BSF 0
-+#define CONFIG_APV_METADATA_BSF 0
-+#define CONFIG_AV1_FRAME_MERGE_BSF 0
-+#define CONFIG_AV1_FRAME_SPLIT_BSF 0
-+#define CONFIG_AV1_METADATA_BSF 0
-+#define CONFIG_CHOMP_BSF 0
-+#define CONFIG_DUMP_EXTRADATA_BSF 0
-+#define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
-+#define CONFIG_DTS2PTS_BSF 0
-+#define CONFIG_DV_ERROR_MARKER_BSF 0
-+#define CONFIG_EAC3_CORE_BSF 0
-+#define CONFIG_EIA608_TO_SMPTE436M_BSF 0
-+#define CONFIG_EVC_FRAME_MERGE_BSF 0
-+#define CONFIG_EXTRACT_EXTRADATA_BSF 0
-+#define CONFIG_FILTER_UNITS_BSF 0
-+#define CONFIG_H264_METADATA_BSF 0
-+#define CONFIG_H264_MP4TOANNEXB_BSF 0
-+#define CONFIG_H264_REDUNDANT_PPS_BSF 0
-+#define CONFIG_HAPQA_EXTRACT_BSF 0
-+#define CONFIG_HEVC_METADATA_BSF 0
-+#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
-+#define CONFIG_IMX_DUMP_HEADER_BSF 0
-+#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
-+#define CONFIG_MJPEG2JPEG_BSF 0
-+#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
-+#define CONFIG_MPEG2_METADATA_BSF 0
-+#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
-+#define CONFIG_MOV2TEXTSUB_BSF 0
-+#define CONFIG_NOISE_BSF 0
-+#define CONFIG_NULL_BSF 0
-+#define CONFIG_OPUS_METADATA_BSF 0
-+#define CONFIG_PCM_RECHUNK_BSF 0
-+#define CONFIG_PGS_FRAME_MERGE_BSF 0
-+#define CONFIG_PRORES_METADATA_BSF 0
-+#define CONFIG_REMOVE_EXTRADATA_BSF 0
-+#define CONFIG_SETTS_BSF 0
-+#define CONFIG_SHOWINFO_BSF 0
-+#define CONFIG_SMPTE436M_TO_EIA608_BSF 0
-+#define CONFIG_TEXT2MOVSUB_BSF 0
-+#define CONFIG_TRACE_HEADERS_BSF 0
-+#define CONFIG_TRUEHD_CORE_BSF 0
-+#define CONFIG_VP9_METADATA_BSF 0
-+#define CONFIG_VP9_RAW_REORDER_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
-+#define CONFIG_VVC_METADATA_BSF 0
-+#define CONFIG_VVC_MP4TOANNEXB_BSF 0
-+#define CONFIG_AASC_DECODER 0
-+#define CONFIG_AIC_DECODER 0
-+#define CONFIG_ALIAS_PIX_DECODER 0
-+#define CONFIG_AGM_DECODER 0
-+#define CONFIG_AMV_DECODER 0
-+#define CONFIG_ANM_DECODER 0
-+#define CONFIG_ANSI_DECODER 0
-+#define CONFIG_APNG_DECODER 0
-+#define CONFIG_APV_DECODER 0
-+#define CONFIG_ARBC_DECODER 0
-+#define CONFIG_ARGO_DECODER 0
-+#define CONFIG_ASV1_DECODER 0
-+#define CONFIG_ASV2_DECODER 0
-+#define CONFIG_AURA_DECODER 0
-+#define CONFIG_AURA2_DECODER 0
-+#define CONFIG_AVRP_DECODER 0
-+#define CONFIG_AVRN_DECODER 0
-+#define CONFIG_AVS_DECODER 0
-+#define CONFIG_AVUI_DECODER 0
-+#define CONFIG_BETHSOFTVID_DECODER 0
-+#define CONFIG_BFI_DECODER 0
-+#define CONFIG_BINK_DECODER 0
-+#define CONFIG_BITPACKED_DECODER 0
-+#define CONFIG_BMP_DECODER 0
-+#define CONFIG_BMV_VIDEO_DECODER 0
-+#define CONFIG_BRENDER_PIX_DECODER 0
-+#define CONFIG_C93_DECODER 0
-+#define CONFIG_CAVS_DECODER 0
-+#define CONFIG_CDGRAPHICS_DECODER 0
-+#define CONFIG_CDTOONS_DECODER 0
-+#define CONFIG_CDXL_DECODER 0
-+#define CONFIG_CFHD_DECODER 0
-+#define CONFIG_CINEPAK_DECODER 0
-+#define CONFIG_CLEARVIDEO_DECODER 0
-+#define CONFIG_CLJR_DECODER 0
-+#define CONFIG_CLLC_DECODER 0
-+#define CONFIG_COMFORTNOISE_DECODER 0
-+#define CONFIG_CPIA_DECODER 0
-+#define CONFIG_CRI_DECODER 0
-+#define CONFIG_CSCD_DECODER 0
-+#define CONFIG_CYUV_DECODER 0
-+#define CONFIG_DDS_DECODER 0
-+#define CONFIG_DFA_DECODER 0
-+#define CONFIG_DIRAC_DECODER 0
-+#define CONFIG_DNXHD_DECODER 0
-+#define CONFIG_DPX_DECODER 0
-+#define CONFIG_DSICINVIDEO_DECODER 0
-+#define CONFIG_DVAUDIO_DECODER 0
-+#define CONFIG_DVVIDEO_DECODER 0
-+#define CONFIG_DXA_DECODER 0
-+#define CONFIG_DXTORY_DECODER 0
-+#define CONFIG_DXV_DECODER 0
-+#define CONFIG_EACMV_DECODER 0
-+#define CONFIG_EAMAD_DECODER 0
-+#define CONFIG_EATGQ_DECODER 0
-+#define CONFIG_EATGV_DECODER 0
-+#define CONFIG_EATQI_DECODER 0
-+#define CONFIG_EIGHTBPS_DECODER 0
-+#define CONFIG_EIGHTSVX_EXP_DECODER 0
-+#define CONFIG_EIGHTSVX_FIB_DECODER 0
-+#define CONFIG_ESCAPE124_DECODER 0
-+#define CONFIG_ESCAPE130_DECODER 0
-+#define CONFIG_EXR_DECODER 0
-+#define CONFIG_FFV1_DECODER 0
-+#define CONFIG_FFVHUFF_DECODER 0
-+#define CONFIG_FIC_DECODER 0
-+#define CONFIG_FITS_DECODER 0
-+#define CONFIG_FLASHSV_DECODER 0
-+#define CONFIG_FLASHSV2_DECODER 0
-+#define CONFIG_FLIC_DECODER 0
-+#define CONFIG_FLV_DECODER 0
-+#define CONFIG_FMVC_DECODER 0
-+#define CONFIG_FOURXM_DECODER 0
-+#define CONFIG_FRAPS_DECODER 0
-+#define CONFIG_FRWU_DECODER 0
-+#define CONFIG_G2M_DECODER 0
-+#define CONFIG_GDV_DECODER 0
-+#define CONFIG_GEM_DECODER 0
-+#define CONFIG_GIF_DECODER 0
-+#define CONFIG_H261_DECODER 0
-+#define CONFIG_H263_DECODER 0
-+#define CONFIG_H263I_DECODER 0
-+#define CONFIG_H263P_DECODER 0
-+#define CONFIG_H263_V4L2M2M_DECODER 0
-+#define CONFIG_H264_DECODER 1
-+#define CONFIG_H264_V4L2M2M_DECODER 0
-+#define CONFIG_H264_MEDIACODEC_DECODER 0
-+#define CONFIG_H264_MMAL_DECODER 0
-+#define CONFIG_H264_QSV_DECODER 0
-+#define CONFIG_H264_RKMPP_DECODER 0
-+#define CONFIG_HAP_DECODER 0
-+#define CONFIG_HEVC_DECODER 0
-+#define CONFIG_HEVC_QSV_DECODER 0
-+#define CONFIG_HEVC_RKMPP_DECODER 0
-+#define CONFIG_HEVC_V4L2M2M_DECODER 0
-+#define CONFIG_HNM4_VIDEO_DECODER 0
-+#define CONFIG_HQ_HQA_DECODER 0
-+#define CONFIG_HQX_DECODER 0
-+#define CONFIG_HUFFYUV_DECODER 0
-+#define CONFIG_HYMT_DECODER 0
-+#define CONFIG_IDCIN_DECODER 0
-+#define CONFIG_IFF_ILBM_DECODER 0
-+#define CONFIG_IMM4_DECODER 0
-+#define CONFIG_IMM5_DECODER 0
-+#define CONFIG_INDEO2_DECODER 0
-+#define CONFIG_INDEO3_DECODER 0
-+#define CONFIG_INDEO4_DECODER 0
-+#define CONFIG_INDEO5_DECODER 0
-+#define CONFIG_INTERPLAY_VIDEO_DECODER 0
-+#define CONFIG_IPU_DECODER 0
-+#define CONFIG_JPEG2000_DECODER 0
-+#define CONFIG_JPEGLS_DECODER 0
-+#define CONFIG_JV_DECODER 0
-+#define CONFIG_KGV1_DECODER 0
-+#define CONFIG_KMVC_DECODER 0
-+#define CONFIG_LAGARITH_DECODER 0
-+#define CONFIG_LEAD_DECODER 0
-+#define CONFIG_LOCO_DECODER 0
-+#define CONFIG_LSCR_DECODER 0
-+#define CONFIG_M101_DECODER 0
-+#define CONFIG_MAGICYUV_DECODER 0
-+#define CONFIG_MDEC_DECODER 0
-+#define CONFIG_MEDIA100_DECODER 0
-+#define CONFIG_MIMIC_DECODER 0
-+#define CONFIG_MJPEG_DECODER 0
-+#define CONFIG_MJPEGB_DECODER 0
-+#define CONFIG_MMVIDEO_DECODER 0
-+#define CONFIG_MOBICLIP_DECODER 0
-+#define CONFIG_MOTIONPIXELS_DECODER 0
-+#define CONFIG_MPEG1VIDEO_DECODER 0
-+#define CONFIG_MPEG2VIDEO_DECODER 0
-+#define CONFIG_MPEG4_DECODER 0
-+#define CONFIG_MPEG4_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG4_MMAL_DECODER 0
-+#define CONFIG_MPEGVIDEO_DECODER 0
-+#define CONFIG_MPEG1_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_MMAL_DECODER 0
-+#define CONFIG_MPEG2_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_QSV_DECODER 0
-+#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
-+#define CONFIG_MSA1_DECODER 0
-+#define CONFIG_MSCC_DECODER 0
-+#define CONFIG_MSMPEG4V1_DECODER 0
-+#define CONFIG_MSMPEG4V2_DECODER 0
-+#define CONFIG_MSMPEG4V3_DECODER 0
-+#define CONFIG_MSP2_DECODER 0
-+#define CONFIG_MSRLE_DECODER 0
-+#define CONFIG_MSS1_DECODER 0
-+#define CONFIG_MSS2_DECODER 0
-+#define CONFIG_MSVIDEO1_DECODER 0
-+#define CONFIG_MSZH_DECODER 0
-+#define CONFIG_MTS2_DECODER 0
-+#define CONFIG_MV30_DECODER 0
-+#define CONFIG_MVC1_DECODER 0
-+#define CONFIG_MVC2_DECODER 0
-+#define CONFIG_MVDV_DECODER 0
-+#define CONFIG_MVHA_DECODER 0
-+#define CONFIG_MWSC_DECODER 0
-+#define CONFIG_MXPEG_DECODER 0
-+#define CONFIG_NOTCHLC_DECODER 0
-+#define CONFIG_NUV_DECODER 0
-+#define CONFIG_PAF_VIDEO_DECODER 0
-+#define CONFIG_PAM_DECODER 0
-+#define CONFIG_PBM_DECODER 0
-+#define CONFIG_PCX_DECODER 0
-+#define CONFIG_PDV_DECODER 0
-+#define CONFIG_PFM_DECODER 0
-+#define CONFIG_PGM_DECODER 0
-+#define CONFIG_PGMYUV_DECODER 0
-+#define CONFIG_PGX_DECODER 0
-+#define CONFIG_PHM_DECODER 0
-+#define CONFIG_PHOTOCD_DECODER 0
-+#define CONFIG_PICTOR_DECODER 0
-+#define CONFIG_PIXLET_DECODER 0
-+#define CONFIG_PNG_DECODER 0
-+#define CONFIG_PPM_DECODER 0
-+#define CONFIG_PRORES_DECODER 0
-+#define CONFIG_PRORES_RAW_DECODER 0
-+#define CONFIG_PROSUMER_DECODER 0
-+#define CONFIG_PSD_DECODER 0
-+#define CONFIG_PTX_DECODER 0
-+#define CONFIG_QDRAW_DECODER 0
-+#define CONFIG_QOI_DECODER 0
-+#define CONFIG_QPEG_DECODER 0
-+#define CONFIG_QTRLE_DECODER 0
-+#define CONFIG_R10K_DECODER 0
-+#define CONFIG_R210_DECODER 0
-+#define CONFIG_RASC_DECODER 0
-+#define CONFIG_RAWVIDEO_DECODER 0
-+#define CONFIG_RKA_DECODER 0
-+#define CONFIG_RL2_DECODER 0
-+#define CONFIG_ROQ_DECODER 0
-+#define CONFIG_RPZA_DECODER 0
-+#define CONFIG_RSCC_DECODER 0
-+#define CONFIG_RTV1_DECODER 0
-+#define CONFIG_RV10_DECODER 0
-+#define CONFIG_RV20_DECODER 0
-+#define CONFIG_RV30_DECODER 0
-+#define CONFIG_RV40_DECODER 0
-+#define CONFIG_RV60_DECODER 0
-+#define CONFIG_S302M_DECODER 0
-+#define CONFIG_SANM_DECODER 0
-+#define CONFIG_SCPR_DECODER 0
-+#define CONFIG_SCREENPRESSO_DECODER 0
-+#define CONFIG_SGA_DECODER 0
-+#define CONFIG_SGI_DECODER 0
-+#define CONFIG_SGIRLE_DECODER 0
-+#define CONFIG_SHEERVIDEO_DECODER 0
-+#define CONFIG_SIMBIOSIS_IMX_DECODER 0
-+#define CONFIG_SMACKER_DECODER 0
-+#define CONFIG_SMC_DECODER 0
-+#define CONFIG_SMVJPEG_DECODER 0
-+#define CONFIG_SNOW_DECODER 0
-+#define CONFIG_SP5X_DECODER 0
-+#define CONFIG_SPEEDHQ_DECODER 0
-+#define CONFIG_SPEEX_DECODER 0
-+#define CONFIG_SRGC_DECODER 0
-+#define CONFIG_SUNRAST_DECODER 0
-+#define CONFIG_SVQ1_DECODER 0
-+#define CONFIG_SVQ3_DECODER 0
-+#define CONFIG_TARGA_DECODER 0
-+#define CONFIG_TARGA_Y216_DECODER 0
-+#define CONFIG_TDSC_DECODER 0
-+#define CONFIG_THEORA_DECODER 0
-+#define CONFIG_THP_DECODER 0
-+#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
-+#define CONFIG_TIFF_DECODER 0
-+#define CONFIG_TMV_DECODER 0
-+#define CONFIG_TRUEMOTION1_DECODER 0
-+#define CONFIG_TRUEMOTION2_DECODER 0
-+#define CONFIG_TRUEMOTION2RT_DECODER 0
-+#define CONFIG_TSCC_DECODER 0
-+#define CONFIG_TSCC2_DECODER 0
-+#define CONFIG_TXD_DECODER 0
-+#define CONFIG_ULTI_DECODER 0
-+#define CONFIG_UTVIDEO_DECODER 0
-+#define CONFIG_V210_DECODER 0
-+#define CONFIG_V210X_DECODER 0
-+#define CONFIG_V308_DECODER 0
-+#define CONFIG_V408_DECODER 0
-+#define CONFIG_V410_DECODER 0
-+#define CONFIG_VB_DECODER 0
-+#define CONFIG_VBN_DECODER 0
-+#define CONFIG_VBLE_DECODER 0
-+#define CONFIG_VC1_DECODER 0
-+#define CONFIG_VC1IMAGE_DECODER 0
-+#define CONFIG_VC1_MMAL_DECODER 0
-+#define CONFIG_VC1_QSV_DECODER 0
-+#define CONFIG_VC1_V4L2M2M_DECODER 0
-+#define CONFIG_VCR1_DECODER 0
-+#define CONFIG_VMDVIDEO_DECODER 0
-+#define CONFIG_VMIX_DECODER 0
-+#define CONFIG_VMNC_DECODER 0
-+#define CONFIG_VP3_DECODER 0
-+#define CONFIG_VP4_DECODER 0
-+#define CONFIG_VP5_DECODER 0
-+#define CONFIG_VP6_DECODER 0
-+#define CONFIG_VP6A_DECODER 0
-+#define CONFIG_VP6F_DECODER 0
-+#define CONFIG_VP7_DECODER 0
-+#define CONFIG_VP8_DECODER 0
-+#define CONFIG_VP8_RKMPP_DECODER 0
-+#define CONFIG_VP8_V4L2M2M_DECODER 0
-+#define CONFIG_VP9_DECODER 0
-+#define CONFIG_VP9_RKMPP_DECODER 0
-+#define CONFIG_VP9_V4L2M2M_DECODER 0
-+#define CONFIG_VQA_DECODER 0
-+#define CONFIG_VQC_DECODER 0
-+#define CONFIG_VVC_DECODER 0
-+#define CONFIG_WBMP_DECODER 0
-+#define CONFIG_WEBP_DECODER 0
-+#define CONFIG_WCMV_DECODER 0
-+#define CONFIG_WRAPPED_AVFRAME_DECODER 0
-+#define CONFIG_WMV1_DECODER 0
-+#define CONFIG_WMV2_DECODER 0
-+#define CONFIG_WMV3_DECODER 0
-+#define CONFIG_WMV3IMAGE_DECODER 0
-+#define CONFIG_WNV1_DECODER 0
-+#define CONFIG_XAN_WC3_DECODER 0
-+#define CONFIG_XAN_WC4_DECODER 0
-+#define CONFIG_XBM_DECODER 0
-+#define CONFIG_XFACE_DECODER 0
-+#define CONFIG_XL_DECODER 0
-+#define CONFIG_XPM_DECODER 0
-+#define CONFIG_XWD_DECODER 0
-+#define CONFIG_Y41P_DECODER 0
-+#define CONFIG_YLC_DECODER 0
-+#define CONFIG_YOP_DECODER 0
-+#define CONFIG_YUV4_DECODER 0
-+#define CONFIG_ZERO12V_DECODER 0
-+#define CONFIG_ZEROCODEC_DECODER 0
-+#define CONFIG_ZLIB_DECODER 0
-+#define CONFIG_ZMBV_DECODER 0
-+#define CONFIG_AAC_DECODER 1
-+#define CONFIG_AAC_FIXED_DECODER 0
-+#define CONFIG_AAC_LATM_DECODER 0
-+#define CONFIG_AC3_DECODER 0
-+#define CONFIG_AC3_FIXED_DECODER 0
-+#define CONFIG_ACELP_KELVIN_DECODER 0
-+#define CONFIG_ALAC_DECODER 0
-+#define CONFIG_ALS_DECODER 0
-+#define CONFIG_AMRNB_DECODER 0
-+#define CONFIG_AMRWB_DECODER 0
-+#define CONFIG_APAC_DECODER 0
-+#define CONFIG_APE_DECODER 0
-+#define CONFIG_APTX_DECODER 0
-+#define CONFIG_APTX_HD_DECODER 0
-+#define CONFIG_ATRAC1_DECODER 0
-+#define CONFIG_ATRAC3_DECODER 0
-+#define CONFIG_ATRAC3AL_DECODER 0
-+#define CONFIG_ATRAC3P_DECODER 0
-+#define CONFIG_ATRAC3PAL_DECODER 0
-+#define CONFIG_ATRAC9_DECODER 0
-+#define CONFIG_BINKAUDIO_DCT_DECODER 0
-+#define CONFIG_BINKAUDIO_RDFT_DECODER 0
-+#define CONFIG_BMV_AUDIO_DECODER 0
-+#define CONFIG_BONK_DECODER 0
-+#define CONFIG_COOK_DECODER 0
-+#define CONFIG_DCA_DECODER 0
-+#define CONFIG_DFPWM_DECODER 0
-+#define CONFIG_DOLBY_E_DECODER 0
-+#define CONFIG_DSD_LSBF_DECODER 0
-+#define CONFIG_DSD_MSBF_DECODER 0
-+#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
-+#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
-+#define CONFIG_DSICINAUDIO_DECODER 0
-+#define CONFIG_DSS_SP_DECODER 0
-+#define CONFIG_DST_DECODER 0
-+#define CONFIG_EAC3_DECODER 0
-+#define CONFIG_EVRC_DECODER 0
-+#define CONFIG_FASTAUDIO_DECODER 0
-+#define CONFIG_FFWAVESYNTH_DECODER 0
-+#define CONFIG_FLAC_DECODER 1
-+#define CONFIG_FTR_DECODER 0
-+#define CONFIG_G723_1_DECODER 0
-+#define CONFIG_G728_DECODER 0
-+#define CONFIG_G729_DECODER 0
-+#define CONFIG_GSM_DECODER 0
-+#define CONFIG_GSM_MS_DECODER 0
-+#define CONFIG_HCA_DECODER 0
-+#define CONFIG_HCOM_DECODER 0
-+#define CONFIG_HDR_DECODER 0
-+#define CONFIG_IAC_DECODER 0
-+#define CONFIG_ILBC_DECODER 0
-+#define CONFIG_IMC_DECODER 0
-+#define CONFIG_INTERPLAY_ACM_DECODER 0
-+#define CONFIG_MACE3_DECODER 0
-+#define CONFIG_MACE6_DECODER 0
-+#define CONFIG_METASOUND_DECODER 0
-+#define CONFIG_MISC4_DECODER 0
-+#define CONFIG_MLP_DECODER 0
-+#define CONFIG_MP1_DECODER 0
-+#define CONFIG_MP1FLOAT_DECODER 0
-+#define CONFIG_MP2_DECODER 0
-+#define CONFIG_MP2FLOAT_DECODER 0
-+#define CONFIG_MP3FLOAT_DECODER 0
-+#define CONFIG_MP3_DECODER 1
-+#define CONFIG_MP3ADUFLOAT_DECODER 0
-+#define CONFIG_MP3ADU_DECODER 0
-+#define CONFIG_MP3ON4FLOAT_DECODER 0
-+#define CONFIG_MP3ON4_DECODER 0
-+#define CONFIG_MPC7_DECODER 0
-+#define CONFIG_MPC8_DECODER 0
-+#define CONFIG_MSNSIREN_DECODER 0
-+#define CONFIG_NELLYMOSER_DECODER 0
-+#define CONFIG_ON2AVC_DECODER 0
-+#define CONFIG_OPUS_DECODER 0
-+#define CONFIG_OSQ_DECODER 0
-+#define CONFIG_PAF_AUDIO_DECODER 0
-+#define CONFIG_QCELP_DECODER 0
-+#define CONFIG_QDM2_DECODER 0
-+#define CONFIG_QDMC_DECODER 0
-+#define CONFIG_QOA_DECODER 0
-+#define CONFIG_RA_144_DECODER 0
-+#define CONFIG_RA_288_DECODER 0
-+#define CONFIG_RALF_DECODER 0
-+#define CONFIG_SBC_DECODER 0
-+#define CONFIG_SHORTEN_DECODER 0
-+#define CONFIG_SIPR_DECODER 0
-+#define CONFIG_SIREN_DECODER 0
-+#define CONFIG_SMACKAUD_DECODER 0
-+#define CONFIG_SONIC_DECODER 0
-+#define CONFIG_TAK_DECODER 0
-+#define CONFIG_TRUEHD_DECODER 0
-+#define CONFIG_TRUESPEECH_DECODER 0
-+#define CONFIG_TTA_DECODER 0
-+#define CONFIG_TWINVQ_DECODER 0
-+#define CONFIG_VMDAUDIO_DECODER 0
-+#define CONFIG_VORBIS_DECODER 1
-+#define CONFIG_WAVARC_DECODER 0
-+#define CONFIG_WAVPACK_DECODER 0
-+#define CONFIG_WMALOSSLESS_DECODER 0
-+#define CONFIG_WMAPRO_DECODER 0
-+#define CONFIG_WMAV1_DECODER 0
-+#define CONFIG_WMAV2_DECODER 0
-+#define CONFIG_WMAVOICE_DECODER 0
-+#define CONFIG_WS_SND1_DECODER 0
-+#define CONFIG_XMA1_DECODER 0
-+#define CONFIG_XMA2_DECODER 0
-+#define CONFIG_PCM_ALAW_DECODER 1
-+#define CONFIG_PCM_BLURAY_DECODER 0
-+#define CONFIG_PCM_DVD_DECODER 0
-+#define CONFIG_PCM_F16LE_DECODER 0
-+#define CONFIG_PCM_F24LE_DECODER 0
-+#define CONFIG_PCM_F32BE_DECODER 0
-+#define CONFIG_PCM_F32LE_DECODER 1
-+#define CONFIG_PCM_F64BE_DECODER 0
-+#define CONFIG_PCM_F64LE_DECODER 0
-+#define CONFIG_PCM_LXF_DECODER 0
-+#define CONFIG_PCM_MULAW_DECODER 1
-+#define CONFIG_PCM_S8_DECODER 0
-+#define CONFIG_PCM_S8_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16BE_DECODER 1
-+#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16LE_DECODER 1
-+#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S24BE_DECODER 1
-+#define CONFIG_PCM_S24DAUD_DECODER 0
-+#define CONFIG_PCM_S24LE_DECODER 1
-+#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S32BE_DECODER 0
-+#define CONFIG_PCM_S32LE_DECODER 1
-+#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S64BE_DECODER 0
-+#define CONFIG_PCM_S64LE_DECODER 0
-+#define CONFIG_PCM_SGA_DECODER 0
-+#define CONFIG_PCM_U8_DECODER 1
-+#define CONFIG_PCM_U16BE_DECODER 0
-+#define CONFIG_PCM_U16LE_DECODER 0
-+#define CONFIG_PCM_U24BE_DECODER 0
-+#define CONFIG_PCM_U24LE_DECODER 0
-+#define CONFIG_PCM_U32BE_DECODER 0
-+#define CONFIG_PCM_U32LE_DECODER 0
-+#define CONFIG_PCM_VIDC_DECODER 0
-+#define CONFIG_CBD2_DPCM_DECODER 0
-+#define CONFIG_DERF_DPCM_DECODER 0
-+#define CONFIG_GREMLIN_DPCM_DECODER 0
-+#define CONFIG_INTERPLAY_DPCM_DECODER 0
-+#define CONFIG_ROQ_DPCM_DECODER 0
-+#define CONFIG_SDX2_DPCM_DECODER 0
-+#define CONFIG_SOL_DPCM_DECODER 0
-+#define CONFIG_XAN_DPCM_DECODER 0
-+#define CONFIG_WADY_DPCM_DECODER 0
-+#define CONFIG_ADPCM_4XM_DECODER 0
-+#define CONFIG_ADPCM_ADX_DECODER 0
-+#define CONFIG_ADPCM_AFC_DECODER 0
-+#define CONFIG_ADPCM_AGM_DECODER 0
-+#define CONFIG_ADPCM_AICA_DECODER 0
-+#define CONFIG_ADPCM_ARGO_DECODER 0
-+#define CONFIG_ADPCM_CT_DECODER 0
-+#define CONFIG_ADPCM_DTK_DECODER 0
-+#define CONFIG_ADPCM_EA_DECODER 0
-+#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
-+#define CONFIG_ADPCM_EA_R1_DECODER 0
-+#define CONFIG_ADPCM_EA_R2_DECODER 0
-+#define CONFIG_ADPCM_EA_R3_DECODER 0
-+#define CONFIG_ADPCM_EA_XAS_DECODER 0
-+#define CONFIG_ADPCM_G722_DECODER 0
-+#define CONFIG_ADPCM_G726_DECODER 0
-+#define CONFIG_ADPCM_G726LE_DECODER 0
-+#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
-+#define CONFIG_ADPCM_IMA_AMV_DECODER 0
-+#define CONFIG_ADPCM_IMA_ALP_DECODER 0
-+#define CONFIG_ADPCM_IMA_APC_DECODER 0
-+#define CONFIG_ADPCM_IMA_APM_DECODER 0
-+#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
-+#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK3_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK4_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_ISS_DECODER 0
-+#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
-+#define CONFIG_ADPCM_IMA_MTF_DECODER 0
-+#define CONFIG_ADPCM_IMA_OKI_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_DECODER 0
-+#define CONFIG_ADPCM_IMA_RAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_SSI_DECODER 0
-+#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
-+#define CONFIG_ADPCM_IMA_WAV_DECODER 0
-+#define CONFIG_ADPCM_IMA_WS_DECODER 0
-+#define CONFIG_ADPCM_IMA_XBOX_DECODER 0
-+#define CONFIG_ADPCM_MS_DECODER 0
-+#define CONFIG_ADPCM_MTAF_DECODER 0
-+#define CONFIG_ADPCM_PSX_DECODER 0
-+#define CONFIG_ADPCM_SANYO_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_2_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_3_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_4_DECODER 0
-+#define CONFIG_ADPCM_SWF_DECODER 0
-+#define CONFIG_ADPCM_THP_DECODER 0
-+#define CONFIG_ADPCM_THP_LE_DECODER 0
-+#define CONFIG_ADPCM_VIMA_DECODER 0
-+#define CONFIG_ADPCM_XA_DECODER 0
-+#define CONFIG_ADPCM_XMD_DECODER 0
-+#define CONFIG_ADPCM_YAMAHA_DECODER 0
-+#define CONFIG_ADPCM_ZORK_DECODER 0
-+#define CONFIG_SSA_DECODER 0
-+#define CONFIG_ASS_DECODER 0
-+#define CONFIG_CCAPTION_DECODER 0
-+#define CONFIG_DVBSUB_DECODER 0
-+#define CONFIG_DVDSUB_DECODER 0
-+#define CONFIG_JACOSUB_DECODER 0
-+#define CONFIG_MICRODVD_DECODER 0
-+#define CONFIG_MOVTEXT_DECODER 0
-+#define CONFIG_MPL2_DECODER 0
-+#define CONFIG_PGSSUB_DECODER 0
-+#define CONFIG_PJS_DECODER 0
-+#define CONFIG_REALTEXT_DECODER 0
-+#define CONFIG_SAMI_DECODER 0
-+#define CONFIG_SRT_DECODER 0
-+#define CONFIG_STL_DECODER 0
-+#define CONFIG_SUBRIP_DECODER 0
-+#define CONFIG_SUBVIEWER_DECODER 0
-+#define CONFIG_SUBVIEWER1_DECODER 0
-+#define CONFIG_TEXT_DECODER 0
-+#define CONFIG_VPLAYER_DECODER 0
-+#define CONFIG_WEBVTT_DECODER 0
-+#define CONFIG_XSUB_DECODER 0
-+#define CONFIG_AAC_AT_DECODER 0
-+#define CONFIG_AC3_AT_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
-+#define CONFIG_ALAC_AT_DECODER 0
-+#define CONFIG_AMR_NB_AT_DECODER 0
-+#define CONFIG_EAC3_AT_DECODER 0
-+#define CONFIG_GSM_MS_AT_DECODER 0
-+#define CONFIG_ILBC_AT_DECODER 0
-+#define CONFIG_MP1_AT_DECODER 0
-+#define CONFIG_MP2_AT_DECODER 0
-+#define CONFIG_MP3_AT_DECODER 0
-+#define CONFIG_PCM_ALAW_AT_DECODER 0
-+#define CONFIG_PCM_MULAW_AT_DECODER 0
-+#define CONFIG_QDMC_AT_DECODER 0
-+#define CONFIG_QDM2_AT_DECODER 0
-+#define CONFIG_LIBARIBCAPTION_DECODER 0
-+#define CONFIG_LIBARIBB24_DECODER 0
-+#define CONFIG_LIBCELT_DECODER 0
-+#define CONFIG_LIBCODEC2_DECODER 0
-+#define CONFIG_LIBDAV1D_DECODER 0
-+#define CONFIG_LIBDAVS2_DECODER 0
-+#define CONFIG_LIBFDK_AAC_DECODER 0
-+#define CONFIG_LIBGSM_DECODER 0
-+#define CONFIG_LIBGSM_MS_DECODER 0
-+#define CONFIG_LIBILBC_DECODER 0
-+#define CONFIG_LIBJXL_ANIM_DECODER 0
-+#define CONFIG_LIBJXL_DECODER 0
-+#define CONFIG_LIBLC3_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
-+#define CONFIG_LIBOPUS_DECODER 1
-+#define CONFIG_LIBRSVG_DECODER 0
-+#define CONFIG_LIBSPEEX_DECODER 0
-+#define CONFIG_LIBUAVS3D_DECODER 0
-+#define CONFIG_LIBVORBIS_DECODER 0
-+#define CONFIG_LIBVPX_VP8_DECODER 0
-+#define CONFIG_LIBVPX_VP9_DECODER 0
-+#define CONFIG_LIBXEVD_DECODER 0
-+#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
-+#define CONFIG_BINTEXT_DECODER 0
-+#define CONFIG_XBIN_DECODER 0
-+#define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
-+#define CONFIG_LIBAOM_AV1_DECODER 0
-+#define CONFIG_AV1_DECODER 0
-+#define CONFIG_AV1_CUVID_DECODER 0
-+#define CONFIG_AV1_MEDIACODEC_DECODER 0
-+#define CONFIG_AV1_QSV_DECODER 0
-+#define CONFIG_AV1_AMF_DECODER 0
-+#define CONFIG_LIBOPENH264_DECODER 0
-+#define CONFIG_H264_AMF_DECODER 0
-+#define CONFIG_H264_CUVID_DECODER 0
-+#define CONFIG_H264_OH_DECODER 0
-+#define CONFIG_HEVC_AMF_DECODER 0
-+#define CONFIG_HEVC_CUVID_DECODER 0
-+#define CONFIG_HEVC_MEDIACODEC_DECODER 0
-+#define CONFIG_HEVC_OH_DECODER 0
-+#define CONFIG_MJPEG_CUVID_DECODER 0
-+#define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
-+#define CONFIG_MPEG1_CUVID_DECODER 0
-+#define CONFIG_MPEG2_CUVID_DECODER 0
-+#define CONFIG_MPEG4_CUVID_DECODER 0
-+#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
-+#define CONFIG_VC1_CUVID_DECODER 0
-+#define CONFIG_VP8_CUVID_DECODER 0
-+#define CONFIG_VP8_MEDIACODEC_DECODER 0
-+#define CONFIG_VP8_QSV_DECODER 0
-+#define CONFIG_VP9_AMF_DECODER 0
-+#define CONFIG_VP9_CUVID_DECODER 0
-+#define CONFIG_VP9_MEDIACODEC_DECODER 0
-+#define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
-+#define CONFIG_VNULL_DECODER 0
-+#define CONFIG_ANULL_DECODER 0
-+#define CONFIG_A64MULTI_ENCODER 0
-+#define CONFIG_A64MULTI5_ENCODER 0
-+#define CONFIG_ALIAS_PIX_ENCODER 0
-+#define CONFIG_AMV_ENCODER 0
-+#define CONFIG_APNG_ENCODER 0
-+#define CONFIG_ASV1_ENCODER 0
-+#define CONFIG_ASV2_ENCODER 0
-+#define CONFIG_AVRP_ENCODER 0
-+#define CONFIG_AVUI_ENCODER 0
-+#define CONFIG_BITPACKED_ENCODER 0
-+#define CONFIG_BMP_ENCODER 0
-+#define CONFIG_CFHD_ENCODER 0
-+#define CONFIG_CINEPAK_ENCODER 0
-+#define CONFIG_CLJR_ENCODER 0
-+#define CONFIG_COMFORTNOISE_ENCODER 0
-+#define CONFIG_DNXHD_ENCODER 0
-+#define CONFIG_DPX_ENCODER 0
-+#define CONFIG_DVVIDEO_ENCODER 0
-+#define CONFIG_DXV_ENCODER 0
-+#define CONFIG_EXR_ENCODER 0
-+#define CONFIG_FFV1_ENCODER 0
-+#define CONFIG_FFV1_VULKAN_ENCODER 0
-+#define CONFIG_FFVHUFF_ENCODER 0
-+#define CONFIG_FITS_ENCODER 0
-+#define CONFIG_FLASHSV_ENCODER 0
-+#define CONFIG_FLASHSV2_ENCODER 0
-+#define CONFIG_FLV_ENCODER 0
-+#define CONFIG_GIF_ENCODER 0
-+#define CONFIG_H261_ENCODER 0
-+#define CONFIG_H263_ENCODER 0
-+#define CONFIG_H263P_ENCODER 0
-+#define CONFIG_H264_MEDIACODEC_ENCODER 0
-+#define CONFIG_HAP_ENCODER 0
-+#define CONFIG_HUFFYUV_ENCODER 0
-+#define CONFIG_JPEG2000_ENCODER 0
-+#define CONFIG_JPEGLS_ENCODER 0
-+#define CONFIG_LJPEG_ENCODER 0
-+#define CONFIG_MAGICYUV_ENCODER 0
-+#define CONFIG_MJPEG_ENCODER 0
-+#define CONFIG_MPEG1VIDEO_ENCODER 0
-+#define CONFIG_MPEG2VIDEO_ENCODER 0
-+#define CONFIG_MPEG4_ENCODER 0
-+#define CONFIG_MSMPEG4V2_ENCODER 0
-+#define CONFIG_MSMPEG4V3_ENCODER 0
-+#define CONFIG_MSRLE_ENCODER 0
-+#define CONFIG_MSVIDEO1_ENCODER 0
-+#define CONFIG_PAM_ENCODER 0
-+#define CONFIG_PBM_ENCODER 0
-+#define CONFIG_PCX_ENCODER 0
-+#define CONFIG_PFM_ENCODER 0
-+#define CONFIG_PGM_ENCODER 0
-+#define CONFIG_PGMYUV_ENCODER 0
-+#define CONFIG_PHM_ENCODER 0
-+#define CONFIG_PNG_ENCODER 0
-+#define CONFIG_PPM_ENCODER 0
-+#define CONFIG_PRORES_ENCODER 0
-+#define CONFIG_PRORES_AW_ENCODER 0
-+#define CONFIG_PRORES_KS_ENCODER 0
-+#define CONFIG_QOI_ENCODER 0
-+#define CONFIG_QTRLE_ENCODER 0
-+#define CONFIG_R10K_ENCODER 0
-+#define CONFIG_R210_ENCODER 0
-+#define CONFIG_RAWVIDEO_ENCODER 0
-+#define CONFIG_ROQ_ENCODER 0
-+#define CONFIG_RPZA_ENCODER 0
-+#define CONFIG_RV10_ENCODER 0
-+#define CONFIG_RV20_ENCODER 0
-+#define CONFIG_S302M_ENCODER 0
-+#define CONFIG_SGI_ENCODER 0
-+#define CONFIG_SMC_ENCODER 0
-+#define CONFIG_SNOW_ENCODER 0
-+#define CONFIG_SPEEDHQ_ENCODER 0
-+#define CONFIG_SUNRAST_ENCODER 0
-+#define CONFIG_SVQ1_ENCODER 0
-+#define CONFIG_TARGA_ENCODER 0
-+#define CONFIG_TIFF_ENCODER 0
-+#define CONFIG_UTVIDEO_ENCODER 0
-+#define CONFIG_V210_ENCODER 0
-+#define CONFIG_V308_ENCODER 0
-+#define CONFIG_V408_ENCODER 0
-+#define CONFIG_V410_ENCODER 0
-+#define CONFIG_VBN_ENCODER 0
-+#define CONFIG_VC2_ENCODER 0
-+#define CONFIG_WBMP_ENCODER 0
-+#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
-+#define CONFIG_WMV1_ENCODER 0
-+#define CONFIG_WMV2_ENCODER 0
-+#define CONFIG_XBM_ENCODER 0
-+#define CONFIG_XFACE_ENCODER 0
-+#define CONFIG_XWD_ENCODER 0
-+#define CONFIG_Y41P_ENCODER 0
-+#define CONFIG_YUV4_ENCODER 0
-+#define CONFIG_ZLIB_ENCODER 0
-+#define CONFIG_ZMBV_ENCODER 0
-+#define CONFIG_AAC_ENCODER 0
-+#define CONFIG_AC3_ENCODER 0
-+#define CONFIG_AC3_FIXED_ENCODER 0
-+#define CONFIG_ALAC_ENCODER 0
-+#define CONFIG_APTX_ENCODER 0
-+#define CONFIG_APTX_HD_ENCODER 0
-+#define CONFIG_DCA_ENCODER 0
-+#define CONFIG_DFPWM_ENCODER 0
-+#define CONFIG_EAC3_ENCODER 0
-+#define CONFIG_FLAC_ENCODER 0
-+#define CONFIG_G723_1_ENCODER 0
-+#define CONFIG_HDR_ENCODER 0
-+#define CONFIG_MLP_ENCODER 0
-+#define CONFIG_MP2_ENCODER 0
-+#define CONFIG_MP2FIXED_ENCODER 0
-+#define CONFIG_NELLYMOSER_ENCODER 0
-+#define CONFIG_OPUS_ENCODER 0
-+#define CONFIG_RA_144_ENCODER 0
-+#define CONFIG_SBC_ENCODER 0
-+#define CONFIG_SONIC_ENCODER 0
-+#define CONFIG_SONIC_LS_ENCODER 0
-+#define CONFIG_TRUEHD_ENCODER 0
-+#define CONFIG_TTA_ENCODER 0
-+#define CONFIG_VORBIS_ENCODER 0
-+#define CONFIG_WAVPACK_ENCODER 0
-+#define CONFIG_WMAV1_ENCODER 0
-+#define CONFIG_WMAV2_ENCODER 0
-+#define CONFIG_PCM_ALAW_ENCODER 0
-+#define CONFIG_PCM_BLURAY_ENCODER 0
-+#define CONFIG_PCM_DVD_ENCODER 0
-+#define CONFIG_PCM_F32BE_ENCODER 0
-+#define CONFIG_PCM_F32LE_ENCODER 0
-+#define CONFIG_PCM_F64BE_ENCODER 0
-+#define CONFIG_PCM_F64LE_ENCODER 0
-+#define CONFIG_PCM_MULAW_ENCODER 0
-+#define CONFIG_PCM_S8_ENCODER 0
-+#define CONFIG_PCM_S8_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16BE_ENCODER 0
-+#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16LE_ENCODER 0
-+#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S24BE_ENCODER 0
-+#define CONFIG_PCM_S24DAUD_ENCODER 0
-+#define CONFIG_PCM_S24LE_ENCODER 0
-+#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S32BE_ENCODER 0
-+#define CONFIG_PCM_S32LE_ENCODER 0
-+#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S64BE_ENCODER 0
-+#define CONFIG_PCM_S64LE_ENCODER 0
-+#define CONFIG_PCM_U8_ENCODER 0
-+#define CONFIG_PCM_U16BE_ENCODER 0
-+#define CONFIG_PCM_U16LE_ENCODER 0
-+#define CONFIG_PCM_U24BE_ENCODER 0
-+#define CONFIG_PCM_U24LE_ENCODER 0
-+#define CONFIG_PCM_U32BE_ENCODER 0
-+#define CONFIG_PCM_U32LE_ENCODER 0
-+#define CONFIG_PCM_VIDC_ENCODER 0
-+#define CONFIG_ROQ_DPCM_ENCODER 0
-+#define CONFIG_ADPCM_ADX_ENCODER 0
-+#define CONFIG_ADPCM_ARGO_ENCODER 0
-+#define CONFIG_ADPCM_G722_ENCODER 0
-+#define CONFIG_ADPCM_G726_ENCODER 0
-+#define CONFIG_ADPCM_G726LE_ENCODER 0
-+#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
-+#define CONFIG_ADPCM_IMA_APM_ENCODER 0
-+#define CONFIG_ADPCM_IMA_QT_ENCODER 0
-+#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WS_ENCODER 0
-+#define CONFIG_ADPCM_MS_ENCODER 0
-+#define CONFIG_ADPCM_SWF_ENCODER 0
-+#define CONFIG_ADPCM_YAMAHA_ENCODER 0
-+#define CONFIG_SSA_ENCODER 0
-+#define CONFIG_ASS_ENCODER 0
-+#define CONFIG_DVBSUB_ENCODER 0
-+#define CONFIG_DVDSUB_ENCODER 0
-+#define CONFIG_MOVTEXT_ENCODER 0
-+#define CONFIG_SRT_ENCODER 0
-+#define CONFIG_SUBRIP_ENCODER 0
-+#define CONFIG_TEXT_ENCODER 0
-+#define CONFIG_TTML_ENCODER 0
-+#define CONFIG_WEBVTT_ENCODER 0
-+#define CONFIG_XSUB_ENCODER 0
-+#define CONFIG_AAC_AT_ENCODER 0
-+#define CONFIG_ALAC_AT_ENCODER 0
-+#define CONFIG_ILBC_AT_ENCODER 0
-+#define CONFIG_PCM_ALAW_AT_ENCODER 0
-+#define CONFIG_PCM_MULAW_AT_ENCODER 0
-+#define CONFIG_LIBAOM_AV1_ENCODER 0
-+#define CONFIG_LIBCODEC2_ENCODER 0
-+#define CONFIG_LIBFDK_AAC_ENCODER 0
-+#define CONFIG_LIBGSM_ENCODER 0
-+#define CONFIG_LIBGSM_MS_ENCODER 0
-+#define CONFIG_LIBILBC_ENCODER 0
-+#define CONFIG_LIBJXL_ANIM_ENCODER 0
-+#define CONFIG_LIBJXL_ENCODER 0
-+#define CONFIG_LIBLC3_ENCODER 0
-+#define CONFIG_LIBMP3LAME_ENCODER 0
-+#define CONFIG_LIBOAPV_ENCODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
-+#define CONFIG_LIBOPENJPEG_ENCODER 0
-+#define CONFIG_LIBOPUS_ENCODER 0
-+#define CONFIG_LIBRAV1E_ENCODER 0
-+#define CONFIG_LIBSHINE_ENCODER 0
-+#define CONFIG_LIBSPEEX_ENCODER 0
-+#define CONFIG_LIBSVTAV1_ENCODER 0
-+#define CONFIG_LIBTHEORA_ENCODER 0
-+#define CONFIG_LIBTWOLAME_ENCODER 0
-+#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
-+#define CONFIG_LIBVORBIS_ENCODER 0
-+#define CONFIG_LIBVPX_VP8_ENCODER 0
-+#define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
-+#define CONFIG_LIBWEBP_ANIM_ENCODER 0
-+#define CONFIG_LIBWEBP_ENCODER 0
-+#define CONFIG_LIBX262_ENCODER 0
-+#define CONFIG_LIBX264_ENCODER 0
-+#define CONFIG_LIBX264RGB_ENCODER 0
-+#define CONFIG_LIBX265_ENCODER 0
-+#define CONFIG_LIBXEVE_ENCODER 0
-+#define CONFIG_LIBXAVS_ENCODER 0
-+#define CONFIG_LIBXAVS2_ENCODER 0
-+#define CONFIG_LIBXVID_ENCODER 0
-+#define CONFIG_AAC_MF_ENCODER 0
-+#define CONFIG_AC3_MF_ENCODER 0
-+#define CONFIG_H263_V4L2M2M_ENCODER 0
-+#define CONFIG_AV1_MEDIACODEC_ENCODER 0
-+#define CONFIG_AV1_NVENC_ENCODER 0
-+#define CONFIG_AV1_QSV_ENCODER 0
-+#define CONFIG_AV1_AMF_ENCODER 0
-+#define CONFIG_AV1_MF_ENCODER 0
-+#define CONFIG_AV1_VAAPI_ENCODER 0
-+#define CONFIG_AV1_VULKAN_ENCODER 0
-+#define CONFIG_LIBOPENH264_ENCODER 0
-+#define CONFIG_H264_AMF_ENCODER 0
-+#define CONFIG_H264_MF_ENCODER 0
-+#define CONFIG_H264_NVENC_ENCODER 0
-+#define CONFIG_H264_OH_ENCODER 0
-+#define CONFIG_H264_OMX_ENCODER 0
-+#define CONFIG_H264_QSV_ENCODER 0
-+#define CONFIG_H264_V4L2M2M_ENCODER 0
-+#define CONFIG_H264_VAAPI_ENCODER 0
-+#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
-+#define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
-+#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
-+#define CONFIG_HEVC_MF_ENCODER 0
-+#define CONFIG_HEVC_NVENC_ENCODER 0
-+#define CONFIG_HEVC_OH_ENCODER 0
-+#define CONFIG_HEVC_QSV_ENCODER 0
-+#define CONFIG_HEVC_V4L2M2M_ENCODER 0
-+#define CONFIG_HEVC_VAAPI_ENCODER 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
-+#define CONFIG_LIBKVAZAAR_ENCODER 0
-+#define CONFIG_MJPEG_QSV_ENCODER 0
-+#define CONFIG_MJPEG_VAAPI_ENCODER 0
-+#define CONFIG_MP3_MF_ENCODER 0
-+#define CONFIG_MPEG2_QSV_ENCODER 0
-+#define CONFIG_MPEG2_VAAPI_ENCODER 0
-+#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
-+#define CONFIG_MPEG4_OMX_ENCODER 0
-+#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_VP8_MEDIACODEC_ENCODER 0
-+#define CONFIG_VP8_V4L2M2M_ENCODER 0
-+#define CONFIG_VP8_VAAPI_ENCODER 0
-+#define CONFIG_VP9_MEDIACODEC_ENCODER 0
-+#define CONFIG_VP9_VAAPI_ENCODER 0
-+#define CONFIG_VP9_QSV_ENCODER 0
-+#define CONFIG_VNULL_ENCODER 0
-+#define CONFIG_ANULL_ENCODER 0
-+#define CONFIG_AV1_D3D11VA_HWACCEL 0
-+#define CONFIG_AV1_D3D11VA2_HWACCEL 0
-+#define CONFIG_AV1_D3D12VA_HWACCEL 0
-+#define CONFIG_AV1_DXVA2_HWACCEL 0
-+#define CONFIG_AV1_NVDEC_HWACCEL 0
-+#define CONFIG_AV1_VAAPI_HWACCEL 0
-+#define CONFIG_AV1_VDPAU_HWACCEL 0
-+#define CONFIG_AV1_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_AV1_VULKAN_HWACCEL 0
-+#define CONFIG_FFV1_VULKAN_HWACCEL 0
-+#define CONFIG_H263_VAAPI_HWACCEL 0
-+#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_H264_D3D11VA_HWACCEL 0
-+#define CONFIG_H264_D3D11VA2_HWACCEL 0
-+#define CONFIG_H264_D3D12VA_HWACCEL 0
-+#define CONFIG_H264_DXVA2_HWACCEL 0
-+#define CONFIG_H264_NVDEC_HWACCEL 0
-+#define CONFIG_H264_VAAPI_HWACCEL 0
-+#define CONFIG_H264_VDPAU_HWACCEL 0
-+#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_H264_VULKAN_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
-+#define CONFIG_HEVC_D3D12VA_HWACCEL 0
-+#define CONFIG_HEVC_DXVA2_HWACCEL 0
-+#define CONFIG_HEVC_NVDEC_HWACCEL 0
-+#define CONFIG_HEVC_VAAPI_HWACCEL 0
-+#define CONFIG_HEVC_VDPAU_HWACCEL 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_HEVC_VULKAN_HWACCEL 0
-+#define CONFIG_MJPEG_NVDEC_HWACCEL 0
-+#define CONFIG_MJPEG_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG1_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG1_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
-+#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
-+#define CONFIG_MPEG2_DXVA2_HWACCEL 0
-+#define CONFIG_MPEG2_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG2_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG2_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG4_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG4_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG4_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_RAW_VULKAN_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA2_HWACCEL 0
-+#define CONFIG_VC1_D3D12VA_HWACCEL 0
-+#define CONFIG_VC1_DXVA2_HWACCEL 0
-+#define CONFIG_VC1_NVDEC_HWACCEL 0
-+#define CONFIG_VC1_VAAPI_HWACCEL 0
-+#define CONFIG_VC1_VDPAU_HWACCEL 0
-+#define CONFIG_VP8_NVDEC_HWACCEL 0
-+#define CONFIG_VP8_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA2_HWACCEL 0
-+#define CONFIG_VP9_D3D12VA_HWACCEL 0
-+#define CONFIG_VP9_DXVA2_HWACCEL 0
-+#define CONFIG_VP9_NVDEC_HWACCEL 0
-+#define CONFIG_VP9_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_VDPAU_HWACCEL 0
-+#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_VP9_VULKAN_HWACCEL 0
-+#define CONFIG_VVC_VAAPI_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
-+#define CONFIG_WMV3_D3D12VA_HWACCEL 0
-+#define CONFIG_WMV3_DXVA2_HWACCEL 0
-+#define CONFIG_WMV3_NVDEC_HWACCEL 0
-+#define CONFIG_WMV3_VAAPI_HWACCEL 0
-+#define CONFIG_WMV3_VDPAU_HWACCEL 0
-+#define CONFIG_AAC_PARSER 1
-+#define CONFIG_AAC_LATM_PARSER 0
-+#define CONFIG_AC3_PARSER 0
-+#define CONFIG_ADX_PARSER 0
-+#define CONFIG_AMR_PARSER 0
-+#define CONFIG_APV_PARSER 0
-+#define CONFIG_AV1_PARSER 0
-+#define CONFIG_AVS2_PARSER 0
-+#define CONFIG_AVS3_PARSER 0
-+#define CONFIG_BMP_PARSER 0
-+#define CONFIG_CAVSVIDEO_PARSER 0
-+#define CONFIG_COOK_PARSER 0
-+#define CONFIG_CRI_PARSER 0
-+#define CONFIG_DCA_PARSER 0
-+#define CONFIG_DIRAC_PARSER 0
-+#define CONFIG_DNXHD_PARSER 0
-+#define CONFIG_DNXUC_PARSER 0
-+#define CONFIG_DOLBY_E_PARSER 0
-+#define CONFIG_DPX_PARSER 0
-+#define CONFIG_DVAUDIO_PARSER 0
-+#define CONFIG_DVBSUB_PARSER 0
-+#define CONFIG_DVDSUB_PARSER 0
-+#define CONFIG_DVD_NAV_PARSER 0
-+#define CONFIG_EVC_PARSER 0
-+#define CONFIG_FLAC_PARSER 1
-+#define CONFIG_FTR_PARSER 0
-+#define CONFIG_FFV1_PARSER 0
-+#define CONFIG_G723_1_PARSER 0
-+#define CONFIG_G729_PARSER 0
-+#define CONFIG_GIF_PARSER 0
-+#define CONFIG_GSM_PARSER 0
-+#define CONFIG_H261_PARSER 0
-+#define CONFIG_H263_PARSER 0
-+#define CONFIG_H264_PARSER 1
-+#define CONFIG_HEVC_PARSER 0
-+#define CONFIG_HDR_PARSER 0
-+#define CONFIG_IPU_PARSER 0
-+#define CONFIG_JPEG2000_PARSER 0
-+#define CONFIG_JPEGXL_PARSER 0
-+#define CONFIG_MISC4_PARSER 0
-+#define CONFIG_MJPEG_PARSER 0
-+#define CONFIG_MLP_PARSER 0
-+#define CONFIG_MPEG4VIDEO_PARSER 0
-+#define CONFIG_MPEGAUDIO_PARSER 1
-+#define CONFIG_MPEGVIDEO_PARSER 0
-+#define CONFIG_OPUS_PARSER 1
-+#define CONFIG_PNG_PARSER 0
-+#define CONFIG_PNM_PARSER 0
-+#define CONFIG_PRORES_RAW_PARSER 0
-+#define CONFIG_QOI_PARSER 0
-+#define CONFIG_RV34_PARSER 0
-+#define CONFIG_SBC_PARSER 0
-+#define CONFIG_SIPR_PARSER 0
-+#define CONFIG_TAK_PARSER 0
-+#define CONFIG_VC1_PARSER 0
-+#define CONFIG_VORBIS_PARSER 1
-+#define CONFIG_VP3_PARSER 0
-+#define CONFIG_VP8_PARSER 0
-+#define CONFIG_VP9_PARSER 1
-+#define CONFIG_VVC_PARSER 0
-+#define CONFIG_WEBP_PARSER 0
-+#define CONFIG_XBM_PARSER 0
-+#define CONFIG_XMA_PARSER 0
-+#define CONFIG_XWD_PARSER 0
-+#define CONFIG_ALSA_INDEV 0
-+#define CONFIG_ANDROID_CAMERA_INDEV 0
-+#define CONFIG_AVFOUNDATION_INDEV 0
-+#define CONFIG_DECKLINK_INDEV 0
-+#define CONFIG_DSHOW_INDEV 0
-+#define CONFIG_FBDEV_INDEV 0
-+#define CONFIG_GDIGRAB_INDEV 0
-+#define CONFIG_IEC61883_INDEV 0
-+#define CONFIG_JACK_INDEV 0
-+#define CONFIG_KMSGRAB_INDEV 0
-+#define CONFIG_LAVFI_INDEV 0
-+#define CONFIG_OPENAL_INDEV 0
-+#define CONFIG_OSS_INDEV 0
-+#define CONFIG_PULSE_INDEV 0
-+#define CONFIG_SNDIO_INDEV 0
-+#define CONFIG_V4L2_INDEV 0
-+#define CONFIG_VFWCAP_INDEV 0
-+#define CONFIG_XCBGRAB_INDEV 0
-+#define CONFIG_LIBCDIO_INDEV 0
-+#define CONFIG_LIBDC1394_INDEV 0
-+#define CONFIG_ALSA_OUTDEV 0
-+#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
-+#define CONFIG_CACA_OUTDEV 0
-+#define CONFIG_DECKLINK_OUTDEV 0
-+#define CONFIG_FBDEV_OUTDEV 0
-+#define CONFIG_OSS_OUTDEV 0
-+#define CONFIG_PULSE_OUTDEV 0
-+#define CONFIG_SNDIO_OUTDEV 0
-+#define CONFIG_V4L2_OUTDEV 0
-+#define CONFIG_XV_OUTDEV 0
-+#define CONFIG_AAP_FILTER 0
-+#define CONFIG_ABENCH_FILTER 0
-+#define CONFIG_ACOMPRESSOR_FILTER 0
-+#define CONFIG_ACONTRAST_FILTER 0
-+#define CONFIG_ACOPY_FILTER 0
-+#define CONFIG_ACUE_FILTER 0
-+#define CONFIG_ACROSSFADE_FILTER 0
-+#define CONFIG_ACROSSOVER_FILTER 0
-+#define CONFIG_ACRUSHER_FILTER 0
-+#define CONFIG_ADECLICK_FILTER 0
-+#define CONFIG_ADECLIP_FILTER 0
-+#define CONFIG_ADECORRELATE_FILTER 0
-+#define CONFIG_ADELAY_FILTER 0
-+#define CONFIG_ADENORM_FILTER 0
-+#define CONFIG_ADERIVATIVE_FILTER 0
-+#define CONFIG_ADRC_FILTER 0
-+#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
-+#define CONFIG_ADYNAMICSMOOTH_FILTER 0
-+#define CONFIG_AECHO_FILTER 0
-+#define CONFIG_AEMPHASIS_FILTER 0
-+#define CONFIG_AEVAL_FILTER 0
-+#define CONFIG_AEXCITER_FILTER 0
-+#define CONFIG_AFADE_FILTER 0
-+#define CONFIG_AFFTDN_FILTER 0
-+#define CONFIG_AFFTFILT_FILTER 0
-+#define CONFIG_AFIR_FILTER 0
-+#define CONFIG_AFORMAT_FILTER 0
-+#define CONFIG_AFREQSHIFT_FILTER 0
-+#define CONFIG_AFWTDN_FILTER 0
-+#define CONFIG_AGATE_FILTER 0
-+#define CONFIG_AIIR_FILTER 0
-+#define CONFIG_AINTEGRAL_FILTER 0
-+#define CONFIG_AINTERLEAVE_FILTER 0
-+#define CONFIG_ALATENCY_FILTER 0
-+#define CONFIG_ALIMITER_FILTER 0
-+#define CONFIG_ALLPASS_FILTER 0
-+#define CONFIG_ALOOP_FILTER 0
-+#define CONFIG_AMERGE_FILTER 0
-+#define CONFIG_AMETADATA_FILTER 0
-+#define CONFIG_AMIX_FILTER 0
-+#define CONFIG_AMULTIPLY_FILTER 0
-+#define CONFIG_ANEQUALIZER_FILTER 0
-+#define CONFIG_ANLMDN_FILTER 0
-+#define CONFIG_ANLMF_FILTER 0
-+#define CONFIG_ANLMS_FILTER 0
-+#define CONFIG_ANULL_FILTER 0
-+#define CONFIG_APAD_FILTER 0
-+#define CONFIG_APERMS_FILTER 0
-+#define CONFIG_APHASER_FILTER 0
-+#define CONFIG_APHASESHIFT_FILTER 0
-+#define CONFIG_APSNR_FILTER 0
-+#define CONFIG_APSYCLIP_FILTER 0
-+#define CONFIG_APULSATOR_FILTER 0
-+#define CONFIG_AREALTIME_FILTER 0
-+#define CONFIG_ARESAMPLE_FILTER 0
-+#define CONFIG_AREVERSE_FILTER 0
-+#define CONFIG_ARLS_FILTER 0
-+#define CONFIG_ARNNDN_FILTER 0
-+#define CONFIG_ASDR_FILTER 0
-+#define CONFIG_ASEGMENT_FILTER 0
-+#define CONFIG_ASELECT_FILTER 0
-+#define CONFIG_ASENDCMD_FILTER 0
-+#define CONFIG_ASETNSAMPLES_FILTER 0
-+#define CONFIG_ASETPTS_FILTER 0
-+#define CONFIG_ASETRATE_FILTER 0
-+#define CONFIG_ASETTB_FILTER 0
-+#define CONFIG_ASHOWINFO_FILTER 0
-+#define CONFIG_ASIDEDATA_FILTER 0
-+#define CONFIG_ASISDR_FILTER 0
-+#define CONFIG_ASOFTCLIP_FILTER 0
-+#define CONFIG_ASPECTRALSTATS_FILTER 0
-+#define CONFIG_ASPLIT_FILTER 0
-+#define CONFIG_ASR_FILTER 0
-+#define CONFIG_ASTATS_FILTER 0
-+#define CONFIG_ASTREAMSELECT_FILTER 0
-+#define CONFIG_ASUBBOOST_FILTER 0
-+#define CONFIG_ASUBCUT_FILTER 0
-+#define CONFIG_ASUPERCUT_FILTER 0
-+#define CONFIG_ASUPERPASS_FILTER 0
-+#define CONFIG_ASUPERSTOP_FILTER 0
-+#define CONFIG_ATEMPO_FILTER 0
-+#define CONFIG_ATILT_FILTER 0
-+#define CONFIG_ATRIM_FILTER 0
-+#define CONFIG_AXCORRELATE_FILTER 0
-+#define CONFIG_AZMQ_FILTER 0
-+#define CONFIG_BANDPASS_FILTER 0
-+#define CONFIG_BANDREJECT_FILTER 0
-+#define CONFIG_BASS_FILTER 0
-+#define CONFIG_BIQUAD_FILTER 0
-+#define CONFIG_BS2B_FILTER 0
-+#define CONFIG_CHANNELMAP_FILTER 0
-+#define CONFIG_CHANNELSPLIT_FILTER 0
-+#define CONFIG_CHORUS_FILTER 0
-+#define CONFIG_COMPAND_FILTER 0
-+#define CONFIG_COMPENSATIONDELAY_FILTER 0
-+#define CONFIG_CROSSFEED_FILTER 0
-+#define CONFIG_CRYSTALIZER_FILTER 0
-+#define CONFIG_DCSHIFT_FILTER 0
-+#define CONFIG_DEESSER_FILTER 0
-+#define CONFIG_DIALOGUENHANCE_FILTER 0
-+#define CONFIG_DRMETER_FILTER 0
-+#define CONFIG_DYNAUDNORM_FILTER 0
-+#define CONFIG_EARWAX_FILTER 0
-+#define CONFIG_EBUR128_FILTER 0
-+#define CONFIG_EQUALIZER_FILTER 0
-+#define CONFIG_EXTRASTEREO_FILTER 0
-+#define CONFIG_FIREQUALIZER_FILTER 0
-+#define CONFIG_FLANGER_FILTER 0
-+#define CONFIG_HAAS_FILTER 0
-+#define CONFIG_HDCD_FILTER 0
-+#define CONFIG_HEADPHONE_FILTER 0
-+#define CONFIG_HIGHPASS_FILTER 0
-+#define CONFIG_HIGHSHELF_FILTER 0
-+#define CONFIG_JOIN_FILTER 0
-+#define CONFIG_LADSPA_FILTER 0
-+#define CONFIG_LOUDNORM_FILTER 0
-+#define CONFIG_LOWPASS_FILTER 0
-+#define CONFIG_LOWSHELF_FILTER 0
-+#define CONFIG_LV2_FILTER 0
-+#define CONFIG_MCOMPAND_FILTER 0
-+#define CONFIG_PAN_FILTER 0
-+#define CONFIG_REPLAYGAIN_FILTER 0
-+#define CONFIG_RUBBERBAND_FILTER 0
-+#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
-+#define CONFIG_SIDECHAINGATE_FILTER 0
-+#define CONFIG_SILENCEDETECT_FILTER 0
-+#define CONFIG_SILENCEREMOVE_FILTER 0
-+#define CONFIG_SOFALIZER_FILTER 0
-+#define CONFIG_SPEECHNORM_FILTER 0
-+#define CONFIG_STEREOTOOLS_FILTER 0
-+#define CONFIG_STEREOWIDEN_FILTER 0
-+#define CONFIG_SUPEREQUALIZER_FILTER 0
-+#define CONFIG_SURROUND_FILTER 0
-+#define CONFIG_TILTSHELF_FILTER 0
-+#define CONFIG_TREBLE_FILTER 0
-+#define CONFIG_TREMOLO_FILTER 0
-+#define CONFIG_VIBRATO_FILTER 0
-+#define CONFIG_VIRTUALBASS_FILTER 0
-+#define CONFIG_VOLUME_FILTER 0
-+#define CONFIG_VOLUMEDETECT_FILTER 0
-+#define CONFIG_WHISPER_FILTER 0
-+#define CONFIG_AEVALSRC_FILTER 0
-+#define CONFIG_AFDELAYSRC_FILTER 0
-+#define CONFIG_AFIREQSRC_FILTER 0
-+#define CONFIG_AFIRSRC_FILTER 0
-+#define CONFIG_ANOISESRC_FILTER 0
-+#define CONFIG_ANULLSRC_FILTER 0
-+#define CONFIG_FLITE_FILTER 0
-+#define CONFIG_HILBERT_FILTER 0
-+#define CONFIG_SINC_FILTER 0
-+#define CONFIG_SINE_FILTER 0
-+#define CONFIG_ANULLSINK_FILTER 0
-+#define CONFIG_ADDROI_FILTER 0
-+#define CONFIG_ALPHAEXTRACT_FILTER 0
-+#define CONFIG_ALPHAMERGE_FILTER 0
-+#define CONFIG_AMPLIFY_FILTER 0
-+#define CONFIG_ASS_FILTER 0
-+#define CONFIG_ATADENOISE_FILTER 0
-+#define CONFIG_AVGBLUR_FILTER 0
-+#define CONFIG_AVGBLUR_OPENCL_FILTER 0
-+#define CONFIG_AVGBLUR_VULKAN_FILTER 0
-+#define CONFIG_BACKGROUNDKEY_FILTER 0
-+#define CONFIG_BBOX_FILTER 0
-+#define CONFIG_BENCH_FILTER 0
-+#define CONFIG_BILATERAL_FILTER 0
-+#define CONFIG_BILATERAL_CUDA_FILTER 0
-+#define CONFIG_BITPLANENOISE_FILTER 0
-+#define CONFIG_BLACKDETECT_FILTER 0
-+#define CONFIG_BLACKDETECT_VULKAN_FILTER 0
-+#define CONFIG_BLACKFRAME_FILTER 0
-+#define CONFIG_BLEND_FILTER 0
-+#define CONFIG_BLEND_VULKAN_FILTER 0
-+#define CONFIG_BLOCKDETECT_FILTER 0
-+#define CONFIG_BLURDETECT_FILTER 0
-+#define CONFIG_BM3D_FILTER 0
-+#define CONFIG_BOXBLUR_FILTER 0
-+#define CONFIG_BOXBLUR_OPENCL_FILTER 0
-+#define CONFIG_BWDIF_FILTER 0
-+#define CONFIG_BWDIF_CUDA_FILTER 0
-+#define CONFIG_BWDIF_VULKAN_FILTER 0
-+#define CONFIG_CAS_FILTER 0
-+#define CONFIG_CCREPACK_FILTER 0
-+#define CONFIG_CHROMABER_VULKAN_FILTER 0
-+#define CONFIG_CHROMAHOLD_FILTER 0
-+#define CONFIG_CHROMAKEY_FILTER 0
-+#define CONFIG_CHROMAKEY_CUDA_FILTER 0
-+#define CONFIG_CHROMANR_FILTER 0
-+#define CONFIG_CHROMASHIFT_FILTER 0
-+#define CONFIG_CIESCOPE_FILTER 0
-+#define CONFIG_CODECVIEW_FILTER 0
-+#define CONFIG_COLORBALANCE_FILTER 0
-+#define CONFIG_COLORCHANNELMIXER_FILTER 0
-+#define CONFIG_COLORCONTRAST_FILTER 0
-+#define CONFIG_COLORCORRECT_FILTER 0
-+#define CONFIG_COLORDETECT_FILTER 0
-+#define CONFIG_COLORIZE_FILTER 0
-+#define CONFIG_COLORKEY_FILTER 0
-+#define CONFIG_COLORKEY_OPENCL_FILTER 0
-+#define CONFIG_COLORHOLD_FILTER 0
-+#define CONFIG_COLORLEVELS_FILTER 0
-+#define CONFIG_COLORMAP_FILTER 0
-+#define CONFIG_COLORMATRIX_FILTER 0
-+#define CONFIG_COLORSPACE_FILTER 0
-+#define CONFIG_COLORSPACE_CUDA_FILTER 0
-+#define CONFIG_COLORTEMPERATURE_FILTER 0
-+#define CONFIG_CONVOLUTION_FILTER 0
-+#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
-+#define CONFIG_CONVOLVE_FILTER 0
-+#define CONFIG_COPY_FILTER 0
-+#define CONFIG_COREIMAGE_FILTER 0
-+#define CONFIG_CORR_FILTER 0
-+#define CONFIG_COVER_RECT_FILTER 0
-+#define CONFIG_CROP_FILTER 0
-+#define CONFIG_CROPDETECT_FILTER 0
-+#define CONFIG_CUE_FILTER 0
-+#define CONFIG_CURVES_FILTER 0
-+#define CONFIG_DATASCOPE_FILTER 0
-+#define CONFIG_DBLUR_FILTER 0
-+#define CONFIG_DCTDNOIZ_FILTER 0
-+#define CONFIG_DEBAND_FILTER 0
-+#define CONFIG_DEBLOCK_FILTER 0
-+#define CONFIG_DECIMATE_FILTER 0
-+#define CONFIG_DECONVOLVE_FILTER 0
-+#define CONFIG_DEDOT_FILTER 0
-+#define CONFIG_DEFLATE_FILTER 0
-+#define CONFIG_DEFLICKER_FILTER 0
-+#define CONFIG_DEINTERLACE_QSV_FILTER 0
-+#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
-+#define CONFIG_DEJUDDER_FILTER 0
-+#define CONFIG_DELOGO_FILTER 0
-+#define CONFIG_DENOISE_VAAPI_FILTER 0
-+#define CONFIG_DERAIN_FILTER 0
-+#define CONFIG_DESHAKE_FILTER 0
-+#define CONFIG_DESHAKE_OPENCL_FILTER 0
-+#define CONFIG_DESPILL_FILTER 0
-+#define CONFIG_DETELECINE_FILTER 0
-+#define CONFIG_DILATION_FILTER 0
-+#define CONFIG_DILATION_OPENCL_FILTER 0
-+#define CONFIG_DISPLACE_FILTER 0
-+#define CONFIG_DNN_CLASSIFY_FILTER 0
-+#define CONFIG_DNN_DETECT_FILTER 0
-+#define CONFIG_DNN_PROCESSING_FILTER 0
-+#define CONFIG_DOUBLEWEAVE_FILTER 0
-+#define CONFIG_DRAWBOX_FILTER 0
-+#define CONFIG_DRAWGRAPH_FILTER 0
-+#define CONFIG_DRAWGRID_FILTER 0
-+#define CONFIG_DRAWTEXT_FILTER 0
-+#define CONFIG_EDGEDETECT_FILTER 0
-+#define CONFIG_ELBG_FILTER 0
-+#define CONFIG_ENTROPY_FILTER 0
-+#define CONFIG_EPX_FILTER 0
-+#define CONFIG_EQ_FILTER 0
-+#define CONFIG_EROSION_FILTER 0
-+#define CONFIG_EROSION_OPENCL_FILTER 0
-+#define CONFIG_ESTDIF_FILTER 0
-+#define CONFIG_EXPOSURE_FILTER 0
-+#define CONFIG_EXTRACTPLANES_FILTER 0
-+#define CONFIG_FADE_FILTER 0
-+#define CONFIG_FEEDBACK_FILTER 0
-+#define CONFIG_FFTDNOIZ_FILTER 0
-+#define CONFIG_FFTFILT_FILTER 0
-+#define CONFIG_FIELD_FILTER 0
-+#define CONFIG_FIELDHINT_FILTER 0
-+#define CONFIG_FIELDMATCH_FILTER 0
-+#define CONFIG_FIELDORDER_FILTER 0
-+#define CONFIG_FILLBORDERS_FILTER 0
-+#define CONFIG_FIND_RECT_FILTER 0
-+#define CONFIG_FLIP_VULKAN_FILTER 0
-+#define CONFIG_FLOODFILL_FILTER 0
-+#define CONFIG_FORMAT_FILTER 0
-+#define CONFIG_FPS_FILTER 0
-+#define CONFIG_FRAMEPACK_FILTER 0
-+#define CONFIG_FRAMERATE_FILTER 0
-+#define CONFIG_FRAMESTEP_FILTER 0
-+#define CONFIG_FREEZEDETECT_FILTER 0
-+#define CONFIG_FREEZEFRAMES_FILTER 0
-+#define CONFIG_FREI0R_FILTER 0
-+#define CONFIG_FSPP_FILTER 0
-+#define CONFIG_FSYNC_FILTER 0
-+#define CONFIG_GBLUR_FILTER 0
-+#define CONFIG_GBLUR_VULKAN_FILTER 0
-+#define CONFIG_GEQ_FILTER 0
-+#define CONFIG_GRADFUN_FILTER 0
-+#define CONFIG_GRAPHMONITOR_FILTER 0
-+#define CONFIG_GRAYWORLD_FILTER 0
-+#define CONFIG_GREYEDGE_FILTER 0
-+#define CONFIG_GUIDED_FILTER 0
-+#define CONFIG_HALDCLUT_FILTER 0
-+#define CONFIG_HFLIP_FILTER 0
-+#define CONFIG_HFLIP_VULKAN_FILTER 0
-+#define CONFIG_HISTEQ_FILTER 0
-+#define CONFIG_HISTOGRAM_FILTER 0
-+#define CONFIG_HQDN3D_FILTER 0
-+#define CONFIG_HQX_FILTER 0
-+#define CONFIG_HSTACK_FILTER 0
-+#define CONFIG_HSVHOLD_FILTER 0
-+#define CONFIG_HSVKEY_FILTER 0
-+#define CONFIG_HUE_FILTER 0
-+#define CONFIG_HUESATURATION_FILTER 0
-+#define CONFIG_HWDOWNLOAD_FILTER 0
-+#define CONFIG_HWMAP_FILTER 0
-+#define CONFIG_HWUPLOAD_FILTER 0
-+#define CONFIG_HWUPLOAD_CUDA_FILTER 0
-+#define CONFIG_HYSTERESIS_FILTER 0
-+#define CONFIG_ICCDETECT_FILTER 0
-+#define CONFIG_ICCGEN_FILTER 0
-+#define CONFIG_IDENTITY_FILTER 0
-+#define CONFIG_IDET_FILTER 0
-+#define CONFIG_IL_FILTER 0
-+#define CONFIG_INFLATE_FILTER 0
-+#define CONFIG_INTERLACE_FILTER 0
-+#define CONFIG_INTERLACE_VULKAN_FILTER 0
-+#define CONFIG_INTERLEAVE_FILTER 0
-+#define CONFIG_KERNDEINT_FILTER 0
-+#define CONFIG_KIRSCH_FILTER 0
-+#define CONFIG_LAGFUN_FILTER 0
-+#define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
-+#define CONFIG_LENSCORRECTION_FILTER 0
-+#define CONFIG_LENSFUN_FILTER 0
-+#define CONFIG_LIBPLACEBO_FILTER 0
-+#define CONFIG_LIBVMAF_FILTER 0
-+#define CONFIG_LIBVMAF_CUDA_FILTER 0
-+#define CONFIG_LIMITDIFF_FILTER 0
-+#define CONFIG_LIMITER_FILTER 0
-+#define CONFIG_LOOP_FILTER 0
-+#define CONFIG_LUMAKEY_FILTER 0
-+#define CONFIG_LUT_FILTER 0
-+#define CONFIG_LUT1D_FILTER 0
-+#define CONFIG_LUT2_FILTER 0
-+#define CONFIG_LUT3D_FILTER 0
-+#define CONFIG_LUTRGB_FILTER 0
-+#define CONFIG_LUTYUV_FILTER 0
-+#define CONFIG_MASKEDCLAMP_FILTER 0
-+#define CONFIG_MASKEDMAX_FILTER 0
-+#define CONFIG_MASKEDMERGE_FILTER 0
-+#define CONFIG_MASKEDMIN_FILTER 0
-+#define CONFIG_MASKEDTHRESHOLD_FILTER 0
-+#define CONFIG_MASKFUN_FILTER 0
-+#define CONFIG_MCDEINT_FILTER 0
-+#define CONFIG_MEDIAN_FILTER 0
-+#define CONFIG_MERGEPLANES_FILTER 0
-+#define CONFIG_MESTIMATE_FILTER 0
-+#define CONFIG_METADATA_FILTER 0
-+#define CONFIG_MIDEQUALIZER_FILTER 0
-+#define CONFIG_MINTERPOLATE_FILTER 0
-+#define CONFIG_MIX_FILTER 0
-+#define CONFIG_MONOCHROME_FILTER 0
-+#define CONFIG_MORPHO_FILTER 0
-+#define CONFIG_MPDECIMATE_FILTER 0
-+#define CONFIG_MSAD_FILTER 0
-+#define CONFIG_MULTIPLY_FILTER 0
-+#define CONFIG_NEGATE_FILTER 0
-+#define CONFIG_NLMEANS_FILTER 0
-+#define CONFIG_NLMEANS_OPENCL_FILTER 0
-+#define CONFIG_NLMEANS_VULKAN_FILTER 0
-+#define CONFIG_NNEDI_FILTER 0
-+#define CONFIG_NOFORMAT_FILTER 0
-+#define CONFIG_NOISE_FILTER 0
-+#define CONFIG_NORMALIZE_FILTER 0
-+#define CONFIG_NULL_FILTER 0
-+#define CONFIG_OCR_FILTER 0
-+#define CONFIG_OCV_FILTER 0
-+#define CONFIG_OSCILLOSCOPE_FILTER 0
-+#define CONFIG_OVERLAY_FILTER 0
-+#define CONFIG_OVERLAY_OPENCL_FILTER 0
-+#define CONFIG_OVERLAY_QSV_FILTER 0
-+#define CONFIG_OVERLAY_VAAPI_FILTER 0
-+#define CONFIG_OVERLAY_VULKAN_FILTER 0
-+#define CONFIG_OVERLAY_CUDA_FILTER 0
-+#define CONFIG_OWDENOISE_FILTER 0
-+#define CONFIG_PAD_FILTER 0
-+#define CONFIG_PAD_CUDA_FILTER 0
-+#define CONFIG_PAD_OPENCL_FILTER 0
-+#define CONFIG_PALETTEGEN_FILTER 0
-+#define CONFIG_PALETTEUSE_FILTER 0
-+#define CONFIG_PERMS_FILTER 0
-+#define CONFIG_PERSPECTIVE_FILTER 0
-+#define CONFIG_PHASE_FILTER 0
-+#define CONFIG_PHOTOSENSITIVITY_FILTER 0
-+#define CONFIG_PIXDESCTEST_FILTER 0
-+#define CONFIG_PIXELIZE_FILTER 0
-+#define CONFIG_PIXSCOPE_FILTER 0
-+#define CONFIG_PP7_FILTER 0
-+#define CONFIG_PREMULTIPLY_FILTER 0
-+#define CONFIG_PREWITT_FILTER 0
-+#define CONFIG_PREWITT_OPENCL_FILTER 0
-+#define CONFIG_PROCAMP_VAAPI_FILTER 0
-+#define CONFIG_PROGRAM_OPENCL_FILTER 0
-+#define CONFIG_PSEUDOCOLOR_FILTER 0
-+#define CONFIG_PSNR_FILTER 0
-+#define CONFIG_PULLUP_FILTER 0
-+#define CONFIG_QP_FILTER 0
-+#define CONFIG_QRENCODE_FILTER 0
-+#define CONFIG_QUIRC_FILTER 0
-+#define CONFIG_RANDOM_FILTER 0
-+#define CONFIG_READEIA608_FILTER 0
-+#define CONFIG_READVITC_FILTER 0
-+#define CONFIG_REALTIME_FILTER 0
-+#define CONFIG_REMAP_FILTER 0
-+#define CONFIG_REMAP_OPENCL_FILTER 0
-+#define CONFIG_REMOVEGRAIN_FILTER 0
-+#define CONFIG_REMOVELOGO_FILTER 0
-+#define CONFIG_REPEATFIELDS_FILTER 0
-+#define CONFIG_REVERSE_FILTER 0
-+#define CONFIG_RGBASHIFT_FILTER 0
-+#define CONFIG_ROBERTS_FILTER 0
-+#define CONFIG_ROBERTS_OPENCL_FILTER 0
-+#define CONFIG_ROTATE_FILTER 0
-+#define CONFIG_SAB_FILTER 0
-+#define CONFIG_SCALE_FILTER 0
-+#define CONFIG_VPP_AMF_FILTER 0
-+#define CONFIG_SR_AMF_FILTER 0
-+#define CONFIG_SCALE_CUDA_FILTER 0
-+#define CONFIG_SCALE_D3D11_FILTER 0
-+#define CONFIG_SCALE_NPP_FILTER 0
-+#define CONFIG_SCALE_QSV_FILTER 0
-+#define CONFIG_SCALE_VAAPI_FILTER 0
-+#define CONFIG_SCALE_VT_FILTER 0
-+#define CONFIG_SCALE_VULKAN_FILTER 0
-+#define CONFIG_SCALE2REF_FILTER 0
-+#define CONFIG_SCALE2REF_NPP_FILTER 0
-+#define CONFIG_SCDET_FILTER 0
-+#define CONFIG_SCDET_VULKAN_FILTER 0
-+#define CONFIG_SCHARR_FILTER 0
-+#define CONFIG_SCROLL_FILTER 0
-+#define CONFIG_SEGMENT_FILTER 0
-+#define CONFIG_SELECT_FILTER 0
-+#define CONFIG_SELECTIVECOLOR_FILTER 0
-+#define CONFIG_SENDCMD_FILTER 0
-+#define CONFIG_SEPARATEFIELDS_FILTER 0
-+#define CONFIG_SETDAR_FILTER 0
-+#define CONFIG_SETFIELD_FILTER 0
-+#define CONFIG_SETPARAMS_FILTER 0
-+#define CONFIG_SETPTS_FILTER 0
-+#define CONFIG_SETRANGE_FILTER 0
-+#define CONFIG_SETSAR_FILTER 0
-+#define CONFIG_SETTB_FILTER 0
-+#define CONFIG_SHARPEN_NPP_FILTER 0
-+#define CONFIG_SHARPNESS_VAAPI_FILTER 0
-+#define CONFIG_SHEAR_FILTER 0
-+#define CONFIG_SHOWINFO_FILTER 0
-+#define CONFIG_SHOWPALETTE_FILTER 0
-+#define CONFIG_SHUFFLEFRAMES_FILTER 0
-+#define CONFIG_SHUFFLEPIXELS_FILTER 0
-+#define CONFIG_SHUFFLEPLANES_FILTER 0
-+#define CONFIG_SIDEDATA_FILTER 0
-+#define CONFIG_SIGNALSTATS_FILTER 0
-+#define CONFIG_SIGNATURE_FILTER 0
-+#define CONFIG_SITI_FILTER 0
-+#define CONFIG_SMARTBLUR_FILTER 0
-+#define CONFIG_SOBEL_FILTER 0
-+#define CONFIG_SOBEL_OPENCL_FILTER 0
-+#define CONFIG_SPLIT_FILTER 0
-+#define CONFIG_SPP_FILTER 0
-+#define CONFIG_SR_FILTER 0
-+#define CONFIG_SSIM_FILTER 0
-+#define CONFIG_SSIM360_FILTER 0
-+#define CONFIG_STEREO3D_FILTER 0
-+#define CONFIG_STREAMSELECT_FILTER 0
-+#define CONFIG_SUBTITLES_FILTER 0
-+#define CONFIG_SUPER2XSAI_FILTER 0
-+#define CONFIG_SWAPRECT_FILTER 0
-+#define CONFIG_SWAPUV_FILTER 0
-+#define CONFIG_TBLEND_FILTER 0
-+#define CONFIG_TELECINE_FILTER 0
-+#define CONFIG_THISTOGRAM_FILTER 0
-+#define CONFIG_THRESHOLD_FILTER 0
-+#define CONFIG_THUMBNAIL_FILTER 0
-+#define CONFIG_THUMBNAIL_CUDA_FILTER 0
-+#define CONFIG_TILE_FILTER 0
-+#define CONFIG_TILTANDSHIFT_FILTER 0
-+#define CONFIG_TINTERLACE_FILTER 0
-+#define CONFIG_TLUT2_FILTER 0
-+#define CONFIG_TMEDIAN_FILTER 0
-+#define CONFIG_TMIDEQUALIZER_FILTER 0
-+#define CONFIG_TMIX_FILTER 0
-+#define CONFIG_TONEMAP_FILTER 0
-+#define CONFIG_TONEMAP_OPENCL_FILTER 0
-+#define CONFIG_TONEMAP_VAAPI_FILTER 0
-+#define CONFIG_TPAD_FILTER 0
-+#define CONFIG_TRANSPOSE_FILTER 0
-+#define CONFIG_TRANSPOSE_NPP_FILTER 0
-+#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
-+#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
-+#define CONFIG_TRANSPOSE_VT_FILTER 0
-+#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
-+#define CONFIG_TRIM_FILTER 0
-+#define CONFIG_UNPREMULTIPLY_FILTER 0
-+#define CONFIG_UNSHARP_FILTER 0
-+#define CONFIG_UNSHARP_OPENCL_FILTER 0
-+#define CONFIG_UNTILE_FILTER 0
-+#define CONFIG_USPP_FILTER 0
-+#define CONFIG_V360_FILTER 0
-+#define CONFIG_VAGUEDENOISER_FILTER 0
-+#define CONFIG_VARBLUR_FILTER 0
-+#define CONFIG_VECTORSCOPE_FILTER 0
-+#define CONFIG_VFLIP_FILTER 0
-+#define CONFIG_VFLIP_VULKAN_FILTER 0
-+#define CONFIG_VFRDET_FILTER 0
-+#define CONFIG_VIBRANCE_FILTER 0
-+#define CONFIG_VIDSTABDETECT_FILTER 0
-+#define CONFIG_VIDSTABTRANSFORM_FILTER 0
-+#define CONFIG_VIF_FILTER 0
-+#define CONFIG_VIGNETTE_FILTER 0
-+#define CONFIG_VMAFMOTION_FILTER 0
-+#define CONFIG_VPP_QSV_FILTER 0
-+#define CONFIG_VSTACK_FILTER 0
-+#define CONFIG_W3FDIF_FILTER 0
-+#define CONFIG_WAVEFORM_FILTER 0
-+#define CONFIG_WEAVE_FILTER 0
-+#define CONFIG_XBR_FILTER 0
-+#define CONFIG_XCORRELATE_FILTER 0
-+#define CONFIG_XFADE_FILTER 0
-+#define CONFIG_XFADE_OPENCL_FILTER 0
-+#define CONFIG_XFADE_VULKAN_FILTER 0
-+#define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
-+#define CONFIG_XSTACK_FILTER 0
-+#define CONFIG_YADIF_FILTER 0
-+#define CONFIG_YADIF_CUDA_FILTER 0
-+#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
-+#define CONFIG_YAEPBLUR_FILTER 0
-+#define CONFIG_ZMQ_FILTER 0
-+#define CONFIG_ZOOMPAN_FILTER 0
-+#define CONFIG_ZSCALE_FILTER 0
-+#define CONFIG_HSTACK_VAAPI_FILTER 0
-+#define CONFIG_VSTACK_VAAPI_FILTER 0
-+#define CONFIG_XSTACK_VAAPI_FILTER 0
-+#define CONFIG_HSTACK_QSV_FILTER 0
-+#define CONFIG_VSTACK_QSV_FILTER 0
-+#define CONFIG_XSTACK_QSV_FILTER 0
-+#define CONFIG_PAD_VAAPI_FILTER 0
-+#define CONFIG_DRAWBOX_VAAPI_FILTER 0
-+#define CONFIG_ALLRGB_FILTER 0
-+#define CONFIG_ALLYUV_FILTER 0
-+#define CONFIG_CELLAUTO_FILTER 0
-+#define CONFIG_COLOR_FILTER 0
-+#define CONFIG_COLOR_VULKAN_FILTER 0
-+#define CONFIG_COLORCHART_FILTER 0
-+#define CONFIG_COLORSPECTRUM_FILTER 0
-+#define CONFIG_COREIMAGESRC_FILTER 0
-+#define CONFIG_DDAGRAB_FILTER 0
-+#define CONFIG_FREI0R_SRC_FILTER 0
-+#define CONFIG_GRADIENTS_FILTER 0
-+#define CONFIG_HALDCLUTSRC_FILTER 0
-+#define CONFIG_LIFE_FILTER 0
-+#define CONFIG_MANDELBROT_FILTER 0
-+#define CONFIG_MPTESTSRC_FILTER 0
-+#define CONFIG_NULLSRC_FILTER 0
-+#define CONFIG_OPENCLSRC_FILTER 0
-+#define CONFIG_QRENCODESRC_FILTER 0
-+#define CONFIG_PAL75BARS_FILTER 0
-+#define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
-+#define CONFIG_RGBTESTSRC_FILTER 0
-+#define CONFIG_SIERPINSKI_FILTER 0
-+#define CONFIG_SMPTEBARS_FILTER 0
-+#define CONFIG_SMPTEHDBARS_FILTER 0
-+#define CONFIG_TESTSRC_FILTER 0
-+#define CONFIG_TESTSRC2_FILTER 0
-+#define CONFIG_YUVTESTSRC_FILTER 0
-+#define CONFIG_ZONEPLATE_FILTER 0
-+#define CONFIG_NULLSINK_FILTER 0
-+#define CONFIG_A3DSCOPE_FILTER 0
-+#define CONFIG_ABITSCOPE_FILTER 0
-+#define CONFIG_ADRAWGRAPH_FILTER 0
-+#define CONFIG_AGRAPHMONITOR_FILTER 0
-+#define CONFIG_AHISTOGRAM_FILTER 0
-+#define CONFIG_APHASEMETER_FILTER 0
-+#define CONFIG_AVECTORSCOPE_FILTER 0
-+#define CONFIG_CONCAT_FILTER 0
-+#define CONFIG_SHOWCQT_FILTER 0
-+#define CONFIG_SHOWCWT_FILTER 0
-+#define CONFIG_SHOWFREQS_FILTER 0
-+#define CONFIG_SHOWSPATIAL_FILTER 0
-+#define CONFIG_SHOWSPECTRUM_FILTER 0
-+#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
-+#define CONFIG_SHOWVOLUME_FILTER 0
-+#define CONFIG_SHOWWAVES_FILTER 0
-+#define CONFIG_SHOWWAVESPIC_FILTER 0
-+#define CONFIG_SPECTRUMSYNTH_FILTER 0
-+#define CONFIG_AVSYNCTEST_FILTER 0
-+#define CONFIG_AMOVIE_FILTER 0
-+#define CONFIG_MOVIE_FILTER 0
-+#define CONFIG_AA_DEMUXER 0
-+#define CONFIG_AAC_DEMUXER 1
-+#define CONFIG_AAX_DEMUXER 0
-+#define CONFIG_AC3_DEMUXER 0
-+#define CONFIG_AC4_DEMUXER 0
-+#define CONFIG_ACE_DEMUXER 0
-+#define CONFIG_ACM_DEMUXER 0
-+#define CONFIG_ACT_DEMUXER 0
-+#define CONFIG_ADF_DEMUXER 0
-+#define CONFIG_ADP_DEMUXER 0
-+#define CONFIG_ADS_DEMUXER 0
-+#define CONFIG_ADX_DEMUXER 0
-+#define CONFIG_AEA_DEMUXER 0
-+#define CONFIG_AFC_DEMUXER 0
-+#define CONFIG_AIFF_DEMUXER 0
-+#define CONFIG_AIX_DEMUXER 0
-+#define CONFIG_ALP_DEMUXER 0
-+#define CONFIG_AMR_DEMUXER 0
-+#define CONFIG_AMRNB_DEMUXER 0
-+#define CONFIG_AMRWB_DEMUXER 0
-+#define CONFIG_ANM_DEMUXER 0
-+#define CONFIG_APAC_DEMUXER 0
-+#define CONFIG_APC_DEMUXER 0
-+#define CONFIG_APE_DEMUXER 0
-+#define CONFIG_APM_DEMUXER 0
-+#define CONFIG_APNG_DEMUXER 0
-+#define CONFIG_APTX_DEMUXER 0
-+#define CONFIG_APTX_HD_DEMUXER 0
-+#define CONFIG_APV_DEMUXER 0
-+#define CONFIG_AQTITLE_DEMUXER 0
-+#define CONFIG_ARGO_ASF_DEMUXER 0
-+#define CONFIG_ARGO_BRP_DEMUXER 0
-+#define CONFIG_ARGO_CVG_DEMUXER 0
-+#define CONFIG_ASF_DEMUXER 0
-+#define CONFIG_ASF_O_DEMUXER 0
-+#define CONFIG_ASS_DEMUXER 0
-+#define CONFIG_AST_DEMUXER 0
-+#define CONFIG_AU_DEMUXER 0
-+#define CONFIG_AV1_DEMUXER 0
-+#define CONFIG_AVI_DEMUXER 0
-+#define CONFIG_AVR_DEMUXER 0
-+#define CONFIG_AVS_DEMUXER 0
-+#define CONFIG_AVS2_DEMUXER 0
-+#define CONFIG_AVS3_DEMUXER 0
-+#define CONFIG_BETHSOFTVID_DEMUXER 0
-+#define CONFIG_BFI_DEMUXER 0
-+#define CONFIG_BINTEXT_DEMUXER 0
-+#define CONFIG_BINK_DEMUXER 0
-+#define CONFIG_BINKA_DEMUXER 0
-+#define CONFIG_BIT_DEMUXER 0
-+#define CONFIG_BITPACKED_DEMUXER 0
-+#define CONFIG_BMV_DEMUXER 0
-+#define CONFIG_BFSTM_DEMUXER 0
-+#define CONFIG_BRSTM_DEMUXER 0
-+#define CONFIG_BOA_DEMUXER 0
-+#define CONFIG_BONK_DEMUXER 0
-+#define CONFIG_C93_DEMUXER 0
-+#define CONFIG_CAF_DEMUXER 0
-+#define CONFIG_CAVSVIDEO_DEMUXER 0
-+#define CONFIG_CDG_DEMUXER 0
-+#define CONFIG_CDXL_DEMUXER 0
-+#define CONFIG_CINE_DEMUXER 0
-+#define CONFIG_CODEC2_DEMUXER 0
-+#define CONFIG_CODEC2RAW_DEMUXER 0
-+#define CONFIG_CONCAT_DEMUXER 0
-+#define CONFIG_DASH_DEMUXER 0
-+#define CONFIG_DATA_DEMUXER 0
-+#define CONFIG_DAUD_DEMUXER 0
-+#define CONFIG_DCSTR_DEMUXER 0
-+#define CONFIG_DERF_DEMUXER 0
-+#define CONFIG_DFA_DEMUXER 0
-+#define CONFIG_DFPWM_DEMUXER 0
-+#define CONFIG_DHAV_DEMUXER 0
-+#define CONFIG_DIRAC_DEMUXER 0
-+#define CONFIG_DNXHD_DEMUXER 0
-+#define CONFIG_DSF_DEMUXER 0
-+#define CONFIG_DSICIN_DEMUXER 0
-+#define CONFIG_DSS_DEMUXER 0
-+#define CONFIG_DTS_DEMUXER 0
-+#define CONFIG_DTSHD_DEMUXER 0
-+#define CONFIG_DV_DEMUXER 0
-+#define CONFIG_DVBSUB_DEMUXER 0
-+#define CONFIG_DVBTXT_DEMUXER 0
-+#define CONFIG_DXA_DEMUXER 0
-+#define CONFIG_EA_DEMUXER 0
-+#define CONFIG_EA_CDATA_DEMUXER 0
-+#define CONFIG_EAC3_DEMUXER 0
-+#define CONFIG_EPAF_DEMUXER 0
-+#define CONFIG_EVC_DEMUXER 0
-+#define CONFIG_FFMETADATA_DEMUXER 0
-+#define CONFIG_FILMSTRIP_DEMUXER 0
-+#define CONFIG_FITS_DEMUXER 0
-+#define CONFIG_FLAC_DEMUXER 1
-+#define CONFIG_FLIC_DEMUXER 0
-+#define CONFIG_FLV_DEMUXER 0
-+#define CONFIG_LIVE_FLV_DEMUXER 0
-+#define CONFIG_FOURXM_DEMUXER 0
-+#define CONFIG_FRM_DEMUXER 0
-+#define CONFIG_FSB_DEMUXER 0
-+#define CONFIG_FWSE_DEMUXER 0
-+#define CONFIG_G722_DEMUXER 0
-+#define CONFIG_G723_1_DEMUXER 0
-+#define CONFIG_G726_DEMUXER 0
-+#define CONFIG_G726LE_DEMUXER 0
-+#define CONFIG_G728_DEMUXER 0
-+#define CONFIG_G729_DEMUXER 0
-+#define CONFIG_GDV_DEMUXER 0
-+#define CONFIG_GENH_DEMUXER 0
-+#define CONFIG_GIF_DEMUXER 0
-+#define CONFIG_GSM_DEMUXER 0
-+#define CONFIG_GXF_DEMUXER 0
-+#define CONFIG_H261_DEMUXER 0
-+#define CONFIG_H263_DEMUXER 0
-+#define CONFIG_H264_DEMUXER 0
-+#define CONFIG_HCA_DEMUXER 0
-+#define CONFIG_HCOM_DEMUXER 0
-+#define CONFIG_HEVC_DEMUXER 0
-+#define CONFIG_HLS_DEMUXER 0
-+#define CONFIG_HNM_DEMUXER 0
-+#define CONFIG_IAMF_DEMUXER 0
-+#define CONFIG_ICO_DEMUXER 0
-+#define CONFIG_IDCIN_DEMUXER 0
-+#define CONFIG_IDF_DEMUXER 0
-+#define CONFIG_IFF_DEMUXER 0
-+#define CONFIG_IFV_DEMUXER 0
-+#define CONFIG_ILBC_DEMUXER 0
-+#define CONFIG_IMAGE2_DEMUXER 0
-+#define CONFIG_IMAGE2PIPE_DEMUXER 0
-+#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
-+#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
-+#define CONFIG_IMF_DEMUXER 0
-+#define CONFIG_INGENIENT_DEMUXER 0
-+#define CONFIG_IPMOVIE_DEMUXER 0
-+#define CONFIG_IPU_DEMUXER 0
-+#define CONFIG_IRCAM_DEMUXER 0
-+#define CONFIG_ISS_DEMUXER 0
-+#define CONFIG_IV8_DEMUXER 0
-+#define CONFIG_IVF_DEMUXER 0
-+#define CONFIG_IVR_DEMUXER 0
-+#define CONFIG_JACOSUB_DEMUXER 0
-+#define CONFIG_JV_DEMUXER 0
-+#define CONFIG_JPEGXL_ANIM_DEMUXER 0
-+#define CONFIG_KUX_DEMUXER 0
-+#define CONFIG_KVAG_DEMUXER 0
-+#define CONFIG_LAF_DEMUXER 0
-+#define CONFIG_LC3_DEMUXER 0
-+#define CONFIG_LMLM4_DEMUXER 0
-+#define CONFIG_LOAS_DEMUXER 0
-+#define CONFIG_LUODAT_DEMUXER 0
-+#define CONFIG_LRC_DEMUXER 0
-+#define CONFIG_LVF_DEMUXER 0
-+#define CONFIG_LXF_DEMUXER 0
-+#define CONFIG_M4V_DEMUXER 0
-+#define CONFIG_MCA_DEMUXER 0
-+#define CONFIG_MCC_DEMUXER 0
-+#define CONFIG_MATROSKA_DEMUXER 1
-+#define CONFIG_MGSTS_DEMUXER 0
-+#define CONFIG_MICRODVD_DEMUXER 0
-+#define CONFIG_MJPEG_DEMUXER 0
-+#define CONFIG_MJPEG_2000_DEMUXER 0
-+#define CONFIG_MLP_DEMUXER 0
-+#define CONFIG_MLV_DEMUXER 0
-+#define CONFIG_MM_DEMUXER 0
-+#define CONFIG_MMF_DEMUXER 0
-+#define CONFIG_MODS_DEMUXER 0
-+#define CONFIG_MOFLEX_DEMUXER 0
-+#define CONFIG_MOV_DEMUXER 1
-+#define CONFIG_MP3_DEMUXER 1
-+#define CONFIG_MPC_DEMUXER 0
-+#define CONFIG_MPC8_DEMUXER 0
-+#define CONFIG_MPEGPS_DEMUXER 0
-+#define CONFIG_MPEGTS_DEMUXER 0
-+#define CONFIG_MPEGTSRAW_DEMUXER 0
-+#define CONFIG_MPEGVIDEO_DEMUXER 0
-+#define CONFIG_MPJPEG_DEMUXER 0
-+#define CONFIG_MPL2_DEMUXER 0
-+#define CONFIG_MPSUB_DEMUXER 0
-+#define CONFIG_MSF_DEMUXER 0
-+#define CONFIG_MSNWC_TCP_DEMUXER 0
-+#define CONFIG_MSP_DEMUXER 0
-+#define CONFIG_MTAF_DEMUXER 0
-+#define CONFIG_MTV_DEMUXER 0
-+#define CONFIG_MUSX_DEMUXER 0
-+#define CONFIG_MV_DEMUXER 0
-+#define CONFIG_MVI_DEMUXER 0
-+#define CONFIG_MXF_DEMUXER 0
-+#define CONFIG_MXG_DEMUXER 0
-+#define CONFIG_NC_DEMUXER 0
-+#define CONFIG_NISTSPHERE_DEMUXER 0
-+#define CONFIG_NSP_DEMUXER 0
-+#define CONFIG_NSV_DEMUXER 0
-+#define CONFIG_NUT_DEMUXER 0
-+#define CONFIG_NUV_DEMUXER 0
-+#define CONFIG_OBU_DEMUXER 0
-+#define CONFIG_OGG_DEMUXER 1
-+#define CONFIG_OMA_DEMUXER 0
-+#define CONFIG_OSQ_DEMUXER 0
-+#define CONFIG_PAF_DEMUXER 0
-+#define CONFIG_PCM_ALAW_DEMUXER 0
-+#define CONFIG_PCM_MULAW_DEMUXER 0
-+#define CONFIG_PCM_VIDC_DEMUXER 0
-+#define CONFIG_PCM_F64BE_DEMUXER 0
-+#define CONFIG_PCM_F64LE_DEMUXER 0
-+#define CONFIG_PCM_F32BE_DEMUXER 0
-+#define CONFIG_PCM_F32LE_DEMUXER 0
-+#define CONFIG_PCM_S32BE_DEMUXER 0
-+#define CONFIG_PCM_S32LE_DEMUXER 0
-+#define CONFIG_PCM_S24BE_DEMUXER 0
-+#define CONFIG_PCM_S24LE_DEMUXER 0
-+#define CONFIG_PCM_S16BE_DEMUXER 0
-+#define CONFIG_PCM_S16LE_DEMUXER 0
-+#define CONFIG_PCM_S8_DEMUXER 0
-+#define CONFIG_PCM_U32BE_DEMUXER 0
-+#define CONFIG_PCM_U32LE_DEMUXER 0
-+#define CONFIG_PCM_U24BE_DEMUXER 0
-+#define CONFIG_PCM_U24LE_DEMUXER 0
-+#define CONFIG_PCM_U16BE_DEMUXER 0
-+#define CONFIG_PCM_U16LE_DEMUXER 0
-+#define CONFIG_PCM_U8_DEMUXER 0
-+#define CONFIG_PDV_DEMUXER 0
-+#define CONFIG_PJS_DEMUXER 0
-+#define CONFIG_PMP_DEMUXER 0
-+#define CONFIG_PP_BNK_DEMUXER 0
-+#define CONFIG_PVA_DEMUXER 0
-+#define CONFIG_PVF_DEMUXER 0
-+#define CONFIG_QCP_DEMUXER 0
-+#define CONFIG_QOA_DEMUXER 0
-+#define CONFIG_R3D_DEMUXER 0
-+#define CONFIG_RAWVIDEO_DEMUXER 0
-+#define CONFIG_RCWT_DEMUXER 0
-+#define CONFIG_REALTEXT_DEMUXER 0
-+#define CONFIG_REDSPARK_DEMUXER 0
-+#define CONFIG_RKA_DEMUXER 0
-+#define CONFIG_RL2_DEMUXER 0
-+#define CONFIG_RM_DEMUXER 0
-+#define CONFIG_ROQ_DEMUXER 0
-+#define CONFIG_RPL_DEMUXER 0
-+#define CONFIG_RSD_DEMUXER 0
-+#define CONFIG_RSO_DEMUXER 0
-+#define CONFIG_RTP_DEMUXER 0
-+#define CONFIG_RTSP_DEMUXER 0
-+#define CONFIG_S337M_DEMUXER 0
-+#define CONFIG_SAMI_DEMUXER 0
-+#define CONFIG_SAP_DEMUXER 0
-+#define CONFIG_SBC_DEMUXER 0
-+#define CONFIG_SBG_DEMUXER 0
-+#define CONFIG_SCC_DEMUXER 0
-+#define CONFIG_SCD_DEMUXER 0
-+#define CONFIG_SDNS_DEMUXER 0
-+#define CONFIG_SDP_DEMUXER 0
-+#define CONFIG_SDR2_DEMUXER 0
-+#define CONFIG_SDS_DEMUXER 0
-+#define CONFIG_SDX_DEMUXER 0
-+#define CONFIG_SEGAFILM_DEMUXER 0
-+#define CONFIG_SER_DEMUXER 0
-+#define CONFIG_SGA_DEMUXER 0
-+#define CONFIG_SHORTEN_DEMUXER 0
-+#define CONFIG_SIFF_DEMUXER 0
-+#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
-+#define CONFIG_SLN_DEMUXER 0
-+#define CONFIG_SMACKER_DEMUXER 0
-+#define CONFIG_SMJPEG_DEMUXER 0
-+#define CONFIG_SMUSH_DEMUXER 0
-+#define CONFIG_SOL_DEMUXER 0
-+#define CONFIG_SOX_DEMUXER 0
-+#define CONFIG_SPDIF_DEMUXER 0
-+#define CONFIG_SRT_DEMUXER 0
-+#define CONFIG_STR_DEMUXER 0
-+#define CONFIG_STL_DEMUXER 0
-+#define CONFIG_SUBVIEWER1_DEMUXER 0
-+#define CONFIG_SUBVIEWER_DEMUXER 0
-+#define CONFIG_SUP_DEMUXER 0
-+#define CONFIG_SVAG_DEMUXER 0
-+#define CONFIG_SVS_DEMUXER 0
-+#define CONFIG_SWF_DEMUXER 0
-+#define CONFIG_TAK_DEMUXER 0
-+#define CONFIG_TEDCAPTIONS_DEMUXER 0
-+#define CONFIG_THP_DEMUXER 0
-+#define CONFIG_THREEDOSTR_DEMUXER 0
-+#define CONFIG_TIERTEXSEQ_DEMUXER 0
-+#define CONFIG_TMV_DEMUXER 0
-+#define CONFIG_TRUEHD_DEMUXER 0
-+#define CONFIG_TTA_DEMUXER 0
-+#define CONFIG_TXD_DEMUXER 0
-+#define CONFIG_TTY_DEMUXER 0
-+#define CONFIG_TY_DEMUXER 0
-+#define CONFIG_USM_DEMUXER 0
-+#define CONFIG_V210_DEMUXER 0
-+#define CONFIG_V210X_DEMUXER 0
-+#define CONFIG_VAG_DEMUXER 0
-+#define CONFIG_VC1_DEMUXER 0
-+#define CONFIG_VC1T_DEMUXER 0
-+#define CONFIG_VIVIDAS_DEMUXER 0
-+#define CONFIG_VIVO_DEMUXER 0
-+#define CONFIG_VMD_DEMUXER 0
-+#define CONFIG_VOBSUB_DEMUXER 0
-+#define CONFIG_VOC_DEMUXER 0
-+#define CONFIG_VPK_DEMUXER 0
-+#define CONFIG_VPLAYER_DEMUXER 0
-+#define CONFIG_VQF_DEMUXER 0
-+#define CONFIG_VVC_DEMUXER 0
-+#define CONFIG_W64_DEMUXER 0
-+#define CONFIG_WADY_DEMUXER 0
-+#define CONFIG_WAVARC_DEMUXER 0
-+#define CONFIG_WAV_DEMUXER 1
-+#define CONFIG_WC3_DEMUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
-+#define CONFIG_WEBVTT_DEMUXER 0
-+#define CONFIG_WSAUD_DEMUXER 0
-+#define CONFIG_WSD_DEMUXER 0
-+#define CONFIG_WSVQA_DEMUXER 0
-+#define CONFIG_WTV_DEMUXER 0
-+#define CONFIG_WVE_DEMUXER 0
-+#define CONFIG_WV_DEMUXER 0
-+#define CONFIG_XA_DEMUXER 0
-+#define CONFIG_XBIN_DEMUXER 0
-+#define CONFIG_XMD_DEMUXER 0
-+#define CONFIG_XMV_DEMUXER 0
-+#define CONFIG_XVAG_DEMUXER 0
-+#define CONFIG_XWMA_DEMUXER 0
-+#define CONFIG_YOP_DEMUXER 0
-+#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
-+#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
-+#define CONFIG_AVISYNTH_DEMUXER 0
-+#define CONFIG_DVDVIDEO_DEMUXER 0
-+#define CONFIG_LIBGME_DEMUXER 0
-+#define CONFIG_LIBMODPLUG_DEMUXER 0
-+#define CONFIG_LIBOPENMPT_DEMUXER 0
-+#define CONFIG_VAPOURSYNTH_DEMUXER 0
-+#define CONFIG_A64_MUXER 0
-+#define CONFIG_AC3_MUXER 0
-+#define CONFIG_AC4_MUXER 0
-+#define CONFIG_ADTS_MUXER 0
-+#define CONFIG_ADX_MUXER 0
-+#define CONFIG_AEA_MUXER 0
-+#define CONFIG_AIFF_MUXER 0
-+#define CONFIG_ALP_MUXER 0
-+#define CONFIG_AMR_MUXER 0
-+#define CONFIG_AMV_MUXER 0
-+#define CONFIG_APM_MUXER 0
-+#define CONFIG_APNG_MUXER 0
-+#define CONFIG_APTX_MUXER 0
-+#define CONFIG_APTX_HD_MUXER 0
-+#define CONFIG_APV_MUXER 0
-+#define CONFIG_ARGO_ASF_MUXER 0
-+#define CONFIG_ARGO_CVG_MUXER 0
-+#define CONFIG_ASF_MUXER 0
-+#define CONFIG_ASS_MUXER 0
-+#define CONFIG_AST_MUXER 0
-+#define CONFIG_ASF_STREAM_MUXER 0
-+#define CONFIG_AU_MUXER 0
-+#define CONFIG_AVI_MUXER 0
-+#define CONFIG_AVIF_MUXER 0
-+#define CONFIG_AVM2_MUXER 0
-+#define CONFIG_AVS2_MUXER 0
-+#define CONFIG_AVS3_MUXER 0
-+#define CONFIG_BIT_MUXER 0
-+#define CONFIG_CAF_MUXER 0
-+#define CONFIG_CAVSVIDEO_MUXER 0
-+#define CONFIG_CODEC2_MUXER 0
-+#define CONFIG_CODEC2RAW_MUXER 0
-+#define CONFIG_CRC_MUXER 0
-+#define CONFIG_DASH_MUXER 0
-+#define CONFIG_DATA_MUXER 0
-+#define CONFIG_DAUD_MUXER 0
-+#define CONFIG_DFPWM_MUXER 0
-+#define CONFIG_DIRAC_MUXER 0
-+#define CONFIG_DNXHD_MUXER 0
-+#define CONFIG_DTS_MUXER 0
-+#define CONFIG_DV_MUXER 0
-+#define CONFIG_EAC3_MUXER 0
-+#define CONFIG_EVC_MUXER 0
-+#define CONFIG_F4V_MUXER 0
-+#define CONFIG_FFMETADATA_MUXER 0
-+#define CONFIG_FIFO_MUXER 0
-+#define CONFIG_FILMSTRIP_MUXER 0
-+#define CONFIG_FITS_MUXER 0
-+#define CONFIG_FLAC_MUXER 0
-+#define CONFIG_FLV_MUXER 0
-+#define CONFIG_FRAMECRC_MUXER 0
-+#define CONFIG_FRAMEHASH_MUXER 0
-+#define CONFIG_FRAMEMD5_MUXER 0
-+#define CONFIG_G722_MUXER 0
-+#define CONFIG_G723_1_MUXER 0
-+#define CONFIG_G726_MUXER 0
-+#define CONFIG_G726LE_MUXER 0
-+#define CONFIG_GIF_MUXER 0
-+#define CONFIG_GSM_MUXER 0
-+#define CONFIG_GXF_MUXER 0
-+#define CONFIG_H261_MUXER 0
-+#define CONFIG_H263_MUXER 0
-+#define CONFIG_H264_MUXER 0
-+#define CONFIG_HASH_MUXER 0
-+#define CONFIG_HDS_MUXER 0
-+#define CONFIG_HEVC_MUXER 0
-+#define CONFIG_HLS_MUXER 0
-+#define CONFIG_IAMF_MUXER 0
-+#define CONFIG_ICO_MUXER 0
-+#define CONFIG_ILBC_MUXER 0
-+#define CONFIG_IMAGE2_MUXER 0
-+#define CONFIG_IMAGE2PIPE_MUXER 0
-+#define CONFIG_IPOD_MUXER 0
-+#define CONFIG_IRCAM_MUXER 0
-+#define CONFIG_ISMV_MUXER 0
-+#define CONFIG_IVF_MUXER 0
-+#define CONFIG_JACOSUB_MUXER 0
-+#define CONFIG_KVAG_MUXER 0
-+#define CONFIG_LATM_MUXER 0
-+#define CONFIG_LC3_MUXER 0
-+#define CONFIG_LRC_MUXER 0
-+#define CONFIG_M4V_MUXER 0
-+#define CONFIG_MCC_MUXER 0
-+#define CONFIG_MD5_MUXER 0
-+#define CONFIG_MATROSKA_MUXER 0
-+#define CONFIG_MATROSKA_AUDIO_MUXER 0
-+#define CONFIG_MICRODVD_MUXER 0
-+#define CONFIG_MJPEG_MUXER 0
-+#define CONFIG_MLP_MUXER 0
-+#define CONFIG_MMF_MUXER 0
-+#define CONFIG_MOV_MUXER 0
-+#define CONFIG_MP2_MUXER 0
-+#define CONFIG_MP3_MUXER 0
-+#define CONFIG_MP4_MUXER 0
-+#define CONFIG_MPEG1SYSTEM_MUXER 0
-+#define CONFIG_MPEG1VCD_MUXER 0
-+#define CONFIG_MPEG1VIDEO_MUXER 0
-+#define CONFIG_MPEG2DVD_MUXER 0
-+#define CONFIG_MPEG2SVCD_MUXER 0
-+#define CONFIG_MPEG2VIDEO_MUXER 0
-+#define CONFIG_MPEG2VOB_MUXER 0
-+#define CONFIG_MPEGTS_MUXER 0
-+#define CONFIG_MPJPEG_MUXER 0
-+#define CONFIG_MXF_MUXER 0
-+#define CONFIG_MXF_D10_MUXER 0
-+#define CONFIG_MXF_OPATOM_MUXER 0
-+#define CONFIG_NULL_MUXER 0
-+#define CONFIG_NUT_MUXER 0
-+#define CONFIG_OBU_MUXER 0
-+#define CONFIG_OGA_MUXER 0
-+#define CONFIG_OGG_MUXER 0
-+#define CONFIG_OGV_MUXER 0
-+#define CONFIG_OMA_MUXER 0
-+#define CONFIG_OPUS_MUXER 0
-+#define CONFIG_PCM_ALAW_MUXER 0
-+#define CONFIG_PCM_MULAW_MUXER 0
-+#define CONFIG_PCM_VIDC_MUXER 0
-+#define CONFIG_PCM_F64BE_MUXER 0
-+#define CONFIG_PCM_F64LE_MUXER 0
-+#define CONFIG_PCM_F32BE_MUXER 0
-+#define CONFIG_PCM_F32LE_MUXER 0
-+#define CONFIG_PCM_S32BE_MUXER 0
-+#define CONFIG_PCM_S32LE_MUXER 0
-+#define CONFIG_PCM_S24BE_MUXER 0
-+#define CONFIG_PCM_S24LE_MUXER 0
-+#define CONFIG_PCM_S16BE_MUXER 0
-+#define CONFIG_PCM_S16LE_MUXER 0
-+#define CONFIG_PCM_S8_MUXER 0
-+#define CONFIG_PCM_U32BE_MUXER 0
-+#define CONFIG_PCM_U32LE_MUXER 0
-+#define CONFIG_PCM_U24BE_MUXER 0
-+#define CONFIG_PCM_U24LE_MUXER 0
-+#define CONFIG_PCM_U16BE_MUXER 0
-+#define CONFIG_PCM_U16LE_MUXER 0
-+#define CONFIG_PCM_U8_MUXER 0
-+#define CONFIG_PSP_MUXER 0
-+#define CONFIG_RAWVIDEO_MUXER 0
-+#define CONFIG_RCWT_MUXER 0
-+#define CONFIG_RM_MUXER 0
-+#define CONFIG_ROQ_MUXER 0
-+#define CONFIG_RSO_MUXER 0
-+#define CONFIG_RTP_MUXER 0
-+#define CONFIG_RTP_MPEGTS_MUXER 0
-+#define CONFIG_RTSP_MUXER 0
-+#define CONFIG_SAP_MUXER 0
-+#define CONFIG_SBC_MUXER 0
-+#define CONFIG_SCC_MUXER 0
-+#define CONFIG_SEGAFILM_MUXER 0
-+#define CONFIG_SEGMENT_MUXER 0
-+#define CONFIG_STREAM_SEGMENT_MUXER 0
-+#define CONFIG_SMJPEG_MUXER 0
-+#define CONFIG_SMOOTHSTREAMING_MUXER 0
-+#define CONFIG_SOX_MUXER 0
-+#define CONFIG_SPX_MUXER 0
-+#define CONFIG_SPDIF_MUXER 0
-+#define CONFIG_SRT_MUXER 0
-+#define CONFIG_STREAMHASH_MUXER 0
-+#define CONFIG_SUP_MUXER 0
-+#define CONFIG_SWF_MUXER 0
-+#define CONFIG_TEE_MUXER 0
-+#define CONFIG_TG2_MUXER 0
-+#define CONFIG_TGP_MUXER 0
-+#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
-+#define CONFIG_TRUEHD_MUXER 0
-+#define CONFIG_TTA_MUXER 0
-+#define CONFIG_TTML_MUXER 0
-+#define CONFIG_UNCODEDFRAMECRC_MUXER 0
-+#define CONFIG_VC1_MUXER 0
-+#define CONFIG_VC1T_MUXER 0
-+#define CONFIG_VOC_MUXER 0
-+#define CONFIG_VVC_MUXER 0
-+#define CONFIG_W64_MUXER 0
-+#define CONFIG_WAV_MUXER 0
-+#define CONFIG_WEBM_MUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
-+#define CONFIG_WEBM_CHUNK_MUXER 0
-+#define CONFIG_WEBP_MUXER 0
-+#define CONFIG_WEBVTT_MUXER 0
-+#define CONFIG_WHIP_MUXER 0
-+#define CONFIG_WSAUD_MUXER 0
-+#define CONFIG_WTV_MUXER 0
-+#define CONFIG_WV_MUXER 0
-+#define CONFIG_YUV4MPEGPIPE_MUXER 0
-+#define CONFIG_CHROMAPRINT_MUXER 0
-+#define CONFIG_ANDROID_CONTENT_PROTOCOL 0
-+#define CONFIG_ASYNC_PROTOCOL 0
-+#define CONFIG_BLURAY_PROTOCOL 0
-+#define CONFIG_CACHE_PROTOCOL 0
-+#define CONFIG_CONCAT_PROTOCOL 0
-+#define CONFIG_CONCATF_PROTOCOL 0
-+#define CONFIG_CRYPTO_PROTOCOL 0
-+#define CONFIG_DATA_PROTOCOL 0
-+#define CONFIG_FD_PROTOCOL 0
-+#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
-+#define CONFIG_FFRTMPHTTP_PROTOCOL 0
-+#define CONFIG_FILE_PROTOCOL 0
-+#define CONFIG_FTP_PROTOCOL 0
-+#define CONFIG_GOPHER_PROTOCOL 0
-+#define CONFIG_GOPHERS_PROTOCOL 0
-+#define CONFIG_HLS_PROTOCOL 0
-+#define CONFIG_HTTP_PROTOCOL 0
-+#define CONFIG_HTTPPROXY_PROTOCOL 0
-+#define CONFIG_HTTPS_PROTOCOL 0
-+#define CONFIG_ICECAST_PROTOCOL 0
-+#define CONFIG_MMSH_PROTOCOL 0
-+#define CONFIG_MMST_PROTOCOL 0
-+#define CONFIG_MD5_PROTOCOL 0
-+#define CONFIG_PIPE_PROTOCOL 0
-+#define CONFIG_PROMPEG_PROTOCOL 0
-+#define CONFIG_RTMP_PROTOCOL 0
-+#define CONFIG_RTMPE_PROTOCOL 0
-+#define CONFIG_RTMPS_PROTOCOL 0
-+#define CONFIG_RTMPT_PROTOCOL 0
-+#define CONFIG_RTMPTE_PROTOCOL 0
-+#define CONFIG_RTMPTS_PROTOCOL 0
-+#define CONFIG_RTP_PROTOCOL 0
-+#define CONFIG_SCTP_PROTOCOL 0
-+#define CONFIG_SRTP_PROTOCOL 0
-+#define CONFIG_SUBFILE_PROTOCOL 0
-+#define CONFIG_TEE_PROTOCOL 0
-+#define CONFIG_TCP_PROTOCOL 0
-+#define CONFIG_TLS_PROTOCOL 0
-+#define CONFIG_DTLS_PROTOCOL 0
-+#define CONFIG_UDP_PROTOCOL 0
-+#define CONFIG_UDPLITE_PROTOCOL 0
-+#define CONFIG_UNIX_PROTOCOL 0
-+#define CONFIG_LIBAMQP_PROTOCOL 0
-+#define CONFIG_LIBRIST_PROTOCOL 0
-+#define CONFIG_LIBRTMP_PROTOCOL 0
-+#define CONFIG_LIBRTMPE_PROTOCOL 0
-+#define CONFIG_LIBRTMPS_PROTOCOL 0
-+#define CONFIG_LIBRTMPT_PROTOCOL 0
-+#define CONFIG_LIBRTMPTE_PROTOCOL 0
-+#define CONFIG_LIBSRT_PROTOCOL 0
-+#define CONFIG_LIBSSH_PROTOCOL 0
-+#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
-+#define CONFIG_LIBZMQ_PROTOCOL 0
-+#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
-+#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
-+#endif /* FFMPEG_CONFIG_COMPONENTS_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
-new file mode 100644
-index 0000000000..7ff70c6e2d
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
-@@ -0,0 +1,2 @@
-+static const FFBitStreamFilter * const bitstream_filters[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
-new file mode 100644
-index 0000000000..fe5adb0d92
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
-@@ -0,0 +1,17 @@
-+static const FFCodec * const codec_list[] = {
-+    &ff_h264_decoder,
-+    &ff_aac_decoder,
-+    &ff_flac_decoder,
-+    &ff_mp3_decoder,
-+    &ff_vorbis_decoder,
-+    &ff_pcm_alaw_decoder,
-+    &ff_pcm_f32le_decoder,
-+    &ff_pcm_mulaw_decoder,
-+    &ff_pcm_s16be_decoder,
-+    &ff_pcm_s16le_decoder,
-+    &ff_pcm_s24be_decoder,
-+    &ff_pcm_s24le_decoder,
-+    &ff_pcm_s32le_decoder,
-+    &ff_pcm_u8_decoder,
-+    &ff_libopus_decoder,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
-new file mode 100644
-index 0000000000..3e4fa9c320
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
-@@ -0,0 +1,9 @@
-+static const AVCodecParser * const parser_list[] = {
-+    &ff_aac_parser,
-+    &ff_flac_parser,
-+    &ff_h264_parser,
-+    &ff_mpegaudio_parser,
-+    &ff_opus_parser,
-+    &ff_vorbis_parser,
-+    &ff_vp9_parser,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
-new file mode 100644
-index 0000000000..920b22bfa7
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
-@@ -0,0 +1,9 @@
-+static const AVInputFormat * const demuxer_list[] = {
-+    &ff_aac_demuxer,
-+    &ff_flac_demuxer,
-+    &ff_matroska_demuxer,
-+    &ff_mov_demuxer,
-+    &ff_mp3_demuxer,
-+    &ff_ogg_demuxer,
-+    &ff_wav_demuxer,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
-new file mode 100644
-index 0000000000..ae54c39f23
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
-@@ -0,0 +1,2 @@
-+static const FFOutputFormat * const muxer_list[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
-new file mode 100644
-index 0000000000..247e1e4c3a
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
-@@ -0,0 +1,2 @@
-+static const URLProtocol * const url_protocols[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
-new file mode 100644
-index 0000000000..c289fbb551
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
-@@ -0,0 +1,6 @@
-+/* Generated by ffmpeg configure */
-+#ifndef AVUTIL_AVCONFIG_H
-+#define AVUTIL_AVCONFIG_H
-+#define AV_HAVE_BIGENDIAN 0
-+#define AV_HAVE_FAST_UNALIGNED 1
-+#endif /* AVUTIL_AVCONFIG_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h
-new file mode 100644
-index 0000000000..52b8160ee4
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h
-@@ -0,0 +1,5 @@
-+/* Automatically generated by version.sh, do not manually edit! */
-+#ifndef AVUTIL_FFVERSION_H
-+#define AVUTIL_FFVERSION_H
-+#define FFMPEG_VERSION "n5.0.1"
-+#endif /* AVUTIL_FFVERSION_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
-new file mode 100644
-index 0000000000..3b500ef436
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
-@@ -0,0 +1,1574 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\"-O2\\\"' --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264' --disable-iamf"
-+#define FFMPEG_LICENSE "LGPL version 2.1 or later"
-+#define CONFIG_THIS_YEAR 2025
-+#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
-+#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 20.1.5 (https://github.com/llvm/llvm-project 7b09d7b446383b71b63d429b21ee45ba389c5134)"
-+#define OS_NAME linux
-+#define EXTERN_PREFIX ""
-+#define EXTERN_ASM 
-+#define BUILDSUF ""
-+#define SLIBSUF ".so"
-+#define SWS_MAX_FILTER_SIZE 256
-+#define ARCH_AARCH64 0
-+#define ARCH_ARM 0
-+#define ARCH_IA64 0
-+#define ARCH_LOONGARCH 1
-+#define ARCH_LOONGARCH32 0
-+#define ARCH_LOONGARCH64 1
-+#define ARCH_M68K 0
-+#define ARCH_MIPS 0
-+#define ARCH_MIPS64 0
-+#define ARCH_PARISC 0
-+#define ARCH_PPC 0
-+#define ARCH_PPC64 0
-+#define ARCH_RISCV 0
-+#define ARCH_S390 0
-+#define ARCH_SPARC 0
-+#define ARCH_SPARC64 0
-+#define ARCH_TILEGX 0
-+#define ARCH_TILEPRO 0
-+#define ARCH_WASM 0
-+#define ARCH_X86 0
-+#define ARCH_X86_32 0
-+#define ARCH_X86_64 0
-+#define HAVE_ARMV5TE 0
-+#define HAVE_ARMV6 0
-+#define HAVE_ARMV6T2 0
-+#define HAVE_ARMV8 0
-+#define HAVE_DOTPROD 0
-+#define HAVE_I8MM 0
-+#define HAVE_NEON 0
-+#define HAVE_VFP 0
-+#define HAVE_VFPV3 0
-+#define HAVE_SETEND 0
-+#define HAVE_SVE 0
-+#define HAVE_SVE2 0
-+#define HAVE_ALTIVEC 0
-+#define HAVE_DCBZL 0
-+#define HAVE_LDBRX 0
-+#define HAVE_POWER8 0
-+#define HAVE_PPC4XX 0
-+#define HAVE_VEC_XL 0
-+#define HAVE_VSX 0
-+#define HAVE_RV 0
-+#define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
-+#define HAVE_RV_ZVBB 0
-+#define HAVE_SIMD128 0
-+#define HAVE_AESNI 0
-+#define HAVE_AMD3DNOW 0
-+#define HAVE_AMD3DNOWEXT 0
-+#define HAVE_AVX 0
-+#define HAVE_AVX2 0
-+#define HAVE_AVX512 0
-+#define HAVE_AVX512ICL 0
-+#define HAVE_FMA3 0
-+#define HAVE_FMA4 0
-+#define HAVE_MMX 0
-+#define HAVE_MMXEXT 0
-+#define HAVE_SSE 0
-+#define HAVE_SSE2 0
-+#define HAVE_SSE3 0
-+#define HAVE_SSE4 0
-+#define HAVE_SSE42 0
-+#define HAVE_SSSE3 0
-+#define HAVE_XOP 0
-+#define HAVE_I686 0
-+#define HAVE_MIPSFPU 0
-+#define HAVE_MIPS32R2 0
-+#define HAVE_MIPS32R5 0
-+#define HAVE_MIPS64R2 0
-+#define HAVE_MIPS32R6 0
-+#define HAVE_MIPS64R6 0
-+#define HAVE_MIPSDSP 0
-+#define HAVE_MIPSDSPR2 0
-+#define HAVE_MSA 0
-+#define HAVE_LOONGSON2 0
-+#define HAVE_LOONGSON3 0
-+#define HAVE_MMI 0
-+#define HAVE_LSX 0
-+#define HAVE_LASX 0
-+#define HAVE_ARMV5TE_EXTERNAL 0
-+#define HAVE_ARMV6_EXTERNAL 0
-+#define HAVE_ARMV6T2_EXTERNAL 0
-+#define HAVE_ARMV8_EXTERNAL 0
-+#define HAVE_DOTPROD_EXTERNAL 0
-+#define HAVE_I8MM_EXTERNAL 0
-+#define HAVE_NEON_EXTERNAL 0
-+#define HAVE_VFP_EXTERNAL 0
-+#define HAVE_VFPV3_EXTERNAL 0
-+#define HAVE_SETEND_EXTERNAL 0
-+#define HAVE_SVE_EXTERNAL 0
-+#define HAVE_SVE2_EXTERNAL 0
-+#define HAVE_ALTIVEC_EXTERNAL 0
-+#define HAVE_DCBZL_EXTERNAL 0
-+#define HAVE_LDBRX_EXTERNAL 0
-+#define HAVE_POWER8_EXTERNAL 0
-+#define HAVE_PPC4XX_EXTERNAL 0
-+#define HAVE_VEC_XL_EXTERNAL 0
-+#define HAVE_VSX_EXTERNAL 0
-+#define HAVE_RV_EXTERNAL 0
-+#define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
-+#define HAVE_RV_ZVBB_EXTERNAL 0
-+#define HAVE_SIMD128_EXTERNAL 0
-+#define HAVE_AESNI_EXTERNAL 0
-+#define HAVE_AMD3DNOW_EXTERNAL 0
-+#define HAVE_AMD3DNOWEXT_EXTERNAL 0
-+#define HAVE_AVX_EXTERNAL 0
-+#define HAVE_AVX2_EXTERNAL 0
-+#define HAVE_AVX512_EXTERNAL 0
-+#define HAVE_AVX512ICL_EXTERNAL 0
-+#define HAVE_FMA3_EXTERNAL 0
-+#define HAVE_FMA4_EXTERNAL 0
-+#define HAVE_MMX_EXTERNAL 0
-+#define HAVE_MMXEXT_EXTERNAL 0
-+#define HAVE_SSE_EXTERNAL 0
-+#define HAVE_SSE2_EXTERNAL 0
-+#define HAVE_SSE3_EXTERNAL 0
-+#define HAVE_SSE4_EXTERNAL 0
-+#define HAVE_SSE42_EXTERNAL 0
-+#define HAVE_SSSE3_EXTERNAL 0
-+#define HAVE_XOP_EXTERNAL 0
-+#define HAVE_I686_EXTERNAL 0
-+#define HAVE_MIPSFPU_EXTERNAL 0
-+#define HAVE_MIPS32R2_EXTERNAL 0
-+#define HAVE_MIPS32R5_EXTERNAL 0
-+#define HAVE_MIPS64R2_EXTERNAL 0
-+#define HAVE_MIPS32R6_EXTERNAL 0
-+#define HAVE_MIPS64R6_EXTERNAL 0
-+#define HAVE_MIPSDSP_EXTERNAL 0
-+#define HAVE_MIPSDSPR2_EXTERNAL 0
-+#define HAVE_MSA_EXTERNAL 0
-+#define HAVE_LOONGSON2_EXTERNAL 0
-+#define HAVE_LOONGSON3_EXTERNAL 0
-+#define HAVE_MMI_EXTERNAL 0
-+#define HAVE_LSX_EXTERNAL 0
-+#define HAVE_LASX_EXTERNAL 0
-+#define HAVE_ARMV5TE_INLINE 0
-+#define HAVE_ARMV6_INLINE 0
-+#define HAVE_ARMV6T2_INLINE 0
-+#define HAVE_ARMV8_INLINE 0
-+#define HAVE_DOTPROD_INLINE 0
-+#define HAVE_I8MM_INLINE 0
-+#define HAVE_NEON_INLINE 0
-+#define HAVE_VFP_INLINE 0
-+#define HAVE_VFPV3_INLINE 0
-+#define HAVE_SETEND_INLINE 0
-+#define HAVE_SVE_INLINE 0
-+#define HAVE_SVE2_INLINE 0
-+#define HAVE_ALTIVEC_INLINE 0
-+#define HAVE_DCBZL_INLINE 0
-+#define HAVE_LDBRX_INLINE 0
-+#define HAVE_POWER8_INLINE 0
-+#define HAVE_PPC4XX_INLINE 0
-+#define HAVE_VEC_XL_INLINE 0
-+#define HAVE_VSX_INLINE 0
-+#define HAVE_RV_INLINE 0
-+#define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
-+#define HAVE_RV_ZVBB_INLINE 0
-+#define HAVE_SIMD128_INLINE 0
-+#define HAVE_AESNI_INLINE 0
-+#define HAVE_AMD3DNOW_INLINE 0
-+#define HAVE_AMD3DNOWEXT_INLINE 0
-+#define HAVE_AVX_INLINE 0
-+#define HAVE_AVX2_INLINE 0
-+#define HAVE_AVX512_INLINE 0
-+#define HAVE_AVX512ICL_INLINE 0
-+#define HAVE_FMA3_INLINE 0
-+#define HAVE_FMA4_INLINE 0
-+#define HAVE_MMX_INLINE 0
-+#define HAVE_MMXEXT_INLINE 0
-+#define HAVE_SSE_INLINE 0
-+#define HAVE_SSE2_INLINE 0
-+#define HAVE_SSE3_INLINE 0
-+#define HAVE_SSE4_INLINE 0
-+#define HAVE_SSE42_INLINE 0
-+#define HAVE_SSSE3_INLINE 0
-+#define HAVE_XOP_INLINE 0
-+#define HAVE_I686_INLINE 0
-+#define HAVE_MIPSFPU_INLINE 0
-+#define HAVE_MIPS32R2_INLINE 0
-+#define HAVE_MIPS32R5_INLINE 0
-+#define HAVE_MIPS64R2_INLINE 0
-+#define HAVE_MIPS32R6_INLINE 0
-+#define HAVE_MIPS64R6_INLINE 0
-+#define HAVE_MIPSDSP_INLINE 0
-+#define HAVE_MIPSDSPR2_INLINE 0
-+#define HAVE_MSA_INLINE 0
-+#define HAVE_LOONGSON2_INLINE 0
-+#define HAVE_LOONGSON3_INLINE 0
-+#define HAVE_MMI_INLINE 0
-+#define HAVE_LSX_INLINE 0
-+#define HAVE_LASX_INLINE 0
-+#define HAVE_ALIGNED_STACK 0
-+#define HAVE_FAST_64BIT 1
-+#define HAVE_FAST_CLZ 1
-+#define HAVE_FAST_CMOV 0
-+#define HAVE_FAST_FLOAT16 0
-+#define HAVE_SIMD_ALIGN_16 0
-+#define HAVE_SIMD_ALIGN_32 1
-+#define HAVE_SIMD_ALIGN_64 0
-+#define HAVE_MEMORYBARRIER 0
-+#define HAVE_MM_EMPTY 0
-+#define HAVE_RDTSC 0
-+#define HAVE_SEM_TIMEDWAIT 1
-+#define HAVE_INLINE_ASM 1
-+#define HAVE_SYMVER 0
-+#define HAVE_X86ASM 0
-+#define HAVE_BIGENDIAN 0
-+#define HAVE_FAST_UNALIGNED 1
-+#define HAVE_ARPA_INET_H 0
-+#define HAVE_ASM_HWPROBE_H 0
-+#define HAVE_ASM_TYPES_H 1
-+#define HAVE_CDIO_PARANOIA_H 0
-+#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
-+#define HAVE_CUDA_H 0
-+#define HAVE_DISPATCH_DISPATCH_H 0
-+#define HAVE_DIRECT_H 0
-+#define HAVE_DIRENT_H 1
-+#define HAVE_DXGIDEBUG_H 0
-+#define HAVE_DXVA_H 0
-+#define HAVE_ES2_GL_H 0
-+#define HAVE_GSM_H 0
-+#define HAVE_IO_H 0
-+#define HAVE_LINUX_DMA_BUF_H 0
-+#define HAVE_LINUX_PERF_EVENT_H 1
-+#define HAVE_MALLOC_H 1
-+#define HAVE_OPENCV2_CORE_CORE_C_H 0
-+#define HAVE_POLL_H 1
-+#define HAVE_PTHREAD_NP_H 0
-+#define HAVE_SYS_HWPROBE_H 0
-+#define HAVE_SYS_PARAM_H 1
-+#define HAVE_SYS_RESOURCE_H 1
-+#define HAVE_SYS_SELECT_H 1
-+#define HAVE_SYS_SOUNDCARD_H 1
-+#define HAVE_SYS_TIME_H 1
-+#define HAVE_SYS_UN_H 1
-+#define HAVE_SYS_VIDEOIO_H 0
-+#define HAVE_TERMIOS_H 1
-+#define HAVE_UDPLITE_H 0
-+#define HAVE_UNISTD_H 1
-+#define HAVE_VALGRIND_VALGRIND_H 0
-+#define HAVE_WINDOWS_H 0
-+#define HAVE_WINSOCK2_H 0
-+#define HAVE_INTRINSICS_NEON 0
-+#define HAVE_INTRINSICS_SSE2 0
-+#define HAVE_ATANF 1
-+#define HAVE_ATAN2F 1
-+#define HAVE_CBRT 1
-+#define HAVE_CBRTF 1
-+#define HAVE_COPYSIGN 1
-+#define HAVE_COSF 1
-+#define HAVE_ERF 1
-+#define HAVE_EXP2 1
-+#define HAVE_EXP2F 1
-+#define HAVE_EXPF 1
-+#define HAVE_HYPOT 1
-+#define HAVE_ISFINITE 1
-+#define HAVE_ISINF 1
-+#define HAVE_ISNAN 1
-+#define HAVE_LDEXPF 1
-+#define HAVE_LLRINT 1
-+#define HAVE_LLRINTF 1
-+#define HAVE_LOG2 1
-+#define HAVE_LOG2F 1
-+#define HAVE_LOG10F 1
-+#define HAVE_LRINT 1
-+#define HAVE_LRINTF 1
-+#define HAVE_POWF 1
-+#define HAVE_RINT 1
-+#define HAVE_ROUND 1
-+#define HAVE_ROUNDF 1
-+#define HAVE_SINF 1
-+#define HAVE_TRUNC 1
-+#define HAVE_TRUNCF 1
-+#define HAVE_DOS_PATHS 0
-+#define HAVE_LIBC_MSVCRT 0
-+#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
-+#define HAVE_SECTION_DATA_REL_RO 1
-+#define HAVE_THREADS 1
-+#define HAVE_UWP 0
-+#define HAVE_WINRT 0
-+#define HAVE_ACCESS 1
-+#define HAVE_ALIGNED_MALLOC 0
-+#define HAVE_ARC4RANDOM_BUF 0
-+#define HAVE_CLOCK_GETTIME 1
-+#define HAVE_CLOSESOCKET 0
-+#define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
-+#define HAVE_FCNTL 1
-+#define HAVE_GETADDRINFO 0
-+#define HAVE_GETAUXVAL 1
-+#define HAVE_GETENV 1
-+#define HAVE_GETHRTIME 0
-+#define HAVE_GETOPT 1
-+#define HAVE_GETMODULEHANDLE 0
-+#define HAVE_GETPROCESSAFFINITYMASK 0
-+#define HAVE_GETPROCESSMEMORYINFO 0
-+#define HAVE_GETPROCESSTIMES 0
-+#define HAVE_GETRUSAGE 1
-+#define HAVE_GETSTDHANDLE 0
-+#define HAVE_GETSYSTEMTIMEASFILETIME 0
-+#define HAVE_GETTIMEOFDAY 1
-+#define HAVE_GLOB 1
-+#define HAVE_GLXGETPROCADDRESS 0
-+#define HAVE_GMTIME_R 1
-+#define HAVE_INET_ATON 0
-+#define HAVE_ISATTY 1
-+#define HAVE_KBHIT 0
-+#define HAVE_LOCALTIME_R 1
-+#define HAVE_LSTAT 1
-+#define HAVE_LZO1X_999_COMPRESS 0
-+#define HAVE_MACH_ABSOLUTE_TIME 0
-+#define HAVE_MAPVIEWOFFILE 0
-+#define HAVE_MEMALIGN 1
-+#define HAVE_MKSTEMP 1
-+#define HAVE_MMAP 1
-+#define HAVE_MPROTECT 1
-+#define HAVE_NANOSLEEP 1
-+#define HAVE_PEEKNAMEDPIPE 0
-+#define HAVE_POSIX_MEMALIGN 1
-+#define HAVE_PRCTL 1
-+#define HAVE_PTHREAD_CANCEL 1
-+#define HAVE_PTHREAD_SET_NAME_NP 0
-+#define HAVE_PTHREAD_SETNAME_NP 0
-+#define HAVE_SCHED_GETAFFINITY 1
-+#define HAVE_SECITEMIMPORT 0
-+#define HAVE_SETCONSOLETEXTATTRIBUTE 0
-+#define HAVE_SETCONSOLECTRLHANDLER 0
-+#define HAVE_SETDLLDIRECTORY 0
-+#define HAVE_SETMODE 0
-+#define HAVE_SETRLIMIT 1
-+#define HAVE_SLEEP 0
-+#define HAVE_STRERROR_R 1
-+#define HAVE_SYSCONF 1
-+#define HAVE_SYSCTL 0
-+#define HAVE_SYSCTLBYNAME 0
-+#define HAVE_TEMPNAM 1
-+#define HAVE_USLEEP 1
-+#define HAVE_UTGETOSTYPEFROMSTRING 0
-+#define HAVE_VIRTUALALLOC 0
-+#define HAVE_WGLGETPROCADDRESS 0
-+#define HAVE_BCRYPT 0
-+#define HAVE_VAAPI_DRM 0
-+#define HAVE_VAAPI_X11 0
-+#define HAVE_VAAPI_WIN32 0
-+#define HAVE_VDPAU_X11 0
-+#define HAVE_PTHREADS 1
-+#define HAVE_OS2THREADS 0
-+#define HAVE_W32THREADS 0
-+#define HAVE_AS_ARCH_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_SVE_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_SVE2_DIRECTIVE 0
-+#define HAVE_AS_DN_DIRECTIVE 0
-+#define HAVE_AS_FPU_DIRECTIVE 0
-+#define HAVE_AS_FUNC 0
-+#define HAVE_AS_OBJECT_ARCH 0
-+#define HAVE_ASM_MOD_Q 0
-+#define HAVE_BLOCKS_EXTENSION 0
-+#define HAVE_EBP_AVAILABLE 0
-+#define HAVE_EBX_AVAILABLE 0
-+#define HAVE_GNU_AS 0
-+#define HAVE_GNU_WINDRES 0
-+#define HAVE_IBM_ASM 0
-+#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
-+#define HAVE_INLINE_ASM_LABELS 1
-+#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
-+#define HAVE_PRAGMA_DEPRECATED 1
-+#define HAVE_RSYNC_CONTIMEOUT 1
-+#define HAVE_SYMVER_ASM_LABEL 1
-+#define HAVE_SYMVER_GNU_ASM 1
-+#define HAVE_VFP_ARGS 0
-+#define HAVE_XFORM_ASM 0
-+#define HAVE_XMM_CLOBBERS 0
-+#define HAVE_DPI_AWARENESS_CONTEXT 0
-+#define HAVE_IDXGIOUTPUT5 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
-+#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
-+#define HAVE_KCMVIDEOCODECTYPE_VP9 0
-+#define HAVE_KCMVIDEOCODECTYPE_AV1 0
-+#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
-+#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
-+#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
-+#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
-+#define HAVE_KVTQPMODULATIONLEVEL_DEFAULT 0
-+#define HAVE_SECPKGCONTEXT_KEYINGMATERIALINFO 0
-+#define HAVE_SOCKLEN_T 0
-+#define HAVE_STRUCT_ADDRINFO 0
-+#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
-+#define HAVE_STRUCT_IP_MREQ_SOURCE 0
-+#define HAVE_STRUCT_IPV6_MREQ 0
-+#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
-+#define HAVE_STRUCT_POLLFD 0
-+#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
-+#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
-+#define HAVE_STRUCT_SOCKADDR_IN6 0
-+#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
-+#define HAVE_STRUCT_SOCKADDR_STORAGE 0
-+#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
-+#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 1
-+#define HAVE_STRUCT_MFXCONFIGINTERFACE 0
-+#define HAVE_GZIP 1
-+#define HAVE_IOCTL_POSIX 0
-+#define HAVE_LIBDRM_GETFB2 0
-+#define HAVE_MAKEINFO 0
-+#define HAVE_MAKEINFO_HTML 0
-+#define HAVE_OPENCL_D3D11 0
-+#define HAVE_OPENCL_DRM_ARM 0
-+#define HAVE_OPENCL_DRM_BEIGNET 0
-+#define HAVE_OPENCL_DXVA2 0
-+#define HAVE_OPENCL_VAAPI_BEIGNET 0
-+#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
-+#define HAVE_OPENCL_VIDEOTOOLBOX 0
-+#define HAVE_PERL 1
-+#define HAVE_POD2MAN 1
-+#define HAVE_TEXI2HTML 0
-+#define HAVE_XMLLINT 0
-+#define HAVE_ZLIB_GZIP 0
-+#define HAVE_OPENVINO2 0
-+#define CONFIG_DOC 0
-+#define CONFIG_HTMLPAGES 0
-+#define CONFIG_MANPAGES 0
-+#define CONFIG_PODPAGES 0
-+#define CONFIG_TXTPAGES 0
-+#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
-+#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
-+#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
-+#define CONFIG_DECODE_AUDIO_EXAMPLE 1
-+#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
-+#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
-+#define CONFIG_DECODE_VIDEO_EXAMPLE 1
-+#define CONFIG_DEMUX_DECODE_EXAMPLE 1
-+#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
-+#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
-+#define CONFIG_EXTRACT_MVS_EXAMPLE 1
-+#define CONFIG_FILTER_AUDIO_EXAMPLE 0
-+#define CONFIG_HW_DECODE_EXAMPLE 1
-+#define CONFIG_MUX_EXAMPLE 0
-+#define CONFIG_QSV_DECODE_EXAMPLE 0
-+#define CONFIG_REMUX_EXAMPLE 1
-+#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
-+#define CONFIG_SCALE_VIDEO_EXAMPLE 0
-+#define CONFIG_SHOW_METADATA_EXAMPLE 1
-+#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
-+#define CONFIG_TRANSCODE_EXAMPLE 0
-+#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
-+#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
-+#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
-+#define CONFIG_AVISYNTH 0
-+#define CONFIG_FREI0R 0
-+#define CONFIG_LIBCDIO 0
-+#define CONFIG_LIBDAVS2 0
-+#define CONFIG_LIBDVDNAV 0
-+#define CONFIG_LIBDVDREAD 0
-+#define CONFIG_LIBRUBBERBAND 0
-+#define CONFIG_LIBVIDSTAB 0
-+#define CONFIG_LIBX264 0
-+#define CONFIG_LIBX265 0
-+#define CONFIG_LIBXAVS 0
-+#define CONFIG_LIBXAVS2 0
-+#define CONFIG_LIBXVID 0
-+#define CONFIG_DECKLINK 0
-+#define CONFIG_LIBFDK_AAC 0
-+#define CONFIG_LIBTLS 0
-+#define CONFIG_GMP 0
-+#define CONFIG_LIBARIBB24 0
-+#define CONFIG_LIBLENSFUN 0
-+#define CONFIG_LIBOPENCORE_AMRNB 0
-+#define CONFIG_LIBOPENCORE_AMRWB 0
-+#define CONFIG_LIBVO_AMRWBENC 0
-+#define CONFIG_MBEDTLS 0
-+#define CONFIG_RKMPP 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_CHROMAPRINT 0
-+#define CONFIG_GCRYPT 0
-+#define CONFIG_GNUTLS 0
-+#define CONFIG_JNI 0
-+#define CONFIG_LADSPA 0
-+#define CONFIG_LCMS2 0
-+#define CONFIG_LIBAOM 0
-+#define CONFIG_LIBARIBCAPTION 0
-+#define CONFIG_LIBASS 0
-+#define CONFIG_LIBBLURAY 0
-+#define CONFIG_LIBBS2B 0
-+#define CONFIG_LIBCACA 0
-+#define CONFIG_LIBCELT 0
-+#define CONFIG_LIBCODEC2 0
-+#define CONFIG_LIBDAV1D 0
-+#define CONFIG_LIBDC1394 0
-+#define CONFIG_LIBFLITE 0
-+#define CONFIG_LIBFONTCONFIG 0
-+#define CONFIG_LIBFREETYPE 0
-+#define CONFIG_LIBFRIBIDI 0
-+#define CONFIG_LIBHARFBUZZ 0
-+#define CONFIG_LIBGLSLANG 0
-+#define CONFIG_LIBGME 0
-+#define CONFIG_LIBGSM 0
-+#define CONFIG_LIBIEC61883 0
-+#define CONFIG_LIBILBC 0
-+#define CONFIG_LIBJACK 0
-+#define CONFIG_LIBJXL 0
-+#define CONFIG_LIBKLVANC 0
-+#define CONFIG_LIBKVAZAAR 0
-+#define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
-+#define CONFIG_LIBMODPLUG 0
-+#define CONFIG_LIBMP3LAME 0
-+#define CONFIG_LIBMYSOFA 0
-+#define CONFIG_LIBOAPV 0
-+#define CONFIG_LIBOPENCV 0
-+#define CONFIG_LIBOPENH264 0
-+#define CONFIG_LIBOPENJPEG 0
-+#define CONFIG_LIBOPENMPT 0
-+#define CONFIG_LIBOPENVINO 0
-+#define CONFIG_LIBOPUS 1
-+#define CONFIG_LIBPLACEBO 0
-+#define CONFIG_LIBPULSE 0
-+#define CONFIG_LIBQRENCODE 0
-+#define CONFIG_LIBQUIRC 0
-+#define CONFIG_LIBRABBITMQ 0
-+#define CONFIG_LIBRAV1E 0
-+#define CONFIG_LIBRIST 0
-+#define CONFIG_LIBRSVG 0
-+#define CONFIG_LIBRTMP 0
-+#define CONFIG_LIBSHADERC 0
-+#define CONFIG_LIBSHINE 0
-+#define CONFIG_LIBSMBCLIENT 0
-+#define CONFIG_LIBSNAPPY 0
-+#define CONFIG_LIBSOXR 0
-+#define CONFIG_LIBSPEEX 0
-+#define CONFIG_LIBSRT 0
-+#define CONFIG_LIBSSH 0
-+#define CONFIG_LIBSVTAV1 0
-+#define CONFIG_LIBTENSORFLOW 0
-+#define CONFIG_LIBTESSERACT 0
-+#define CONFIG_LIBTHEORA 0
-+#define CONFIG_LIBTORCH 0
-+#define CONFIG_LIBTWOLAME 0
-+#define CONFIG_LIBUAVS3D 0
-+#define CONFIG_LIBV4L2 0
-+#define CONFIG_LIBVMAF 0
-+#define CONFIG_LIBVORBIS 0
-+#define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
-+#define CONFIG_LIBWEBP 0
-+#define CONFIG_LIBXEVD 0
-+#define CONFIG_LIBXEVE 0
-+#define CONFIG_LIBXML2 0
-+#define CONFIG_LIBZIMG 0
-+#define CONFIG_LIBZMQ 0
-+#define CONFIG_LIBZVBI 0
-+#define CONFIG_LV2 0
-+#define CONFIG_MEDIACODEC 0
-+#define CONFIG_OHCODEC 0
-+#define CONFIG_OPENAL 0
-+#define CONFIG_OPENGL 0
-+#define CONFIG_OPENSSL 0
-+#define CONFIG_POCKETSPHINX 0
-+#define CONFIG_VAPOURSYNTH 0
-+#define CONFIG_VULKAN_STATIC 0
-+#define CONFIG_WHISPER 0
-+#define CONFIG_ALSA 0
-+#define CONFIG_APPKIT 0
-+#define CONFIG_AVFOUNDATION 0
-+#define CONFIG_BZLIB 0
-+#define CONFIG_COREIMAGE 0
-+#define CONFIG_ICONV 0
-+#define CONFIG_LIBXCB 0
-+#define CONFIG_LIBXCB_SHM 0
-+#define CONFIG_LIBXCB_SHAPE 0
-+#define CONFIG_LIBXCB_XFIXES 0
-+#define CONFIG_LZMA 0
-+#define CONFIG_MEDIAFOUNDATION 0
-+#define CONFIG_METAL 0
-+#define CONFIG_SCHANNEL 0
-+#define CONFIG_SDL2 0
-+#define CONFIG_SECURETRANSPORT 0
-+#define CONFIG_SNDIO 0
-+#define CONFIG_XLIB 0
-+#define CONFIG_ZLIB 0
-+#define CONFIG_CUDA_NVCC 0
-+#define CONFIG_CUDA_SDK 0
-+#define CONFIG_LIBNPP 0
-+#define CONFIG_LIBMFX 0
-+#define CONFIG_LIBVPL 0
-+#define CONFIG_MMAL 0
-+#define CONFIG_OMX 0
-+#define CONFIG_OPENCL 0
-+#define CONFIG_AMF 0
-+#define CONFIG_AUDIOTOOLBOX 0
-+#define CONFIG_CUDA 0
-+#define CONFIG_CUDA_LLVM 0
-+#define CONFIG_CUVID 0
-+#define CONFIG_D3D11VA 0
-+#define CONFIG_D3D12VA 0
-+#define CONFIG_DXVA2 0
-+#define CONFIG_FFNVCODEC 0
-+#define CONFIG_LIBDRM 0
-+#define CONFIG_NVDEC 0
-+#define CONFIG_NVENC 0
-+#define CONFIG_VAAPI 0
-+#define CONFIG_VDPAU 0
-+#define CONFIG_VIDEOTOOLBOX 0
-+#define CONFIG_VULKAN 0
-+#define CONFIG_V4L2_M2M 0
-+#define CONFIG_FTRAPV 0
-+#define CONFIG_GRAY 0
-+#define CONFIG_HARDCODED_TABLES 0
-+#define CONFIG_OMX_RPI 0
-+#define CONFIG_RUNTIME_CPUDETECT 1
-+#define CONFIG_SAFE_BITSTREAM_READER 1
-+#define CONFIG_SHARED 0
-+#define CONFIG_SMALL 0
-+#define CONFIG_STATIC 1
-+#define CONFIG_SWSCALE_ALPHA 1
-+#define CONFIG_GPL 0
-+#define CONFIG_NONFREE 0
-+#define CONFIG_VERSION3 0
-+#define CONFIG_AVDEVICE 0
-+#define CONFIG_AVFILTER 0
-+#define CONFIG_SWSCALE 0
-+#define CONFIG_AVFORMAT 1
-+#define CONFIG_AVCODEC 1
-+#define CONFIG_SWRESAMPLE 0
-+#define CONFIG_AVUTIL 1
-+#define CONFIG_FFPLAY 0
-+#define CONFIG_FFPROBE 0
-+#define CONFIG_FFMPEG 0
-+#define CONFIG_DWT 0
-+#define CONFIG_ERROR_RESILIENCE 0
-+#define CONFIG_FAAN 0
-+#define CONFIG_FAST_UNALIGNED 1
-+#define CONFIG_IAMF 0
-+#define CONFIG_LSP 0
-+#define CONFIG_PIXELUTILS 0
-+#define CONFIG_NETWORK 0
-+#define CONFIG_AUTODETECT 0
-+#define CONFIG_FONTCONFIG 0
-+#define CONFIG_LARGE_TESTS 1
-+#define CONFIG_LINUX_PERF 0
-+#define CONFIG_MACOS_KPERF 0
-+#define CONFIG_MEMORY_POISONING 0
-+#define CONFIG_NEON_CLOBBER_TEST 0
-+#define CONFIG_OSSFUZZ 0
-+#define CONFIG_PIC 1
-+#define CONFIG_PTX_COMPRESSION 0
-+#define CONFIG_RESOURCE_COMPRESSION 0
-+#define CONFIG_THUMB 0
-+#define CONFIG_VALGRIND_BACKTRACE 0
-+#define CONFIG_XMM_CLOBBER_TEST 0
-+#define CONFIG_BSFS 0
-+#define CONFIG_DECODERS 1
-+#define CONFIG_ENCODERS 0
-+#define CONFIG_HWACCELS 0
-+#define CONFIG_PARSERS 1
-+#define CONFIG_INDEVS 0
-+#define CONFIG_OUTDEVS 0
-+#define CONFIG_FILTERS 0
-+#define CONFIG_DEMUXERS 1
-+#define CONFIG_MUXERS 0
-+#define CONFIG_PROTOCOLS 0
-+#define CONFIG_AANDCTTABLES 0
-+#define CONFIG_AC3DSP 0
-+#define CONFIG_ADTS_HEADER 1
-+#define CONFIG_ATSC_A53 1
-+#define CONFIG_AUDIO_FRAME_QUEUE 0
-+#define CONFIG_AUDIODSP 0
-+#define CONFIG_BLOCKDSP 0
-+#define CONFIG_BSWAPDSP 0
-+#define CONFIG_CABAC 1
-+#define CONFIG_CBS 0
-+#define CONFIG_CBS_APV 0
-+#define CONFIG_CBS_AV1 0
-+#define CONFIG_CBS_H264 0
-+#define CONFIG_CBS_H265 0
-+#define CONFIG_CBS_H266 0
-+#define CONFIG_CBS_JPEG 0
-+#define CONFIG_CBS_MPEG2 0
-+#define CONFIG_CBS_VP8 0
-+#define CONFIG_CBS_VP9 0
-+#define CONFIG_CELP_MATH 0
-+#define CONFIG_D3D12VA_ENCODE 0
-+#define CONFIG_DEFLATE_WRAPPER 0
-+#define CONFIG_DIRAC_PARSE 1
-+#define CONFIG_DNN 0
-+#define CONFIG_DOVI_RPUDEC 0
-+#define CONFIG_DOVI_RPUENC 0
-+#define CONFIG_DVPROFILE 0
-+#define CONFIG_EVCPARSE 0
-+#define CONFIG_EXIF 0
-+#define CONFIG_FAANDCT 0
-+#define CONFIG_FAANIDCT 0
-+#define CONFIG_FDCTDSP 0
-+#define CONFIG_FMTCONVERT 0
-+#define CONFIG_FRAME_THREAD_ENCODER 0
-+#define CONFIG_G722DSP 0
-+#define CONFIG_GOLOMB 1
-+#define CONFIG_GPLV3 0
-+#define CONFIG_H263DSP 0
-+#define CONFIG_H264CHROMA 1
-+#define CONFIG_H264DSP 1
-+#define CONFIG_H264PARSE 1
-+#define CONFIG_H264PRED 1
-+#define CONFIG_H264QPEL 1
-+#define CONFIG_H264_SEI 1
-+#define CONFIG_HEVCPARSE 0
-+#define CONFIG_HEVC_SEI 0
-+#define CONFIG_HPELDSP 0
-+#define CONFIG_HUFFMAN 0
-+#define CONFIG_HUFFYUVDSP 0
-+#define CONFIG_HUFFYUVENCDSP 0
-+#define CONFIG_IAMFDEC 0
-+#define CONFIG_IAMFENC 0
-+#define CONFIG_IDCTDSP 0
-+#define CONFIG_INFLATE_WRAPPER 0
-+#define CONFIG_INTRAX8 0
-+#define CONFIG_ISO_MEDIA 1
-+#define CONFIG_ISO_WRITER 0
-+#define CONFIG_IVIDSP 0
-+#define CONFIG_JPEGTABLES 0
-+#define CONFIG_LGPLV3 0
-+#define CONFIG_LIBX262 0
-+#define CONFIG_LIBX264_HDR10 0
-+#define CONFIG_LLAUDDSP 0
-+#define CONFIG_LLVIDDSP 0
-+#define CONFIG_LLVIDENCDSP 0
-+#define CONFIG_LPC 0
-+#define CONFIG_LZF 0
-+#define CONFIG_ME_CMP 0
-+#define CONFIG_MPEG_ER 0
-+#define CONFIG_MPEGAUDIO 1
-+#define CONFIG_MPEGAUDIODSP 1
-+#define CONFIG_MPEGAUDIOHEADER 1
-+#define CONFIG_MPEG4AUDIO 1
-+#define CONFIG_MPEGVIDEO 0
-+#define CONFIG_MPEGVIDEODEC 0
-+#define CONFIG_MPEGVIDEOENC 0
-+#define CONFIG_MPEGVIDEOENCDSP 0
-+#define CONFIG_MSMPEG4DEC 0
-+#define CONFIG_MSMPEG4ENC 0
-+#define CONFIG_MSS34DSP 0
-+#define CONFIG_PIXBLOCKDSP 0
-+#define CONFIG_QPELDSP 0
-+#define CONFIG_QSV 0
-+#define CONFIG_QSVDEC 0
-+#define CONFIG_QSVENC 0
-+#define CONFIG_QSVVPP 0
-+#define CONFIG_RANGECODER 0
-+#define CONFIG_RIFFDEC 1
-+#define CONFIG_RIFFENC 0
-+#define CONFIG_RTPDEC 0
-+#define CONFIG_RTPENC_CHAIN 0
-+#define CONFIG_RV34DSP 0
-+#define CONFIG_SCENE_SAD 0
-+#define CONFIG_SINEWIN 1
-+#define CONFIG_SMPTE_436M 0
-+#define CONFIG_SNAPPY 0
-+#define CONFIG_SRTP 0
-+#define CONFIG_STARTCODE 1
-+#define CONFIG_TEXTUREDSP 0
-+#define CONFIG_TEXTUREDSPENC 0
-+#define CONFIG_TPELDSP 0
-+#define CONFIG_VAAPI_1 0
-+#define CONFIG_VAAPI_ENCODE 0
-+#define CONFIG_VULKAN_1_4 0
-+#define CONFIG_VC1DSP 0
-+#define CONFIG_VIDEODSP 1
-+#define CONFIG_VP3DSP 0
-+#define CONFIG_VP56DSP 0
-+#define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
-+#define CONFIG_VVC_SEI 0
-+#define CONFIG_WMA_FREQS 0
-+#define CONFIG_WMV2DSP 0
-+#endif /* FFMPEG_CONFIG_H */
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIG_H
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\\\\\"-O2\\\\\\\\\"' --cc=clang --cxx=clang++ --ld=clang" */
-+#define FFMPEG_LICENSE "LGPL version 2.1 or later"
-+#define CONFIG_THIS_YEAR 2024
++#define CONFIG_THIS_YEAR 2023
 +#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
 +#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
 +#define CC_IDENT "clang version 17.0.6"
 +#define OS_NAME linux
 +#define av_restrict restrict
 +#define EXTERN_PREFIX ""
-+#define EXTERN_ASM 
++#define EXTERN_ASM
 +#define BUILDSUF ""
 +#define SLIBSUF ".so"
++#define HAVE_MMX2 HAVE_MMXEXT
 +#define SWS_MAX_FILTER_SIZE 256
 +#define ARCH_AARCH64 0
 +#define ARCH_ALPHA 0
@@ -7724,6 +3661,7 @@ index 0000000000..3b500ef436
 +#define ARCH_SPARC64 0
 +#define ARCH_TILEGX 0
 +#define ARCH_TILEPRO 0
++#define ARCH_TOMI 0
 +#define ARCH_X86 0
 +#define ARCH_X86_32 0
 +#define ARCH_X86_64 0
@@ -7743,7 +3681,6 @@ index 0000000000..3b500ef436
 +#define HAVE_POWER8 0
 +#define HAVE_PPC4XX 0
 +#define HAVE_VSX 0
-+#define HAVE_RV 0
 +#define HAVE_RVV 0
 +#define HAVE_AESNI 0
 +#define HAVE_AMD3DNOW 0
@@ -7795,7 +3732,6 @@ index 0000000000..3b500ef436
 +#define HAVE_POWER8_EXTERNAL 0
 +#define HAVE_PPC4XX_EXTERNAL 0
 +#define HAVE_VSX_EXTERNAL 0
-+#define HAVE_RV_EXTERNAL 0
 +#define HAVE_RVV_EXTERNAL 0
 +#define HAVE_AESNI_EXTERNAL 0
 +#define HAVE_AMD3DNOW_EXTERNAL 0
@@ -7847,7 +3783,6 @@ index 0000000000..3b500ef436
 +#define HAVE_POWER8_INLINE 0
 +#define HAVE_PPC4XX_INLINE 0
 +#define HAVE_VSX_INLINE 0
-+#define HAVE_RV_INLINE 0
 +#define HAVE_RVV_INLINE 0
 +#define HAVE_AESNI_INLINE 0
 +#define HAVE_AMD3DNOW_INLINE 0
@@ -7905,6 +3840,7 @@ index 0000000000..3b500ef436
 +#define HAVE_BIGENDIAN 0
 +#define HAVE_FAST_UNALIGNED 1
 +#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_HWCAP_H 1
 +#define HAVE_ASM_TYPES_H 1
 +#define HAVE_CDIO_PARANOIA_H 0
 +#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
@@ -7930,7 +3866,6 @@ index 0000000000..3b500ef436
 +#define HAVE_OPENCV2_CORE_CORE_C_H 0
 +#define HAVE_OPENGL_GL3_H 0
 +#define HAVE_POLL_H 1
-+#define HAVE_PTHREAD_NP_H 0
 +#define HAVE_SYS_PARAM_H 1
 +#define HAVE_SYS_RESOURCE_H 1
 +#define HAVE_SYS_SELECT_H 1
@@ -8021,8 +3956,6 @@ index 0000000000..3b500ef436
 +#define HAVE_POSIX_MEMALIGN 1
 +#define HAVE_PRCTL 1
 +#define HAVE_PTHREAD_CANCEL 1
-+#define HAVE_PTHREAD_SET_NAME_NP 0
-+#define HAVE_PTHREAD_SETNAME_NP 0
 +#define HAVE_SCHED_GETAFFINITY 1
 +#define HAVE_SECITEMIMPORT 0
 +#define HAVE_SETCONSOLETEXTATTRIBUTE 0
@@ -8119,7 +4052,6 @@ index 0000000000..3b500ef436
 +#define HAVE_TEXI2HTML 0
 +#define HAVE_XMLLINT 1
 +#define HAVE_ZLIB_GZIP 0
-+#define HAVE_OPENVINO2 0
 +#define CONFIG_DOC 0
 +#define CONFIG_HTMLPAGES 0
 +#define CONFIG_MANPAGES 0
@@ -8188,6 +4120,7 @@ index 0000000000..3b500ef436
 +#define CONFIG_LIBCODEC2 0
 +#define CONFIG_LIBDAV1D 0
 +#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBDRM 0
 +#define CONFIG_LIBFLITE 0
 +#define CONFIG_LIBFONTCONFIG 0
 +#define CONFIG_LIBFREETYPE 0
@@ -8213,8 +4146,6 @@ index 0000000000..3b500ef436
 +#define CONFIG_LIBOPUS 1
 +#define CONFIG_LIBPLACEBO 0
 +#define CONFIG_LIBPULSE 0
-+#define CONFIG_LIBQRENCODE 0
-+#define CONFIG_LIBQUIRC 0
 +#define CONFIG_LIBRABBITMQ 0
 +#define CONFIG_LIBRAV1E 0
 +#define CONFIG_LIBRIST 0
@@ -8239,8 +4170,6 @@ index 0000000000..3b500ef436
 +#define CONFIG_LIBVORBIS 0
 +#define CONFIG_LIBVPX 0
 +#define CONFIG_LIBWEBP 0
-+#define CONFIG_LIBXEVD 0
-+#define CONFIG_LIBXEVE 0
 +#define CONFIG_LIBXML2 0
 +#define CONFIG_LIBZIMG 0
 +#define CONFIG_LIBZMQ 0
@@ -8286,10 +4215,8 @@ index 0000000000..3b500ef436
 +#define CONFIG_CUDA_LLVM 0
 +#define CONFIG_CUVID 0
 +#define CONFIG_D3D11VA 0
-+#define CONFIG_D3D12VA 0
 +#define CONFIG_DXVA2 0
 +#define CONFIG_FFNVCODEC 0
-+#define CONFIG_LIBDRM 0
 +#define CONFIG_NVDEC 0
 +#define CONFIG_NVENC 0
 +#define CONFIG_VAAPI 0
@@ -8321,13 +4248,17 @@ index 0000000000..3b500ef436
 +#define CONFIG_FFPLAY 0
 +#define CONFIG_FFPROBE 0
 +#define CONFIG_FFMPEG 0
++#define CONFIG_DCT 1
 +#define CONFIG_DWT 0
 +#define CONFIG_ERROR_RESILIENCE 0
 +#define CONFIG_FAAN 0
 +#define CONFIG_FAST_UNALIGNED 1
++#define CONFIG_FFT 1
 +#define CONFIG_LSP 0
++#define CONFIG_MDCT 0
 +#define CONFIG_PIXELUTILS 0
 +#define CONFIG_NETWORK 0
++#define CONFIG_RDFT 1
 +#define CONFIG_AUTODETECT 0
 +#define CONFIG_FONTCONFIG 0
 +#define CONFIG_LARGE_TESTS 1
@@ -8354,13 +4285,13 @@ index 0000000000..3b500ef436
 +#define CONFIG_PROTOCOLS 0
 +#define CONFIG_AANDCTTABLES 0
 +#define CONFIG_AC3DSP 0
-+#define CONFIG_ADTS_HEADER 0
-+#define CONFIG_ATSC_A53 0
++#define CONFIG_ADTS_HEADER 1
++#define CONFIG_ATSC_A53 1
 +#define CONFIG_AUDIO_FRAME_QUEUE 0
 +#define CONFIG_AUDIODSP 0
 +#define CONFIG_BLOCKDSP 0
 +#define CONFIG_BSWAPDSP 0
-+#define CONFIG_CABAC 0
++#define CONFIG_CABAC 1
 +#define CONFIG_CBS 0
 +#define CONFIG_CBS_AV1 0
 +#define CONFIG_CBS_H264 0
@@ -8368,7 +4299,6 @@ index 0000000000..3b500ef436
 +#define CONFIG_CBS_H266 0
 +#define CONFIG_CBS_JPEG 0
 +#define CONFIG_CBS_MPEG2 0
-+#define CONFIG_CBS_VP8 0
 +#define CONFIG_CBS_VP9 0
 +#define CONFIG_DEFLATE_WRAPPER 0
 +#define CONFIG_DIRAC_PARSE 1
@@ -8386,20 +4316,18 @@ index 0000000000..3b500ef436
 +#define CONFIG_GOLOMB 1
 +#define CONFIG_GPLV3 0
 +#define CONFIG_H263DSP 0
-+#define CONFIG_H264CHROMA 0
-+#define CONFIG_H264DSP 0
-+#define CONFIG_H264PARSE 0
-+#define CONFIG_H264PRED 0
-+#define CONFIG_H264QPEL 0
-+#define CONFIG_H264_SEI 0
++#define CONFIG_H264CHROMA 1
++#define CONFIG_H264DSP 1
++#define CONFIG_H264PARSE 1
++#define CONFIG_H264PRED 1
++#define CONFIG_H264QPEL 1
++#define CONFIG_H264_SEI 1
 +#define CONFIG_HEVCPARSE 0
 +#define CONFIG_HEVC_SEI 0
-+#define CONFIG_HPELDSP 0
++#define CONFIG_HPELDSP 1
 +#define CONFIG_HUFFMAN 0
 +#define CONFIG_HUFFYUVDSP 0
 +#define CONFIG_HUFFYUVENCDSP 0
-+#define CONFIG_IAMFDEC 0
-+#define CONFIG_IAMFENC 0
 +#define CONFIG_IDCTDSP 0
 +#define CONFIG_IIRFILTER 0
 +#define CONFIG_INFLATE_WRAPPER 0
@@ -8439,2303 +4367,31 @@ index 0000000000..3b500ef436
 +#define CONFIG_RTPENC_CHAIN 0
 +#define CONFIG_RV34DSP 0
 +#define CONFIG_SCENE_SAD 0
-+#define CONFIG_SINEWIN 0
++#define CONFIG_SINEWIN 1
 +#define CONFIG_SNAPPY 0
 +#define CONFIG_SRTP 0
-+#define CONFIG_STARTCODE 0
++#define CONFIG_STARTCODE 1
 +#define CONFIG_TEXTUREDSP 0
 +#define CONFIG_TEXTUREDSPENC 0
 +#define CONFIG_TPELDSP 0
 +#define CONFIG_VAAPI_1 0
 +#define CONFIG_VAAPI_ENCODE 0
 +#define CONFIG_VC1DSP 0
-+#define CONFIG_VIDEODSP 0
-+#define CONFIG_VP3DSP 0
++#define CONFIG_VIDEODSP 1
++#define CONFIG_VP3DSP 1
 +#define CONFIG_VP56DSP 0
-+#define CONFIG_VP8DSP 0
++#define CONFIG_VP8DSP 1
++#define CONFIG_VVC_SEI 0
 +#define CONFIG_WMA_FREQS 0
 +#define CONFIG_WMV2DSP 0
-+#endif /* FFMPEG_CONFIG_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
-new file mode 100644
-index 0000000000..a3b50bec45
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
-@@ -0,0 +1,4492 @@
-+/* Automatically generated by configure - do not modify! */
-+#ifndef FFMPEG_CONFIG_COMPONENTS_H
-+#define FFMPEG_CONFIG_COMPONENTS_H
-+#define CONFIG_AAC_ADTSTOASC_BSF 0
-+#define CONFIG_APV_METADATA_BSF 0
-+#define CONFIG_AV1_FRAME_MERGE_BSF 0
-+#define CONFIG_AV1_FRAME_SPLIT_BSF 0
-+#define CONFIG_AV1_METADATA_BSF 0
-+#define CONFIG_CHOMP_BSF 0
-+#define CONFIG_DUMP_EXTRADATA_BSF 0
-+#define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
-+#define CONFIG_DTS2PTS_BSF 0
-+#define CONFIG_DV_ERROR_MARKER_BSF 0
-+#define CONFIG_EAC3_CORE_BSF 0
-+#define CONFIG_EIA608_TO_SMPTE436M_BSF 0
-+#define CONFIG_EVC_FRAME_MERGE_BSF 0
-+#define CONFIG_EXTRACT_EXTRADATA_BSF 0
-+#define CONFIG_FILTER_UNITS_BSF 0
-+#define CONFIG_H264_METADATA_BSF 0
-+#define CONFIG_H264_MP4TOANNEXB_BSF 0
-+#define CONFIG_H264_REDUNDANT_PPS_BSF 0
-+#define CONFIG_HAPQA_EXTRACT_BSF 0
-+#define CONFIG_HEVC_METADATA_BSF 0
-+#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
-+#define CONFIG_IMX_DUMP_HEADER_BSF 0
-+#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
-+#define CONFIG_MJPEG2JPEG_BSF 0
-+#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
-+#define CONFIG_MPEG2_METADATA_BSF 0
-+#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
-+#define CONFIG_MOV2TEXTSUB_BSF 0
-+#define CONFIG_NOISE_BSF 0
-+#define CONFIG_NULL_BSF 0
-+#define CONFIG_OPUS_METADATA_BSF 0
-+#define CONFIG_PCM_RECHUNK_BSF 0
-+#define CONFIG_PGS_FRAME_MERGE_BSF 0
-+#define CONFIG_PRORES_METADATA_BSF 0
-+#define CONFIG_REMOVE_EXTRADATA_BSF 0
-+#define CONFIG_SETTS_BSF 0
-+#define CONFIG_SHOWINFO_BSF 0
-+#define CONFIG_SMPTE436M_TO_EIA608_BSF 0
-+#define CONFIG_TEXT2MOVSUB_BSF 0
-+#define CONFIG_TRACE_HEADERS_BSF 0
-+#define CONFIG_TRUEHD_CORE_BSF 0
-+#define CONFIG_VP9_METADATA_BSF 0
-+#define CONFIG_VP9_RAW_REORDER_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_BSF 0
-+#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
-+#define CONFIG_VVC_METADATA_BSF 0
-+#define CONFIG_VVC_MP4TOANNEXB_BSF 0
-+#define CONFIG_AASC_DECODER 0
-+#define CONFIG_AIC_DECODER 0
-+#define CONFIG_ALIAS_PIX_DECODER 0
-+#define CONFIG_AGM_DECODER 0
-+#define CONFIG_AMV_DECODER 0
-+#define CONFIG_ANM_DECODER 0
-+#define CONFIG_ANSI_DECODER 0
-+#define CONFIG_APNG_DECODER 0
-+#define CONFIG_APV_DECODER 0
-+#define CONFIG_ARBC_DECODER 0
-+#define CONFIG_ARGO_DECODER 0
-+#define CONFIG_ASV1_DECODER 0
-+#define CONFIG_ASV2_DECODER 0
-+#define CONFIG_AURA_DECODER 0
-+#define CONFIG_AURA2_DECODER 0
-+#define CONFIG_AVRP_DECODER 0
-+#define CONFIG_AVRN_DECODER 0
-+#define CONFIG_AVS_DECODER 0
-+#define CONFIG_AVUI_DECODER 0
-+#define CONFIG_BETHSOFTVID_DECODER 0
-+#define CONFIG_BFI_DECODER 0
-+#define CONFIG_BINK_DECODER 0
-+#define CONFIG_BITPACKED_DECODER 0
-+#define CONFIG_BMP_DECODER 0
-+#define CONFIG_BMV_VIDEO_DECODER 0
-+#define CONFIG_BRENDER_PIX_DECODER 0
-+#define CONFIG_C93_DECODER 0
-+#define CONFIG_CAVS_DECODER 0
-+#define CONFIG_CDGRAPHICS_DECODER 0
-+#define CONFIG_CDTOONS_DECODER 0
-+#define CONFIG_CDXL_DECODER 0
-+#define CONFIG_CFHD_DECODER 0
-+#define CONFIG_CINEPAK_DECODER 0
-+#define CONFIG_CLEARVIDEO_DECODER 0
-+#define CONFIG_CLJR_DECODER 0
-+#define CONFIG_CLLC_DECODER 0
-+#define CONFIG_COMFORTNOISE_DECODER 0
-+#define CONFIG_CPIA_DECODER 0
-+#define CONFIG_CRI_DECODER 0
-+#define CONFIG_CSCD_DECODER 0
-+#define CONFIG_CYUV_DECODER 0
-+#define CONFIG_DDS_DECODER 0
-+#define CONFIG_DFA_DECODER 0
-+#define CONFIG_DIRAC_DECODER 0
-+#define CONFIG_DNXHD_DECODER 0
-+#define CONFIG_DPX_DECODER 0
-+#define CONFIG_DSICINVIDEO_DECODER 0
-+#define CONFIG_DVAUDIO_DECODER 0
-+#define CONFIG_DVVIDEO_DECODER 0
-+#define CONFIG_DXA_DECODER 0
-+#define CONFIG_DXTORY_DECODER 0
-+#define CONFIG_DXV_DECODER 0
-+#define CONFIG_EACMV_DECODER 0
-+#define CONFIG_EAMAD_DECODER 0
-+#define CONFIG_EATGQ_DECODER 0
-+#define CONFIG_EATGV_DECODER 0
-+#define CONFIG_EATQI_DECODER 0
-+#define CONFIG_EIGHTBPS_DECODER 0
-+#define CONFIG_EIGHTSVX_EXP_DECODER 0
-+#define CONFIG_EIGHTSVX_FIB_DECODER 0
-+#define CONFIG_ESCAPE124_DECODER 0
-+#define CONFIG_ESCAPE130_DECODER 0
-+#define CONFIG_EXR_DECODER 0
-+#define CONFIG_FFV1_DECODER 0
-+#define CONFIG_FFVHUFF_DECODER 0
-+#define CONFIG_FIC_DECODER 0
-+#define CONFIG_FITS_DECODER 0
-+#define CONFIG_FLASHSV_DECODER 0
-+#define CONFIG_FLASHSV2_DECODER 0
-+#define CONFIG_FLIC_DECODER 0
-+#define CONFIG_FLV_DECODER 0
-+#define CONFIG_FMVC_DECODER 0
-+#define CONFIG_FOURXM_DECODER 0
-+#define CONFIG_FRAPS_DECODER 0
-+#define CONFIG_FRWU_DECODER 0
-+#define CONFIG_G2M_DECODER 0
-+#define CONFIG_GDV_DECODER 0
-+#define CONFIG_GEM_DECODER 0
-+#define CONFIG_GIF_DECODER 0
-+#define CONFIG_H261_DECODER 0
-+#define CONFIG_H263_DECODER 0
-+#define CONFIG_H263I_DECODER 0
-+#define CONFIG_H263P_DECODER 0
-+#define CONFIG_H263_V4L2M2M_DECODER 0
-+#define CONFIG_H264_DECODER 1
-+#define CONFIG_H264_V4L2M2M_DECODER 0
-+#define CONFIG_H264_MEDIACODEC_DECODER 0
-+#define CONFIG_H264_MMAL_DECODER 0
-+#define CONFIG_H264_QSV_DECODER 0
-+#define CONFIG_H264_RKMPP_DECODER 0
-+#define CONFIG_HAP_DECODER 0
-+#define CONFIG_HEVC_DECODER 0
-+#define CONFIG_HEVC_QSV_DECODER 0
-+#define CONFIG_HEVC_RKMPP_DECODER 0
-+#define CONFIG_HEVC_V4L2M2M_DECODER 0
-+#define CONFIG_HNM4_VIDEO_DECODER 0
-+#define CONFIG_HQ_HQA_DECODER 0
-+#define CONFIG_HQX_DECODER 0
-+#define CONFIG_HUFFYUV_DECODER 0
-+#define CONFIG_HYMT_DECODER 0
-+#define CONFIG_IDCIN_DECODER 0
-+#define CONFIG_IFF_ILBM_DECODER 0
-+#define CONFIG_IMM4_DECODER 0
-+#define CONFIG_IMM5_DECODER 0
-+#define CONFIG_INDEO2_DECODER 0
-+#define CONFIG_INDEO3_DECODER 0
-+#define CONFIG_INDEO4_DECODER 0
-+#define CONFIG_INDEO5_DECODER 0
-+#define CONFIG_INTERPLAY_VIDEO_DECODER 0
-+#define CONFIG_IPU_DECODER 0
-+#define CONFIG_JPEG2000_DECODER 0
-+#define CONFIG_JPEGLS_DECODER 0
-+#define CONFIG_JV_DECODER 0
-+#define CONFIG_KGV1_DECODER 0
-+#define CONFIG_KMVC_DECODER 0
-+#define CONFIG_LAGARITH_DECODER 0
-+#define CONFIG_LEAD_DECODER 0
-+#define CONFIG_LOCO_DECODER 0
-+#define CONFIG_LSCR_DECODER 0
-+#define CONFIG_M101_DECODER 0
-+#define CONFIG_MAGICYUV_DECODER 0
-+#define CONFIG_MDEC_DECODER 0
-+#define CONFIG_MEDIA100_DECODER 0
-+#define CONFIG_MIMIC_DECODER 0
-+#define CONFIG_MJPEG_DECODER 0
-+#define CONFIG_MJPEGB_DECODER 0
-+#define CONFIG_MMVIDEO_DECODER 0
-+#define CONFIG_MOBICLIP_DECODER 0
-+#define CONFIG_MOTIONPIXELS_DECODER 0
-+#define CONFIG_MPEG1VIDEO_DECODER 0
-+#define CONFIG_MPEG2VIDEO_DECODER 0
-+#define CONFIG_MPEG4_DECODER 0
-+#define CONFIG_MPEG4_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG4_MMAL_DECODER 0
-+#define CONFIG_MPEGVIDEO_DECODER 0
-+#define CONFIG_MPEG1_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_MMAL_DECODER 0
-+#define CONFIG_MPEG2_V4L2M2M_DECODER 0
-+#define CONFIG_MPEG2_QSV_DECODER 0
-+#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
-+#define CONFIG_MSA1_DECODER 0
-+#define CONFIG_MSCC_DECODER 0
-+#define CONFIG_MSMPEG4V1_DECODER 0
-+#define CONFIG_MSMPEG4V2_DECODER 0
-+#define CONFIG_MSMPEG4V3_DECODER 0
-+#define CONFIG_MSP2_DECODER 0
-+#define CONFIG_MSRLE_DECODER 0
-+#define CONFIG_MSS1_DECODER 0
-+#define CONFIG_MSS2_DECODER 0
-+#define CONFIG_MSVIDEO1_DECODER 0
-+#define CONFIG_MSZH_DECODER 0
-+#define CONFIG_MTS2_DECODER 0
-+#define CONFIG_MV30_DECODER 0
-+#define CONFIG_MVC1_DECODER 0
-+#define CONFIG_MVC2_DECODER 0
-+#define CONFIG_MVDV_DECODER 0
-+#define CONFIG_MVHA_DECODER 0
-+#define CONFIG_MWSC_DECODER 0
-+#define CONFIG_MXPEG_DECODER 0
-+#define CONFIG_NOTCHLC_DECODER 0
-+#define CONFIG_NUV_DECODER 0
-+#define CONFIG_PAF_VIDEO_DECODER 0
-+#define CONFIG_PAM_DECODER 0
-+#define CONFIG_PBM_DECODER 0
-+#define CONFIG_PCX_DECODER 0
-+#define CONFIG_PDV_DECODER 0
-+#define CONFIG_PFM_DECODER 0
-+#define CONFIG_PGM_DECODER 0
-+#define CONFIG_PGMYUV_DECODER 0
-+#define CONFIG_PGX_DECODER 0
-+#define CONFIG_PHM_DECODER 0
-+#define CONFIG_PHOTOCD_DECODER 0
-+#define CONFIG_PICTOR_DECODER 0
-+#define CONFIG_PIXLET_DECODER 0
-+#define CONFIG_PNG_DECODER 0
-+#define CONFIG_PPM_DECODER 0
-+#define CONFIG_PRORES_DECODER 0
-+#define CONFIG_PRORES_RAW_DECODER 0
-+#define CONFIG_PROSUMER_DECODER 0
-+#define CONFIG_PSD_DECODER 0
-+#define CONFIG_PTX_DECODER 0
-+#define CONFIG_QDRAW_DECODER 0
-+#define CONFIG_QOI_DECODER 0
-+#define CONFIG_QPEG_DECODER 0
-+#define CONFIG_QTRLE_DECODER 0
-+#define CONFIG_R10K_DECODER 0
-+#define CONFIG_R210_DECODER 0
-+#define CONFIG_RASC_DECODER 0
-+#define CONFIG_RAWVIDEO_DECODER 0
-+#define CONFIG_RKA_DECODER 0
-+#define CONFIG_RL2_DECODER 0
-+#define CONFIG_ROQ_DECODER 0
-+#define CONFIG_RPZA_DECODER 0
-+#define CONFIG_RSCC_DECODER 0
-+#define CONFIG_RTV1_DECODER 0
-+#define CONFIG_RV10_DECODER 0
-+#define CONFIG_RV20_DECODER 0
-+#define CONFIG_RV30_DECODER 0
-+#define CONFIG_RV40_DECODER 0
-+#define CONFIG_RV60_DECODER 0
-+#define CONFIG_S302M_DECODER 0
-+#define CONFIG_SANM_DECODER 0
-+#define CONFIG_SCPR_DECODER 0
-+#define CONFIG_SCREENPRESSO_DECODER 0
-+#define CONFIG_SGA_DECODER 0
-+#define CONFIG_SGI_DECODER 0
-+#define CONFIG_SGIRLE_DECODER 0
-+#define CONFIG_SHEERVIDEO_DECODER 0
-+#define CONFIG_SIMBIOSIS_IMX_DECODER 0
-+#define CONFIG_SMACKER_DECODER 0
-+#define CONFIG_SMC_DECODER 0
-+#define CONFIG_SMVJPEG_DECODER 0
-+#define CONFIG_SNOW_DECODER 0
-+#define CONFIG_SP5X_DECODER 0
-+#define CONFIG_SPEEDHQ_DECODER 0
-+#define CONFIG_SPEEX_DECODER 0
-+#define CONFIG_SRGC_DECODER 0
-+#define CONFIG_SUNRAST_DECODER 0
-+#define CONFIG_SVQ1_DECODER 0
-+#define CONFIG_SVQ3_DECODER 0
-+#define CONFIG_TARGA_DECODER 0
-+#define CONFIG_TARGA_Y216_DECODER 0
-+#define CONFIG_TDSC_DECODER 0
-+#define CONFIG_THEORA_DECODER 0
-+#define CONFIG_THP_DECODER 0
-+#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
-+#define CONFIG_TIFF_DECODER 0
-+#define CONFIG_TMV_DECODER 0
-+#define CONFIG_TRUEMOTION1_DECODER 0
-+#define CONFIG_TRUEMOTION2_DECODER 0
-+#define CONFIG_TRUEMOTION2RT_DECODER 0
-+#define CONFIG_TSCC_DECODER 0
-+#define CONFIG_TSCC2_DECODER 0
-+#define CONFIG_TXD_DECODER 0
-+#define CONFIG_ULTI_DECODER 0
-+#define CONFIG_UTVIDEO_DECODER 0
-+#define CONFIG_V210_DECODER 0
-+#define CONFIG_V210X_DECODER 0
-+#define CONFIG_V308_DECODER 0
-+#define CONFIG_V408_DECODER 0
-+#define CONFIG_V410_DECODER 0
-+#define CONFIG_VB_DECODER 0
-+#define CONFIG_VBN_DECODER 0
-+#define CONFIG_VBLE_DECODER 0
-+#define CONFIG_VC1_DECODER 0
-+#define CONFIG_VC1IMAGE_DECODER 0
-+#define CONFIG_VC1_MMAL_DECODER 0
-+#define CONFIG_VC1_QSV_DECODER 0
-+#define CONFIG_VC1_V4L2M2M_DECODER 0
-+#define CONFIG_VCR1_DECODER 0
-+#define CONFIG_VMDVIDEO_DECODER 0
-+#define CONFIG_VMIX_DECODER 0
-+#define CONFIG_VMNC_DECODER 0
-+#define CONFIG_VP3_DECODER 0
-+#define CONFIG_VP4_DECODER 0
-+#define CONFIG_VP5_DECODER 0
-+#define CONFIG_VP6_DECODER 0
-+#define CONFIG_VP6A_DECODER 0
-+#define CONFIG_VP6F_DECODER 0
-+#define CONFIG_VP7_DECODER 0
-+#define CONFIG_VP8_DECODER 0
-+#define CONFIG_VP8_RKMPP_DECODER 0
-+#define CONFIG_VP8_V4L2M2M_DECODER 0
-+#define CONFIG_VP9_DECODER 0
-+#define CONFIG_VP9_RKMPP_DECODER 0
-+#define CONFIG_VP9_V4L2M2M_DECODER 0
-+#define CONFIG_VQA_DECODER 0
-+#define CONFIG_VQC_DECODER 0
-+#define CONFIG_VVC_DECODER 0
-+#define CONFIG_WBMP_DECODER 0
-+#define CONFIG_WEBP_DECODER 0
-+#define CONFIG_WCMV_DECODER 0
-+#define CONFIG_WRAPPED_AVFRAME_DECODER 0
-+#define CONFIG_WMV1_DECODER 0
-+#define CONFIG_WMV2_DECODER 0
-+#define CONFIG_WMV3_DECODER 0
-+#define CONFIG_WMV3IMAGE_DECODER 0
-+#define CONFIG_WNV1_DECODER 0
-+#define CONFIG_XAN_WC3_DECODER 0
-+#define CONFIG_XAN_WC4_DECODER 0
-+#define CONFIG_XBM_DECODER 0
-+#define CONFIG_XFACE_DECODER 0
-+#define CONFIG_XL_DECODER 0
-+#define CONFIG_XPM_DECODER 0
-+#define CONFIG_XWD_DECODER 0
-+#define CONFIG_Y41P_DECODER 0
-+#define CONFIG_YLC_DECODER 0
-+#define CONFIG_YOP_DECODER 0
-+#define CONFIG_YUV4_DECODER 0
-+#define CONFIG_ZERO12V_DECODER 0
-+#define CONFIG_ZEROCODEC_DECODER 0
-+#define CONFIG_ZLIB_DECODER 0
-+#define CONFIG_ZMBV_DECODER 0
-+#define CONFIG_AAC_DECODER 1
-+#define CONFIG_AAC_FIXED_DECODER 0
-+#define CONFIG_AAC_LATM_DECODER 0
-+#define CONFIG_AC3_DECODER 0
-+#define CONFIG_AC3_FIXED_DECODER 0
-+#define CONFIG_ACELP_KELVIN_DECODER 0
-+#define CONFIG_ALAC_DECODER 0
-+#define CONFIG_ALS_DECODER 0
-+#define CONFIG_AMRNB_DECODER 0
-+#define CONFIG_AMRWB_DECODER 0
-+#define CONFIG_APAC_DECODER 0
-+#define CONFIG_APE_DECODER 0
-+#define CONFIG_APTX_DECODER 0
-+#define CONFIG_APTX_HD_DECODER 0
-+#define CONFIG_ATRAC1_DECODER 0
-+#define CONFIG_ATRAC3_DECODER 0
-+#define CONFIG_ATRAC3AL_DECODER 0
-+#define CONFIG_ATRAC3P_DECODER 0
-+#define CONFIG_ATRAC3PAL_DECODER 0
-+#define CONFIG_ATRAC9_DECODER 0
-+#define CONFIG_BINKAUDIO_DCT_DECODER 0
-+#define CONFIG_BINKAUDIO_RDFT_DECODER 0
-+#define CONFIG_BMV_AUDIO_DECODER 0
-+#define CONFIG_BONK_DECODER 0
-+#define CONFIG_COOK_DECODER 0
-+#define CONFIG_DCA_DECODER 0
-+#define CONFIG_DFPWM_DECODER 0
-+#define CONFIG_DOLBY_E_DECODER 0
-+#define CONFIG_DSD_LSBF_DECODER 0
-+#define CONFIG_DSD_MSBF_DECODER 0
-+#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
-+#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
-+#define CONFIG_DSICINAUDIO_DECODER 0
-+#define CONFIG_DSS_SP_DECODER 0
-+#define CONFIG_DST_DECODER 0
-+#define CONFIG_EAC3_DECODER 0
-+#define CONFIG_EVRC_DECODER 0
-+#define CONFIG_FASTAUDIO_DECODER 0
-+#define CONFIG_FFWAVESYNTH_DECODER 0
-+#define CONFIG_FLAC_DECODER 1
-+#define CONFIG_FTR_DECODER 0
-+#define CONFIG_G723_1_DECODER 0
-+#define CONFIG_G728_DECODER 0
-+#define CONFIG_G729_DECODER 0
-+#define CONFIG_GSM_DECODER 0
-+#define CONFIG_GSM_MS_DECODER 0
-+#define CONFIG_HCA_DECODER 0
-+#define CONFIG_HCOM_DECODER 0
-+#define CONFIG_HDR_DECODER 0
-+#define CONFIG_IAC_DECODER 0
-+#define CONFIG_ILBC_DECODER 0
-+#define CONFIG_IMC_DECODER 0
-+#define CONFIG_INTERPLAY_ACM_DECODER 0
-+#define CONFIG_MACE3_DECODER 0
-+#define CONFIG_MACE6_DECODER 0
-+#define CONFIG_METASOUND_DECODER 0
-+#define CONFIG_MISC4_DECODER 0
-+#define CONFIG_MLP_DECODER 0
-+#define CONFIG_MP1_DECODER 0
-+#define CONFIG_MP1FLOAT_DECODER 0
-+#define CONFIG_MP2_DECODER 0
-+#define CONFIG_MP2FLOAT_DECODER 0
-+#define CONFIG_MP3FLOAT_DECODER 0
-+#define CONFIG_MP3_DECODER 1
-+#define CONFIG_MP3ADUFLOAT_DECODER 0
-+#define CONFIG_MP3ADU_DECODER 0
-+#define CONFIG_MP3ON4FLOAT_DECODER 0
-+#define CONFIG_MP3ON4_DECODER 0
-+#define CONFIG_MPC7_DECODER 0
-+#define CONFIG_MPC8_DECODER 0
-+#define CONFIG_MSNSIREN_DECODER 0
-+#define CONFIG_NELLYMOSER_DECODER 0
-+#define CONFIG_ON2AVC_DECODER 0
-+#define CONFIG_OPUS_DECODER 0
-+#define CONFIG_OSQ_DECODER 0
-+#define CONFIG_PAF_AUDIO_DECODER 0
-+#define CONFIG_QCELP_DECODER 0
-+#define CONFIG_QDM2_DECODER 0
-+#define CONFIG_QDMC_DECODER 0
-+#define CONFIG_QOA_DECODER 0
-+#define CONFIG_RA_144_DECODER 0
-+#define CONFIG_RA_288_DECODER 0
-+#define CONFIG_RALF_DECODER 0
-+#define CONFIG_SBC_DECODER 0
-+#define CONFIG_SHORTEN_DECODER 0
-+#define CONFIG_SIPR_DECODER 0
-+#define CONFIG_SIREN_DECODER 0
-+#define CONFIG_SMACKAUD_DECODER 0
-+#define CONFIG_SONIC_DECODER 0
-+#define CONFIG_TAK_DECODER 0
-+#define CONFIG_TRUEHD_DECODER 0
-+#define CONFIG_TRUESPEECH_DECODER 0
-+#define CONFIG_TTA_DECODER 0
-+#define CONFIG_TWINVQ_DECODER 0
-+#define CONFIG_VMDAUDIO_DECODER 0
-+#define CONFIG_VORBIS_DECODER 1
-+#define CONFIG_WAVARC_DECODER 0
-+#define CONFIG_WAVPACK_DECODER 0
-+#define CONFIG_WMALOSSLESS_DECODER 0
-+#define CONFIG_WMAPRO_DECODER 0
-+#define CONFIG_WMAV1_DECODER 0
-+#define CONFIG_WMAV2_DECODER 0
-+#define CONFIG_WMAVOICE_DECODER 0
-+#define CONFIG_WS_SND1_DECODER 0
-+#define CONFIG_XMA1_DECODER 0
-+#define CONFIG_XMA2_DECODER 0
-+#define CONFIG_PCM_ALAW_DECODER 1
-+#define CONFIG_PCM_BLURAY_DECODER 0
-+#define CONFIG_PCM_DVD_DECODER 0
-+#define CONFIG_PCM_F16LE_DECODER 0
-+#define CONFIG_PCM_F24LE_DECODER 0
-+#define CONFIG_PCM_F32BE_DECODER 0
-+#define CONFIG_PCM_F32LE_DECODER 1
-+#define CONFIG_PCM_F64BE_DECODER 0
-+#define CONFIG_PCM_F64LE_DECODER 0
-+#define CONFIG_PCM_LXF_DECODER 0
-+#define CONFIG_PCM_MULAW_DECODER 1
-+#define CONFIG_PCM_S8_DECODER 0
-+#define CONFIG_PCM_S8_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16BE_DECODER 1
-+#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S16LE_DECODER 1
-+#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S24BE_DECODER 1
-+#define CONFIG_PCM_S24DAUD_DECODER 0
-+#define CONFIG_PCM_S24LE_DECODER 1
-+#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S32BE_DECODER 0
-+#define CONFIG_PCM_S32LE_DECODER 1
-+#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
-+#define CONFIG_PCM_S64BE_DECODER 0
-+#define CONFIG_PCM_S64LE_DECODER 0
-+#define CONFIG_PCM_SGA_DECODER 0
-+#define CONFIG_PCM_U8_DECODER 1
-+#define CONFIG_PCM_U16BE_DECODER 0
-+#define CONFIG_PCM_U16LE_DECODER 0
-+#define CONFIG_PCM_U24BE_DECODER 0
-+#define CONFIG_PCM_U24LE_DECODER 0
-+#define CONFIG_PCM_U32BE_DECODER 0
-+#define CONFIG_PCM_U32LE_DECODER 0
-+#define CONFIG_PCM_VIDC_DECODER 0
-+#define CONFIG_CBD2_DPCM_DECODER 0
-+#define CONFIG_DERF_DPCM_DECODER 0
-+#define CONFIG_GREMLIN_DPCM_DECODER 0
-+#define CONFIG_INTERPLAY_DPCM_DECODER 0
-+#define CONFIG_ROQ_DPCM_DECODER 0
-+#define CONFIG_SDX2_DPCM_DECODER 0
-+#define CONFIG_SOL_DPCM_DECODER 0
-+#define CONFIG_XAN_DPCM_DECODER 0
-+#define CONFIG_WADY_DPCM_DECODER 0
-+#define CONFIG_ADPCM_4XM_DECODER 0
-+#define CONFIG_ADPCM_ADX_DECODER 0
-+#define CONFIG_ADPCM_AFC_DECODER 0
-+#define CONFIG_ADPCM_AGM_DECODER 0
-+#define CONFIG_ADPCM_AICA_DECODER 0
-+#define CONFIG_ADPCM_ARGO_DECODER 0
-+#define CONFIG_ADPCM_CT_DECODER 0
-+#define CONFIG_ADPCM_DTK_DECODER 0
-+#define CONFIG_ADPCM_EA_DECODER 0
-+#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
-+#define CONFIG_ADPCM_EA_R1_DECODER 0
-+#define CONFIG_ADPCM_EA_R2_DECODER 0
-+#define CONFIG_ADPCM_EA_R3_DECODER 0
-+#define CONFIG_ADPCM_EA_XAS_DECODER 0
-+#define CONFIG_ADPCM_G722_DECODER 0
-+#define CONFIG_ADPCM_G726_DECODER 0
-+#define CONFIG_ADPCM_G726LE_DECODER 0
-+#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
-+#define CONFIG_ADPCM_IMA_AMV_DECODER 0
-+#define CONFIG_ADPCM_IMA_ALP_DECODER 0
-+#define CONFIG_ADPCM_IMA_APC_DECODER 0
-+#define CONFIG_ADPCM_IMA_APM_DECODER 0
-+#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
-+#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK3_DECODER 0
-+#define CONFIG_ADPCM_IMA_DK4_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
-+#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_ISS_DECODER 0
-+#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
-+#define CONFIG_ADPCM_IMA_MTF_DECODER 0
-+#define CONFIG_ADPCM_IMA_OKI_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_DECODER 0
-+#define CONFIG_ADPCM_IMA_RAD_DECODER 0
-+#define CONFIG_ADPCM_IMA_SSI_DECODER 0
-+#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
-+#define CONFIG_ADPCM_IMA_WAV_DECODER 0
-+#define CONFIG_ADPCM_IMA_WS_DECODER 0
-+#define CONFIG_ADPCM_IMA_XBOX_DECODER 0
-+#define CONFIG_ADPCM_MS_DECODER 0
-+#define CONFIG_ADPCM_MTAF_DECODER 0
-+#define CONFIG_ADPCM_PSX_DECODER 0
-+#define CONFIG_ADPCM_SANYO_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_2_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_3_DECODER 0
-+#define CONFIG_ADPCM_SBPRO_4_DECODER 0
-+#define CONFIG_ADPCM_SWF_DECODER 0
-+#define CONFIG_ADPCM_THP_DECODER 0
-+#define CONFIG_ADPCM_THP_LE_DECODER 0
-+#define CONFIG_ADPCM_VIMA_DECODER 0
-+#define CONFIG_ADPCM_XA_DECODER 0
-+#define CONFIG_ADPCM_XMD_DECODER 0
-+#define CONFIG_ADPCM_YAMAHA_DECODER 0
-+#define CONFIG_ADPCM_ZORK_DECODER 0
-+#define CONFIG_SSA_DECODER 0
-+#define CONFIG_ASS_DECODER 0
-+#define CONFIG_CCAPTION_DECODER 0
-+#define CONFIG_DVBSUB_DECODER 0
-+#define CONFIG_DVDSUB_DECODER 0
-+#define CONFIG_JACOSUB_DECODER 0
-+#define CONFIG_MICRODVD_DECODER 0
-+#define CONFIG_MOVTEXT_DECODER 0
-+#define CONFIG_MPL2_DECODER 0
-+#define CONFIG_PGSSUB_DECODER 0
-+#define CONFIG_PJS_DECODER 0
-+#define CONFIG_REALTEXT_DECODER 0
-+#define CONFIG_SAMI_DECODER 0
-+#define CONFIG_SRT_DECODER 0
-+#define CONFIG_STL_DECODER 0
-+#define CONFIG_SUBRIP_DECODER 0
-+#define CONFIG_SUBVIEWER_DECODER 0
-+#define CONFIG_SUBVIEWER1_DECODER 0
-+#define CONFIG_TEXT_DECODER 0
-+#define CONFIG_VPLAYER_DECODER 0
-+#define CONFIG_WEBVTT_DECODER 0
-+#define CONFIG_XSUB_DECODER 0
-+#define CONFIG_AAC_AT_DECODER 0
-+#define CONFIG_AC3_AT_DECODER 0
-+#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
-+#define CONFIG_ALAC_AT_DECODER 0
-+#define CONFIG_AMR_NB_AT_DECODER 0
-+#define CONFIG_EAC3_AT_DECODER 0
-+#define CONFIG_GSM_MS_AT_DECODER 0
-+#define CONFIG_ILBC_AT_DECODER 0
-+#define CONFIG_MP1_AT_DECODER 0
-+#define CONFIG_MP2_AT_DECODER 0
-+#define CONFIG_MP3_AT_DECODER 0
-+#define CONFIG_PCM_ALAW_AT_DECODER 0
-+#define CONFIG_PCM_MULAW_AT_DECODER 0
-+#define CONFIG_QDMC_AT_DECODER 0
-+#define CONFIG_QDM2_AT_DECODER 0
-+#define CONFIG_LIBARIBCAPTION_DECODER 0
-+#define CONFIG_LIBARIBB24_DECODER 0
-+#define CONFIG_LIBCELT_DECODER 0
-+#define CONFIG_LIBCODEC2_DECODER 0
-+#define CONFIG_LIBDAV1D_DECODER 0
-+#define CONFIG_LIBDAVS2_DECODER 0
-+#define CONFIG_LIBFDK_AAC_DECODER 0
-+#define CONFIG_LIBGSM_DECODER 0
-+#define CONFIG_LIBGSM_MS_DECODER 0
-+#define CONFIG_LIBILBC_DECODER 0
-+#define CONFIG_LIBJXL_ANIM_DECODER 0
-+#define CONFIG_LIBJXL_DECODER 0
-+#define CONFIG_LIBLC3_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
-+#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
-+#define CONFIG_LIBOPUS_DECODER 1
-+#define CONFIG_LIBRSVG_DECODER 0
-+#define CONFIG_LIBSPEEX_DECODER 0
-+#define CONFIG_LIBUAVS3D_DECODER 0
-+#define CONFIG_LIBVORBIS_DECODER 0
-+#define CONFIG_LIBVPX_VP8_DECODER 0
-+#define CONFIG_LIBVPX_VP9_DECODER 0
-+#define CONFIG_LIBXEVD_DECODER 0
-+#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
-+#define CONFIG_BINTEXT_DECODER 0
-+#define CONFIG_XBIN_DECODER 0
-+#define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
-+#define CONFIG_LIBAOM_AV1_DECODER 0
-+#define CONFIG_AV1_DECODER 0
-+#define CONFIG_AV1_CUVID_DECODER 0
-+#define CONFIG_AV1_MEDIACODEC_DECODER 0
-+#define CONFIG_AV1_QSV_DECODER 0
-+#define CONFIG_AV1_AMF_DECODER 0
-+#define CONFIG_LIBOPENH264_DECODER 0
-+#define CONFIG_H264_AMF_DECODER 0
-+#define CONFIG_H264_CUVID_DECODER 0
-+#define CONFIG_H264_OH_DECODER 0
-+#define CONFIG_HEVC_AMF_DECODER 0
-+#define CONFIG_HEVC_CUVID_DECODER 0
-+#define CONFIG_HEVC_MEDIACODEC_DECODER 0
-+#define CONFIG_HEVC_OH_DECODER 0
-+#define CONFIG_MJPEG_CUVID_DECODER 0
-+#define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
-+#define CONFIG_MPEG1_CUVID_DECODER 0
-+#define CONFIG_MPEG2_CUVID_DECODER 0
-+#define CONFIG_MPEG4_CUVID_DECODER 0
-+#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
-+#define CONFIG_VC1_CUVID_DECODER 0
-+#define CONFIG_VP8_CUVID_DECODER 0
-+#define CONFIG_VP8_MEDIACODEC_DECODER 0
-+#define CONFIG_VP8_QSV_DECODER 0
-+#define CONFIG_VP9_AMF_DECODER 0
-+#define CONFIG_VP9_CUVID_DECODER 0
-+#define CONFIG_VP9_MEDIACODEC_DECODER 0
-+#define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
-+#define CONFIG_VNULL_DECODER 0
-+#define CONFIG_ANULL_DECODER 0
-+#define CONFIG_A64MULTI_ENCODER 0
-+#define CONFIG_A64MULTI5_ENCODER 0
-+#define CONFIG_ALIAS_PIX_ENCODER 0
-+#define CONFIG_AMV_ENCODER 0
-+#define CONFIG_APNG_ENCODER 0
-+#define CONFIG_ASV1_ENCODER 0
-+#define CONFIG_ASV2_ENCODER 0
-+#define CONFIG_AVRP_ENCODER 0
-+#define CONFIG_AVUI_ENCODER 0
-+#define CONFIG_BITPACKED_ENCODER 0
-+#define CONFIG_BMP_ENCODER 0
-+#define CONFIG_CFHD_ENCODER 0
-+#define CONFIG_CINEPAK_ENCODER 0
-+#define CONFIG_CLJR_ENCODER 0
-+#define CONFIG_COMFORTNOISE_ENCODER 0
-+#define CONFIG_DNXHD_ENCODER 0
-+#define CONFIG_DPX_ENCODER 0
-+#define CONFIG_DVVIDEO_ENCODER 0
-+#define CONFIG_DXV_ENCODER 0
-+#define CONFIG_EXR_ENCODER 0
-+#define CONFIG_FFV1_ENCODER 0
-+#define CONFIG_FFV1_VULKAN_ENCODER 0
-+#define CONFIG_FFVHUFF_ENCODER 0
-+#define CONFIG_FITS_ENCODER 0
-+#define CONFIG_FLASHSV_ENCODER 0
-+#define CONFIG_FLASHSV2_ENCODER 0
-+#define CONFIG_FLV_ENCODER 0
-+#define CONFIG_GIF_ENCODER 0
-+#define CONFIG_H261_ENCODER 0
-+#define CONFIG_H263_ENCODER 0
-+#define CONFIG_H263P_ENCODER 0
-+#define CONFIG_H264_MEDIACODEC_ENCODER 0
-+#define CONFIG_HAP_ENCODER 0
-+#define CONFIG_HUFFYUV_ENCODER 0
-+#define CONFIG_JPEG2000_ENCODER 0
-+#define CONFIG_JPEGLS_ENCODER 0
-+#define CONFIG_LJPEG_ENCODER 0
-+#define CONFIG_MAGICYUV_ENCODER 0
-+#define CONFIG_MJPEG_ENCODER 0
-+#define CONFIG_MPEG1VIDEO_ENCODER 0
-+#define CONFIG_MPEG2VIDEO_ENCODER 0
-+#define CONFIG_MPEG4_ENCODER 0
-+#define CONFIG_MSMPEG4V2_ENCODER 0
-+#define CONFIG_MSMPEG4V3_ENCODER 0
-+#define CONFIG_MSRLE_ENCODER 0
-+#define CONFIG_MSVIDEO1_ENCODER 0
-+#define CONFIG_PAM_ENCODER 0
-+#define CONFIG_PBM_ENCODER 0
-+#define CONFIG_PCX_ENCODER 0
-+#define CONFIG_PFM_ENCODER 0
-+#define CONFIG_PGM_ENCODER 0
-+#define CONFIG_PGMYUV_ENCODER 0
-+#define CONFIG_PHM_ENCODER 0
-+#define CONFIG_PNG_ENCODER 0
-+#define CONFIG_PPM_ENCODER 0
-+#define CONFIG_PRORES_ENCODER 0
-+#define CONFIG_PRORES_AW_ENCODER 0
-+#define CONFIG_PRORES_KS_ENCODER 0
-+#define CONFIG_QOI_ENCODER 0
-+#define CONFIG_QTRLE_ENCODER 0
-+#define CONFIG_R10K_ENCODER 0
-+#define CONFIG_R210_ENCODER 0
-+#define CONFIG_RAWVIDEO_ENCODER 0
-+#define CONFIG_ROQ_ENCODER 0
-+#define CONFIG_RPZA_ENCODER 0
-+#define CONFIG_RV10_ENCODER 0
-+#define CONFIG_RV20_ENCODER 0
-+#define CONFIG_S302M_ENCODER 0
-+#define CONFIG_SGI_ENCODER 0
-+#define CONFIG_SMC_ENCODER 0
-+#define CONFIG_SNOW_ENCODER 0
-+#define CONFIG_SPEEDHQ_ENCODER 0
-+#define CONFIG_SUNRAST_ENCODER 0
-+#define CONFIG_SVQ1_ENCODER 0
-+#define CONFIG_TARGA_ENCODER 0
-+#define CONFIG_TIFF_ENCODER 0
-+#define CONFIG_UTVIDEO_ENCODER 0
-+#define CONFIG_V210_ENCODER 0
-+#define CONFIG_V308_ENCODER 0
-+#define CONFIG_V408_ENCODER 0
-+#define CONFIG_V410_ENCODER 0
-+#define CONFIG_VBN_ENCODER 0
-+#define CONFIG_VC2_ENCODER 0
-+#define CONFIG_WBMP_ENCODER 0
-+#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
-+#define CONFIG_WMV1_ENCODER 0
-+#define CONFIG_WMV2_ENCODER 0
-+#define CONFIG_XBM_ENCODER 0
-+#define CONFIG_XFACE_ENCODER 0
-+#define CONFIG_XWD_ENCODER 0
-+#define CONFIG_Y41P_ENCODER 0
-+#define CONFIG_YUV4_ENCODER 0
-+#define CONFIG_ZLIB_ENCODER 0
-+#define CONFIG_ZMBV_ENCODER 0
-+#define CONFIG_AAC_ENCODER 0
-+#define CONFIG_AC3_ENCODER 0
-+#define CONFIG_AC3_FIXED_ENCODER 0
-+#define CONFIG_ALAC_ENCODER 0
-+#define CONFIG_APTX_ENCODER 0
-+#define CONFIG_APTX_HD_ENCODER 0
-+#define CONFIG_DCA_ENCODER 0
-+#define CONFIG_DFPWM_ENCODER 0
-+#define CONFIG_EAC3_ENCODER 0
-+#define CONFIG_FLAC_ENCODER 0
-+#define CONFIG_G723_1_ENCODER 0
-+#define CONFIG_HDR_ENCODER 0
-+#define CONFIG_MLP_ENCODER 0
-+#define CONFIG_MP2_ENCODER 0
-+#define CONFIG_MP2FIXED_ENCODER 0
-+#define CONFIG_NELLYMOSER_ENCODER 0
-+#define CONFIG_OPUS_ENCODER 0
-+#define CONFIG_RA_144_ENCODER 0
-+#define CONFIG_SBC_ENCODER 0
-+#define CONFIG_SONIC_ENCODER 0
-+#define CONFIG_SONIC_LS_ENCODER 0
-+#define CONFIG_TRUEHD_ENCODER 0
-+#define CONFIG_TTA_ENCODER 0
-+#define CONFIG_VORBIS_ENCODER 0
-+#define CONFIG_WAVPACK_ENCODER 0
-+#define CONFIG_WMAV1_ENCODER 0
-+#define CONFIG_WMAV2_ENCODER 0
-+#define CONFIG_PCM_ALAW_ENCODER 0
-+#define CONFIG_PCM_BLURAY_ENCODER 0
-+#define CONFIG_PCM_DVD_ENCODER 0
-+#define CONFIG_PCM_F32BE_ENCODER 0
-+#define CONFIG_PCM_F32LE_ENCODER 0
-+#define CONFIG_PCM_F64BE_ENCODER 0
-+#define CONFIG_PCM_F64LE_ENCODER 0
-+#define CONFIG_PCM_MULAW_ENCODER 0
-+#define CONFIG_PCM_S8_ENCODER 0
-+#define CONFIG_PCM_S8_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16BE_ENCODER 0
-+#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S16LE_ENCODER 0
-+#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S24BE_ENCODER 0
-+#define CONFIG_PCM_S24DAUD_ENCODER 0
-+#define CONFIG_PCM_S24LE_ENCODER 0
-+#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S32BE_ENCODER 0
-+#define CONFIG_PCM_S32LE_ENCODER 0
-+#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
-+#define CONFIG_PCM_S64BE_ENCODER 0
-+#define CONFIG_PCM_S64LE_ENCODER 0
-+#define CONFIG_PCM_U8_ENCODER 0
-+#define CONFIG_PCM_U16BE_ENCODER 0
-+#define CONFIG_PCM_U16LE_ENCODER 0
-+#define CONFIG_PCM_U24BE_ENCODER 0
-+#define CONFIG_PCM_U24LE_ENCODER 0
-+#define CONFIG_PCM_U32BE_ENCODER 0
-+#define CONFIG_PCM_U32LE_ENCODER 0
-+#define CONFIG_PCM_VIDC_ENCODER 0
-+#define CONFIG_ROQ_DPCM_ENCODER 0
-+#define CONFIG_ADPCM_ADX_ENCODER 0
-+#define CONFIG_ADPCM_ARGO_ENCODER 0
-+#define CONFIG_ADPCM_G722_ENCODER 0
-+#define CONFIG_ADPCM_G726_ENCODER 0
-+#define CONFIG_ADPCM_G726LE_ENCODER 0
-+#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
-+#define CONFIG_ADPCM_IMA_APM_ENCODER 0
-+#define CONFIG_ADPCM_IMA_QT_ENCODER 0
-+#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
-+#define CONFIG_ADPCM_IMA_WS_ENCODER 0
-+#define CONFIG_ADPCM_MS_ENCODER 0
-+#define CONFIG_ADPCM_SWF_ENCODER 0
-+#define CONFIG_ADPCM_YAMAHA_ENCODER 0
-+#define CONFIG_SSA_ENCODER 0
-+#define CONFIG_ASS_ENCODER 0
-+#define CONFIG_DVBSUB_ENCODER 0
-+#define CONFIG_DVDSUB_ENCODER 0
-+#define CONFIG_MOVTEXT_ENCODER 0
-+#define CONFIG_SRT_ENCODER 0
-+#define CONFIG_SUBRIP_ENCODER 0
-+#define CONFIG_TEXT_ENCODER 0
-+#define CONFIG_TTML_ENCODER 0
-+#define CONFIG_WEBVTT_ENCODER 0
-+#define CONFIG_XSUB_ENCODER 0
-+#define CONFIG_AAC_AT_ENCODER 0
-+#define CONFIG_ALAC_AT_ENCODER 0
-+#define CONFIG_ILBC_AT_ENCODER 0
-+#define CONFIG_PCM_ALAW_AT_ENCODER 0
-+#define CONFIG_PCM_MULAW_AT_ENCODER 0
-+#define CONFIG_LIBAOM_AV1_ENCODER 0
-+#define CONFIG_LIBCODEC2_ENCODER 0
-+#define CONFIG_LIBFDK_AAC_ENCODER 0
-+#define CONFIG_LIBGSM_ENCODER 0
-+#define CONFIG_LIBGSM_MS_ENCODER 0
-+#define CONFIG_LIBILBC_ENCODER 0
-+#define CONFIG_LIBJXL_ANIM_ENCODER 0
-+#define CONFIG_LIBJXL_ENCODER 0
-+#define CONFIG_LIBLC3_ENCODER 0
-+#define CONFIG_LIBMP3LAME_ENCODER 0
-+#define CONFIG_LIBOAPV_ENCODER 0
-+#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
-+#define CONFIG_LIBOPENJPEG_ENCODER 0
-+#define CONFIG_LIBOPUS_ENCODER 0
-+#define CONFIG_LIBRAV1E_ENCODER 0
-+#define CONFIG_LIBSHINE_ENCODER 0
-+#define CONFIG_LIBSPEEX_ENCODER 0
-+#define CONFIG_LIBSVTAV1_ENCODER 0
-+#define CONFIG_LIBTHEORA_ENCODER 0
-+#define CONFIG_LIBTWOLAME_ENCODER 0
-+#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
-+#define CONFIG_LIBVORBIS_ENCODER 0
-+#define CONFIG_LIBVPX_VP8_ENCODER 0
-+#define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
-+#define CONFIG_LIBWEBP_ANIM_ENCODER 0
-+#define CONFIG_LIBWEBP_ENCODER 0
-+#define CONFIG_LIBX262_ENCODER 0
-+#define CONFIG_LIBX264_ENCODER 0
-+#define CONFIG_LIBX264RGB_ENCODER 0
-+#define CONFIG_LIBX265_ENCODER 0
-+#define CONFIG_LIBXEVE_ENCODER 0
-+#define CONFIG_LIBXAVS_ENCODER 0
-+#define CONFIG_LIBXAVS2_ENCODER 0
-+#define CONFIG_LIBXVID_ENCODER 0
-+#define CONFIG_AAC_MF_ENCODER 0
-+#define CONFIG_AC3_MF_ENCODER 0
-+#define CONFIG_H263_V4L2M2M_ENCODER 0
-+#define CONFIG_AV1_MEDIACODEC_ENCODER 0
-+#define CONFIG_AV1_NVENC_ENCODER 0
-+#define CONFIG_AV1_QSV_ENCODER 0
-+#define CONFIG_AV1_AMF_ENCODER 0
-+#define CONFIG_AV1_MF_ENCODER 0
-+#define CONFIG_AV1_VAAPI_ENCODER 0
-+#define CONFIG_AV1_VULKAN_ENCODER 0
-+#define CONFIG_LIBOPENH264_ENCODER 0
-+#define CONFIG_H264_AMF_ENCODER 0
-+#define CONFIG_H264_MF_ENCODER 0
-+#define CONFIG_H264_NVENC_ENCODER 0
-+#define CONFIG_H264_OH_ENCODER 0
-+#define CONFIG_H264_OMX_ENCODER 0
-+#define CONFIG_H264_QSV_ENCODER 0
-+#define CONFIG_H264_V4L2M2M_ENCODER 0
-+#define CONFIG_H264_VAAPI_ENCODER 0
-+#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
-+#define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
-+#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
-+#define CONFIG_HEVC_MF_ENCODER 0
-+#define CONFIG_HEVC_NVENC_ENCODER 0
-+#define CONFIG_HEVC_OH_ENCODER 0
-+#define CONFIG_HEVC_QSV_ENCODER 0
-+#define CONFIG_HEVC_V4L2M2M_ENCODER 0
-+#define CONFIG_HEVC_VAAPI_ENCODER 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
-+#define CONFIG_LIBKVAZAAR_ENCODER 0
-+#define CONFIG_MJPEG_QSV_ENCODER 0
-+#define CONFIG_MJPEG_VAAPI_ENCODER 0
-+#define CONFIG_MP3_MF_ENCODER 0
-+#define CONFIG_MPEG2_QSV_ENCODER 0
-+#define CONFIG_MPEG2_VAAPI_ENCODER 0
-+#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
-+#define CONFIG_MPEG4_OMX_ENCODER 0
-+#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_VP8_MEDIACODEC_ENCODER 0
-+#define CONFIG_VP8_V4L2M2M_ENCODER 0
-+#define CONFIG_VP8_VAAPI_ENCODER 0
-+#define CONFIG_VP9_MEDIACODEC_ENCODER 0
-+#define CONFIG_VP9_VAAPI_ENCODER 0
-+#define CONFIG_VP9_QSV_ENCODER 0
-+#define CONFIG_VNULL_ENCODER 0
-+#define CONFIG_ANULL_ENCODER 0
-+#define CONFIG_AV1_D3D11VA_HWACCEL 0
-+#define CONFIG_AV1_D3D11VA2_HWACCEL 0
-+#define CONFIG_AV1_D3D12VA_HWACCEL 0
-+#define CONFIG_AV1_DXVA2_HWACCEL 0
-+#define CONFIG_AV1_NVDEC_HWACCEL 0
-+#define CONFIG_AV1_VAAPI_HWACCEL 0
-+#define CONFIG_AV1_VDPAU_HWACCEL 0
-+#define CONFIG_AV1_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_AV1_VULKAN_HWACCEL 0
-+#define CONFIG_FFV1_VULKAN_HWACCEL 0
-+#define CONFIG_H263_VAAPI_HWACCEL 0
-+#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_H264_D3D11VA_HWACCEL 0
-+#define CONFIG_H264_D3D11VA2_HWACCEL 0
 +#define CONFIG_H264_D3D12VA_HWACCEL 0
-+#define CONFIG_H264_DXVA2_HWACCEL 0
-+#define CONFIG_H264_NVDEC_HWACCEL 0
-+#define CONFIG_H264_VAAPI_HWACCEL 0
-+#define CONFIG_H264_VDPAU_HWACCEL 0
-+#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_H264_VULKAN_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA_HWACCEL 0
-+#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
-+#define CONFIG_HEVC_D3D12VA_HWACCEL 0
-+#define CONFIG_HEVC_DXVA2_HWACCEL 0
-+#define CONFIG_HEVC_NVDEC_HWACCEL 0
-+#define CONFIG_HEVC_VAAPI_HWACCEL 0
-+#define CONFIG_HEVC_VDPAU_HWACCEL 0
-+#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_HEVC_VULKAN_HWACCEL 0
-+#define CONFIG_MJPEG_NVDEC_HWACCEL 0
-+#define CONFIG_MJPEG_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG1_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG1_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
-+#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
-+#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
-+#define CONFIG_MPEG2_DXVA2_HWACCEL 0
-+#define CONFIG_MPEG2_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG2_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG2_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_MPEG4_NVDEC_HWACCEL 0
-+#define CONFIG_MPEG4_VAAPI_HWACCEL 0
-+#define CONFIG_MPEG4_VDPAU_HWACCEL 0
-+#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_RAW_VULKAN_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA_HWACCEL 0
-+#define CONFIG_VC1_D3D11VA2_HWACCEL 0
-+#define CONFIG_VC1_D3D12VA_HWACCEL 0
-+#define CONFIG_VC1_DXVA2_HWACCEL 0
-+#define CONFIG_VC1_NVDEC_HWACCEL 0
-+#define CONFIG_VC1_VAAPI_HWACCEL 0
-+#define CONFIG_VC1_VDPAU_HWACCEL 0
-+#define CONFIG_VP8_NVDEC_HWACCEL 0
-+#define CONFIG_VP8_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA_HWACCEL 0
-+#define CONFIG_VP9_D3D11VA2_HWACCEL 0
-+#define CONFIG_VP9_D3D12VA_HWACCEL 0
-+#define CONFIG_VP9_DXVA2_HWACCEL 0
-+#define CONFIG_VP9_NVDEC_HWACCEL 0
-+#define CONFIG_VP9_VAAPI_HWACCEL 0
-+#define CONFIG_VP9_VDPAU_HWACCEL 0
-+#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_VP9_VULKAN_HWACCEL 0
-+#define CONFIG_VVC_VAAPI_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA_HWACCEL 0
-+#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
-+#define CONFIG_WMV3_D3D12VA_HWACCEL 0
-+#define CONFIG_WMV3_DXVA2_HWACCEL 0
-+#define CONFIG_WMV3_NVDEC_HWACCEL 0
-+#define CONFIG_WMV3_VAAPI_HWACCEL 0
-+#define CONFIG_WMV3_VDPAU_HWACCEL 0
-+#define CONFIG_AAC_PARSER 1
-+#define CONFIG_AAC_LATM_PARSER 0
-+#define CONFIG_AC3_PARSER 0
-+#define CONFIG_ADX_PARSER 0
-+#define CONFIG_AMR_PARSER 0
-+#define CONFIG_APV_PARSER 0
-+#define CONFIG_AV1_PARSER 0
-+#define CONFIG_AVS2_PARSER 0
-+#define CONFIG_AVS3_PARSER 0
-+#define CONFIG_BMP_PARSER 0
-+#define CONFIG_CAVSVIDEO_PARSER 0
-+#define CONFIG_COOK_PARSER 0
-+#define CONFIG_CRI_PARSER 0
-+#define CONFIG_DCA_PARSER 0
-+#define CONFIG_DIRAC_PARSER 0
-+#define CONFIG_DNXHD_PARSER 0
-+#define CONFIG_DNXUC_PARSER 0
-+#define CONFIG_DOLBY_E_PARSER 0
-+#define CONFIG_DPX_PARSER 0
-+#define CONFIG_DVAUDIO_PARSER 0
-+#define CONFIG_DVBSUB_PARSER 0
-+#define CONFIG_DVDSUB_PARSER 0
-+#define CONFIG_DVD_NAV_PARSER 0
-+#define CONFIG_EVC_PARSER 0
-+#define CONFIG_FLAC_PARSER 1
-+#define CONFIG_FTR_PARSER 0
-+#define CONFIG_FFV1_PARSER 0
-+#define CONFIG_G723_1_PARSER 0
-+#define CONFIG_G729_PARSER 0
-+#define CONFIG_GIF_PARSER 0
-+#define CONFIG_GSM_PARSER 0
-+#define CONFIG_H261_PARSER 0
-+#define CONFIG_H263_PARSER 0
-+#define CONFIG_H264_PARSER 1
-+#define CONFIG_HEVC_PARSER 0
-+#define CONFIG_HDR_PARSER 0
-+#define CONFIG_IPU_PARSER 0
-+#define CONFIG_JPEG2000_PARSER 0
-+#define CONFIG_JPEGXL_PARSER 0
-+#define CONFIG_MISC4_PARSER 0
-+#define CONFIG_MJPEG_PARSER 0
-+#define CONFIG_MLP_PARSER 0
-+#define CONFIG_MPEG4VIDEO_PARSER 0
-+#define CONFIG_MPEGAUDIO_PARSER 1
-+#define CONFIG_MPEGVIDEO_PARSER 0
-+#define CONFIG_OPUS_PARSER 1
-+#define CONFIG_PNG_PARSER 0
-+#define CONFIG_PNM_PARSER 0
-+#define CONFIG_PRORES_RAW_PARSER 0
-+#define CONFIG_QOI_PARSER 0
-+#define CONFIG_RV34_PARSER 0
-+#define CONFIG_SBC_PARSER 0
-+#define CONFIG_SIPR_PARSER 0
-+#define CONFIG_TAK_PARSER 0
-+#define CONFIG_VC1_PARSER 0
-+#define CONFIG_VORBIS_PARSER 1
-+#define CONFIG_VP3_PARSER 0
-+#define CONFIG_VP8_PARSER 0
-+#define CONFIG_VP9_PARSER 1
-+#define CONFIG_VVC_PARSER 0
-+#define CONFIG_WEBP_PARSER 0
-+#define CONFIG_XBM_PARSER 0
-+#define CONFIG_XMA_PARSER 0
-+#define CONFIG_XWD_PARSER 0
-+#define CONFIG_ALSA_INDEV 0
-+#define CONFIG_ANDROID_CAMERA_INDEV 0
-+#define CONFIG_AVFOUNDATION_INDEV 0
-+#define CONFIG_DECKLINK_INDEV 0
-+#define CONFIG_DSHOW_INDEV 0
-+#define CONFIG_FBDEV_INDEV 0
-+#define CONFIG_GDIGRAB_INDEV 0
-+#define CONFIG_IEC61883_INDEV 0
-+#define CONFIG_JACK_INDEV 0
-+#define CONFIG_KMSGRAB_INDEV 0
-+#define CONFIG_LAVFI_INDEV 0
-+#define CONFIG_OPENAL_INDEV 0
-+#define CONFIG_OSS_INDEV 0
-+#define CONFIG_PULSE_INDEV 0
-+#define CONFIG_SNDIO_INDEV 0
-+#define CONFIG_V4L2_INDEV 0
-+#define CONFIG_VFWCAP_INDEV 0
-+#define CONFIG_XCBGRAB_INDEV 0
-+#define CONFIG_LIBCDIO_INDEV 0
-+#define CONFIG_LIBDC1394_INDEV 0
-+#define CONFIG_ALSA_OUTDEV 0
-+#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
-+#define CONFIG_CACA_OUTDEV 0
-+#define CONFIG_DECKLINK_OUTDEV 0
-+#define CONFIG_FBDEV_OUTDEV 0
-+#define CONFIG_OSS_OUTDEV 0
-+#define CONFIG_PULSE_OUTDEV 0
-+#define CONFIG_SNDIO_OUTDEV 0
-+#define CONFIG_V4L2_OUTDEV 0
-+#define CONFIG_XV_OUTDEV 0
-+#define CONFIG_AAP_FILTER 0
-+#define CONFIG_ABENCH_FILTER 0
-+#define CONFIG_ACOMPRESSOR_FILTER 0
-+#define CONFIG_ACONTRAST_FILTER 0
-+#define CONFIG_ACOPY_FILTER 0
-+#define CONFIG_ACUE_FILTER 0
-+#define CONFIG_ACROSSFADE_FILTER 0
-+#define CONFIG_ACROSSOVER_FILTER 0
-+#define CONFIG_ACRUSHER_FILTER 0
-+#define CONFIG_ADECLICK_FILTER 0
-+#define CONFIG_ADECLIP_FILTER 0
-+#define CONFIG_ADECORRELATE_FILTER 0
-+#define CONFIG_ADELAY_FILTER 0
-+#define CONFIG_ADENORM_FILTER 0
-+#define CONFIG_ADERIVATIVE_FILTER 0
-+#define CONFIG_ADRC_FILTER 0
-+#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
-+#define CONFIG_ADYNAMICSMOOTH_FILTER 0
-+#define CONFIG_AECHO_FILTER 0
-+#define CONFIG_AEMPHASIS_FILTER 0
-+#define CONFIG_AEVAL_FILTER 0
-+#define CONFIG_AEXCITER_FILTER 0
-+#define CONFIG_AFADE_FILTER 0
-+#define CONFIG_AFFTDN_FILTER 0
-+#define CONFIG_AFFTFILT_FILTER 0
-+#define CONFIG_AFIR_FILTER 0
-+#define CONFIG_AFORMAT_FILTER 0
-+#define CONFIG_AFREQSHIFT_FILTER 0
-+#define CONFIG_AFWTDN_FILTER 0
-+#define CONFIG_AGATE_FILTER 0
-+#define CONFIG_AIIR_FILTER 0
-+#define CONFIG_AINTEGRAL_FILTER 0
-+#define CONFIG_AINTERLEAVE_FILTER 0
-+#define CONFIG_ALATENCY_FILTER 0
-+#define CONFIG_ALIMITER_FILTER 0
-+#define CONFIG_ALLPASS_FILTER 0
-+#define CONFIG_ALOOP_FILTER 0
-+#define CONFIG_AMERGE_FILTER 0
-+#define CONFIG_AMETADATA_FILTER 0
-+#define CONFIG_AMIX_FILTER 0
-+#define CONFIG_AMULTIPLY_FILTER 0
-+#define CONFIG_ANEQUALIZER_FILTER 0
-+#define CONFIG_ANLMDN_FILTER 0
-+#define CONFIG_ANLMF_FILTER 0
-+#define CONFIG_ANLMS_FILTER 0
-+#define CONFIG_ANULL_FILTER 0
-+#define CONFIG_APAD_FILTER 0
-+#define CONFIG_APERMS_FILTER 0
-+#define CONFIG_APHASER_FILTER 0
-+#define CONFIG_APHASESHIFT_FILTER 0
-+#define CONFIG_APSNR_FILTER 0
-+#define CONFIG_APSYCLIP_FILTER 0
-+#define CONFIG_APULSATOR_FILTER 0
-+#define CONFIG_AREALTIME_FILTER 0
-+#define CONFIG_ARESAMPLE_FILTER 0
-+#define CONFIG_AREVERSE_FILTER 0
-+#define CONFIG_ARLS_FILTER 0
-+#define CONFIG_ARNNDN_FILTER 0
-+#define CONFIG_ASDR_FILTER 0
-+#define CONFIG_ASEGMENT_FILTER 0
-+#define CONFIG_ASELECT_FILTER 0
-+#define CONFIG_ASENDCMD_FILTER 0
-+#define CONFIG_ASETNSAMPLES_FILTER 0
-+#define CONFIG_ASETPTS_FILTER 0
-+#define CONFIG_ASETRATE_FILTER 0
-+#define CONFIG_ASETTB_FILTER 0
-+#define CONFIG_ASHOWINFO_FILTER 0
-+#define CONFIG_ASIDEDATA_FILTER 0
-+#define CONFIG_ASISDR_FILTER 0
-+#define CONFIG_ASOFTCLIP_FILTER 0
-+#define CONFIG_ASPECTRALSTATS_FILTER 0
-+#define CONFIG_ASPLIT_FILTER 0
-+#define CONFIG_ASR_FILTER 0
-+#define CONFIG_ASTATS_FILTER 0
-+#define CONFIG_ASTREAMSELECT_FILTER 0
-+#define CONFIG_ASUBBOOST_FILTER 0
-+#define CONFIG_ASUBCUT_FILTER 0
-+#define CONFIG_ASUPERCUT_FILTER 0
-+#define CONFIG_ASUPERPASS_FILTER 0
-+#define CONFIG_ASUPERSTOP_FILTER 0
-+#define CONFIG_ATEMPO_FILTER 0
-+#define CONFIG_ATILT_FILTER 0
-+#define CONFIG_ATRIM_FILTER 0
-+#define CONFIG_AXCORRELATE_FILTER 0
-+#define CONFIG_AZMQ_FILTER 0
-+#define CONFIG_BANDPASS_FILTER 0
-+#define CONFIG_BANDREJECT_FILTER 0
-+#define CONFIG_BASS_FILTER 0
-+#define CONFIG_BIQUAD_FILTER 0
-+#define CONFIG_BS2B_FILTER 0
-+#define CONFIG_CHANNELMAP_FILTER 0
-+#define CONFIG_CHANNELSPLIT_FILTER 0
-+#define CONFIG_CHORUS_FILTER 0
-+#define CONFIG_COMPAND_FILTER 0
-+#define CONFIG_COMPENSATIONDELAY_FILTER 0
-+#define CONFIG_CROSSFEED_FILTER 0
-+#define CONFIG_CRYSTALIZER_FILTER 0
-+#define CONFIG_DCSHIFT_FILTER 0
-+#define CONFIG_DEESSER_FILTER 0
-+#define CONFIG_DIALOGUENHANCE_FILTER 0
-+#define CONFIG_DRMETER_FILTER 0
-+#define CONFIG_DYNAUDNORM_FILTER 0
-+#define CONFIG_EARWAX_FILTER 0
-+#define CONFIG_EBUR128_FILTER 0
-+#define CONFIG_EQUALIZER_FILTER 0
-+#define CONFIG_EXTRASTEREO_FILTER 0
-+#define CONFIG_FIREQUALIZER_FILTER 0
-+#define CONFIG_FLANGER_FILTER 0
-+#define CONFIG_HAAS_FILTER 0
-+#define CONFIG_HDCD_FILTER 0
-+#define CONFIG_HEADPHONE_FILTER 0
-+#define CONFIG_HIGHPASS_FILTER 0
-+#define CONFIG_HIGHSHELF_FILTER 0
-+#define CONFIG_JOIN_FILTER 0
-+#define CONFIG_LADSPA_FILTER 0
-+#define CONFIG_LOUDNORM_FILTER 0
-+#define CONFIG_LOWPASS_FILTER 0
-+#define CONFIG_LOWSHELF_FILTER 0
-+#define CONFIG_LV2_FILTER 0
-+#define CONFIG_MCOMPAND_FILTER 0
-+#define CONFIG_PAN_FILTER 0
-+#define CONFIG_REPLAYGAIN_FILTER 0
-+#define CONFIG_RUBBERBAND_FILTER 0
-+#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
-+#define CONFIG_SIDECHAINGATE_FILTER 0
-+#define CONFIG_SILENCEDETECT_FILTER 0
-+#define CONFIG_SILENCEREMOVE_FILTER 0
-+#define CONFIG_SOFALIZER_FILTER 0
-+#define CONFIG_SPEECHNORM_FILTER 0
-+#define CONFIG_STEREOTOOLS_FILTER 0
-+#define CONFIG_STEREOWIDEN_FILTER 0
-+#define CONFIG_SUPEREQUALIZER_FILTER 0
-+#define CONFIG_SURROUND_FILTER 0
-+#define CONFIG_TILTSHELF_FILTER 0
-+#define CONFIG_TREBLE_FILTER 0
-+#define CONFIG_TREMOLO_FILTER 0
-+#define CONFIG_VIBRATO_FILTER 0
-+#define CONFIG_VIRTUALBASS_FILTER 0
-+#define CONFIG_VOLUME_FILTER 0
-+#define CONFIG_VOLUMEDETECT_FILTER 0
-+#define CONFIG_WHISPER_FILTER 0
-+#define CONFIG_AEVALSRC_FILTER 0
-+#define CONFIG_AFDELAYSRC_FILTER 0
-+#define CONFIG_AFIREQSRC_FILTER 0
-+#define CONFIG_AFIRSRC_FILTER 0
-+#define CONFIG_ANOISESRC_FILTER 0
-+#define CONFIG_ANULLSRC_FILTER 0
-+#define CONFIG_FLITE_FILTER 0
-+#define CONFIG_HILBERT_FILTER 0
-+#define CONFIG_SINC_FILTER 0
-+#define CONFIG_SINE_FILTER 0
-+#define CONFIG_ANULLSINK_FILTER 0
-+#define CONFIG_ADDROI_FILTER 0
-+#define CONFIG_ALPHAEXTRACT_FILTER 0
-+#define CONFIG_ALPHAMERGE_FILTER 0
-+#define CONFIG_AMPLIFY_FILTER 0
-+#define CONFIG_ASS_FILTER 0
-+#define CONFIG_ATADENOISE_FILTER 0
-+#define CONFIG_AVGBLUR_FILTER 0
-+#define CONFIG_AVGBLUR_OPENCL_FILTER 0
-+#define CONFIG_AVGBLUR_VULKAN_FILTER 0
-+#define CONFIG_BACKGROUNDKEY_FILTER 0
-+#define CONFIG_BBOX_FILTER 0
-+#define CONFIG_BENCH_FILTER 0
-+#define CONFIG_BILATERAL_FILTER 0
-+#define CONFIG_BILATERAL_CUDA_FILTER 0
-+#define CONFIG_BITPLANENOISE_FILTER 0
-+#define CONFIG_BLACKDETECT_FILTER 0
-+#define CONFIG_BLACKDETECT_VULKAN_FILTER 0
-+#define CONFIG_BLACKFRAME_FILTER 0
-+#define CONFIG_BLEND_FILTER 0
-+#define CONFIG_BLEND_VULKAN_FILTER 0
-+#define CONFIG_BLOCKDETECT_FILTER 0
-+#define CONFIG_BLURDETECT_FILTER 0
-+#define CONFIG_BM3D_FILTER 0
-+#define CONFIG_BOXBLUR_FILTER 0
-+#define CONFIG_BOXBLUR_OPENCL_FILTER 0
-+#define CONFIG_BWDIF_FILTER 0
-+#define CONFIG_BWDIF_CUDA_FILTER 0
-+#define CONFIG_BWDIF_VULKAN_FILTER 0
-+#define CONFIG_CAS_FILTER 0
-+#define CONFIG_CCREPACK_FILTER 0
-+#define CONFIG_CHROMABER_VULKAN_FILTER 0
-+#define CONFIG_CHROMAHOLD_FILTER 0
-+#define CONFIG_CHROMAKEY_FILTER 0
-+#define CONFIG_CHROMAKEY_CUDA_FILTER 0
-+#define CONFIG_CHROMANR_FILTER 0
-+#define CONFIG_CHROMASHIFT_FILTER 0
-+#define CONFIG_CIESCOPE_FILTER 0
-+#define CONFIG_CODECVIEW_FILTER 0
-+#define CONFIG_COLORBALANCE_FILTER 0
-+#define CONFIG_COLORCHANNELMIXER_FILTER 0
-+#define CONFIG_COLORCONTRAST_FILTER 0
-+#define CONFIG_COLORCORRECT_FILTER 0
-+#define CONFIG_COLORDETECT_FILTER 0
-+#define CONFIG_COLORIZE_FILTER 0
-+#define CONFIG_COLORKEY_FILTER 0
-+#define CONFIG_COLORKEY_OPENCL_FILTER 0
-+#define CONFIG_COLORHOLD_FILTER 0
-+#define CONFIG_COLORLEVELS_FILTER 0
-+#define CONFIG_COLORMAP_FILTER 0
-+#define CONFIG_COLORMATRIX_FILTER 0
-+#define CONFIG_COLORSPACE_FILTER 0
-+#define CONFIG_COLORSPACE_CUDA_FILTER 0
-+#define CONFIG_COLORTEMPERATURE_FILTER 0
-+#define CONFIG_CONVOLUTION_FILTER 0
-+#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
-+#define CONFIG_CONVOLVE_FILTER 0
-+#define CONFIG_COPY_FILTER 0
-+#define CONFIG_COREIMAGE_FILTER 0
-+#define CONFIG_CORR_FILTER 0
-+#define CONFIG_COVER_RECT_FILTER 0
-+#define CONFIG_CROP_FILTER 0
-+#define CONFIG_CROPDETECT_FILTER 0
-+#define CONFIG_CUE_FILTER 0
-+#define CONFIG_CURVES_FILTER 0
-+#define CONFIG_DATASCOPE_FILTER 0
-+#define CONFIG_DBLUR_FILTER 0
-+#define CONFIG_DCTDNOIZ_FILTER 0
-+#define CONFIG_DEBAND_FILTER 0
-+#define CONFIG_DEBLOCK_FILTER 0
-+#define CONFIG_DECIMATE_FILTER 0
-+#define CONFIG_DECONVOLVE_FILTER 0
-+#define CONFIG_DEDOT_FILTER 0
-+#define CONFIG_DEFLATE_FILTER 0
-+#define CONFIG_DEFLICKER_FILTER 0
-+#define CONFIG_DEINTERLACE_QSV_FILTER 0
-+#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
-+#define CONFIG_DEJUDDER_FILTER 0
-+#define CONFIG_DELOGO_FILTER 0
-+#define CONFIG_DENOISE_VAAPI_FILTER 0
-+#define CONFIG_DERAIN_FILTER 0
-+#define CONFIG_DESHAKE_FILTER 0
-+#define CONFIG_DESHAKE_OPENCL_FILTER 0
-+#define CONFIG_DESPILL_FILTER 0
-+#define CONFIG_DETELECINE_FILTER 0
-+#define CONFIG_DILATION_FILTER 0
-+#define CONFIG_DILATION_OPENCL_FILTER 0
-+#define CONFIG_DISPLACE_FILTER 0
-+#define CONFIG_DNN_CLASSIFY_FILTER 0
-+#define CONFIG_DNN_DETECT_FILTER 0
-+#define CONFIG_DNN_PROCESSING_FILTER 0
-+#define CONFIG_DOUBLEWEAVE_FILTER 0
-+#define CONFIG_DRAWBOX_FILTER 0
-+#define CONFIG_DRAWGRAPH_FILTER 0
-+#define CONFIG_DRAWGRID_FILTER 0
-+#define CONFIG_DRAWTEXT_FILTER 0
-+#define CONFIG_EDGEDETECT_FILTER 0
-+#define CONFIG_ELBG_FILTER 0
-+#define CONFIG_ENTROPY_FILTER 0
-+#define CONFIG_EPX_FILTER 0
-+#define CONFIG_EQ_FILTER 0
-+#define CONFIG_EROSION_FILTER 0
-+#define CONFIG_EROSION_OPENCL_FILTER 0
-+#define CONFIG_ESTDIF_FILTER 0
-+#define CONFIG_EXPOSURE_FILTER 0
-+#define CONFIG_EXTRACTPLANES_FILTER 0
-+#define CONFIG_FADE_FILTER 0
-+#define CONFIG_FEEDBACK_FILTER 0
-+#define CONFIG_FFTDNOIZ_FILTER 0
-+#define CONFIG_FFTFILT_FILTER 0
-+#define CONFIG_FIELD_FILTER 0
-+#define CONFIG_FIELDHINT_FILTER 0
-+#define CONFIG_FIELDMATCH_FILTER 0
-+#define CONFIG_FIELDORDER_FILTER 0
-+#define CONFIG_FILLBORDERS_FILTER 0
-+#define CONFIG_FIND_RECT_FILTER 0
-+#define CONFIG_FLIP_VULKAN_FILTER 0
-+#define CONFIG_FLOODFILL_FILTER 0
-+#define CONFIG_FORMAT_FILTER 0
-+#define CONFIG_FPS_FILTER 0
-+#define CONFIG_FRAMEPACK_FILTER 0
-+#define CONFIG_FRAMERATE_FILTER 0
-+#define CONFIG_FRAMESTEP_FILTER 0
-+#define CONFIG_FREEZEDETECT_FILTER 0
-+#define CONFIG_FREEZEFRAMES_FILTER 0
-+#define CONFIG_FREI0R_FILTER 0
-+#define CONFIG_FSPP_FILTER 0
-+#define CONFIG_FSYNC_FILTER 0
-+#define CONFIG_GBLUR_FILTER 0
-+#define CONFIG_GBLUR_VULKAN_FILTER 0
-+#define CONFIG_GEQ_FILTER 0
-+#define CONFIG_GRADFUN_FILTER 0
-+#define CONFIG_GRAPHMONITOR_FILTER 0
-+#define CONFIG_GRAYWORLD_FILTER 0
-+#define CONFIG_GREYEDGE_FILTER 0
-+#define CONFIG_GUIDED_FILTER 0
-+#define CONFIG_HALDCLUT_FILTER 0
-+#define CONFIG_HFLIP_FILTER 0
-+#define CONFIG_HFLIP_VULKAN_FILTER 0
-+#define CONFIG_HISTEQ_FILTER 0
-+#define CONFIG_HISTOGRAM_FILTER 0
-+#define CONFIG_HQDN3D_FILTER 0
-+#define CONFIG_HQX_FILTER 0
-+#define CONFIG_HSTACK_FILTER 0
-+#define CONFIG_HSVHOLD_FILTER 0
-+#define CONFIG_HSVKEY_FILTER 0
-+#define CONFIG_HUE_FILTER 0
-+#define CONFIG_HUESATURATION_FILTER 0
-+#define CONFIG_HWDOWNLOAD_FILTER 0
-+#define CONFIG_HWMAP_FILTER 0
-+#define CONFIG_HWUPLOAD_FILTER 0
-+#define CONFIG_HWUPLOAD_CUDA_FILTER 0
-+#define CONFIG_HYSTERESIS_FILTER 0
-+#define CONFIG_ICCDETECT_FILTER 0
-+#define CONFIG_ICCGEN_FILTER 0
-+#define CONFIG_IDENTITY_FILTER 0
-+#define CONFIG_IDET_FILTER 0
-+#define CONFIG_IL_FILTER 0
-+#define CONFIG_INFLATE_FILTER 0
-+#define CONFIG_INTERLACE_FILTER 0
-+#define CONFIG_INTERLACE_VULKAN_FILTER 0
-+#define CONFIG_INTERLEAVE_FILTER 0
-+#define CONFIG_KERNDEINT_FILTER 0
-+#define CONFIG_KIRSCH_FILTER 0
-+#define CONFIG_LAGFUN_FILTER 0
-+#define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
-+#define CONFIG_LENSCORRECTION_FILTER 0
-+#define CONFIG_LENSFUN_FILTER 0
-+#define CONFIG_LIBPLACEBO_FILTER 0
-+#define CONFIG_LIBVMAF_FILTER 0
-+#define CONFIG_LIBVMAF_CUDA_FILTER 0
-+#define CONFIG_LIMITDIFF_FILTER 0
-+#define CONFIG_LIMITER_FILTER 0
-+#define CONFIG_LOOP_FILTER 0
-+#define CONFIG_LUMAKEY_FILTER 0
-+#define CONFIG_LUT_FILTER 0
-+#define CONFIG_LUT1D_FILTER 0
-+#define CONFIG_LUT2_FILTER 0
-+#define CONFIG_LUT3D_FILTER 0
-+#define CONFIG_LUTRGB_FILTER 0
-+#define CONFIG_LUTYUV_FILTER 0
-+#define CONFIG_MASKEDCLAMP_FILTER 0
-+#define CONFIG_MASKEDMAX_FILTER 0
-+#define CONFIG_MASKEDMERGE_FILTER 0
-+#define CONFIG_MASKEDMIN_FILTER 0
-+#define CONFIG_MASKEDTHRESHOLD_FILTER 0
-+#define CONFIG_MASKFUN_FILTER 0
-+#define CONFIG_MCDEINT_FILTER 0
-+#define CONFIG_MEDIAN_FILTER 0
-+#define CONFIG_MERGEPLANES_FILTER 0
-+#define CONFIG_MESTIMATE_FILTER 0
-+#define CONFIG_METADATA_FILTER 0
-+#define CONFIG_MIDEQUALIZER_FILTER 0
-+#define CONFIG_MINTERPOLATE_FILTER 0
-+#define CONFIG_MIX_FILTER 0
-+#define CONFIG_MONOCHROME_FILTER 0
-+#define CONFIG_MORPHO_FILTER 0
-+#define CONFIG_MPDECIMATE_FILTER 0
-+#define CONFIG_MSAD_FILTER 0
-+#define CONFIG_MULTIPLY_FILTER 0
-+#define CONFIG_NEGATE_FILTER 0
-+#define CONFIG_NLMEANS_FILTER 0
-+#define CONFIG_NLMEANS_OPENCL_FILTER 0
-+#define CONFIG_NLMEANS_VULKAN_FILTER 0
-+#define CONFIG_NNEDI_FILTER 0
-+#define CONFIG_NOFORMAT_FILTER 0
-+#define CONFIG_NOISE_FILTER 0
-+#define CONFIG_NORMALIZE_FILTER 0
-+#define CONFIG_NULL_FILTER 0
-+#define CONFIG_OCR_FILTER 0
-+#define CONFIG_OCV_FILTER 0
-+#define CONFIG_OSCILLOSCOPE_FILTER 0
-+#define CONFIG_OVERLAY_FILTER 0
-+#define CONFIG_OVERLAY_OPENCL_FILTER 0
-+#define CONFIG_OVERLAY_QSV_FILTER 0
-+#define CONFIG_OVERLAY_VAAPI_FILTER 0
-+#define CONFIG_OVERLAY_VULKAN_FILTER 0
-+#define CONFIG_OVERLAY_CUDA_FILTER 0
-+#define CONFIG_OWDENOISE_FILTER 0
-+#define CONFIG_PAD_FILTER 0
-+#define CONFIG_PAD_CUDA_FILTER 0
-+#define CONFIG_PAD_OPENCL_FILTER 0
-+#define CONFIG_PALETTEGEN_FILTER 0
-+#define CONFIG_PALETTEUSE_FILTER 0
-+#define CONFIG_PERMS_FILTER 0
-+#define CONFIG_PERSPECTIVE_FILTER 0
-+#define CONFIG_PHASE_FILTER 0
-+#define CONFIG_PHOTOSENSITIVITY_FILTER 0
-+#define CONFIG_PIXDESCTEST_FILTER 0
-+#define CONFIG_PIXELIZE_FILTER 0
-+#define CONFIG_PIXSCOPE_FILTER 0
-+#define CONFIG_PP7_FILTER 0
-+#define CONFIG_PREMULTIPLY_FILTER 0
-+#define CONFIG_PREWITT_FILTER 0
-+#define CONFIG_PREWITT_OPENCL_FILTER 0
-+#define CONFIG_PROCAMP_VAAPI_FILTER 0
-+#define CONFIG_PROGRAM_OPENCL_FILTER 0
-+#define CONFIG_PSEUDOCOLOR_FILTER 0
-+#define CONFIG_PSNR_FILTER 0
-+#define CONFIG_PULLUP_FILTER 0
-+#define CONFIG_QP_FILTER 0
-+#define CONFIG_QRENCODE_FILTER 0
-+#define CONFIG_QUIRC_FILTER 0
-+#define CONFIG_RANDOM_FILTER 0
-+#define CONFIG_READEIA608_FILTER 0
-+#define CONFIG_READVITC_FILTER 0
-+#define CONFIG_REALTIME_FILTER 0
-+#define CONFIG_REMAP_FILTER 0
-+#define CONFIG_REMAP_OPENCL_FILTER 0
-+#define CONFIG_REMOVEGRAIN_FILTER 0
-+#define CONFIG_REMOVELOGO_FILTER 0
-+#define CONFIG_REPEATFIELDS_FILTER 0
-+#define CONFIG_REVERSE_FILTER 0
-+#define CONFIG_RGBASHIFT_FILTER 0
-+#define CONFIG_ROBERTS_FILTER 0
-+#define CONFIG_ROBERTS_OPENCL_FILTER 0
-+#define CONFIG_ROTATE_FILTER 0
-+#define CONFIG_SAB_FILTER 0
-+#define CONFIG_SCALE_FILTER 0
-+#define CONFIG_VPP_AMF_FILTER 0
-+#define CONFIG_SR_AMF_FILTER 0
-+#define CONFIG_SCALE_CUDA_FILTER 0
-+#define CONFIG_SCALE_D3D11_FILTER 0
-+#define CONFIG_SCALE_NPP_FILTER 0
-+#define CONFIG_SCALE_QSV_FILTER 0
-+#define CONFIG_SCALE_VAAPI_FILTER 0
-+#define CONFIG_SCALE_VT_FILTER 0
-+#define CONFIG_SCALE_VULKAN_FILTER 0
-+#define CONFIG_SCALE2REF_FILTER 0
-+#define CONFIG_SCALE2REF_NPP_FILTER 0
-+#define CONFIG_SCDET_FILTER 0
-+#define CONFIG_SCDET_VULKAN_FILTER 0
-+#define CONFIG_SCHARR_FILTER 0
-+#define CONFIG_SCROLL_FILTER 0
-+#define CONFIG_SEGMENT_FILTER 0
-+#define CONFIG_SELECT_FILTER 0
-+#define CONFIG_SELECTIVECOLOR_FILTER 0
-+#define CONFIG_SENDCMD_FILTER 0
-+#define CONFIG_SEPARATEFIELDS_FILTER 0
-+#define CONFIG_SETDAR_FILTER 0
-+#define CONFIG_SETFIELD_FILTER 0
-+#define CONFIG_SETPARAMS_FILTER 0
-+#define CONFIG_SETPTS_FILTER 0
-+#define CONFIG_SETRANGE_FILTER 0
-+#define CONFIG_SETSAR_FILTER 0
-+#define CONFIG_SETTB_FILTER 0
-+#define CONFIG_SHARPEN_NPP_FILTER 0
-+#define CONFIG_SHARPNESS_VAAPI_FILTER 0
-+#define CONFIG_SHEAR_FILTER 0
-+#define CONFIG_SHOWINFO_FILTER 0
-+#define CONFIG_SHOWPALETTE_FILTER 0
-+#define CONFIG_SHUFFLEFRAMES_FILTER 0
-+#define CONFIG_SHUFFLEPIXELS_FILTER 0
-+#define CONFIG_SHUFFLEPLANES_FILTER 0
-+#define CONFIG_SIDEDATA_FILTER 0
-+#define CONFIG_SIGNALSTATS_FILTER 0
-+#define CONFIG_SIGNATURE_FILTER 0
-+#define CONFIG_SITI_FILTER 0
-+#define CONFIG_SMARTBLUR_FILTER 0
-+#define CONFIG_SOBEL_FILTER 0
-+#define CONFIG_SOBEL_OPENCL_FILTER 0
-+#define CONFIG_SPLIT_FILTER 0
-+#define CONFIG_SPP_FILTER 0
-+#define CONFIG_SR_FILTER 0
-+#define CONFIG_SSIM_FILTER 0
-+#define CONFIG_SSIM360_FILTER 0
-+#define CONFIG_STEREO3D_FILTER 0
-+#define CONFIG_STREAMSELECT_FILTER 0
-+#define CONFIG_SUBTITLES_FILTER 0
-+#define CONFIG_SUPER2XSAI_FILTER 0
-+#define CONFIG_SWAPRECT_FILTER 0
-+#define CONFIG_SWAPUV_FILTER 0
-+#define CONFIG_TBLEND_FILTER 0
-+#define CONFIG_TELECINE_FILTER 0
-+#define CONFIG_THISTOGRAM_FILTER 0
-+#define CONFIG_THRESHOLD_FILTER 0
-+#define CONFIG_THUMBNAIL_FILTER 0
-+#define CONFIG_THUMBNAIL_CUDA_FILTER 0
-+#define CONFIG_TILE_FILTER 0
-+#define CONFIG_TILTANDSHIFT_FILTER 0
-+#define CONFIG_TINTERLACE_FILTER 0
-+#define CONFIG_TLUT2_FILTER 0
-+#define CONFIG_TMEDIAN_FILTER 0
-+#define CONFIG_TMIDEQUALIZER_FILTER 0
-+#define CONFIG_TMIX_FILTER 0
-+#define CONFIG_TONEMAP_FILTER 0
-+#define CONFIG_TONEMAP_OPENCL_FILTER 0
-+#define CONFIG_TONEMAP_VAAPI_FILTER 0
-+#define CONFIG_TPAD_FILTER 0
-+#define CONFIG_TRANSPOSE_FILTER 0
-+#define CONFIG_TRANSPOSE_NPP_FILTER 0
-+#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
-+#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
-+#define CONFIG_TRANSPOSE_VT_FILTER 0
-+#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
-+#define CONFIG_TRIM_FILTER 0
-+#define CONFIG_UNPREMULTIPLY_FILTER 0
-+#define CONFIG_UNSHARP_FILTER 0
-+#define CONFIG_UNSHARP_OPENCL_FILTER 0
-+#define CONFIG_UNTILE_FILTER 0
-+#define CONFIG_USPP_FILTER 0
-+#define CONFIG_V360_FILTER 0
-+#define CONFIG_VAGUEDENOISER_FILTER 0
-+#define CONFIG_VARBLUR_FILTER 0
-+#define CONFIG_VECTORSCOPE_FILTER 0
-+#define CONFIG_VFLIP_FILTER 0
-+#define CONFIG_VFLIP_VULKAN_FILTER 0
-+#define CONFIG_VFRDET_FILTER 0
-+#define CONFIG_VIBRANCE_FILTER 0
-+#define CONFIG_VIDSTABDETECT_FILTER 0
-+#define CONFIG_VIDSTABTRANSFORM_FILTER 0
-+#define CONFIG_VIF_FILTER 0
-+#define CONFIG_VIGNETTE_FILTER 0
-+#define CONFIG_VMAFMOTION_FILTER 0
-+#define CONFIG_VPP_QSV_FILTER 0
-+#define CONFIG_VSTACK_FILTER 0
-+#define CONFIG_W3FDIF_FILTER 0
-+#define CONFIG_WAVEFORM_FILTER 0
-+#define CONFIG_WEAVE_FILTER 0
-+#define CONFIG_XBR_FILTER 0
-+#define CONFIG_XCORRELATE_FILTER 0
-+#define CONFIG_XFADE_FILTER 0
-+#define CONFIG_XFADE_OPENCL_FILTER 0
-+#define CONFIG_XFADE_VULKAN_FILTER 0
-+#define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
-+#define CONFIG_XSTACK_FILTER 0
-+#define CONFIG_YADIF_FILTER 0
-+#define CONFIG_YADIF_CUDA_FILTER 0
-+#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
-+#define CONFIG_YAEPBLUR_FILTER 0
-+#define CONFIG_ZMQ_FILTER 0
-+#define CONFIG_ZOOMPAN_FILTER 0
-+#define CONFIG_ZSCALE_FILTER 0
-+#define CONFIG_HSTACK_VAAPI_FILTER 0
-+#define CONFIG_VSTACK_VAAPI_FILTER 0
-+#define CONFIG_XSTACK_VAAPI_FILTER 0
-+#define CONFIG_HSTACK_QSV_FILTER 0
-+#define CONFIG_VSTACK_QSV_FILTER 0
-+#define CONFIG_XSTACK_QSV_FILTER 0
-+#define CONFIG_PAD_VAAPI_FILTER 0
-+#define CONFIG_DRAWBOX_VAAPI_FILTER 0
-+#define CONFIG_ALLRGB_FILTER 0
-+#define CONFIG_ALLYUV_FILTER 0
-+#define CONFIG_CELLAUTO_FILTER 0
-+#define CONFIG_COLOR_FILTER 0
-+#define CONFIG_COLOR_VULKAN_FILTER 0
-+#define CONFIG_COLORCHART_FILTER 0
-+#define CONFIG_COLORSPECTRUM_FILTER 0
-+#define CONFIG_COREIMAGESRC_FILTER 0
-+#define CONFIG_DDAGRAB_FILTER 0
-+#define CONFIG_FREI0R_SRC_FILTER 0
-+#define CONFIG_GRADIENTS_FILTER 0
-+#define CONFIG_HALDCLUTSRC_FILTER 0
-+#define CONFIG_LIFE_FILTER 0
-+#define CONFIG_MANDELBROT_FILTER 0
-+#define CONFIG_MPTESTSRC_FILTER 0
-+#define CONFIG_NULLSRC_FILTER 0
-+#define CONFIG_OPENCLSRC_FILTER 0
-+#define CONFIG_QRENCODESRC_FILTER 0
-+#define CONFIG_PAL75BARS_FILTER 0
-+#define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
-+#define CONFIG_RGBTESTSRC_FILTER 0
-+#define CONFIG_SIERPINSKI_FILTER 0
-+#define CONFIG_SMPTEBARS_FILTER 0
-+#define CONFIG_SMPTEHDBARS_FILTER 0
-+#define CONFIG_TESTSRC_FILTER 0
-+#define CONFIG_TESTSRC2_FILTER 0
-+#define CONFIG_YUVTESTSRC_FILTER 0
-+#define CONFIG_ZONEPLATE_FILTER 0
-+#define CONFIG_NULLSINK_FILTER 0
-+#define CONFIG_A3DSCOPE_FILTER 0
-+#define CONFIG_ABITSCOPE_FILTER 0
-+#define CONFIG_ADRAWGRAPH_FILTER 0
-+#define CONFIG_AGRAPHMONITOR_FILTER 0
-+#define CONFIG_AHISTOGRAM_FILTER 0
-+#define CONFIG_APHASEMETER_FILTER 0
-+#define CONFIG_AVECTORSCOPE_FILTER 0
-+#define CONFIG_CONCAT_FILTER 0
-+#define CONFIG_SHOWCQT_FILTER 0
-+#define CONFIG_SHOWCWT_FILTER 0
-+#define CONFIG_SHOWFREQS_FILTER 0
-+#define CONFIG_SHOWSPATIAL_FILTER 0
-+#define CONFIG_SHOWSPECTRUM_FILTER 0
-+#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
-+#define CONFIG_SHOWVOLUME_FILTER 0
-+#define CONFIG_SHOWWAVES_FILTER 0
-+#define CONFIG_SHOWWAVESPIC_FILTER 0
-+#define CONFIG_SPECTRUMSYNTH_FILTER 0
-+#define CONFIG_AVSYNCTEST_FILTER 0
-+#define CONFIG_AMOVIE_FILTER 0
-+#define CONFIG_MOVIE_FILTER 0
-+#define CONFIG_AA_DEMUXER 0
-+#define CONFIG_AAC_DEMUXER 1
-+#define CONFIG_AAX_DEMUXER 0
-+#define CONFIG_AC3_DEMUXER 0
-+#define CONFIG_AC4_DEMUXER 0
-+#define CONFIG_ACE_DEMUXER 0
-+#define CONFIG_ACM_DEMUXER 0
-+#define CONFIG_ACT_DEMUXER 0
-+#define CONFIG_ADF_DEMUXER 0
-+#define CONFIG_ADP_DEMUXER 0
-+#define CONFIG_ADS_DEMUXER 0
-+#define CONFIG_ADX_DEMUXER 0
-+#define CONFIG_AEA_DEMUXER 0
-+#define CONFIG_AFC_DEMUXER 0
-+#define CONFIG_AIFF_DEMUXER 0
-+#define CONFIG_AIX_DEMUXER 0
-+#define CONFIG_ALP_DEMUXER 0
-+#define CONFIG_AMR_DEMUXER 0
-+#define CONFIG_AMRNB_DEMUXER 0
-+#define CONFIG_AMRWB_DEMUXER 0
-+#define CONFIG_ANM_DEMUXER 0
-+#define CONFIG_APAC_DEMUXER 0
-+#define CONFIG_APC_DEMUXER 0
-+#define CONFIG_APE_DEMUXER 0
-+#define CONFIG_APM_DEMUXER 0
-+#define CONFIG_APNG_DEMUXER 0
-+#define CONFIG_APTX_DEMUXER 0
-+#define CONFIG_APTX_HD_DEMUXER 0
-+#define CONFIG_APV_DEMUXER 0
-+#define CONFIG_AQTITLE_DEMUXER 0
-+#define CONFIG_ARGO_ASF_DEMUXER 0
-+#define CONFIG_ARGO_BRP_DEMUXER 0
-+#define CONFIG_ARGO_CVG_DEMUXER 0
-+#define CONFIG_ASF_DEMUXER 0
-+#define CONFIG_ASF_O_DEMUXER 0
-+#define CONFIG_ASS_DEMUXER 0
-+#define CONFIG_AST_DEMUXER 0
-+#define CONFIG_AU_DEMUXER 0
-+#define CONFIG_AV1_DEMUXER 0
-+#define CONFIG_AVI_DEMUXER 0
-+#define CONFIG_AVR_DEMUXER 0
-+#define CONFIG_AVS_DEMUXER 0
-+#define CONFIG_AVS2_DEMUXER 0
-+#define CONFIG_AVS3_DEMUXER 0
-+#define CONFIG_BETHSOFTVID_DEMUXER 0
-+#define CONFIG_BFI_DEMUXER 0
-+#define CONFIG_BINTEXT_DEMUXER 0
-+#define CONFIG_BINK_DEMUXER 0
-+#define CONFIG_BINKA_DEMUXER 0
-+#define CONFIG_BIT_DEMUXER 0
-+#define CONFIG_BITPACKED_DEMUXER 0
-+#define CONFIG_BMV_DEMUXER 0
-+#define CONFIG_BFSTM_DEMUXER 0
-+#define CONFIG_BRSTM_DEMUXER 0
-+#define CONFIG_BOA_DEMUXER 0
-+#define CONFIG_BONK_DEMUXER 0
-+#define CONFIG_C93_DEMUXER 0
-+#define CONFIG_CAF_DEMUXER 0
-+#define CONFIG_CAVSVIDEO_DEMUXER 0
-+#define CONFIG_CDG_DEMUXER 0
-+#define CONFIG_CDXL_DEMUXER 0
-+#define CONFIG_CINE_DEMUXER 0
-+#define CONFIG_CODEC2_DEMUXER 0
-+#define CONFIG_CODEC2RAW_DEMUXER 0
-+#define CONFIG_CONCAT_DEMUXER 0
-+#define CONFIG_DASH_DEMUXER 0
-+#define CONFIG_DATA_DEMUXER 0
-+#define CONFIG_DAUD_DEMUXER 0
-+#define CONFIG_DCSTR_DEMUXER 0
-+#define CONFIG_DERF_DEMUXER 0
-+#define CONFIG_DFA_DEMUXER 0
-+#define CONFIG_DFPWM_DEMUXER 0
-+#define CONFIG_DHAV_DEMUXER 0
-+#define CONFIG_DIRAC_DEMUXER 0
-+#define CONFIG_DNXHD_DEMUXER 0
-+#define CONFIG_DSF_DEMUXER 0
-+#define CONFIG_DSICIN_DEMUXER 0
-+#define CONFIG_DSS_DEMUXER 0
-+#define CONFIG_DTS_DEMUXER 0
-+#define CONFIG_DTSHD_DEMUXER 0
-+#define CONFIG_DV_DEMUXER 0
-+#define CONFIG_DVBSUB_DEMUXER 0
-+#define CONFIG_DVBTXT_DEMUXER 0
-+#define CONFIG_DXA_DEMUXER 0
-+#define CONFIG_EA_DEMUXER 0
-+#define CONFIG_EA_CDATA_DEMUXER 0
-+#define CONFIG_EAC3_DEMUXER 0
-+#define CONFIG_EPAF_DEMUXER 0
-+#define CONFIG_EVC_DEMUXER 0
-+#define CONFIG_FFMETADATA_DEMUXER 0
-+#define CONFIG_FILMSTRIP_DEMUXER 0
-+#define CONFIG_FITS_DEMUXER 0
-+#define CONFIG_FLAC_DEMUXER 1
-+#define CONFIG_FLIC_DEMUXER 0
-+#define CONFIG_FLV_DEMUXER 0
-+#define CONFIG_LIVE_FLV_DEMUXER 0
-+#define CONFIG_FOURXM_DEMUXER 0
-+#define CONFIG_FRM_DEMUXER 0
-+#define CONFIG_FSB_DEMUXER 0
-+#define CONFIG_FWSE_DEMUXER 0
-+#define CONFIG_G722_DEMUXER 0
-+#define CONFIG_G723_1_DEMUXER 0
-+#define CONFIG_G726_DEMUXER 0
-+#define CONFIG_G726LE_DEMUXER 0
-+#define CONFIG_G728_DEMUXER 0
-+#define CONFIG_G729_DEMUXER 0
-+#define CONFIG_GDV_DEMUXER 0
-+#define CONFIG_GENH_DEMUXER 0
-+#define CONFIG_GIF_DEMUXER 0
-+#define CONFIG_GSM_DEMUXER 0
-+#define CONFIG_GXF_DEMUXER 0
-+#define CONFIG_H261_DEMUXER 0
-+#define CONFIG_H263_DEMUXER 0
-+#define CONFIG_H264_DEMUXER 0
-+#define CONFIG_HCA_DEMUXER 0
-+#define CONFIG_HCOM_DEMUXER 0
-+#define CONFIG_HEVC_DEMUXER 0
-+#define CONFIG_HLS_DEMUXER 0
-+#define CONFIG_HNM_DEMUXER 0
-+#define CONFIG_IAMF_DEMUXER 0
-+#define CONFIG_ICO_DEMUXER 0
-+#define CONFIG_IDCIN_DEMUXER 0
-+#define CONFIG_IDF_DEMUXER 0
-+#define CONFIG_IFF_DEMUXER 0
-+#define CONFIG_IFV_DEMUXER 0
-+#define CONFIG_ILBC_DEMUXER 0
-+#define CONFIG_IMAGE2_DEMUXER 0
-+#define CONFIG_IMAGE2PIPE_DEMUXER 0
-+#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
-+#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
-+#define CONFIG_IMF_DEMUXER 0
-+#define CONFIG_INGENIENT_DEMUXER 0
-+#define CONFIG_IPMOVIE_DEMUXER 0
-+#define CONFIG_IPU_DEMUXER 0
-+#define CONFIG_IRCAM_DEMUXER 0
-+#define CONFIG_ISS_DEMUXER 0
-+#define CONFIG_IV8_DEMUXER 0
-+#define CONFIG_IVF_DEMUXER 0
-+#define CONFIG_IVR_DEMUXER 0
-+#define CONFIG_JACOSUB_DEMUXER 0
-+#define CONFIG_JV_DEMUXER 0
-+#define CONFIG_JPEGXL_ANIM_DEMUXER 0
-+#define CONFIG_KUX_DEMUXER 0
-+#define CONFIG_KVAG_DEMUXER 0
-+#define CONFIG_LAF_DEMUXER 0
-+#define CONFIG_LC3_DEMUXER 0
-+#define CONFIG_LMLM4_DEMUXER 0
-+#define CONFIG_LOAS_DEMUXER 0
-+#define CONFIG_LUODAT_DEMUXER 0
-+#define CONFIG_LRC_DEMUXER 0
-+#define CONFIG_LVF_DEMUXER 0
-+#define CONFIG_LXF_DEMUXER 0
-+#define CONFIG_M4V_DEMUXER 0
-+#define CONFIG_MCA_DEMUXER 0
-+#define CONFIG_MCC_DEMUXER 0
-+#define CONFIG_MATROSKA_DEMUXER 1
-+#define CONFIG_MGSTS_DEMUXER 0
-+#define CONFIG_MICRODVD_DEMUXER 0
-+#define CONFIG_MJPEG_DEMUXER 0
-+#define CONFIG_MJPEG_2000_DEMUXER 0
-+#define CONFIG_MLP_DEMUXER 0
-+#define CONFIG_MLV_DEMUXER 0
-+#define CONFIG_MM_DEMUXER 0
-+#define CONFIG_MMF_DEMUXER 0
-+#define CONFIG_MODS_DEMUXER 0
-+#define CONFIG_MOFLEX_DEMUXER 0
-+#define CONFIG_MOV_DEMUXER 1
-+#define CONFIG_MP3_DEMUXER 1
-+#define CONFIG_MPC_DEMUXER 0
-+#define CONFIG_MPC8_DEMUXER 0
-+#define CONFIG_MPEGPS_DEMUXER 0
-+#define CONFIG_MPEGTS_DEMUXER 0
-+#define CONFIG_MPEGTSRAW_DEMUXER 0
-+#define CONFIG_MPEGVIDEO_DEMUXER 0
-+#define CONFIG_MPJPEG_DEMUXER 0
-+#define CONFIG_MPL2_DEMUXER 0
-+#define CONFIG_MPSUB_DEMUXER 0
-+#define CONFIG_MSF_DEMUXER 0
-+#define CONFIG_MSNWC_TCP_DEMUXER 0
-+#define CONFIG_MSP_DEMUXER 0
-+#define CONFIG_MTAF_DEMUXER 0
-+#define CONFIG_MTV_DEMUXER 0
-+#define CONFIG_MUSX_DEMUXER 0
-+#define CONFIG_MV_DEMUXER 0
-+#define CONFIG_MVI_DEMUXER 0
-+#define CONFIG_MXF_DEMUXER 0
-+#define CONFIG_MXG_DEMUXER 0
-+#define CONFIG_NC_DEMUXER 0
-+#define CONFIG_NISTSPHERE_DEMUXER 0
-+#define CONFIG_NSP_DEMUXER 0
-+#define CONFIG_NSV_DEMUXER 0
-+#define CONFIG_NUT_DEMUXER 0
-+#define CONFIG_NUV_DEMUXER 0
-+#define CONFIG_OBU_DEMUXER 0
-+#define CONFIG_OGG_DEMUXER 1
-+#define CONFIG_OMA_DEMUXER 0
-+#define CONFIG_OSQ_DEMUXER 0
-+#define CONFIG_PAF_DEMUXER 0
-+#define CONFIG_PCM_ALAW_DEMUXER 0
-+#define CONFIG_PCM_MULAW_DEMUXER 0
-+#define CONFIG_PCM_VIDC_DEMUXER 0
-+#define CONFIG_PCM_F64BE_DEMUXER 0
-+#define CONFIG_PCM_F64LE_DEMUXER 0
-+#define CONFIG_PCM_F32BE_DEMUXER 0
-+#define CONFIG_PCM_F32LE_DEMUXER 0
-+#define CONFIG_PCM_S32BE_DEMUXER 0
-+#define CONFIG_PCM_S32LE_DEMUXER 0
-+#define CONFIG_PCM_S24BE_DEMUXER 0
-+#define CONFIG_PCM_S24LE_DEMUXER 0
-+#define CONFIG_PCM_S16BE_DEMUXER 0
-+#define CONFIG_PCM_S16LE_DEMUXER 0
-+#define CONFIG_PCM_S8_DEMUXER 0
-+#define CONFIG_PCM_U32BE_DEMUXER 0
-+#define CONFIG_PCM_U32LE_DEMUXER 0
-+#define CONFIG_PCM_U24BE_DEMUXER 0
-+#define CONFIG_PCM_U24LE_DEMUXER 0
-+#define CONFIG_PCM_U16BE_DEMUXER 0
-+#define CONFIG_PCM_U16LE_DEMUXER 0
-+#define CONFIG_PCM_U8_DEMUXER 0
-+#define CONFIG_PDV_DEMUXER 0
-+#define CONFIG_PJS_DEMUXER 0
-+#define CONFIG_PMP_DEMUXER 0
-+#define CONFIG_PP_BNK_DEMUXER 0
-+#define CONFIG_PVA_DEMUXER 0
-+#define CONFIG_PVF_DEMUXER 0
-+#define CONFIG_QCP_DEMUXER 0
-+#define CONFIG_QOA_DEMUXER 0
-+#define CONFIG_R3D_DEMUXER 0
-+#define CONFIG_RAWVIDEO_DEMUXER 0
-+#define CONFIG_RCWT_DEMUXER 0
-+#define CONFIG_REALTEXT_DEMUXER 0
-+#define CONFIG_REDSPARK_DEMUXER 0
-+#define CONFIG_RKA_DEMUXER 0
-+#define CONFIG_RL2_DEMUXER 0
-+#define CONFIG_RM_DEMUXER 0
-+#define CONFIG_ROQ_DEMUXER 0
-+#define CONFIG_RPL_DEMUXER 0
-+#define CONFIG_RSD_DEMUXER 0
-+#define CONFIG_RSO_DEMUXER 0
-+#define CONFIG_RTP_DEMUXER 0
-+#define CONFIG_RTSP_DEMUXER 0
-+#define CONFIG_S337M_DEMUXER 0
-+#define CONFIG_SAMI_DEMUXER 0
-+#define CONFIG_SAP_DEMUXER 0
-+#define CONFIG_SBC_DEMUXER 0
-+#define CONFIG_SBG_DEMUXER 0
-+#define CONFIG_SCC_DEMUXER 0
-+#define CONFIG_SCD_DEMUXER 0
-+#define CONFIG_SDNS_DEMUXER 0
-+#define CONFIG_SDP_DEMUXER 0
-+#define CONFIG_SDR2_DEMUXER 0
-+#define CONFIG_SDS_DEMUXER 0
-+#define CONFIG_SDX_DEMUXER 0
-+#define CONFIG_SEGAFILM_DEMUXER 0
-+#define CONFIG_SER_DEMUXER 0
-+#define CONFIG_SGA_DEMUXER 0
-+#define CONFIG_SHORTEN_DEMUXER 0
-+#define CONFIG_SIFF_DEMUXER 0
-+#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
-+#define CONFIG_SLN_DEMUXER 0
-+#define CONFIG_SMACKER_DEMUXER 0
-+#define CONFIG_SMJPEG_DEMUXER 0
-+#define CONFIG_SMUSH_DEMUXER 0
-+#define CONFIG_SOL_DEMUXER 0
-+#define CONFIG_SOX_DEMUXER 0
-+#define CONFIG_SPDIF_DEMUXER 0
-+#define CONFIG_SRT_DEMUXER 0
-+#define CONFIG_STR_DEMUXER 0
-+#define CONFIG_STL_DEMUXER 0
-+#define CONFIG_SUBVIEWER1_DEMUXER 0
-+#define CONFIG_SUBVIEWER_DEMUXER 0
-+#define CONFIG_SUP_DEMUXER 0
-+#define CONFIG_SVAG_DEMUXER 0
-+#define CONFIG_SVS_DEMUXER 0
-+#define CONFIG_SWF_DEMUXER 0
-+#define CONFIG_TAK_DEMUXER 0
-+#define CONFIG_TEDCAPTIONS_DEMUXER 0
-+#define CONFIG_THP_DEMUXER 0
-+#define CONFIG_THREEDOSTR_DEMUXER 0
-+#define CONFIG_TIERTEXSEQ_DEMUXER 0
-+#define CONFIG_TMV_DEMUXER 0
-+#define CONFIG_TRUEHD_DEMUXER 0
-+#define CONFIG_TTA_DEMUXER 0
-+#define CONFIG_TXD_DEMUXER 0
-+#define CONFIG_TTY_DEMUXER 0
-+#define CONFIG_TY_DEMUXER 0
-+#define CONFIG_USM_DEMUXER 0
-+#define CONFIG_V210_DEMUXER 0
-+#define CONFIG_V210X_DEMUXER 0
-+#define CONFIG_VAG_DEMUXER 0
-+#define CONFIG_VC1_DEMUXER 0
-+#define CONFIG_VC1T_DEMUXER 0
-+#define CONFIG_VIVIDAS_DEMUXER 0
-+#define CONFIG_VIVO_DEMUXER 0
-+#define CONFIG_VMD_DEMUXER 0
-+#define CONFIG_VOBSUB_DEMUXER 0
-+#define CONFIG_VOC_DEMUXER 0
-+#define CONFIG_VPK_DEMUXER 0
-+#define CONFIG_VPLAYER_DEMUXER 0
-+#define CONFIG_VQF_DEMUXER 0
-+#define CONFIG_VVC_DEMUXER 0
-+#define CONFIG_W64_DEMUXER 0
-+#define CONFIG_WADY_DEMUXER 0
-+#define CONFIG_WAVARC_DEMUXER 0
-+#define CONFIG_WAV_DEMUXER 1
-+#define CONFIG_WC3_DEMUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
-+#define CONFIG_WEBVTT_DEMUXER 0
-+#define CONFIG_WSAUD_DEMUXER 0
-+#define CONFIG_WSD_DEMUXER 0
-+#define CONFIG_WSVQA_DEMUXER 0
-+#define CONFIG_WTV_DEMUXER 0
-+#define CONFIG_WVE_DEMUXER 0
-+#define CONFIG_WV_DEMUXER 0
-+#define CONFIG_XA_DEMUXER 0
-+#define CONFIG_XBIN_DEMUXER 0
-+#define CONFIG_XMD_DEMUXER 0
-+#define CONFIG_XMV_DEMUXER 0
-+#define CONFIG_XVAG_DEMUXER 0
-+#define CONFIG_XWMA_DEMUXER 0
-+#define CONFIG_YOP_DEMUXER 0
-+#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
-+#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
-+#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
-+#define CONFIG_AVISYNTH_DEMUXER 0
-+#define CONFIG_DVDVIDEO_DEMUXER 0
-+#define CONFIG_LIBGME_DEMUXER 0
-+#define CONFIG_LIBMODPLUG_DEMUXER 0
-+#define CONFIG_LIBOPENMPT_DEMUXER 0
-+#define CONFIG_VAPOURSYNTH_DEMUXER 0
-+#define CONFIG_A64_MUXER 0
-+#define CONFIG_AC3_MUXER 0
-+#define CONFIG_AC4_MUXER 0
-+#define CONFIG_ADTS_MUXER 0
-+#define CONFIG_ADX_MUXER 0
-+#define CONFIG_AEA_MUXER 0
-+#define CONFIG_AIFF_MUXER 0
-+#define CONFIG_ALP_MUXER 0
-+#define CONFIG_AMR_MUXER 0
-+#define CONFIG_AMV_MUXER 0
-+#define CONFIG_APM_MUXER 0
-+#define CONFIG_APNG_MUXER 0
-+#define CONFIG_APTX_MUXER 0
-+#define CONFIG_APTX_HD_MUXER 0
-+#define CONFIG_APV_MUXER 0
-+#define CONFIG_ARGO_ASF_MUXER 0
-+#define CONFIG_ARGO_CVG_MUXER 0
-+#define CONFIG_ASF_MUXER 0
-+#define CONFIG_ASS_MUXER 0
-+#define CONFIG_AST_MUXER 0
-+#define CONFIG_ASF_STREAM_MUXER 0
-+#define CONFIG_AU_MUXER 0
-+#define CONFIG_AVI_MUXER 0
-+#define CONFIG_AVIF_MUXER 0
-+#define CONFIG_AVM2_MUXER 0
-+#define CONFIG_AVS2_MUXER 0
-+#define CONFIG_AVS3_MUXER 0
-+#define CONFIG_BIT_MUXER 0
-+#define CONFIG_CAF_MUXER 0
-+#define CONFIG_CAVSVIDEO_MUXER 0
-+#define CONFIG_CODEC2_MUXER 0
-+#define CONFIG_CODEC2RAW_MUXER 0
-+#define CONFIG_CRC_MUXER 0
-+#define CONFIG_DASH_MUXER 0
-+#define CONFIG_DATA_MUXER 0
-+#define CONFIG_DAUD_MUXER 0
-+#define CONFIG_DFPWM_MUXER 0
-+#define CONFIG_DIRAC_MUXER 0
-+#define CONFIG_DNXHD_MUXER 0
-+#define CONFIG_DTS_MUXER 0
-+#define CONFIG_DV_MUXER 0
-+#define CONFIG_EAC3_MUXER 0
-+#define CONFIG_EVC_MUXER 0
-+#define CONFIG_F4V_MUXER 0
-+#define CONFIG_FFMETADATA_MUXER 0
-+#define CONFIG_FIFO_MUXER 0
-+#define CONFIG_FILMSTRIP_MUXER 0
-+#define CONFIG_FITS_MUXER 0
-+#define CONFIG_FLAC_MUXER 0
-+#define CONFIG_FLV_MUXER 0
-+#define CONFIG_FRAMECRC_MUXER 0
-+#define CONFIG_FRAMEHASH_MUXER 0
-+#define CONFIG_FRAMEMD5_MUXER 0
-+#define CONFIG_G722_MUXER 0
-+#define CONFIG_G723_1_MUXER 0
-+#define CONFIG_G726_MUXER 0
-+#define CONFIG_G726LE_MUXER 0
-+#define CONFIG_GIF_MUXER 0
-+#define CONFIG_GSM_MUXER 0
-+#define CONFIG_GXF_MUXER 0
-+#define CONFIG_H261_MUXER 0
-+#define CONFIG_H263_MUXER 0
-+#define CONFIG_H264_MUXER 0
-+#define CONFIG_HASH_MUXER 0
-+#define CONFIG_HDS_MUXER 0
-+#define CONFIG_HEVC_MUXER 0
-+#define CONFIG_HLS_MUXER 0
-+#define CONFIG_IAMF_MUXER 0
-+#define CONFIG_ICO_MUXER 0
-+#define CONFIG_ILBC_MUXER 0
-+#define CONFIG_IMAGE2_MUXER 0
-+#define CONFIG_IMAGE2PIPE_MUXER 0
-+#define CONFIG_IPOD_MUXER 0
-+#define CONFIG_IRCAM_MUXER 0
-+#define CONFIG_ISMV_MUXER 0
-+#define CONFIG_IVF_MUXER 0
-+#define CONFIG_JACOSUB_MUXER 0
-+#define CONFIG_KVAG_MUXER 0
-+#define CONFIG_LATM_MUXER 0
-+#define CONFIG_LC3_MUXER 0
-+#define CONFIG_LRC_MUXER 0
-+#define CONFIG_M4V_MUXER 0
-+#define CONFIG_MCC_MUXER 0
-+#define CONFIG_MD5_MUXER 0
-+#define CONFIG_MATROSKA_MUXER 0
-+#define CONFIG_MATROSKA_AUDIO_MUXER 0
-+#define CONFIG_MICRODVD_MUXER 0
-+#define CONFIG_MJPEG_MUXER 0
-+#define CONFIG_MLP_MUXER 0
-+#define CONFIG_MMF_MUXER 0
-+#define CONFIG_MOV_MUXER 0
-+#define CONFIG_MP2_MUXER 0
-+#define CONFIG_MP3_MUXER 0
-+#define CONFIG_MP4_MUXER 0
-+#define CONFIG_MPEG1SYSTEM_MUXER 0
-+#define CONFIG_MPEG1VCD_MUXER 0
-+#define CONFIG_MPEG1VIDEO_MUXER 0
-+#define CONFIG_MPEG2DVD_MUXER 0
-+#define CONFIG_MPEG2SVCD_MUXER 0
-+#define CONFIG_MPEG2VIDEO_MUXER 0
-+#define CONFIG_MPEG2VOB_MUXER 0
-+#define CONFIG_MPEGTS_MUXER 0
-+#define CONFIG_MPJPEG_MUXER 0
-+#define CONFIG_MXF_MUXER 0
-+#define CONFIG_MXF_D10_MUXER 0
-+#define CONFIG_MXF_OPATOM_MUXER 0
-+#define CONFIG_NULL_MUXER 0
-+#define CONFIG_NUT_MUXER 0
-+#define CONFIG_OBU_MUXER 0
-+#define CONFIG_OGA_MUXER 0
-+#define CONFIG_OGG_MUXER 0
-+#define CONFIG_OGV_MUXER 0
-+#define CONFIG_OMA_MUXER 0
-+#define CONFIG_OPUS_MUXER 0
-+#define CONFIG_PCM_ALAW_MUXER 0
-+#define CONFIG_PCM_MULAW_MUXER 0
-+#define CONFIG_PCM_VIDC_MUXER 0
-+#define CONFIG_PCM_F64BE_MUXER 0
-+#define CONFIG_PCM_F64LE_MUXER 0
-+#define CONFIG_PCM_F32BE_MUXER 0
-+#define CONFIG_PCM_F32LE_MUXER 0
-+#define CONFIG_PCM_S32BE_MUXER 0
-+#define CONFIG_PCM_S32LE_MUXER 0
-+#define CONFIG_PCM_S24BE_MUXER 0
-+#define CONFIG_PCM_S24LE_MUXER 0
-+#define CONFIG_PCM_S16BE_MUXER 0
-+#define CONFIG_PCM_S16LE_MUXER 0
-+#define CONFIG_PCM_S8_MUXER 0
-+#define CONFIG_PCM_U32BE_MUXER 0
-+#define CONFIG_PCM_U32LE_MUXER 0
-+#define CONFIG_PCM_U24BE_MUXER 0
-+#define CONFIG_PCM_U24LE_MUXER 0
-+#define CONFIG_PCM_U16BE_MUXER 0
-+#define CONFIG_PCM_U16LE_MUXER 0
-+#define CONFIG_PCM_U8_MUXER 0
-+#define CONFIG_PSP_MUXER 0
-+#define CONFIG_RAWVIDEO_MUXER 0
-+#define CONFIG_RCWT_MUXER 0
-+#define CONFIG_RM_MUXER 0
-+#define CONFIG_ROQ_MUXER 0
-+#define CONFIG_RSO_MUXER 0
-+#define CONFIG_RTP_MUXER 0
-+#define CONFIG_RTP_MPEGTS_MUXER 0
-+#define CONFIG_RTSP_MUXER 0
-+#define CONFIG_SAP_MUXER 0
-+#define CONFIG_SBC_MUXER 0
-+#define CONFIG_SCC_MUXER 0
-+#define CONFIG_SEGAFILM_MUXER 0
-+#define CONFIG_SEGMENT_MUXER 0
-+#define CONFIG_STREAM_SEGMENT_MUXER 0
-+#define CONFIG_SMJPEG_MUXER 0
-+#define CONFIG_SMOOTHSTREAMING_MUXER 0
-+#define CONFIG_SOX_MUXER 0
-+#define CONFIG_SPX_MUXER 0
-+#define CONFIG_SPDIF_MUXER 0
-+#define CONFIG_SRT_MUXER 0
-+#define CONFIG_STREAMHASH_MUXER 0
-+#define CONFIG_SUP_MUXER 0
-+#define CONFIG_SWF_MUXER 0
-+#define CONFIG_TEE_MUXER 0
-+#define CONFIG_TG2_MUXER 0
-+#define CONFIG_TGP_MUXER 0
-+#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
-+#define CONFIG_TRUEHD_MUXER 0
-+#define CONFIG_TTA_MUXER 0
-+#define CONFIG_TTML_MUXER 0
-+#define CONFIG_UNCODEDFRAMECRC_MUXER 0
-+#define CONFIG_VC1_MUXER 0
-+#define CONFIG_VC1T_MUXER 0
-+#define CONFIG_VOC_MUXER 0
-+#define CONFIG_VVC_MUXER 0
-+#define CONFIG_W64_MUXER 0
-+#define CONFIG_WAV_MUXER 0
-+#define CONFIG_WEBM_MUXER 0
-+#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
-+#define CONFIG_WEBM_CHUNK_MUXER 0
-+#define CONFIG_WEBP_MUXER 0
-+#define CONFIG_WEBVTT_MUXER 0
-+#define CONFIG_WHIP_MUXER 0
-+#define CONFIG_WSAUD_MUXER 0
-+#define CONFIG_WTV_MUXER 0
-+#define CONFIG_WV_MUXER 0
-+#define CONFIG_YUV4MPEGPIPE_MUXER 0
-+#define CONFIG_CHROMAPRINT_MUXER 0
-+#define CONFIG_ANDROID_CONTENT_PROTOCOL 0
-+#define CONFIG_ASYNC_PROTOCOL 0
-+#define CONFIG_BLURAY_PROTOCOL 0
-+#define CONFIG_CACHE_PROTOCOL 0
-+#define CONFIG_CONCAT_PROTOCOL 0
-+#define CONFIG_CONCATF_PROTOCOL 0
-+#define CONFIG_CRYPTO_PROTOCOL 0
-+#define CONFIG_DATA_PROTOCOL 0
-+#define CONFIG_FD_PROTOCOL 0
-+#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
-+#define CONFIG_FFRTMPHTTP_PROTOCOL 0
-+#define CONFIG_FILE_PROTOCOL 0
-+#define CONFIG_FTP_PROTOCOL 0
-+#define CONFIG_GOPHER_PROTOCOL 0
-+#define CONFIG_GOPHERS_PROTOCOL 0
-+#define CONFIG_HLS_PROTOCOL 0
-+#define CONFIG_HTTP_PROTOCOL 0
-+#define CONFIG_HTTPPROXY_PROTOCOL 0
-+#define CONFIG_HTTPS_PROTOCOL 0
-+#define CONFIG_ICECAST_PROTOCOL 0
-+#define CONFIG_MMSH_PROTOCOL 0
-+#define CONFIG_MMST_PROTOCOL 0
-+#define CONFIG_MD5_PROTOCOL 0
-+#define CONFIG_PIPE_PROTOCOL 0
-+#define CONFIG_PROMPEG_PROTOCOL 0
-+#define CONFIG_RTMP_PROTOCOL 0
-+#define CONFIG_RTMPE_PROTOCOL 0
-+#define CONFIG_RTMPS_PROTOCOL 0
-+#define CONFIG_RTMPT_PROTOCOL 0
-+#define CONFIG_RTMPTE_PROTOCOL 0
-+#define CONFIG_RTMPTS_PROTOCOL 0
-+#define CONFIG_RTP_PROTOCOL 0
-+#define CONFIG_SCTP_PROTOCOL 0
-+#define CONFIG_SRTP_PROTOCOL 0
-+#define CONFIG_SUBFILE_PROTOCOL 0
-+#define CONFIG_TEE_PROTOCOL 0
-+#define CONFIG_TCP_PROTOCOL 0
-+#define CONFIG_TLS_PROTOCOL 0
-+#define CONFIG_DTLS_PROTOCOL 0
-+#define CONFIG_UDP_PROTOCOL 0
-+#define CONFIG_UDPLITE_PROTOCOL 0
-+#define CONFIG_UNIX_PROTOCOL 0
-+#define CONFIG_LIBAMQP_PROTOCOL 0
-+#define CONFIG_LIBRIST_PROTOCOL 0
-+#define CONFIG_LIBRTMP_PROTOCOL 0
-+#define CONFIG_LIBRTMPE_PROTOCOL 0
-+#define CONFIG_LIBRTMPS_PROTOCOL 0
-+#define CONFIG_LIBRTMPT_PROTOCOL 0
-+#define CONFIG_LIBRTMPTE_PROTOCOL 0
-+#define CONFIG_LIBSRT_PROTOCOL 0
-+#define CONFIG_LIBSSH_PROTOCOL 0
-+#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
-+#define CONFIG_LIBZMQ_PROTOCOL 0
-+#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
-+#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
-+#endif /* FFMPEG_CONFIG_COMPONENTS_H */
++#endif /* FFMPEG_CONFIG_H */
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
+new file mode 100644
+index 0000000000..42ac0a52ec
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
+@@ -0,0 +1,2188 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_COMPONENTS_H
 +#define FFMPEG_CONFIG_COMPONENTS_H
@@ -10773,7 +4429,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_PRORES_METADATA_BSF 0
 +#define CONFIG_REMOVE_EXTRADATA_BSF 0
 +#define CONFIG_SETTS_BSF 0
-+#define CONFIG_SHOWINFO_BSF 0
 +#define CONFIG_TEXT2MOVSUB_BSF 0
 +#define CONFIG_TRACE_HEADERS_BSF 0
 +#define CONFIG_TRUEHD_CORE_BSF 0
@@ -10868,7 +4523,7 @@ index 0000000000..a3b50bec45
 +#define CONFIG_H263I_DECODER 0
 +#define CONFIG_H263P_DECODER 0
 +#define CONFIG_H263_V4L2M2M_DECODER 0
-+#define CONFIG_H264_DECODER 0
++#define CONFIG_H264_DECODER 1
 +#define CONFIG_H264_CRYSTALHD_DECODER 0
 +#define CONFIG_H264_V4L2M2M_DECODER 0
 +#define CONFIG_H264_MEDIACODEC_DECODER 0
@@ -10901,7 +4556,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_KGV1_DECODER 0
 +#define CONFIG_KMVC_DECODER 0
 +#define CONFIG_LAGARITH_DECODER 0
-+#define CONFIG_LEAD_DECODER 0
 +#define CONFIG_LOCO_DECODER 0
 +#define CONFIG_LSCR_DECODER 0
 +#define CONFIG_M101_DECODER 0
@@ -11009,7 +4663,7 @@ index 0000000000..a3b50bec45
 +#define CONFIG_TARGA_DECODER 0
 +#define CONFIG_TARGA_Y216_DECODER 0
 +#define CONFIG_TDSC_DECODER 0
-+#define CONFIG_THEORA_DECODER 0
++#define CONFIG_THEORA_DECODER 1
 +#define CONFIG_THP_DECODER 0
 +#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
 +#define CONFIG_TIFF_DECODER 0
@@ -11040,14 +4694,14 @@ index 0000000000..a3b50bec45
 +#define CONFIG_VMDVIDEO_DECODER 0
 +#define CONFIG_VMIX_DECODER 0
 +#define CONFIG_VMNC_DECODER 0
-+#define CONFIG_VP3_DECODER 0
++#define CONFIG_VP3_DECODER 1
 +#define CONFIG_VP4_DECODER 0
 +#define CONFIG_VP5_DECODER 0
 +#define CONFIG_VP6_DECODER 0
 +#define CONFIG_VP6A_DECODER 0
 +#define CONFIG_VP6F_DECODER 0
 +#define CONFIG_VP7_DECODER 0
-+#define CONFIG_VP8_DECODER 0
++#define CONFIG_VP8_DECODER 1
 +#define CONFIG_VP8_RKMPP_DECODER 0
 +#define CONFIG_VP8_V4L2M2M_DECODER 0
 +#define CONFIG_VP9_DECODER 0
@@ -11055,7 +4709,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_VP9_V4L2M2M_DECODER 0
 +#define CONFIG_VQA_DECODER 0
 +#define CONFIG_VQC_DECODER 0
-+#define CONFIG_VVC_DECODER 0
 +#define CONFIG_WBMP_DECODER 0
 +#define CONFIG_WEBP_DECODER 0
 +#define CONFIG_WCMV_DECODER 0
@@ -11081,7 +4734,7 @@ index 0000000000..a3b50bec45
 +#define CONFIG_ZEROCODEC_DECODER 0
 +#define CONFIG_ZLIB_DECODER 0
 +#define CONFIG_ZMBV_DECODER 0
-+#define CONFIG_AAC_DECODER 0
++#define CONFIG_AAC_DECODER 1
 +#define CONFIG_AAC_FIXED_DECODER 0
 +#define CONFIG_AAC_LATM_DECODER 0
 +#define CONFIG_AC3_DECODER 0
@@ -11154,12 +4807,10 @@ index 0000000000..a3b50bec45
 +#define CONFIG_NELLYMOSER_DECODER 0
 +#define CONFIG_ON2AVC_DECODER 0
 +#define CONFIG_OPUS_DECODER 0
-+#define CONFIG_OSQ_DECODER 0
 +#define CONFIG_PAF_AUDIO_DECODER 0
 +#define CONFIG_QCELP_DECODER 0
 +#define CONFIG_QDM2_DECODER 0
 +#define CONFIG_QDMC_DECODER 0
-+#define CONFIG_QOA_DECODER 0
 +#define CONFIG_RA_144_DECODER 0
 +#define CONFIG_RA_288_DECODER 0
 +#define CONFIG_RALF_DECODER 0
@@ -11339,7 +4990,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_LIBVORBIS_DECODER 0
 +#define CONFIG_LIBVPX_VP8_DECODER 0
 +#define CONFIG_LIBVPX_VP9_DECODER 0
-+#define CONFIG_LIBXEVD_DECODER 0
 +#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
 +#define CONFIG_BINTEXT_DECODER 0
 +#define CONFIG_XBIN_DECODER 0
@@ -11387,7 +5037,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_DNXHD_ENCODER 0
 +#define CONFIG_DPX_ENCODER 0
 +#define CONFIG_DVVIDEO_ENCODER 0
-+#define CONFIG_DXV_ENCODER 0
 +#define CONFIG_EXR_ENCODER 0
 +#define CONFIG_FFV1_ENCODER 0
 +#define CONFIG_FFVHUFF_ENCODER 0
@@ -11579,7 +5228,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_LIBX264_ENCODER 0
 +#define CONFIG_LIBX264RGB_ENCODER 0
 +#define CONFIG_LIBX265_ENCODER 0
-+#define CONFIG_LIBXEVE_ENCODER 0
 +#define CONFIG_LIBXAVS_ENCODER 0
 +#define CONFIG_LIBXAVS2_ENCODER 0
 +#define CONFIG_LIBXVID_ENCODER 0
@@ -11590,7 +5238,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_AV1_NVENC_ENCODER 0
 +#define CONFIG_AV1_QSV_ENCODER 0
 +#define CONFIG_AV1_AMF_ENCODER 0
-+#define CONFIG_AV1_VAAPI_ENCODER 0
 +#define CONFIG_LIBOPENH264_ENCODER 0
 +#define CONFIG_H264_AMF_ENCODER 0
 +#define CONFIG_H264_MF_ENCODER 0
@@ -11628,7 +5275,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_ANULL_ENCODER 0
 +#define CONFIG_AV1_D3D11VA_HWACCEL 0
 +#define CONFIG_AV1_D3D11VA2_HWACCEL 0
-+#define CONFIG_AV1_D3D12VA_HWACCEL 0
 +#define CONFIG_AV1_DXVA2_HWACCEL 0
 +#define CONFIG_AV1_NVDEC_HWACCEL 0
 +#define CONFIG_AV1_VAAPI_HWACCEL 0
@@ -11638,7 +5284,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_H264_D3D11VA_HWACCEL 0
 +#define CONFIG_H264_D3D11VA2_HWACCEL 0
-+#define CONFIG_H264_D3D12VA_HWACCEL 0
 +#define CONFIG_H264_DXVA2_HWACCEL 0
 +#define CONFIG_H264_NVDEC_HWACCEL 0
 +#define CONFIG_H264_VAAPI_HWACCEL 0
@@ -11647,7 +5292,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_H264_VULKAN_HWACCEL 0
 +#define CONFIG_HEVC_D3D11VA_HWACCEL 0
 +#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
-+#define CONFIG_HEVC_D3D12VA_HWACCEL 0
 +#define CONFIG_HEVC_DXVA2_HWACCEL 0
 +#define CONFIG_HEVC_NVDEC_HWACCEL 0
 +#define CONFIG_HEVC_VAAPI_HWACCEL 0
@@ -11661,9 +5305,8 @@ index 0000000000..a3b50bec45
 +#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
 +#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
-+#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
-+#define CONFIG_MPEG2_DXVA2_HWACCEL 0
 +#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
 +#define CONFIG_MPEG2_VAAPI_HWACCEL 0
 +#define CONFIG_MPEG2_VDPAU_HWACCEL 0
 +#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
@@ -11674,7 +5317,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_VC1_D3D11VA_HWACCEL 0
 +#define CONFIG_VC1_D3D11VA2_HWACCEL 0
-+#define CONFIG_VC1_D3D12VA_HWACCEL 0
 +#define CONFIG_VC1_DXVA2_HWACCEL 0
 +#define CONFIG_VC1_NVDEC_HWACCEL 0
 +#define CONFIG_VC1_VAAPI_HWACCEL 0
@@ -11683,7 +5325,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_VP8_VAAPI_HWACCEL 0
 +#define CONFIG_VP9_D3D11VA_HWACCEL 0
 +#define CONFIG_VP9_D3D11VA2_HWACCEL 0
-+#define CONFIG_VP9_D3D12VA_HWACCEL 0
 +#define CONFIG_VP9_DXVA2_HWACCEL 0
 +#define CONFIG_VP9_NVDEC_HWACCEL 0
 +#define CONFIG_VP9_VAAPI_HWACCEL 0
@@ -11691,12 +5332,11 @@ index 0000000000..a3b50bec45
 +#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_WMV3_D3D11VA_HWACCEL 0
 +#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
-+#define CONFIG_WMV3_D3D12VA_HWACCEL 0
 +#define CONFIG_WMV3_DXVA2_HWACCEL 0
 +#define CONFIG_WMV3_NVDEC_HWACCEL 0
 +#define CONFIG_WMV3_VAAPI_HWACCEL 0
 +#define CONFIG_WMV3_VDPAU_HWACCEL 0
-+#define CONFIG_AAC_PARSER 0
++#define CONFIG_AAC_PARSER 1
 +#define CONFIG_AAC_LATM_PARSER 0
 +#define CONFIG_AC3_PARSER 0
 +#define CONFIG_ADX_PARSER 0
@@ -11726,12 +5366,11 @@ index 0000000000..a3b50bec45
 +#define CONFIG_GSM_PARSER 0
 +#define CONFIG_H261_PARSER 0
 +#define CONFIG_H263_PARSER 0
-+#define CONFIG_H264_PARSER 0
++#define CONFIG_H264_PARSER 1
 +#define CONFIG_HEVC_PARSER 0
 +#define CONFIG_HDR_PARSER 0
 +#define CONFIG_IPU_PARSER 0
 +#define CONFIG_JPEG2000_PARSER 0
-+#define CONFIG_JPEGXL_PARSER 0
 +#define CONFIG_MISC4_PARSER 0
 +#define CONFIG_MJPEG_PARSER 0
 +#define CONFIG_MLP_PARSER 0
@@ -11742,14 +5381,15 @@ index 0000000000..a3b50bec45
 +#define CONFIG_PNG_PARSER 0
 +#define CONFIG_PNM_PARSER 0
 +#define CONFIG_QOI_PARSER 0
-+#define CONFIG_RV34_PARSER 0
++#define CONFIG_RV30_PARSER 0
++#define CONFIG_RV40_PARSER 0
 +#define CONFIG_SBC_PARSER 0
 +#define CONFIG_SIPR_PARSER 0
 +#define CONFIG_TAK_PARSER 0
 +#define CONFIG_VC1_PARSER 0
 +#define CONFIG_VORBIS_PARSER 1
-+#define CONFIG_VP3_PARSER 0
-+#define CONFIG_VP8_PARSER 0
++#define CONFIG_VP3_PARSER 1
++#define CONFIG_VP8_PARSER 1
 +#define CONFIG_VP9_PARSER 1
 +#define CONFIG_VVC_PARSER 0
 +#define CONFIG_WEBP_PARSER 0
@@ -11789,7 +5429,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_SNDIO_OUTDEV 0
 +#define CONFIG_V4L2_OUTDEV 0
 +#define CONFIG_XV_OUTDEV 0
-+#define CONFIG_AAP_FILTER 0
 +#define CONFIG_ABENCH_FILTER 0
 +#define CONFIG_ACOMPRESSOR_FILTER 0
 +#define CONFIG_ACONTRAST_FILTER 0
@@ -11839,7 +5478,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_APERMS_FILTER 0
 +#define CONFIG_APHASER_FILTER 0
 +#define CONFIG_APHASESHIFT_FILTER 0
-+#define CONFIG_APSNR_FILTER 0
 +#define CONFIG_APSYCLIP_FILTER 0
 +#define CONFIG_APULSATOR_FILTER 0
 +#define CONFIG_AREALTIME_FILTER 0
@@ -11857,7 +5495,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_ASETTB_FILTER 0
 +#define CONFIG_ASHOWINFO_FILTER 0
 +#define CONFIG_ASIDEDATA_FILTER 0
-+#define CONFIG_ASISDR_FILTER 0
 +#define CONFIG_ASOFTCLIP_FILTER 0
 +#define CONFIG_ASPECTRALSTATS_FILTER 0
 +#define CONFIG_ASPLIT_FILTER 0
@@ -12064,7 +5701,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_FREEZEFRAMES_FILTER 0
 +#define CONFIG_FREI0R_FILTER 0
 +#define CONFIG_FSPP_FILTER 0
-+#define CONFIG_FSYNC_FILTER 0
 +#define CONFIG_GBLUR_FILTER 0
 +#define CONFIG_GBLUR_VULKAN_FILTER 0
 +#define CONFIG_GEQ_FILTER 0
@@ -12106,7 +5742,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_LENSFUN_FILTER 0
 +#define CONFIG_LIBPLACEBO_FILTER 0
 +#define CONFIG_LIBVMAF_FILTER 0
-+#define CONFIG_LIBVMAF_CUDA_FILTER 0
 +#define CONFIG_LIMITDIFF_FILTER 0
 +#define CONFIG_LIMITER_FILTER 0
 +#define CONFIG_LOOP_FILTER 0
@@ -12177,8 +5812,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_PSNR_FILTER 0
 +#define CONFIG_PULLUP_FILTER 0
 +#define CONFIG_QP_FILTER 0
-+#define CONFIG_QRENCODE_FILTER 0
-+#define CONFIG_QUIRC_FILTER 0
 +#define CONFIG_RANDOM_FILTER 0
 +#define CONFIG_READEIA608_FILTER 0
 +#define CONFIG_READVITC_FILTER 0
@@ -12199,7 +5832,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_SCALE_NPP_FILTER 0
 +#define CONFIG_SCALE_QSV_FILTER 0
 +#define CONFIG_SCALE_VAAPI_FILTER 0
-+#define CONFIG_SCALE_VT_FILTER 0
 +#define CONFIG_SCALE_VULKAN_FILTER 0
 +#define CONFIG_SCALE2REF_FILTER 0
 +#define CONFIG_SCALE2REF_NPP_FILTER 0
@@ -12251,7 +5883,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_THUMBNAIL_FILTER 0
 +#define CONFIG_THUMBNAIL_CUDA_FILTER 0
 +#define CONFIG_TILE_FILTER 0
-+#define CONFIG_TILTANDSHIFT_FILTER 0
 +#define CONFIG_TINTERLACE_FILTER 0
 +#define CONFIG_TLUT2_FILTER 0
 +#define CONFIG_TMEDIAN_FILTER 0
@@ -12265,7 +5896,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_TRANSPOSE_NPP_FILTER 0
 +#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
 +#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
-+#define CONFIG_TRANSPOSE_VT_FILTER 0
 +#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
 +#define CONFIG_TRIM_FILTER 0
 +#define CONFIG_UNPREMULTIPLY_FILTER 0
@@ -12328,7 +5958,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_MPTESTSRC_FILTER 0
 +#define CONFIG_NULLSRC_FILTER 0
 +#define CONFIG_OPENCLSRC_FILTER 0
-+#define CONFIG_QRENCODESRC_FILTER 0
 +#define CONFIG_PAL75BARS_FILTER 0
 +#define CONFIG_PAL100BARS_FILTER 0
 +#define CONFIG_RGBTESTSRC_FILTER 0
@@ -12361,8 +5990,10 @@ index 0000000000..a3b50bec45
 +#define CONFIG_AVSYNCTEST_FILTER 0
 +#define CONFIG_AMOVIE_FILTER 0
 +#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AFIFO_FILTER 0
++#define CONFIG_FIFO_FILTER 0
 +#define CONFIG_AA_DEMUXER 0
-+#define CONFIG_AAC_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 1
 +#define CONFIG_AAX_DEMUXER 0
 +#define CONFIG_AC3_DEMUXER 0
 +#define CONFIG_AC4_DEMUXER 0
@@ -12479,7 +6110,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_HEVC_DEMUXER 0
 +#define CONFIG_HLS_DEMUXER 0
 +#define CONFIG_HNM_DEMUXER 0
-+#define CONFIG_IAMF_DEMUXER 0
 +#define CONFIG_ICO_DEMUXER 0
 +#define CONFIG_IDCIN_DEMUXER 0
 +#define CONFIG_IDF_DEMUXER 0
@@ -12555,7 +6185,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_OBU_DEMUXER 0
 +#define CONFIG_OGG_DEMUXER 1
 +#define CONFIG_OMA_DEMUXER 0
-+#define CONFIG_OSQ_DEMUXER 0
 +#define CONFIG_PAF_DEMUXER 0
 +#define CONFIG_PCM_ALAW_DEMUXER 0
 +#define CONFIG_PCM_MULAW_DEMUXER 0
@@ -12585,7 +6214,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_PVA_DEMUXER 0
 +#define CONFIG_PVF_DEMUXER 0
 +#define CONFIG_QCP_DEMUXER 0
-+#define CONFIG_QOA_DEMUXER 0
 +#define CONFIG_R3D_DEMUXER 0
 +#define CONFIG_RAWVIDEO_DEMUXER 0
 +#define CONFIG_REALTEXT_DEMUXER 0
@@ -12644,7 +6272,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_TXD_DEMUXER 0
 +#define CONFIG_TTY_DEMUXER 0
 +#define CONFIG_TY_DEMUXER 0
-+#define CONFIG_USM_DEMUXER 0
 +#define CONFIG_V210_DEMUXER 0
 +#define CONFIG_V210X_DEMUXER 0
 +#define CONFIG_VAG_DEMUXER 0
@@ -12786,7 +6413,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_HDS_MUXER 0
 +#define CONFIG_HEVC_MUXER 0
 +#define CONFIG_HLS_MUXER 0
-+#define CONFIG_IAMF_MUXER 0
 +#define CONFIG_ICO_MUXER 0
 +#define CONFIG_ILBC_MUXER 0
 +#define CONFIG_IMAGE2_MUXER 0
@@ -12854,7 +6480,6 @@ index 0000000000..a3b50bec45
 +#define CONFIG_PCM_U8_MUXER 0
 +#define CONFIG_PSP_MUXER 0
 +#define CONFIG_RAWVIDEO_MUXER 0
-+#define CONFIG_RCWT_MUXER 0
 +#define CONFIG_RM_MUXER 0
 +#define CONFIG_ROQ_MUXER 0
 +#define CONFIG_RSO_MUXER 0
@@ -12953,24 +6578,25 @@ index 0000000000..a3b50bec45
 +#define CONFIG_LIBZMQ_PROTOCOL 0
 +#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
 +#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#define CONFIG_H264_D3D12VA_HWACCEL 0
 +#endif /* FFMPEG_CONFIG_COMPONENTS_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
 new file mode 100644
-index 0000000000..7a7c27a9af
+index 0000000000..7ff70c6e2d
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
-@@ -0,0 +1,4 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
+@@ -0,0 +1,2 @@
 +static const FFBitStreamFilter * const bitstream_filters[] = {
 +    NULL };
-+static const FFBitStreamFilter * const bitstream_filters[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
 new file mode 100644
-index 0000000000..7991481724
+index 0000000000..fe5adb0d92
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
-@@ -0,0 +1,30 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
+@@ -0,0 +1,17 @@
 +static const FFCodec * const codec_list[] = {
++    &ff_h264_decoder,
++    &ff_aac_decoder,
 +    &ff_flac_decoder,
 +    &ff_mp3_decoder,
 +    &ff_vorbis_decoder,
@@ -12985,48 +6611,29 @@ index 0000000000..7991481724
 +    &ff_pcm_u8_decoder,
 +    &ff_libopus_decoder,
 +    NULL };
-+static const FFCodec * const codec_list[] = {
-+    &ff_flac_decoder,
-+    &ff_mp3_decoder,
-+    &ff_vorbis_decoder,
-+    &ff_pcm_alaw_decoder,
-+    &ff_pcm_f32le_decoder,
-+    &ff_pcm_mulaw_decoder,
-+    &ff_pcm_s16be_decoder,
-+    &ff_pcm_s16le_decoder,
-+    &ff_pcm_s24be_decoder,
-+    &ff_pcm_s24le_decoder,
-+    &ff_pcm_s32le_decoder,
-+    &ff_pcm_u8_decoder,
-+    &ff_libopus_decoder,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
 new file mode 100644
-index 0000000000..00d9afad02
+index 0000000000..3e4fa9c320
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
-@@ -0,0 +1,14 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
+@@ -0,0 +1,9 @@
 +static const AVCodecParser * const parser_list[] = {
++    &ff_aac_parser,
 +    &ff_flac_parser,
++    &ff_h264_parser,
 +    &ff_mpegaudio_parser,
 +    &ff_opus_parser,
 +    &ff_vorbis_parser,
 +    &ff_vp9_parser,
 +    NULL };
-+static const AVCodecParser * const parser_list[] = {
-+    &ff_flac_parser,
-+    &ff_mpegaudio_parser,
-+    &ff_opus_parser,
-+    &ff_vorbis_parser,
-+    &ff_vp9_parser,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
 new file mode 100644
-index 0000000000..8f104fee8f
+index 0000000000..29f1f59381
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
-@@ -0,0 +1,16 @@
-+static const AVInputFormat * const demuxer_list[] = {
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
+@@ -0,0 +1,9 @@
++static const FFInputFormat * const demuxer_list[] = {
++    &ff_aac_demuxer,
 +    &ff_flac_demuxer,
 +    &ff_matroska_demuxer,
 +    &ff_mov_demuxer,
@@ -13034,91 +6641,63 @@ index 0000000000..8f104fee8f
 +    &ff_ogg_demuxer,
 +    &ff_wav_demuxer,
 +    NULL };
-+static const AVInputFormat * const demuxer_list[] = {
-+    &ff_flac_demuxer,
-+    &ff_matroska_demuxer,
-+    &ff_mov_demuxer,
-+    &ff_mp3_demuxer,
-+    &ff_ogg_demuxer,
-+    &ff_wav_demuxer,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
 new file mode 100644
-index 0000000000..c256faa614
+index 0000000000..ae54c39f23
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
-@@ -0,0 +1,4 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
+@@ -0,0 +1,2 @@
 +static const FFOutputFormat * const muxer_list[] = {
 +    NULL };
-+static const FFOutputFormat * const muxer_list[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
 new file mode 100644
-index 0000000000..a116214119
+index 0000000000..247e1e4c3a
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
-@@ -0,0 +1,4 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
+@@ -0,0 +1,2 @@
 +static const URLProtocol * const url_protocols[] = {
 +    NULL };
-+static const URLProtocol * const url_protocols[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
 new file mode 100644
-index 0000000000..3509e46c05
+index 0000000000..c289fbb551
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
-@@ -0,0 +1,12 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
+@@ -0,0 +1,6 @@
 +/* Generated by ffmpeg configure */
 +#ifndef AVUTIL_AVCONFIG_H
 +#define AVUTIL_AVCONFIG_H
 +#define AV_HAVE_BIGENDIAN 0
 +#define AV_HAVE_FAST_UNALIGNED 1
 +#endif /* AVUTIL_AVCONFIG_H */
-+/* Generated by ffmpeg configure */
-+#ifndef AVUTIL_AVCONFIG_H
-+#define AVUTIL_AVCONFIG_H
-+#define AV_HAVE_BIGENDIAN 0
-+#define AV_HAVE_FAST_UNALIGNED 1
-+#endif /* AVUTIL_AVCONFIG_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
 new file mode 100644
-index 0000000000..bf5487a538
+index 0000000000..44899b6af0
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h
-@@ -0,0 +1,10 @@
-+/* Automatically generated by version.sh, do not manually edit! */
-+#ifndef AVUTIL_FFVERSION_H
-+#define AVUTIL_FFVERSION_H
-+#define FFMPEG_VERSION "n5.0.1"
-+#endif /* AVUTIL_FFVERSION_H */
-+/* Automatically generated by version.sh, do not manually edit! */
-+#ifndef AVUTIL_FFVERSION_H
-+#define AVUTIL_FFVERSION_H
-+#define FFMPEG_VERSION "n5.0.1"
-+#endif /* AVUTIL_FFVERSION_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config.h
-new file mode 100644
-index 0000000000..3fd73dcf72
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config.h
-@@ -0,0 +1,802 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
+@@ -0,0 +1,765 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_H
 +#define FFMPEG_CONFIG_H
-+#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\"-O2\\\"' --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264' --disable-iamf"
++#define FFMPEG_CONFIGURATION "--disable-everything --disable-all --enable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\"-O2\\\\\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --enable-pic --cc=clang --cxx=clang++ --ld=clang"
 +#define FFMPEG_LICENSE "LGPL version 2.1 or later"
-+#define CONFIG_THIS_YEAR 2025
++#define CONFIG_THIS_YEAR 2023
 +#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
 +#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 20.1.5 (https://github.com/llvm/llvm-project 7b09d7b446383b71b63d429b21ee45ba389c5134)"
++#define CC_IDENT "clang version 17.0.6"
 +#define OS_NAME linux
++#define av_restrict restrict
 +#define EXTERN_PREFIX ""
-+#define EXTERN_ASM 
 +#define BUILDSUF ""
 +#define SLIBSUF ".so"
++#define HAVE_MMX2 HAVE_MMXEXT
 +#define SWS_MAX_FILTER_SIZE 256
 +#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
 +#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
 +#define ARCH_IA64 0
 +#define ARCH_LOONGARCH 1
 +#define ARCH_LOONGARCH32 0
@@ -13131,11 +6710,12 @@ index 0000000000..3fd73dcf72
 +#define ARCH_PPC64 0
 +#define ARCH_RISCV 0
 +#define ARCH_S390 0
++#define ARCH_SH4 0
 +#define ARCH_SPARC 0
 +#define ARCH_SPARC64 0
 +#define ARCH_TILEGX 0
 +#define ARCH_TILEPRO 0
-+#define ARCH_WASM 0
++#define ARCH_TOMI 0
 +#define ARCH_X86 0
 +#define ARCH_X86_32 0
 +#define ARCH_X86_64 0
@@ -13149,20 +6729,13 @@ index 0000000000..3fd73dcf72
 +#define HAVE_VFP 0
 +#define HAVE_VFPV3 0
 +#define HAVE_SETEND 0
-+#define HAVE_SVE 0
-+#define HAVE_SVE2 0
 +#define HAVE_ALTIVEC 0
 +#define HAVE_DCBZL 0
 +#define HAVE_LDBRX 0
 +#define HAVE_POWER8 0
 +#define HAVE_PPC4XX 0
-+#define HAVE_VEC_XL 0
 +#define HAVE_VSX 0
-+#define HAVE_RV 0
 +#define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
-+#define HAVE_RV_ZVBB 0
-+#define HAVE_SIMD128 0
 +#define HAVE_AESNI 0
 +#define HAVE_AMD3DNOW 0
 +#define HAVE_AMD3DNOWEXT 0
@@ -13181,6 +6754,7 @@ index 0000000000..3fd73dcf72
 +#define HAVE_SSE42 0
 +#define HAVE_SSSE3 0
 +#define HAVE_XOP 0
++#define HAVE_CPUNOP 0
 +#define HAVE_I686 0
 +#define HAVE_MIPSFPU 0
 +#define HAVE_MIPS32R2 0
@@ -13206,20 +6780,13 @@ index 0000000000..3fd73dcf72
 +#define HAVE_VFP_EXTERNAL 0
 +#define HAVE_VFPV3_EXTERNAL 0
 +#define HAVE_SETEND_EXTERNAL 0
-+#define HAVE_SVE_EXTERNAL 0
-+#define HAVE_SVE2_EXTERNAL 0
 +#define HAVE_ALTIVEC_EXTERNAL 0
 +#define HAVE_DCBZL_EXTERNAL 0
 +#define HAVE_LDBRX_EXTERNAL 0
 +#define HAVE_POWER8_EXTERNAL 0
 +#define HAVE_PPC4XX_EXTERNAL 0
-+#define HAVE_VEC_XL_EXTERNAL 0
 +#define HAVE_VSX_EXTERNAL 0
-+#define HAVE_RV_EXTERNAL 0
 +#define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
-+#define HAVE_RV_ZVBB_EXTERNAL 0
-+#define HAVE_SIMD128_EXTERNAL 0
 +#define HAVE_AESNI_EXTERNAL 0
 +#define HAVE_AMD3DNOW_EXTERNAL 0
 +#define HAVE_AMD3DNOWEXT_EXTERNAL 0
@@ -13238,6 +6805,7 @@ index 0000000000..3fd73dcf72
 +#define HAVE_SSE42_EXTERNAL 0
 +#define HAVE_SSSE3_EXTERNAL 0
 +#define HAVE_XOP_EXTERNAL 0
++#define HAVE_CPUNOP_EXTERNAL 0
 +#define HAVE_I686_EXTERNAL 0
 +#define HAVE_MIPSFPU_EXTERNAL 0
 +#define HAVE_MIPS32R2_EXTERNAL 0
@@ -13263,20 +6831,13 @@ index 0000000000..3fd73dcf72
 +#define HAVE_VFP_INLINE 0
 +#define HAVE_VFPV3_INLINE 0
 +#define HAVE_SETEND_INLINE 0
-+#define HAVE_SVE_INLINE 0
-+#define HAVE_SVE2_INLINE 0
 +#define HAVE_ALTIVEC_INLINE 0
 +#define HAVE_DCBZL_INLINE 0
 +#define HAVE_LDBRX_INLINE 0
 +#define HAVE_POWER8_INLINE 0
 +#define HAVE_PPC4XX_INLINE 0
-+#define HAVE_VEC_XL_INLINE 0
 +#define HAVE_VSX_INLINE 0
-+#define HAVE_RV_INLINE 0
 +#define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
-+#define HAVE_RV_ZVBB_INLINE 0
-+#define HAVE_SIMD128_INLINE 0
 +#define HAVE_AESNI_INLINE 0
 +#define HAVE_AMD3DNOW_INLINE 0
 +#define HAVE_AMD3DNOWEXT_INLINE 0
@@ -13295,6 +6856,7 @@ index 0000000000..3fd73dcf72
 +#define HAVE_SSE42_INLINE 0
 +#define HAVE_SSSE3_INLINE 0
 +#define HAVE_XOP_INLINE 0
++#define HAVE_CPUNOP_INLINE 0
 +#define HAVE_I686_INLINE 0
 +#define HAVE_MIPSFPU_INLINE 0
 +#define HAVE_MIPS32R2_INLINE 0
@@ -13315,25 +6877,34 @@ index 0000000000..3fd73dcf72
 +#define HAVE_FAST_CLZ 1
 +#define HAVE_FAST_CMOV 0
 +#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 1
 +#define HAVE_SIMD_ALIGN_16 0
 +#define HAVE_SIMD_ALIGN_32 1
 +#define HAVE_SIMD_ALIGN_64 0
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
 +#define HAVE_MEMORYBARRIER 0
 +#define HAVE_MM_EMPTY 0
 +#define HAVE_RDTSC 0
 +#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
 +#define HAVE_INLINE_ASM 1
 +#define HAVE_SYMVER 0
 +#define HAVE_X86ASM 0
 +#define HAVE_BIGENDIAN 0
 +#define HAVE_FAST_UNALIGNED 1
 +#define HAVE_ARPA_INET_H 0
-+#define HAVE_ASM_HWPROBE_H 0
++#define HAVE_ASM_HWCAP_H 1
 +#define HAVE_ASM_TYPES_H 1
 +#define HAVE_CDIO_PARANOIA_H 0
 +#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
 +#define HAVE_CUDA_H 0
 +#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
 +#define HAVE_DIRECT_H 0
 +#define HAVE_DIRENT_H 1
 +#define HAVE_DXGIDEBUG_H 0
@@ -13343,11 +6914,12 @@ index 0000000000..3fd73dcf72
 +#define HAVE_IO_H 0
 +#define HAVE_LINUX_DMA_BUF_H 0
 +#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
 +#define HAVE_MALLOC_H 1
 +#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
 +#define HAVE_POLL_H 1
-+#define HAVE_PTHREAD_NP_H 0
-+#define HAVE_SYS_HWPROBE_H 0
 +#define HAVE_SYS_PARAM_H 1
 +#define HAVE_SYS_RESOURCE_H 1
 +#define HAVE_SYS_SELECT_H 1
@@ -13362,7 +6934,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_WINDOWS_H 0
 +#define HAVE_WINSOCK2_H 0
 +#define HAVE_INTRINSICS_NEON 0
-+#define HAVE_INTRINSICS_SSE2 0
 +#define HAVE_ATANF 1
 +#define HAVE_ATAN2F 1
 +#define HAVE_CBRT 1
@@ -13405,7 +6976,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_CLOCK_GETTIME 1
 +#define HAVE_CLOSESOCKET 0
 +#define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
 +#define HAVE_FCNTL 1
 +#define HAVE_GETADDRINFO 0
 +#define HAVE_GETAUXVAL 1
@@ -13440,8 +7010,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_POSIX_MEMALIGN 1
 +#define HAVE_PRCTL 1
 +#define HAVE_PTHREAD_CANCEL 1
-+#define HAVE_PTHREAD_SET_NAME_NP 0
-+#define HAVE_PTHREAD_SETNAME_NP 0
 +#define HAVE_SCHED_GETAFFINITY 1
 +#define HAVE_SECITEMIMPORT 0
 +#define HAVE_SETCONSOLETEXTATTRIBUTE 0
@@ -13454,7 +7022,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_SYSCONF 1
 +#define HAVE_SYSCTL 0
 +#define HAVE_SYSCTLBYNAME 0
-+#define HAVE_TEMPNAM 1
 +#define HAVE_USLEEP 1
 +#define HAVE_UTGETOSTYPEFROMSTRING 0
 +#define HAVE_VIRTUALALLOC 0
@@ -13470,8 +7037,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_AS_ARCH_DIRECTIVE 0
 +#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
 +#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_SVE_DIRECTIVE 0
-+#define HAVE_AS_ARCHEXT_SVE2_DIRECTIVE 0
 +#define HAVE_AS_DN_DIRECTIVE 0
 +#define HAVE_AS_FPU_DIRECTIVE 0
 +#define HAVE_AS_FUNC 0
@@ -13498,7 +7063,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
 +#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
 +#define HAVE_KCMVIDEOCODECTYPE_VP9 0
-+#define HAVE_KCMVIDEOCODECTYPE_AV1 0
 +#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
 +#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
 +#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
@@ -13513,8 +7077,6 @@ index 0000000000..3fd73dcf72
 +#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
 +#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
 +#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
-+#define HAVE_KVTQPMODULATIONLEVEL_DEFAULT 0
-+#define HAVE_SECPKGCONTEXT_KEYINGMATERIALINFO 0
 +#define HAVE_SOCKLEN_T 0
 +#define HAVE_STRUCT_ADDRINFO 0
 +#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
@@ -13528,26 +7090,22 @@ index 0000000000..3fd73dcf72
 +#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
 +#define HAVE_STRUCT_SOCKADDR_STORAGE 0
 +#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
-+#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 1
-+#define HAVE_STRUCT_MFXCONFIGINTERFACE 0
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
 +#define HAVE_GZIP 1
-+#define HAVE_IOCTL_POSIX 0
 +#define HAVE_LIBDRM_GETFB2 0
-+#define HAVE_MAKEINFO 0
-+#define HAVE_MAKEINFO_HTML 0
++#define HAVE_MAKEINFO 1
++#define HAVE_MAKEINFO_HTML 1
 +#define HAVE_OPENCL_D3D11 0
 +#define HAVE_OPENCL_DRM_ARM 0
 +#define HAVE_OPENCL_DRM_BEIGNET 0
 +#define HAVE_OPENCL_DXVA2 0
 +#define HAVE_OPENCL_VAAPI_BEIGNET 0
 +#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
-+#define HAVE_OPENCL_VIDEOTOOLBOX 0
 +#define HAVE_PERL 1
 +#define HAVE_POD2MAN 1
 +#define HAVE_TEXI2HTML 0
-+#define HAVE_XMLLINT 0
++#define HAVE_XMLLINT 1
 +#define HAVE_ZLIB_GZIP 0
-+#define HAVE_OPENVINO2 0
 +#define CONFIG_DOC 0
 +#define CONFIG_HTMLPAGES 0
 +#define CONFIG_MANPAGES 0
@@ -13581,8 +7139,6 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_FREI0R 0
 +#define CONFIG_LIBCDIO 0
 +#define CONFIG_LIBDAVS2 0
-+#define CONFIG_LIBDVDNAV 0
-+#define CONFIG_LIBDVDREAD 0
 +#define CONFIG_LIBRUBBERBAND 0
 +#define CONFIG_LIBVIDSTAB 0
 +#define CONFIG_LIBX264 0
@@ -13618,6 +7174,7 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_LIBCODEC2 0
 +#define CONFIG_LIBDAV1D 0
 +#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBDRM 0
 +#define CONFIG_LIBFLITE 0
 +#define CONFIG_LIBFONTCONFIG 0
 +#define CONFIG_LIBFREETYPE 0
@@ -13632,12 +7189,9 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_LIBJXL 0
 +#define CONFIG_LIBKLVANC 0
 +#define CONFIG_LIBKVAZAAR 0
-+#define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
 +#define CONFIG_LIBMODPLUG 0
 +#define CONFIG_LIBMP3LAME 0
 +#define CONFIG_LIBMYSOFA 0
-+#define CONFIG_LIBOAPV 0
 +#define CONFIG_LIBOPENCV 0
 +#define CONFIG_LIBOPENH264 0
 +#define CONFIG_LIBOPENJPEG 0
@@ -13646,8 +7200,6 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_LIBOPUS 1
 +#define CONFIG_LIBPLACEBO 0
 +#define CONFIG_LIBPULSE 0
-+#define CONFIG_LIBQRENCODE 0
-+#define CONFIG_LIBQUIRC 0
 +#define CONFIG_LIBRABBITMQ 0
 +#define CONFIG_LIBRAV1E 0
 +#define CONFIG_LIBRIST 0
@@ -13665,31 +7217,24 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_LIBTENSORFLOW 0
 +#define CONFIG_LIBTESSERACT 0
 +#define CONFIG_LIBTHEORA 0
-+#define CONFIG_LIBTORCH 0
 +#define CONFIG_LIBTWOLAME 0
 +#define CONFIG_LIBUAVS3D 0
 +#define CONFIG_LIBV4L2 0
 +#define CONFIG_LIBVMAF 0
 +#define CONFIG_LIBVORBIS 0
 +#define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
 +#define CONFIG_LIBWEBP 0
-+#define CONFIG_LIBXEVD 0
-+#define CONFIG_LIBXEVE 0
 +#define CONFIG_LIBXML2 0
 +#define CONFIG_LIBZIMG 0
 +#define CONFIG_LIBZMQ 0
 +#define CONFIG_LIBZVBI 0
 +#define CONFIG_LV2 0
 +#define CONFIG_MEDIACODEC 0
-+#define CONFIG_OHCODEC 0
 +#define CONFIG_OPENAL 0
 +#define CONFIG_OPENGL 0
 +#define CONFIG_OPENSSL 0
 +#define CONFIG_POCKETSPHINX 0
 +#define CONFIG_VAPOURSYNTH 0
-+#define CONFIG_VULKAN_STATIC 0
-+#define CONFIG_WHISPER 0
 +#define CONFIG_ALSA 0
 +#define CONFIG_APPKIT 0
 +#define CONFIG_AVFOUNDATION 0
@@ -13719,14 +7264,13 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_OPENCL 0
 +#define CONFIG_AMF 0
 +#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
 +#define CONFIG_CUDA 0
 +#define CONFIG_CUDA_LLVM 0
 +#define CONFIG_CUVID 0
 +#define CONFIG_D3D11VA 0
-+#define CONFIG_D3D12VA 0
 +#define CONFIG_DXVA2 0
 +#define CONFIG_FFNVCODEC 0
-+#define CONFIG_LIBDRM 0
 +#define CONFIG_NVDEC 0
 +#define CONFIG_NVENC 0
 +#define CONFIG_VAAPI 0
@@ -13750,6 +7294,7 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_AVDEVICE 0
 +#define CONFIG_AVFILTER 0
 +#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
 +#define CONFIG_AVFORMAT 1
 +#define CONFIG_AVCODEC 1
 +#define CONFIG_SWRESAMPLE 0
@@ -13757,14 +7302,17 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_FFPLAY 0
 +#define CONFIG_FFPROBE 0
 +#define CONFIG_FFMPEG 0
++#define CONFIG_DCT 1
 +#define CONFIG_DWT 0
 +#define CONFIG_ERROR_RESILIENCE 0
 +#define CONFIG_FAAN 0
 +#define CONFIG_FAST_UNALIGNED 1
-+#define CONFIG_IAMF 0
++#define CONFIG_FFT 1
 +#define CONFIG_LSP 0
++#define CONFIG_MDCT 0
 +#define CONFIG_PIXELUTILS 0
 +#define CONFIG_NETWORK 0
++#define CONFIG_RDFT 1
 +#define CONFIG_AUTODETECT 0
 +#define CONFIG_FONTCONFIG 0
 +#define CONFIG_LARGE_TESTS 1
@@ -13775,7 +7323,6 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_OSSFUZZ 0
 +#define CONFIG_PIC 1
 +#define CONFIG_PTX_COMPRESSION 0
-+#define CONFIG_RESOURCE_COMPRESSION 0
 +#define CONFIG_THUMB 0
 +#define CONFIG_VALGRIND_BACKTRACE 0
 +#define CONFIG_XMM_CLOBBER_TEST 0
@@ -13792,30 +7339,25 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_PROTOCOLS 0
 +#define CONFIG_AANDCTTABLES 0
 +#define CONFIG_AC3DSP 0
-+#define CONFIG_ADTS_HEADER 1
-+#define CONFIG_ATSC_A53 1
++#define CONFIG_ADTS_HEADER 0
++#define CONFIG_ATSC_A53 0
 +#define CONFIG_AUDIO_FRAME_QUEUE 0
 +#define CONFIG_AUDIODSP 0
 +#define CONFIG_BLOCKDSP 0
 +#define CONFIG_BSWAPDSP 0
-+#define CONFIG_CABAC 1
++#define CONFIG_CABAC 0
 +#define CONFIG_CBS 0
-+#define CONFIG_CBS_APV 0
 +#define CONFIG_CBS_AV1 0
 +#define CONFIG_CBS_H264 0
 +#define CONFIG_CBS_H265 0
 +#define CONFIG_CBS_H266 0
 +#define CONFIG_CBS_JPEG 0
 +#define CONFIG_CBS_MPEG2 0
-+#define CONFIG_CBS_VP8 0
 +#define CONFIG_CBS_VP9 0
-+#define CONFIG_CELP_MATH 0
-+#define CONFIG_D3D12VA_ENCODE 0
 +#define CONFIG_DEFLATE_WRAPPER 0
 +#define CONFIG_DIRAC_PARSE 1
 +#define CONFIG_DNN 0
-+#define CONFIG_DOVI_RPUDEC 0
-+#define CONFIG_DOVI_RPUENC 0
++#define CONFIG_DOVI_RPU 0
 +#define CONFIG_DVPROFILE 0
 +#define CONFIG_EVCPARSE 0
 +#define CONFIG_EXIF 0
@@ -13828,30 +7370,27 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_GOLOMB 1
 +#define CONFIG_GPLV3 0
 +#define CONFIG_H263DSP 0
-+#define CONFIG_H264CHROMA 1
-+#define CONFIG_H264DSP 1
-+#define CONFIG_H264PARSE 1
++#define CONFIG_H264CHROMA 0
++#define CONFIG_H264DSP 0
++#define CONFIG_H264PARSE 0
 +#define CONFIG_H264PRED 1
-+#define CONFIG_H264QPEL 1
-+#define CONFIG_H264_SEI 1
++#define CONFIG_H264QPEL 0
++#define CONFIG_H264_SEI 0
 +#define CONFIG_HEVCPARSE 0
 +#define CONFIG_HEVC_SEI 0
-+#define CONFIG_HPELDSP 0
++#define CONFIG_HPELDSP 1
 +#define CONFIG_HUFFMAN 0
 +#define CONFIG_HUFFYUVDSP 0
 +#define CONFIG_HUFFYUVENCDSP 0
-+#define CONFIG_IAMFDEC 0
-+#define CONFIG_IAMFENC 0
 +#define CONFIG_IDCTDSP 0
++#define CONFIG_IIRFILTER 0
 +#define CONFIG_INFLATE_WRAPPER 0
 +#define CONFIG_INTRAX8 0
 +#define CONFIG_ISO_MEDIA 1
-+#define CONFIG_ISO_WRITER 0
 +#define CONFIG_IVIDSP 0
 +#define CONFIG_JPEGTABLES 0
 +#define CONFIG_LGPLV3 0
 +#define CONFIG_LIBX262 0
-+#define CONFIG_LIBX264_HDR10 0
 +#define CONFIG_LLAUDDSP 0
 +#define CONFIG_LLVIDDSP 0
 +#define CONFIG_LLVIDENCDSP 0
@@ -13866,7 +7405,6 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_MPEGVIDEO 0
 +#define CONFIG_MPEGVIDEODEC 0
 +#define CONFIG_MPEGVIDEOENC 0
-+#define CONFIG_MPEGVIDEOENCDSP 0
 +#define CONFIG_MSMPEG4DEC 0
 +#define CONFIG_MSMPEG4ENC 0
 +#define CONFIG_MSS34DSP 0
@@ -13883,50 +7421,44 @@ index 0000000000..3fd73dcf72
 +#define CONFIG_RTPENC_CHAIN 0
 +#define CONFIG_RV34DSP 0
 +#define CONFIG_SCENE_SAD 0
-+#define CONFIG_SINEWIN 1
-+#define CONFIG_SMPTE_436M 0
++#define CONFIG_SINEWIN 0
 +#define CONFIG_SNAPPY 0
 +#define CONFIG_SRTP 0
-+#define CONFIG_STARTCODE 1
++#define CONFIG_STARTCODE 0
 +#define CONFIG_TEXTUREDSP 0
 +#define CONFIG_TEXTUREDSPENC 0
 +#define CONFIG_TPELDSP 0
 +#define CONFIG_VAAPI_1 0
 +#define CONFIG_VAAPI_ENCODE 0
-+#define CONFIG_VULKAN_1_4 0
 +#define CONFIG_VC1DSP 0
 +#define CONFIG_VIDEODSP 1
-+#define CONFIG_VP3DSP 0
++#define CONFIG_VP3DSP 1
 +#define CONFIG_VP56DSP 0
-+#define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
++#define CONFIG_VP8DSP 1
 +#define CONFIG_VVC_SEI 0
 +#define CONFIG_WMA_FREQS 0
 +#define CONFIG_WMV2DSP 0
++#define CONFIG_H264_D3D12VA_HWACCEL 0
 +#endif /* FFMPEG_CONFIG_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config_components.h
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
 new file mode 100644
-index 0000000000..6dd25c4177
+index 0000000000..3c1d2177ea
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/config_components.h
-@@ -0,0 +1,2274 @@
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
+@@ -0,0 +1,2188 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_COMPONENTS_H
 +#define FFMPEG_CONFIG_COMPONENTS_H
 +#define CONFIG_AAC_ADTSTOASC_BSF 0
-+#define CONFIG_APV_METADATA_BSF 0
 +#define CONFIG_AV1_FRAME_MERGE_BSF 0
 +#define CONFIG_AV1_FRAME_SPLIT_BSF 0
 +#define CONFIG_AV1_METADATA_BSF 0
 +#define CONFIG_CHOMP_BSF 0
 +#define CONFIG_DUMP_EXTRADATA_BSF 0
 +#define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
 +#define CONFIG_DTS2PTS_BSF 0
 +#define CONFIG_DV_ERROR_MARKER_BSF 0
 +#define CONFIG_EAC3_CORE_BSF 0
-+#define CONFIG_EIA608_TO_SMPTE436M_BSF 0
-+#define CONFIG_EVC_FRAME_MERGE_BSF 0
 +#define CONFIG_EXTRACT_EXTRADATA_BSF 0
 +#define CONFIG_FILTER_UNITS_BSF 0
 +#define CONFIG_H264_METADATA_BSF 0
@@ -13939,6 +7471,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
 +#define CONFIG_MJPEG2JPEG_BSF 0
 +#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
 +#define CONFIG_MPEG2_METADATA_BSF 0
 +#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
 +#define CONFIG_MOV2TEXTSUB_BSF 0
@@ -13950,8 +7483,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_PRORES_METADATA_BSF 0
 +#define CONFIG_REMOVE_EXTRADATA_BSF 0
 +#define CONFIG_SETTS_BSF 0
-+#define CONFIG_SHOWINFO_BSF 0
-+#define CONFIG_SMPTE436M_TO_EIA608_BSF 0
 +#define CONFIG_TEXT2MOVSUB_BSF 0
 +#define CONFIG_TRACE_HEADERS_BSF 0
 +#define CONFIG_TRUEHD_CORE_BSF 0
@@ -13961,6 +7492,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
 +#define CONFIG_VVC_METADATA_BSF 0
 +#define CONFIG_VVC_MP4TOANNEXB_BSF 0
++#define CONFIG_EVC_FRAME_MERGE_BSF 0
 +#define CONFIG_AASC_DECODER 0
 +#define CONFIG_AIC_DECODER 0
 +#define CONFIG_ALIAS_PIX_DECODER 0
@@ -13969,7 +7501,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ANM_DECODER 0
 +#define CONFIG_ANSI_DECODER 0
 +#define CONFIG_APNG_DECODER 0
-+#define CONFIG_APV_DECODER 0
 +#define CONFIG_ARBC_DECODER 0
 +#define CONFIG_ARGO_DECODER 0
 +#define CONFIG_ASV1_DECODER 0
@@ -13980,6 +7511,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_AVRN_DECODER 0
 +#define CONFIG_AVS_DECODER 0
 +#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
 +#define CONFIG_BETHSOFTVID_DECODER 0
 +#define CONFIG_BFI_DECODER 0
 +#define CONFIG_BINK_DECODER 0
@@ -14045,7 +7577,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_H263I_DECODER 0
 +#define CONFIG_H263P_DECODER 0
 +#define CONFIG_H263_V4L2M2M_DECODER 0
-+#define CONFIG_H264_DECODER 1
++#define CONFIG_H264_DECODER 0
++#define CONFIG_H264_CRYSTALHD_DECODER 0
 +#define CONFIG_H264_V4L2M2M_DECODER 0
 +#define CONFIG_H264_MEDIACODEC_DECODER 0
 +#define CONFIG_H264_MMAL_DECODER 0
@@ -14077,7 +7610,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_KGV1_DECODER 0
 +#define CONFIG_KMVC_DECODER 0
 +#define CONFIG_LAGARITH_DECODER 0
-+#define CONFIG_LEAD_DECODER 0
 +#define CONFIG_LOCO_DECODER 0
 +#define CONFIG_LSCR_DECODER 0
 +#define CONFIG_M101_DECODER 0
@@ -14093,11 +7625,13 @@ index 0000000000..6dd25c4177
 +#define CONFIG_MPEG1VIDEO_DECODER 0
 +#define CONFIG_MPEG2VIDEO_DECODER 0
 +#define CONFIG_MPEG4_DECODER 0
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
 +#define CONFIG_MPEG4_V4L2M2M_DECODER 0
 +#define CONFIG_MPEG4_MMAL_DECODER 0
 +#define CONFIG_MPEGVIDEO_DECODER 0
 +#define CONFIG_MPEG1_V4L2M2M_DECODER 0
 +#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
 +#define CONFIG_MPEG2_V4L2M2M_DECODER 0
 +#define CONFIG_MPEG2_QSV_DECODER 0
 +#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
@@ -14106,6 +7640,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_MSMPEG4V1_DECODER 0
 +#define CONFIG_MSMPEG4V2_DECODER 0
 +#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
 +#define CONFIG_MSP2_DECODER 0
 +#define CONFIG_MSRLE_DECODER 0
 +#define CONFIG_MSS1_DECODER 0
@@ -14138,7 +7673,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_PNG_DECODER 0
 +#define CONFIG_PPM_DECODER 0
 +#define CONFIG_PRORES_DECODER 0
-+#define CONFIG_PRORES_RAW_DECODER 0
 +#define CONFIG_PROSUMER_DECODER 0
 +#define CONFIG_PSD_DECODER 0
 +#define CONFIG_PTX_DECODER 0
@@ -14160,7 +7694,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_RV20_DECODER 0
 +#define CONFIG_RV30_DECODER 0
 +#define CONFIG_RV40_DECODER 0
-+#define CONFIG_RV60_DECODER 0
 +#define CONFIG_S302M_DECODER 0
 +#define CONFIG_SANM_DECODER 0
 +#define CONFIG_SCPR_DECODER 0
@@ -14184,7 +7717,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_TARGA_DECODER 0
 +#define CONFIG_TARGA_Y216_DECODER 0
 +#define CONFIG_TDSC_DECODER 0
-+#define CONFIG_THEORA_DECODER 0
++#define CONFIG_THEORA_DECODER 1
 +#define CONFIG_THP_DECODER 0
 +#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
 +#define CONFIG_TIFF_DECODER 0
@@ -14206,6 +7739,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VBN_DECODER 0
 +#define CONFIG_VBLE_DECODER 0
 +#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
 +#define CONFIG_VC1IMAGE_DECODER 0
 +#define CONFIG_VC1_MMAL_DECODER 0
 +#define CONFIG_VC1_QSV_DECODER 0
@@ -14214,14 +7748,14 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VMDVIDEO_DECODER 0
 +#define CONFIG_VMIX_DECODER 0
 +#define CONFIG_VMNC_DECODER 0
-+#define CONFIG_VP3_DECODER 0
++#define CONFIG_VP3_DECODER 1
 +#define CONFIG_VP4_DECODER 0
 +#define CONFIG_VP5_DECODER 0
 +#define CONFIG_VP6_DECODER 0
 +#define CONFIG_VP6A_DECODER 0
 +#define CONFIG_VP6F_DECODER 0
 +#define CONFIG_VP7_DECODER 0
-+#define CONFIG_VP8_DECODER 0
++#define CONFIG_VP8_DECODER 1
 +#define CONFIG_VP8_RKMPP_DECODER 0
 +#define CONFIG_VP8_V4L2M2M_DECODER 0
 +#define CONFIG_VP9_DECODER 0
@@ -14229,7 +7763,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VP9_V4L2M2M_DECODER 0
 +#define CONFIG_VQA_DECODER 0
 +#define CONFIG_VQC_DECODER 0
-+#define CONFIG_VVC_DECODER 0
 +#define CONFIG_WBMP_DECODER 0
 +#define CONFIG_WEBP_DECODER 0
 +#define CONFIG_WCMV_DECODER 0
@@ -14237,6 +7770,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_WMV1_DECODER 0
 +#define CONFIG_WMV2_DECODER 0
 +#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
 +#define CONFIG_WMV3IMAGE_DECODER 0
 +#define CONFIG_WNV1_DECODER 0
 +#define CONFIG_XAN_WC3_DECODER 0
@@ -14254,7 +7788,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ZEROCODEC_DECODER 0
 +#define CONFIG_ZLIB_DECODER 0
 +#define CONFIG_ZMBV_DECODER 0
-+#define CONFIG_AAC_DECODER 1
++#define CONFIG_AAC_DECODER 0
 +#define CONFIG_AAC_FIXED_DECODER 0
 +#define CONFIG_AAC_LATM_DECODER 0
 +#define CONFIG_AC3_DECODER 0
@@ -14296,7 +7830,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_FLAC_DECODER 1
 +#define CONFIG_FTR_DECODER 0
 +#define CONFIG_G723_1_DECODER 0
-+#define CONFIG_G728_DECODER 0
 +#define CONFIG_G729_DECODER 0
 +#define CONFIG_GSM_DECODER 0
 +#define CONFIG_GSM_MS_DECODER 0
@@ -14328,12 +7861,10 @@ index 0000000000..6dd25c4177
 +#define CONFIG_NELLYMOSER_DECODER 0
 +#define CONFIG_ON2AVC_DECODER 0
 +#define CONFIG_OPUS_DECODER 0
-+#define CONFIG_OSQ_DECODER 0
 +#define CONFIG_PAF_AUDIO_DECODER 0
 +#define CONFIG_QCELP_DECODER 0
 +#define CONFIG_QDM2_DECODER 0
 +#define CONFIG_QDMC_DECODER 0
-+#define CONFIG_QOA_DECODER 0
 +#define CONFIG_RA_144_DECODER 0
 +#define CONFIG_RA_288_DECODER 0
 +#define CONFIG_RALF_DECODER 0
@@ -14442,11 +7973,9 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
 +#define CONFIG_ADPCM_IMA_WAV_DECODER 0
 +#define CONFIG_ADPCM_IMA_WS_DECODER 0
-+#define CONFIG_ADPCM_IMA_XBOX_DECODER 0
 +#define CONFIG_ADPCM_MS_DECODER 0
 +#define CONFIG_ADPCM_MTAF_DECODER 0
 +#define CONFIG_ADPCM_PSX_DECODER 0
-+#define CONFIG_ADPCM_SANYO_DECODER 0
 +#define CONFIG_ADPCM_SBPRO_2_DECODER 0
 +#define CONFIG_ADPCM_SBPRO_3_DECODER 0
 +#define CONFIG_ADPCM_SBPRO_4_DECODER 0
@@ -14505,9 +8034,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_LIBGSM_DECODER 0
 +#define CONFIG_LIBGSM_MS_DECODER 0
 +#define CONFIG_LIBILBC_DECODER 0
-+#define CONFIG_LIBJXL_ANIM_DECODER 0
 +#define CONFIG_LIBJXL_DECODER 0
-+#define CONFIG_LIBLC3_DECODER 0
 +#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
 +#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
 +#define CONFIG_LIBOPUS_DECODER 1
@@ -14517,31 +8044,21 @@ index 0000000000..6dd25c4177
 +#define CONFIG_LIBVORBIS_DECODER 0
 +#define CONFIG_LIBVPX_VP8_DECODER 0
 +#define CONFIG_LIBVPX_VP9_DECODER 0
-+#define CONFIG_LIBXEVD_DECODER 0
 +#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
 +#define CONFIG_BINTEXT_DECODER 0
 +#define CONFIG_XBIN_DECODER 0
 +#define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
 +#define CONFIG_LIBAOM_AV1_DECODER 0
 +#define CONFIG_AV1_DECODER 0
 +#define CONFIG_AV1_CUVID_DECODER 0
 +#define CONFIG_AV1_MEDIACODEC_DECODER 0
 +#define CONFIG_AV1_QSV_DECODER 0
-+#define CONFIG_AV1_AMF_DECODER 0
 +#define CONFIG_LIBOPENH264_DECODER 0
-+#define CONFIG_H264_AMF_DECODER 0
 +#define CONFIG_H264_CUVID_DECODER 0
-+#define CONFIG_H264_OH_DECODER 0
-+#define CONFIG_HEVC_AMF_DECODER 0
 +#define CONFIG_HEVC_CUVID_DECODER 0
 +#define CONFIG_HEVC_MEDIACODEC_DECODER 0
-+#define CONFIG_HEVC_OH_DECODER 0
 +#define CONFIG_MJPEG_CUVID_DECODER 0
 +#define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
 +#define CONFIG_MPEG1_CUVID_DECODER 0
 +#define CONFIG_MPEG2_CUVID_DECODER 0
 +#define CONFIG_MPEG4_CUVID_DECODER 0
@@ -14550,11 +8067,9 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VP8_CUVID_DECODER 0
 +#define CONFIG_VP8_MEDIACODEC_DECODER 0
 +#define CONFIG_VP8_QSV_DECODER 0
-+#define CONFIG_VP9_AMF_DECODER 0
 +#define CONFIG_VP9_CUVID_DECODER 0
 +#define CONFIG_VP9_MEDIACODEC_DECODER 0
 +#define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
 +#define CONFIG_VNULL_DECODER 0
 +#define CONFIG_ANULL_DECODER 0
 +#define CONFIG_A64MULTI_ENCODER 0
@@ -14566,6 +8081,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ASV2_ENCODER 0
 +#define CONFIG_AVRP_ENCODER 0
 +#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
 +#define CONFIG_BITPACKED_ENCODER 0
 +#define CONFIG_BMP_ENCODER 0
 +#define CONFIG_CFHD_ENCODER 0
@@ -14575,10 +8091,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_DNXHD_ENCODER 0
 +#define CONFIG_DPX_ENCODER 0
 +#define CONFIG_DVVIDEO_ENCODER 0
-+#define CONFIG_DXV_ENCODER 0
 +#define CONFIG_EXR_ENCODER 0
 +#define CONFIG_FFV1_ENCODER 0
-+#define CONFIG_FFV1_VULKAN_ENCODER 0
 +#define CONFIG_FFVHUFF_ENCODER 0
 +#define CONFIG_FITS_ENCODER 0
 +#define CONFIG_FLASHSV_ENCODER 0
@@ -14747,11 +8261,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_LIBGSM_ENCODER 0
 +#define CONFIG_LIBGSM_MS_ENCODER 0
 +#define CONFIG_LIBILBC_ENCODER 0
-+#define CONFIG_LIBJXL_ANIM_ENCODER 0
 +#define CONFIG_LIBJXL_ENCODER 0
-+#define CONFIG_LIBLC3_ENCODER 0
 +#define CONFIG_LIBMP3LAME_ENCODER 0
-+#define CONFIG_LIBOAPV_ENCODER 0
 +#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
 +#define CONFIG_LIBOPENJPEG_ENCODER 0
 +#define CONFIG_LIBOPUS_ENCODER 0
@@ -14765,14 +8276,12 @@ index 0000000000..6dd25c4177
 +#define CONFIG_LIBVORBIS_ENCODER 0
 +#define CONFIG_LIBVPX_VP8_ENCODER 0
 +#define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
 +#define CONFIG_LIBWEBP_ANIM_ENCODER 0
 +#define CONFIG_LIBWEBP_ENCODER 0
 +#define CONFIG_LIBX262_ENCODER 0
 +#define CONFIG_LIBX264_ENCODER 0
 +#define CONFIG_LIBX264RGB_ENCODER 0
 +#define CONFIG_LIBX265_ENCODER 0
-+#define CONFIG_LIBXEVE_ENCODER 0
 +#define CONFIG_LIBXAVS_ENCODER 0
 +#define CONFIG_LIBXAVS2_ENCODER 0
 +#define CONFIG_LIBXVID_ENCODER 0
@@ -14783,31 +8292,23 @@ index 0000000000..6dd25c4177
 +#define CONFIG_AV1_NVENC_ENCODER 0
 +#define CONFIG_AV1_QSV_ENCODER 0
 +#define CONFIG_AV1_AMF_ENCODER 0
-+#define CONFIG_AV1_MF_ENCODER 0
-+#define CONFIG_AV1_VAAPI_ENCODER 0
-+#define CONFIG_AV1_VULKAN_ENCODER 0
 +#define CONFIG_LIBOPENH264_ENCODER 0
 +#define CONFIG_H264_AMF_ENCODER 0
 +#define CONFIG_H264_MF_ENCODER 0
 +#define CONFIG_H264_NVENC_ENCODER 0
-+#define CONFIG_H264_OH_ENCODER 0
 +#define CONFIG_H264_OMX_ENCODER 0
 +#define CONFIG_H264_QSV_ENCODER 0
 +#define CONFIG_H264_V4L2M2M_ENCODER 0
 +#define CONFIG_H264_VAAPI_ENCODER 0
 +#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
 +#define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
 +#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
 +#define CONFIG_HEVC_MF_ENCODER 0
 +#define CONFIG_HEVC_NVENC_ENCODER 0
-+#define CONFIG_HEVC_OH_ENCODER 0
 +#define CONFIG_HEVC_QSV_ENCODER 0
 +#define CONFIG_HEVC_V4L2M2M_ENCODER 0
 +#define CONFIG_HEVC_VAAPI_ENCODER 0
 +#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
 +#define CONFIG_LIBKVAZAAR_ENCODER 0
 +#define CONFIG_MJPEG_QSV_ENCODER 0
 +#define CONFIG_MJPEG_VAAPI_ENCODER 0
@@ -14828,19 +8329,15 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ANULL_ENCODER 0
 +#define CONFIG_AV1_D3D11VA_HWACCEL 0
 +#define CONFIG_AV1_D3D11VA2_HWACCEL 0
-+#define CONFIG_AV1_D3D12VA_HWACCEL 0
 +#define CONFIG_AV1_DXVA2_HWACCEL 0
 +#define CONFIG_AV1_NVDEC_HWACCEL 0
 +#define CONFIG_AV1_VAAPI_HWACCEL 0
 +#define CONFIG_AV1_VDPAU_HWACCEL 0
-+#define CONFIG_AV1_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_AV1_VULKAN_HWACCEL 0
-+#define CONFIG_FFV1_VULKAN_HWACCEL 0
 +#define CONFIG_H263_VAAPI_HWACCEL 0
 +#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_H264_D3D11VA_HWACCEL 0
 +#define CONFIG_H264_D3D11VA2_HWACCEL 0
-+#define CONFIG_H264_D3D12VA_HWACCEL 0
 +#define CONFIG_H264_DXVA2_HWACCEL 0
 +#define CONFIG_H264_NVDEC_HWACCEL 0
 +#define CONFIG_H264_VAAPI_HWACCEL 0
@@ -14849,7 +8346,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_H264_VULKAN_HWACCEL 0
 +#define CONFIG_HEVC_D3D11VA_HWACCEL 0
 +#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
-+#define CONFIG_HEVC_D3D12VA_HWACCEL 0
 +#define CONFIG_HEVC_DXVA2_HWACCEL 0
 +#define CONFIG_HEVC_NVDEC_HWACCEL 0
 +#define CONFIG_HEVC_VAAPI_HWACCEL 0
@@ -14863,9 +8359,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
 +#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
-+#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
-+#define CONFIG_MPEG2_DXVA2_HWACCEL 0
 +#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
 +#define CONFIG_MPEG2_VAAPI_HWACCEL 0
 +#define CONFIG_MPEG2_VDPAU_HWACCEL 0
 +#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
@@ -14874,10 +8369,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_MPEG4_VDPAU_HWACCEL 0
 +#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_PRORES_RAW_VULKAN_HWACCEL 0
 +#define CONFIG_VC1_D3D11VA_HWACCEL 0
 +#define CONFIG_VC1_D3D11VA2_HWACCEL 0
-+#define CONFIG_VC1_D3D12VA_HWACCEL 0
 +#define CONFIG_VC1_DXVA2_HWACCEL 0
 +#define CONFIG_VC1_NVDEC_HWACCEL 0
 +#define CONFIG_VC1_VAAPI_HWACCEL 0
@@ -14886,27 +8379,22 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VP8_VAAPI_HWACCEL 0
 +#define CONFIG_VP9_D3D11VA_HWACCEL 0
 +#define CONFIG_VP9_D3D11VA2_HWACCEL 0
-+#define CONFIG_VP9_D3D12VA_HWACCEL 0
 +#define CONFIG_VP9_DXVA2_HWACCEL 0
 +#define CONFIG_VP9_NVDEC_HWACCEL 0
 +#define CONFIG_VP9_VAAPI_HWACCEL 0
 +#define CONFIG_VP9_VDPAU_HWACCEL 0
 +#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
-+#define CONFIG_VP9_VULKAN_HWACCEL 0
-+#define CONFIG_VVC_VAAPI_HWACCEL 0
 +#define CONFIG_WMV3_D3D11VA_HWACCEL 0
 +#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
-+#define CONFIG_WMV3_D3D12VA_HWACCEL 0
 +#define CONFIG_WMV3_DXVA2_HWACCEL 0
 +#define CONFIG_WMV3_NVDEC_HWACCEL 0
 +#define CONFIG_WMV3_VAAPI_HWACCEL 0
 +#define CONFIG_WMV3_VDPAU_HWACCEL 0
-+#define CONFIG_AAC_PARSER 1
++#define CONFIG_AAC_PARSER 0
 +#define CONFIG_AAC_LATM_PARSER 0
 +#define CONFIG_AC3_PARSER 0
 +#define CONFIG_ADX_PARSER 0
 +#define CONFIG_AMR_PARSER 0
-+#define CONFIG_APV_PARSER 0
 +#define CONFIG_AV1_PARSER 0
 +#define CONFIG_AVS2_PARSER 0
 +#define CONFIG_AVS3_PARSER 0
@@ -14917,7 +8405,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_DCA_PARSER 0
 +#define CONFIG_DIRAC_PARSER 0
 +#define CONFIG_DNXHD_PARSER 0
-+#define CONFIG_DNXUC_PARSER 0
 +#define CONFIG_DOLBY_E_PARSER 0
 +#define CONFIG_DPX_PARSER 0
 +#define CONFIG_DVAUDIO_PARSER 0
@@ -14927,19 +8414,17 @@ index 0000000000..6dd25c4177
 +#define CONFIG_EVC_PARSER 0
 +#define CONFIG_FLAC_PARSER 1
 +#define CONFIG_FTR_PARSER 0
-+#define CONFIG_FFV1_PARSER 0
 +#define CONFIG_G723_1_PARSER 0
 +#define CONFIG_G729_PARSER 0
 +#define CONFIG_GIF_PARSER 0
 +#define CONFIG_GSM_PARSER 0
 +#define CONFIG_H261_PARSER 0
 +#define CONFIG_H263_PARSER 0
-+#define CONFIG_H264_PARSER 1
++#define CONFIG_H264_PARSER 0
 +#define CONFIG_HEVC_PARSER 0
 +#define CONFIG_HDR_PARSER 0
 +#define CONFIG_IPU_PARSER 0
 +#define CONFIG_JPEG2000_PARSER 0
-+#define CONFIG_JPEGXL_PARSER 0
 +#define CONFIG_MISC4_PARSER 0
 +#define CONFIG_MJPEG_PARSER 0
 +#define CONFIG_MLP_PARSER 0
@@ -14949,16 +8434,16 @@ index 0000000000..6dd25c4177
 +#define CONFIG_OPUS_PARSER 1
 +#define CONFIG_PNG_PARSER 0
 +#define CONFIG_PNM_PARSER 0
-+#define CONFIG_PRORES_RAW_PARSER 0
 +#define CONFIG_QOI_PARSER 0
-+#define CONFIG_RV34_PARSER 0
++#define CONFIG_RV30_PARSER 0
++#define CONFIG_RV40_PARSER 0
 +#define CONFIG_SBC_PARSER 0
 +#define CONFIG_SIPR_PARSER 0
 +#define CONFIG_TAK_PARSER 0
 +#define CONFIG_VC1_PARSER 0
 +#define CONFIG_VORBIS_PARSER 1
-+#define CONFIG_VP3_PARSER 0
-+#define CONFIG_VP8_PARSER 0
++#define CONFIG_VP3_PARSER 1
++#define CONFIG_VP8_PARSER 1
 +#define CONFIG_VP9_PARSER 1
 +#define CONFIG_VVC_PARSER 0
 +#define CONFIG_WEBP_PARSER 0
@@ -14968,6 +8453,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ALSA_INDEV 0
 +#define CONFIG_ANDROID_CAMERA_INDEV 0
 +#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
 +#define CONFIG_DECKLINK_INDEV 0
 +#define CONFIG_DSHOW_INDEV 0
 +#define CONFIG_FBDEV_INDEV 0
@@ -14990,12 +8476,13 @@ index 0000000000..6dd25c4177
 +#define CONFIG_CACA_OUTDEV 0
 +#define CONFIG_DECKLINK_OUTDEV 0
 +#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
 +#define CONFIG_OSS_OUTDEV 0
 +#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
 +#define CONFIG_SNDIO_OUTDEV 0
 +#define CONFIG_V4L2_OUTDEV 0
 +#define CONFIG_XV_OUTDEV 0
-+#define CONFIG_AAP_FILTER 0
 +#define CONFIG_ABENCH_FILTER 0
 +#define CONFIG_ACOMPRESSOR_FILTER 0
 +#define CONFIG_ACONTRAST_FILTER 0
@@ -15045,7 +8532,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_APERMS_FILTER 0
 +#define CONFIG_APHASER_FILTER 0
 +#define CONFIG_APHASESHIFT_FILTER 0
-+#define CONFIG_APSNR_FILTER 0
 +#define CONFIG_APSYCLIP_FILTER 0
 +#define CONFIG_APULSATOR_FILTER 0
 +#define CONFIG_AREALTIME_FILTER 0
@@ -15063,7 +8549,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ASETTB_FILTER 0
 +#define CONFIG_ASHOWINFO_FILTER 0
 +#define CONFIG_ASIDEDATA_FILTER 0
-+#define CONFIG_ASISDR_FILTER 0
 +#define CONFIG_ASOFTCLIP_FILTER 0
 +#define CONFIG_ASPECTRALSTATS_FILTER 0
 +#define CONFIG_ASPLIT_FILTER 0
@@ -15135,7 +8620,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_VIRTUALBASS_FILTER 0
 +#define CONFIG_VOLUME_FILTER 0
 +#define CONFIG_VOLUMEDETECT_FILTER 0
-+#define CONFIG_WHISPER_FILTER 0
 +#define CONFIG_AEVALSRC_FILTER 0
 +#define CONFIG_AFDELAYSRC_FILTER 0
 +#define CONFIG_AFIREQSRC_FILTER 0
@@ -15163,7 +8647,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_BILATERAL_CUDA_FILTER 0
 +#define CONFIG_BITPLANENOISE_FILTER 0
 +#define CONFIG_BLACKDETECT_FILTER 0
-+#define CONFIG_BLACKDETECT_VULKAN_FILTER 0
 +#define CONFIG_BLACKFRAME_FILTER 0
 +#define CONFIG_BLEND_FILTER 0
 +#define CONFIG_BLEND_VULKAN_FILTER 0
@@ -15189,7 +8672,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_COLORCHANNELMIXER_FILTER 0
 +#define CONFIG_COLORCONTRAST_FILTER 0
 +#define CONFIG_COLORCORRECT_FILTER 0
-+#define CONFIG_COLORDETECT_FILTER 0
 +#define CONFIG_COLORIZE_FILTER 0
 +#define CONFIG_COLORKEY_FILTER 0
 +#define CONFIG_COLORKEY_OPENCL_FILTER 0
@@ -15273,7 +8755,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_FREEZEFRAMES_FILTER 0
 +#define CONFIG_FREI0R_FILTER 0
 +#define CONFIG_FSPP_FILTER 0
-+#define CONFIG_FSYNC_FILTER 0
 +#define CONFIG_GBLUR_FILTER 0
 +#define CONFIG_GBLUR_VULKAN_FILTER 0
 +#define CONFIG_GEQ_FILTER 0
@@ -15306,18 +8787,15 @@ index 0000000000..6dd25c4177
 +#define CONFIG_IL_FILTER 0
 +#define CONFIG_INFLATE_FILTER 0
 +#define CONFIG_INTERLACE_FILTER 0
-+#define CONFIG_INTERLACE_VULKAN_FILTER 0
 +#define CONFIG_INTERLEAVE_FILTER 0
 +#define CONFIG_KERNDEINT_FILTER 0
 +#define CONFIG_KIRSCH_FILTER 0
 +#define CONFIG_LAGFUN_FILTER 0
 +#define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
 +#define CONFIG_LENSCORRECTION_FILTER 0
 +#define CONFIG_LENSFUN_FILTER 0
 +#define CONFIG_LIBPLACEBO_FILTER 0
 +#define CONFIG_LIBVMAF_FILTER 0
-+#define CONFIG_LIBVMAF_CUDA_FILTER 0
 +#define CONFIG_LIMITDIFF_FILTER 0
 +#define CONFIG_LIMITER_FILTER 0
 +#define CONFIG_LOOP_FILTER 0
@@ -15367,7 +8845,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_OVERLAY_CUDA_FILTER 0
 +#define CONFIG_OWDENOISE_FILTER 0
 +#define CONFIG_PAD_FILTER 0
-+#define CONFIG_PAD_CUDA_FILTER 0
 +#define CONFIG_PAD_OPENCL_FILTER 0
 +#define CONFIG_PALETTEGEN_FILTER 0
 +#define CONFIG_PALETTEUSE_FILTER 0
@@ -15378,6 +8855,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_PIXDESCTEST_FILTER 0
 +#define CONFIG_PIXELIZE_FILTER 0
 +#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
 +#define CONFIG_PP7_FILTER 0
 +#define CONFIG_PREMULTIPLY_FILTER 0
 +#define CONFIG_PREWITT_FILTER 0
@@ -15388,8 +8866,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_PSNR_FILTER 0
 +#define CONFIG_PULLUP_FILTER 0
 +#define CONFIG_QP_FILTER 0
-+#define CONFIG_QRENCODE_FILTER 0
-+#define CONFIG_QUIRC_FILTER 0
 +#define CONFIG_RANDOM_FILTER 0
 +#define CONFIG_READEIA608_FILTER 0
 +#define CONFIG_READVITC_FILTER 0
@@ -15406,19 +8882,14 @@ index 0000000000..6dd25c4177
 +#define CONFIG_ROTATE_FILTER 0
 +#define CONFIG_SAB_FILTER 0
 +#define CONFIG_SCALE_FILTER 0
-+#define CONFIG_VPP_AMF_FILTER 0
-+#define CONFIG_SR_AMF_FILTER 0
 +#define CONFIG_SCALE_CUDA_FILTER 0
-+#define CONFIG_SCALE_D3D11_FILTER 0
 +#define CONFIG_SCALE_NPP_FILTER 0
 +#define CONFIG_SCALE_QSV_FILTER 0
 +#define CONFIG_SCALE_VAAPI_FILTER 0
-+#define CONFIG_SCALE_VT_FILTER 0
 +#define CONFIG_SCALE_VULKAN_FILTER 0
 +#define CONFIG_SCALE2REF_FILTER 0
 +#define CONFIG_SCALE2REF_NPP_FILTER 0
 +#define CONFIG_SCDET_FILTER 0
-+#define CONFIG_SCDET_VULKAN_FILTER 0
 +#define CONFIG_SCHARR_FILTER 0
 +#define CONFIG_SCROLL_FILTER 0
 +#define CONFIG_SEGMENT_FILTER 0
@@ -15466,7 +8937,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_THUMBNAIL_FILTER 0
 +#define CONFIG_THUMBNAIL_CUDA_FILTER 0
 +#define CONFIG_TILE_FILTER 0
-+#define CONFIG_TILTANDSHIFT_FILTER 0
 +#define CONFIG_TINTERLACE_FILTER 0
 +#define CONFIG_TLUT2_FILTER 0
 +#define CONFIG_TMEDIAN_FILTER 0
@@ -15480,7 +8950,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_TRANSPOSE_NPP_FILTER 0
 +#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
 +#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
-+#define CONFIG_TRANSPOSE_VT_FILTER 0
 +#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
 +#define CONFIG_TRIM_FILTER 0
 +#define CONFIG_UNPREMULTIPLY_FILTER 0
@@ -15512,7 +8981,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_XFADE_OPENCL_FILTER 0
 +#define CONFIG_XFADE_VULKAN_FILTER 0
 +#define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
 +#define CONFIG_XSTACK_FILTER 0
 +#define CONFIG_YADIF_FILTER 0
 +#define CONFIG_YADIF_CUDA_FILTER 0
@@ -15527,8 +8995,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_HSTACK_QSV_FILTER 0
 +#define CONFIG_VSTACK_QSV_FILTER 0
 +#define CONFIG_XSTACK_QSV_FILTER 0
-+#define CONFIG_PAD_VAAPI_FILTER 0
-+#define CONFIG_DRAWBOX_VAAPI_FILTER 0
 +#define CONFIG_ALLRGB_FILTER 0
 +#define CONFIG_ALLYUV_FILTER 0
 +#define CONFIG_CELLAUTO_FILTER 0
@@ -15546,10 +9012,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_MPTESTSRC_FILTER 0
 +#define CONFIG_NULLSRC_FILTER 0
 +#define CONFIG_OPENCLSRC_FILTER 0
-+#define CONFIG_QRENCODESRC_FILTER 0
 +#define CONFIG_PAL75BARS_FILTER 0
 +#define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
 +#define CONFIG_RGBTESTSRC_FILTER 0
 +#define CONFIG_SIERPINSKI_FILTER 0
 +#define CONFIG_SMPTEBARS_FILTER 0
@@ -15580,8 +9044,10 @@ index 0000000000..6dd25c4177
 +#define CONFIG_AVSYNCTEST_FILTER 0
 +#define CONFIG_AMOVIE_FILTER 0
 +#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AFIFO_FILTER 0
++#define CONFIG_FIFO_FILTER 0
 +#define CONFIG_AA_DEMUXER 0
-+#define CONFIG_AAC_DEMUXER 1
++#define CONFIG_AAC_DEMUXER 0
 +#define CONFIG_AAX_DEMUXER 0
 +#define CONFIG_AC3_DEMUXER 0
 +#define CONFIG_AC4_DEMUXER 0
@@ -15608,7 +9074,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_APNG_DEMUXER 0
 +#define CONFIG_APTX_DEMUXER 0
 +#define CONFIG_APTX_HD_DEMUXER 0
-+#define CONFIG_APV_DEMUXER 0
 +#define CONFIG_AQTITLE_DEMUXER 0
 +#define CONFIG_ARGO_ASF_DEMUXER 0
 +#define CONFIG_ARGO_BRP_DEMUXER 0
@@ -15620,6 +9085,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_AU_DEMUXER 0
 +#define CONFIG_AV1_DEMUXER 0
 +#define CONFIG_AVI_DEMUXER 0
++#define CONFIG_AVISYNTH_DEMUXER 0
 +#define CONFIG_AVR_DEMUXER 0
 +#define CONFIG_AVS_DEMUXER 0
 +#define CONFIG_AVS2_DEMUXER 0
@@ -15684,7 +9150,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_G723_1_DEMUXER 0
 +#define CONFIG_G726_DEMUXER 0
 +#define CONFIG_G726LE_DEMUXER 0
-+#define CONFIG_G728_DEMUXER 0
 +#define CONFIG_G729_DEMUXER 0
 +#define CONFIG_GDV_DEMUXER 0
 +#define CONFIG_GENH_DEMUXER 0
@@ -15699,7 +9164,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_HEVC_DEMUXER 0
 +#define CONFIG_HLS_DEMUXER 0
 +#define CONFIG_HNM_DEMUXER 0
-+#define CONFIG_IAMF_DEMUXER 0
 +#define CONFIG_ICO_DEMUXER 0
 +#define CONFIG_IDCIN_DEMUXER 0
 +#define CONFIG_IDF_DEMUXER 0
@@ -15725,7 +9189,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_KUX_DEMUXER 0
 +#define CONFIG_KVAG_DEMUXER 0
 +#define CONFIG_LAF_DEMUXER 0
-+#define CONFIG_LC3_DEMUXER 0
 +#define CONFIG_LMLM4_DEMUXER 0
 +#define CONFIG_LOAS_DEMUXER 0
 +#define CONFIG_LUODAT_DEMUXER 0
@@ -15776,7 +9239,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_OBU_DEMUXER 0
 +#define CONFIG_OGG_DEMUXER 1
 +#define CONFIG_OMA_DEMUXER 0
-+#define CONFIG_OSQ_DEMUXER 0
 +#define CONFIG_PAF_DEMUXER 0
 +#define CONFIG_PCM_ALAW_DEMUXER 0
 +#define CONFIG_PCM_MULAW_DEMUXER 0
@@ -15806,10 +9268,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_PVA_DEMUXER 0
 +#define CONFIG_PVF_DEMUXER 0
 +#define CONFIG_QCP_DEMUXER 0
-+#define CONFIG_QOA_DEMUXER 0
 +#define CONFIG_R3D_DEMUXER 0
 +#define CONFIG_RAWVIDEO_DEMUXER 0
-+#define CONFIG_RCWT_DEMUXER 0
 +#define CONFIG_REALTEXT_DEMUXER 0
 +#define CONFIG_REDSPARK_DEMUXER 0
 +#define CONFIG_RKA_DEMUXER 0
@@ -15866,7 +9326,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_TXD_DEMUXER 0
 +#define CONFIG_TTY_DEMUXER 0
 +#define CONFIG_TY_DEMUXER 0
-+#define CONFIG_USM_DEMUXER 0
 +#define CONFIG_V210_DEMUXER 0
 +#define CONFIG_V210X_DEMUXER 0
 +#define CONFIG_VAG_DEMUXER 0
@@ -15938,8 +9397,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
 +#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
 +#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
-+#define CONFIG_AVISYNTH_DEMUXER 0
-+#define CONFIG_DVDVIDEO_DEMUXER 0
 +#define CONFIG_LIBGME_DEMUXER 0
 +#define CONFIG_LIBMODPLUG_DEMUXER 0
 +#define CONFIG_LIBOPENMPT_DEMUXER 0
@@ -15949,7 +9406,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_AC4_MUXER 0
 +#define CONFIG_ADTS_MUXER 0
 +#define CONFIG_ADX_MUXER 0
-+#define CONFIG_AEA_MUXER 0
 +#define CONFIG_AIFF_MUXER 0
 +#define CONFIG_ALP_MUXER 0
 +#define CONFIG_AMR_MUXER 0
@@ -15958,7 +9414,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_APNG_MUXER 0
 +#define CONFIG_APTX_MUXER 0
 +#define CONFIG_APTX_HD_MUXER 0
-+#define CONFIG_APV_MUXER 0
 +#define CONFIG_ARGO_ASF_MUXER 0
 +#define CONFIG_ARGO_CVG_MUXER 0
 +#define CONFIG_ASF_MUXER 0
@@ -15990,6 +9445,7 @@ index 0000000000..6dd25c4177
 +#define CONFIG_F4V_MUXER 0
 +#define CONFIG_FFMETADATA_MUXER 0
 +#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
 +#define CONFIG_FILMSTRIP_MUXER 0
 +#define CONFIG_FITS_MUXER 0
 +#define CONFIG_FLAC_MUXER 0
@@ -16011,7 +9467,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_HDS_MUXER 0
 +#define CONFIG_HEVC_MUXER 0
 +#define CONFIG_HLS_MUXER 0
-+#define CONFIG_IAMF_MUXER 0
 +#define CONFIG_ICO_MUXER 0
 +#define CONFIG_ILBC_MUXER 0
 +#define CONFIG_IMAGE2_MUXER 0
@@ -16023,10 +9478,8 @@ index 0000000000..6dd25c4177
 +#define CONFIG_JACOSUB_MUXER 0
 +#define CONFIG_KVAG_MUXER 0
 +#define CONFIG_LATM_MUXER 0
-+#define CONFIG_LC3_MUXER 0
 +#define CONFIG_LRC_MUXER 0
 +#define CONFIG_M4V_MUXER 0
-+#define CONFIG_MCC_MUXER 0
 +#define CONFIG_MD5_MUXER 0
 +#define CONFIG_MATROSKA_MUXER 0
 +#define CONFIG_MATROSKA_AUDIO_MUXER 0
@@ -16081,7 +9534,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_PCM_U8_MUXER 0
 +#define CONFIG_PSP_MUXER 0
 +#define CONFIG_RAWVIDEO_MUXER 0
-+#define CONFIG_RCWT_MUXER 0
 +#define CONFIG_RM_MUXER 0
 +#define CONFIG_ROQ_MUXER 0
 +#define CONFIG_RSO_MUXER 0
@@ -16122,13 +9574,11 @@ index 0000000000..6dd25c4177
 +#define CONFIG_WEBM_CHUNK_MUXER 0
 +#define CONFIG_WEBP_MUXER 0
 +#define CONFIG_WEBVTT_MUXER 0
-+#define CONFIG_WHIP_MUXER 0
 +#define CONFIG_WSAUD_MUXER 0
 +#define CONFIG_WTV_MUXER 0
 +#define CONFIG_WV_MUXER 0
 +#define CONFIG_YUV4MPEGPIPE_MUXER 0
 +#define CONFIG_CHROMAPRINT_MUXER 0
-+#define CONFIG_ANDROID_CONTENT_PROTOCOL 0
 +#define CONFIG_ASYNC_PROTOCOL 0
 +#define CONFIG_BLURAY_PROTOCOL 0
 +#define CONFIG_CACHE_PROTOCOL 0
@@ -16166,7 +9616,6 @@ index 0000000000..6dd25c4177
 +#define CONFIG_TEE_PROTOCOL 0
 +#define CONFIG_TCP_PROTOCOL 0
 +#define CONFIG_TLS_PROTOCOL 0
-+#define CONFIG_DTLS_PROTOCOL 0
 +#define CONFIG_UDP_PROTOCOL 0
 +#define CONFIG_UDPLITE_PROTOCOL 0
 +#define CONFIG_UNIX_PROTOCOL 0
@@ -16183,3070 +9632,92 @@ index 0000000000..6dd25c4177
 +#define CONFIG_LIBZMQ_PROTOCOL 0
 +#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
 +#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#define CONFIG_H264_D3D12VA_HWACCEL 0
 +#endif /* FFMPEG_CONFIG_COMPONENTS_H */
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/doc/config.texi b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/doc/config.texi
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
 new file mode 100644
-index 0000000000..8d834e7ec5
+index 0000000000..7ff70c6e2d
 --- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/doc/config.texi
-@@ -0,0 +1,3057 @@
-+@c auto-generated by configure - do not modify! 
-+@c @set arch-aarch64 no
-+@c @set arch-arm no
-+@c @set arch-ia64 no
-+@set arch-loongarch yes
-+@c @set arch-loongarch32 no
-+@set arch-loongarch64 yes
-+@c @set arch-m68k no
-+@c @set arch-mips no
-+@c @set arch-mips64 no
-+@c @set arch-parisc no
-+@c @set arch-ppc no
-+@c @set arch-ppc64 no
-+@c @set arch-riscv no
-+@c @set arch-s390 no
-+@c @set arch-sparc no
-+@c @set arch-sparc64 no
-+@c @set arch-tilegx no
-+@c @set arch-tilepro no
-+@c @set arch-wasm no
-+@c @set arch-x86 no
-+@c @set arch-x86-32 no
-+@c @set arch-x86-64 no
-+@c @set have-armv5te no
-+@c @set have-armv6 no
-+@c @set have-armv6t2 no
-+@c @set have-armv8 no
-+@c @set have-dotprod no
-+@c @set have-i8mm no
-+@c @set have-neon no
-+@c @set have-vfp no
-+@c @set have-vfpv3 no
-+@c @set have-setend no
-+@c @set have-sve no
-+@c @set have-sve2 no
-+@c @set have-altivec no
-+@c @set have-dcbzl no
-+@c @set have-ldbrx no
-+@c @set have-power8 no
-+@c @set have-ppc4xx no
-+@c @set have-vec-xl no
-+@c @set have-vsx no
-+@c @set have-rv no
-+@c @set have-rvv no
-+@set have-rv-zicbop yes
-+@c @set have-rv-zvbb no
-+@c @set have-simd128 no
-+@c @set have-aesni no
-+@c @set have-amd3dnow no
-+@c @set have-amd3dnowext no
-+@c @set have-avx no
-+@c @set have-avx2 no
-+@c @set have-avx512 no
-+@c @set have-avx512icl no
-+@c @set have-fma3 no
-+@c @set have-fma4 no
-+@c @set have-mmx no
-+@c @set have-mmxext no
-+@c @set have-sse no
-+@c @set have-sse2 no
-+@c @set have-sse3 no
-+@c @set have-sse4 no
-+@c @set have-sse42 no
-+@c @set have-ssse3 no
-+@c @set have-xop no
-+@c @set have-i686 no
-+@c @set have-mipsfpu no
-+@c @set have-mips32r2 no
-+@c @set have-mips32r5 no
-+@c @set have-mips64r2 no
-+@c @set have-mips32r6 no
-+@c @set have-mips64r6 no
-+@c @set have-mipsdsp no
-+@c @set have-mipsdspr2 no
-+@c @set have-msa no
-+@c @set have-loongson2 no
-+@c @set have-loongson3 no
-+@c @set have-mmi no
-+@c @set have-lsx no
-+@c @set have-lasx no
-+@c @set have-armv5te-external no
-+@c @set have-armv6-external no
-+@c @set have-armv6t2-external no
-+@c @set have-armv8-external no
-+@c @set have-dotprod-external no
-+@c @set have-i8mm-external no
-+@c @set have-neon-external no
-+@c @set have-vfp-external no
-+@c @set have-vfpv3-external no
-+@c @set have-setend-external no
-+@c @set have-sve-external no
-+@c @set have-sve2-external no
-+@c @set have-altivec-external no
-+@c @set have-dcbzl-external no
-+@c @set have-ldbrx-external no
-+@c @set have-power8-external no
-+@c @set have-ppc4xx-external no
-+@c @set have-vec-xl-external no
-+@c @set have-vsx-external no
-+@c @set have-rv-external no
-+@c @set have-rvv-external no
-+@c @set have-rv-zicbop-external no
-+@c @set have-rv-zvbb-external no
-+@c @set have-simd128-external no
-+@c @set have-aesni-external no
-+@c @set have-amd3dnow-external no
-+@c @set have-amd3dnowext-external no
-+@c @set have-avx-external no
-+@c @set have-avx2-external no
-+@c @set have-avx512-external no
-+@c @set have-avx512icl-external no
-+@c @set have-fma3-external no
-+@c @set have-fma4-external no
-+@c @set have-mmx-external no
-+@c @set have-mmxext-external no
-+@c @set have-sse-external no
-+@c @set have-sse2-external no
-+@c @set have-sse3-external no
-+@c @set have-sse4-external no
-+@c @set have-sse42-external no
-+@c @set have-ssse3-external no
-+@c @set have-xop-external no
-+@c @set have-i686-external no
-+@c @set have-mipsfpu-external no
-+@c @set have-mips32r2-external no
-+@c @set have-mips32r5-external no
-+@c @set have-mips64r2-external no
-+@c @set have-mips32r6-external no
-+@c @set have-mips64r6-external no
-+@c @set have-mipsdsp-external no
-+@c @set have-mipsdspr2-external no
-+@c @set have-msa-external no
-+@c @set have-loongson2-external no
-+@c @set have-loongson3-external no
-+@c @set have-mmi-external no
-+@c @set have-lsx-external no
-+@c @set have-lasx-external no
-+@c @set have-armv5te-inline no
-+@c @set have-armv6-inline no
-+@c @set have-armv6t2-inline no
-+@c @set have-armv8-inline no
-+@c @set have-dotprod-inline no
-+@c @set have-i8mm-inline no
-+@c @set have-neon-inline no
-+@c @set have-vfp-inline no
-+@c @set have-vfpv3-inline no
-+@c @set have-setend-inline no
-+@c @set have-sve-inline no
-+@c @set have-sve2-inline no
-+@c @set have-altivec-inline no
-+@c @set have-dcbzl-inline no
-+@c @set have-ldbrx-inline no
-+@c @set have-power8-inline no
-+@c @set have-ppc4xx-inline no
-+@c @set have-vec-xl-inline no
-+@c @set have-vsx-inline no
-+@c @set have-rv-inline no
-+@c @set have-rvv-inline no
-+@c @set have-rv-zicbop-inline no
-+@c @set have-rv-zvbb-inline no
-+@c @set have-simd128-inline no
-+@c @set have-aesni-inline no
-+@c @set have-amd3dnow-inline no
-+@c @set have-amd3dnowext-inline no
-+@c @set have-avx-inline no
-+@c @set have-avx2-inline no
-+@c @set have-avx512-inline no
-+@c @set have-avx512icl-inline no
-+@c @set have-fma3-inline no
-+@c @set have-fma4-inline no
-+@c @set have-mmx-inline no
-+@c @set have-mmxext-inline no
-+@c @set have-sse-inline no
-+@c @set have-sse2-inline no
-+@c @set have-sse3-inline no
-+@c @set have-sse4-inline no
-+@c @set have-sse42-inline no
-+@c @set have-ssse3-inline no
-+@c @set have-xop-inline no
-+@c @set have-i686-inline no
-+@c @set have-mipsfpu-inline no
-+@c @set have-mips32r2-inline no
-+@c @set have-mips32r5-inline no
-+@c @set have-mips64r2-inline no
-+@c @set have-mips32r6-inline no
-+@c @set have-mips64r6-inline no
-+@c @set have-mipsdsp-inline no
-+@c @set have-mipsdspr2-inline no
-+@c @set have-msa-inline no
-+@c @set have-loongson2-inline no
-+@c @set have-loongson3-inline no
-+@c @set have-mmi-inline no
-+@c @set have-lsx-inline no
-+@c @set have-lasx-inline no
-+@c @set have-aligned-stack no
-+@set have-fast-64bit yes
-+@set have-fast-clz yes
-+@c @set have-fast-cmov no
-+@c @set have-fast-float16 no
-+@c @set have-simd-align-16 no
-+@set have-simd-align-32 yes
-+@c @set have-simd-align-64 no
-+@c @set have-memorybarrier no
-+@c @set have-mm-empty no
-+@c @set have-rdtsc no
-+@set have-sem-timedwait yes
-+@set have-inline-asm yes
-+@c @set have-symver no
-+@c @set have-x86asm no
-+@c @set have-bigendian no
-+@set have-fast-unaligned yes
-+@c @set have-arpa-inet-h no
-+@c @set have-asm-hwprobe-h no
-+@set have-asm-types-h yes
-+@c @set have-cdio-paranoia-h no
-+@c @set have-cdio-paranoia-paranoia-h no
-+@c @set have-cuda-h no
-+@c @set have-dispatch-dispatch-h no
-+@c @set have-direct-h no
-+@set have-dirent-h yes
-+@c @set have-dxgidebug-h no
-+@c @set have-dxva-h no
-+@c @set have-es2-gl-h no
-+@c @set have-gsm-h no
-+@c @set have-io-h no
-+@c @set have-linux-dma-buf-h no
-+@set have-linux-perf-event-h yes
-+@set have-malloc-h yes
-+@c @set have-opencv2-core-core-c-h no
-+@set have-poll-h yes
-+@c @set have-pthread-np-h no
-+@c @set have-sys-hwprobe-h no
-+@set have-sys-param-h yes
-+@set have-sys-resource-h yes
-+@set have-sys-select-h yes
-+@set have-sys-soundcard-h yes
-+@set have-sys-time-h yes
-+@set have-sys-un-h yes
-+@c @set have-sys-videoio-h no
-+@set have-termios-h yes
-+@c @set have-udplite-h no
-+@set have-unistd-h yes
-+@c @set have-valgrind-valgrind-h no
-+@c @set have-windows-h no
-+@c @set have-winsock2-h no
-+@c @set have-intrinsics-neon no
-+@c @set have-intrinsics-sse2 no
-+@set have-atanf yes
-+@set have-atan2f yes
-+@set have-cbrt yes
-+@set have-cbrtf yes
-+@set have-copysign yes
-+@set have-cosf yes
-+@set have-erf yes
-+@set have-exp2 yes
-+@set have-exp2f yes
-+@set have-expf yes
-+@set have-hypot yes
-+@set have-isfinite yes
-+@set have-isinf yes
-+@set have-isnan yes
-+@set have-ldexpf yes
-+@set have-llrint yes
-+@set have-llrintf yes
-+@set have-log2 yes
-+@set have-log2f yes
-+@set have-log10f yes
-+@set have-lrint yes
-+@set have-lrintf yes
-+@set have-powf yes
-+@set have-rint yes
-+@set have-round yes
-+@set have-roundf yes
-+@set have-sinf yes
-+@set have-trunc yes
-+@set have-truncf yes
-+@c @set have-dos-paths no
-+@c @set have-libc-msvcrt no
-+@c @set have-mmal-parameter-video-max-num-callbacks no
-+@set have-section-data-rel-ro yes
-+@set have-threads yes
-+@c @set have-uwp no
-+@c @set have-winrt no
-+@set have-access yes
-+@c @set have-aligned-malloc no
-+@c @set have-arc4random-buf no
-+@set have-clock-gettime yes
-+@c @set have-closesocket no
-+@c @set have-commandlinetoargvw no
-+@c @set have-elf-aux-info no
-+@set have-fcntl yes
-+@c @set have-getaddrinfo no
-+@set have-getauxval yes
-+@set have-getenv yes
-+@c @set have-gethrtime no
-+@set have-getopt yes
-+@c @set have-getmodulehandle no
-+@c @set have-getprocessaffinitymask no
-+@c @set have-getprocessmemoryinfo no
-+@c @set have-getprocesstimes no
-+@set have-getrusage yes
-+@c @set have-getstdhandle no
-+@c @set have-getsystemtimeasfiletime no
-+@set have-gettimeofday yes
-+@set have-glob yes
-+@c @set have-glxgetprocaddress no
-+@set have-gmtime-r yes
-+@c @set have-inet-aton no
-+@set have-isatty yes
-+@c @set have-kbhit no
-+@set have-localtime-r yes
-+@set have-lstat yes
-+@c @set have-lzo1x-999-compress no
-+@c @set have-mach-absolute-time no
-+@c @set have-mapviewoffile no
-+@set have-memalign yes
-+@set have-mkstemp yes
-+@set have-mmap yes
-+@set have-mprotect yes
-+@set have-nanosleep yes
-+@c @set have-peeknamedpipe no
-+@set have-posix-memalign yes
-+@set have-prctl yes
-+@set have-pthread-cancel yes
-+@c @set have-pthread-set-name-np no
-+@c @set have-pthread-setname-np no
-+@set have-sched-getaffinity yes
-+@c @set have-secitemimport no
-+@c @set have-setconsoletextattribute no
-+@c @set have-setconsolectrlhandler no
-+@c @set have-setdlldirectory no
-+@c @set have-setmode no
-+@set have-setrlimit yes
-+@c @set have-sleep no
-+@set have-strerror-r yes
-+@set have-sysconf yes
-+@c @set have-sysctl no
-+@c @set have-sysctlbyname no
-+@set have-tempnam yes
-+@set have-usleep yes
-+@c @set have-utgetostypefromstring no
-+@c @set have-virtualalloc no
-+@c @set have-wglgetprocaddress no
-+@c @set have-bcrypt no
-+@c @set have-vaapi-drm no
-+@c @set have-vaapi-x11 no
-+@c @set have-vaapi-win32 no
-+@c @set have-vdpau-x11 no
-+@set have-pthreads yes
-+@c @set have-os2threads no
-+@c @set have-w32threads no
-+@c @set have-as-arch-directive no
-+@c @set have-as-archext-dotprod-directive no
-+@c @set have-as-archext-i8mm-directive no
-+@c @set have-as-archext-sve-directive no
-+@c @set have-as-archext-sve2-directive no
-+@c @set have-as-dn-directive no
-+@c @set have-as-fpu-directive no
-+@c @set have-as-func no
-+@c @set have-as-object-arch no
-+@c @set have-asm-mod-q no
-+@c @set have-blocks-extension no
-+@c @set have-ebp-available no
-+@c @set have-ebx-available no
-+@c @set have-gnu-as no
-+@c @set have-gnu-windres no
-+@c @set have-ibm-asm no
-+@c @set have-inline-asm-direct-symbol-refs no
-+@set have-inline-asm-labels yes
-+@set have-inline-asm-nonlocal-labels yes
-+@set have-pragma-deprecated yes
-+@set have-rsync-contimeout yes
-+@set have-symver-asm-label yes
-+@set have-symver-gnu-asm yes
-+@c @set have-vfp-args no
-+@c @set have-xform-asm no
-+@c @set have-xmm-clobbers no
-+@c @set have-dpi-awareness-context no
-+@c @set have-idxgioutput5 no
-+@c @set have-kcmvideocodectype-hevc no
-+@c @set have-kcmvideocodectype-hevcwithalpha no
-+@c @set have-kcmvideocodectype-vp9 no
-+@c @set have-kcmvideocodectype-av1 no
-+@c @set have-kcvpixelformattype-420ypcbcr10biplanarvideorange no
-+@c @set have-kcvpixelformattype-422ypcbcr8biplanarvideorange no
-+@c @set have-kcvpixelformattype-422ypcbcr10biplanarvideorange no
-+@c @set have-kcvpixelformattype-422ypcbcr16biplanarvideorange no
-+@c @set have-kcvpixelformattype-444ypcbcr8biplanarvideorange no
-+@c @set have-kcvpixelformattype-444ypcbcr10biplanarvideorange no
-+@c @set have-kcvpixelformattype-444ypcbcr16biplanarvideorange no
-+@c @set have-kcvimagebuffertransferfunction-smpte-st-2084-pq no
-+@c @set have-kcvimagebuffertransferfunction-itu-r-2100-hlg no
-+@c @set have-kcvimagebuffertransferfunction-linear no
-+@c @set have-kcvimagebufferycbcrmatrix-itu-r-2020 no
-+@c @set have-kcvimagebuffercolorprimaries-itu-r-2020 no
-+@c @set have-kcvimagebuffertransferfunction-itu-r-2020 no
-+@c @set have-kcvimagebuffertransferfunction-smpte-st-428-1 no
-+@c @set have-kvtqpmodulationlevel-default no
-+@c @set have-secpkgcontext-keyingmaterialinfo no
-+@c @set have-socklen-t no
-+@c @set have-struct-addrinfo no
-+@c @set have-struct-group-source-req no
-+@c @set have-struct-ip-mreq-source no
-+@c @set have-struct-ipv6-mreq no
-+@c @set have-struct-msghdr-msg-flags no
-+@c @set have-struct-pollfd no
-+@set have-struct-rusage-ru-maxrss yes
-+@c @set have-struct-sctp-event-subscribe no
-+@c @set have-struct-sockaddr-in6 no
-+@c @set have-struct-sockaddr-sa-len no
-+@c @set have-struct-sockaddr-storage no
-+@set have-struct-stat-st-mtim-tv-nsec yes
-+@set have-struct-v4l2-frmivalenum-discrete yes
-+@c @set have-struct-mfxconfiginterface no
-+@set have-gzip yes
-+@c @set have-ioctl-posix no
-+@c @set have-libdrm-getfb2 no
-+@c @set have-makeinfo no
-+@c @set have-makeinfo-html no
-+@c @set have-opencl-d3d11 no
-+@c @set have-opencl-drm-arm no
-+@c @set have-opencl-drm-beignet no
-+@c @set have-opencl-dxva2 no
-+@c @set have-opencl-vaapi-beignet no
-+@c @set have-opencl-vaapi-intel-media no
-+@c @set have-opencl-videotoolbox no
-+@set have-perl yes
-+@set have-pod2man yes
-+@c @set have-texi2html no
-+@c @set have-xmllint no
-+@c @set have-zlib-gzip no
-+@c @set have-openvino2 no
-+@c @set config-doc no
-+@c @set config-htmlpages no
-+@c @set config-manpages no
-+@c @set config-podpages no
-+@c @set config-txtpages no
-+@set config-avio-http-serve-files-example yes
-+@set config-avio-list-dir-example yes
-+@set config-avio-read-callback-example yes
-+@set config-decode-audio-example yes
-+@c @set config-decode-filter-audio-example no
-+@c @set config-decode-filter-video-example no
-+@set config-decode-video-example yes
-+@set config-demux-decode-example yes
-+@set config-encode-audio-example yes
-+@set config-encode-video-example yes
-+@set config-extract-mvs-example yes
-+@c @set config-filter-audio-example no
-+@set config-hw-decode-example yes
-+@c @set config-mux-example no
-+@c @set config-qsv-decode-example no
-+@set config-remux-example yes
-+@c @set config-resample-audio-example no
-+@c @set config-scale-video-example no
-+@set config-show-metadata-example yes
-+@c @set config-transcode-aac-example no
-+@c @set config-transcode-example no
-+@c @set config-vaapi-encode-example no
-+@c @set config-vaapi-transcode-example no
-+@c @set config-qsv-transcode-example no
-+@c @set config-avisynth no
-+@c @set config-frei0r no
-+@c @set config-libcdio no
-+@c @set config-libdavs2 no
-+@c @set config-libdvdnav no
-+@c @set config-libdvdread no
-+@c @set config-librubberband no
-+@c @set config-libvidstab no
-+@c @set config-libx264 no
-+@c @set config-libx265 no
-+@c @set config-libxavs no
-+@c @set config-libxavs2 no
-+@c @set config-libxvid no
-+@c @set config-decklink no
-+@c @set config-libfdk-aac no
-+@c @set config-libtls no
-+@c @set config-gmp no
-+@c @set config-libaribb24 no
-+@c @set config-liblensfun no
-+@c @set config-libopencore-amrnb no
-+@c @set config-libopencore-amrwb no
-+@c @set config-libvo-amrwbenc no
-+@c @set config-mbedtls no
-+@c @set config-rkmpp no
-+@c @set config-libsmbclient no
-+@c @set config-chromaprint no
-+@c @set config-gcrypt no
-+@c @set config-gnutls no
-+@c @set config-jni no
-+@c @set config-ladspa no
-+@c @set config-lcms2 no
-+@c @set config-libaom no
-+@c @set config-libaribcaption no
-+@c @set config-libass no
-+@c @set config-libbluray no
-+@c @set config-libbs2b no
-+@c @set config-libcaca no
-+@c @set config-libcelt no
-+@c @set config-libcodec2 no
-+@c @set config-libdav1d no
-+@c @set config-libdc1394 no
-+@c @set config-libflite no
-+@c @set config-libfontconfig no
-+@c @set config-libfreetype no
-+@c @set config-libfribidi no
-+@c @set config-libharfbuzz no
-+@c @set config-libglslang no
-+@c @set config-libgme no
-+@c @set config-libgsm no
-+@c @set config-libiec61883 no
-+@c @set config-libilbc no
-+@c @set config-libjack no
-+@c @set config-libjxl no
-+@c @set config-libklvanc no
-+@c @set config-libkvazaar no
-+@c @set config-liblc3 no
-+@c @set config-liblcevc-dec no
-+@c @set config-libmodplug no
-+@c @set config-libmp3lame no
-+@c @set config-libmysofa no
-+@c @set config-liboapv no
-+@c @set config-libopencv no
-+@c @set config-libopenh264 no
-+@c @set config-libopenjpeg no
-+@c @set config-libopenmpt no
-+@c @set config-libopenvino no
-+@set config-libopus yes
-+@c @set config-libplacebo no
-+@c @set config-libpulse no
-+@c @set config-libqrencode no
-+@c @set config-libquirc no
-+@c @set config-librabbitmq no
-+@c @set config-librav1e no
-+@c @set config-librist no
-+@c @set config-librsvg no
-+@c @set config-librtmp no
-+@c @set config-libshaderc no
-+@c @set config-libshine no
-+@c @set config-libsmbclient no
-+@c @set config-libsnappy no
-+@c @set config-libsoxr no
-+@c @set config-libspeex no
-+@c @set config-libsrt no
-+@c @set config-libssh no
-+@c @set config-libsvtav1 no
-+@c @set config-libtensorflow no
-+@c @set config-libtesseract no
-+@c @set config-libtheora no
-+@c @set config-libtorch no
-+@c @set config-libtwolame no
-+@c @set config-libuavs3d no
-+@c @set config-libv4l2 no
-+@c @set config-libvmaf no
-+@c @set config-libvorbis no
-+@c @set config-libvpx no
-+@c @set config-libvvenc no
-+@c @set config-libwebp no
-+@c @set config-libxevd no
-+@c @set config-libxeve no
-+@c @set config-libxml2 no
-+@c @set config-libzimg no
-+@c @set config-libzmq no
-+@c @set config-libzvbi no
-+@c @set config-lv2 no
-+@c @set config-mediacodec no
-+@c @set config-ohcodec no
-+@c @set config-openal no
-+@c @set config-opengl no
-+@c @set config-openssl no
-+@c @set config-pocketsphinx no
-+@c @set config-vapoursynth no
-+@c @set config-vulkan-static no
-+@c @set config-whisper no
-+@c @set config-alsa no
-+@c @set config-appkit no
-+@c @set config-avfoundation no
-+@c @set config-bzlib no
-+@c @set config-coreimage no
-+@c @set config-iconv no
-+@c @set config-libxcb no
-+@c @set config-libxcb-shm no
-+@c @set config-libxcb-shape no
-+@c @set config-libxcb-xfixes no
-+@c @set config-lzma no
-+@c @set config-mediafoundation no
-+@c @set config-metal no
-+@c @set config-schannel no
-+@c @set config-sdl2 no
-+@c @set config-securetransport no
-+@c @set config-sndio no
-+@c @set config-xlib no
-+@c @set config-zlib no
-+@c @set config-cuda-nvcc no
-+@c @set config-cuda-sdk no
-+@c @set config-libnpp no
-+@c @set config-libmfx no
-+@c @set config-libvpl no
-+@c @set config-mmal no
-+@c @set config-omx no
-+@c @set config-opencl no
-+@c @set config-amf no
-+@c @set config-audiotoolbox no
-+@c @set config-cuda no
-+@c @set config-cuda-llvm no
-+@c @set config-cuvid no
-+@c @set config-d3d11va no
-+@c @set config-d3d12va no
-+@c @set config-dxva2 no
-+@c @set config-ffnvcodec no
-+@c @set config-libdrm no
-+@c @set config-nvdec no
-+@c @set config-nvenc no
-+@c @set config-vaapi no
-+@c @set config-vdpau no
-+@c @set config-videotoolbox no
-+@c @set config-vulkan no
-+@c @set config-v4l2-m2m no
-+@c @set config-ftrapv no
-+@c @set config-gray no
-+@c @set config-hardcoded-tables no
-+@c @set config-omx-rpi no
-+@set config-runtime-cpudetect yes
-+@set config-safe-bitstream-reader yes
-+@c @set config-shared no
-+@c @set config-small no
-+@set config-static yes
-+@set config-swscale-alpha yes
-+@c @set config-gpl no
-+@c @set config-nonfree no
-+@c @set config-version3 no
-+@c @set config-avdevice no
-+@c @set config-avfilter no
-+@c @set config-swscale no
-+@set config-avformat yes
-+@set config-avcodec yes
-+@c @set config-swresample no
-+@set config-avutil yes
-+@c @set config-ffplay no
-+@c @set config-ffprobe no
-+@c @set config-ffmpeg no
-+@c @set config-dwt no
-+@c @set config-error-resilience no
-+@c @set config-faan no
-+@set config-fast-unaligned yes
-+@c @set config-iamf no
-+@c @set config-lsp no
-+@c @set config-pixelutils no
-+@c @set config-network no
-+@c @set config-autodetect no
-+@c @set config-fontconfig no
-+@set config-large-tests yes
-+@c @set config-linux-perf no
-+@c @set config-macos-kperf no
-+@c @set config-memory-poisoning no
-+@c @set config-neon-clobber-test no
-+@c @set config-ossfuzz no
-+@set config-pic yes
-+@c @set config-ptx-compression no
-+@c @set config-resource-compression no
-+@c @set config-thumb no
-+@c @set config-valgrind-backtrace no
-+@c @set config-xmm-clobber-test no
-+@c @set config-bsfs no
-+@set config-decoders yes
-+@c @set config-encoders no
-+@c @set config-hwaccels no
-+@set config-parsers yes
-+@c @set config-indevs no
-+@c @set config-outdevs no
-+@c @set config-filters no
-+@set config-demuxers yes
-+@c @set config-muxers no
-+@c @set config-protocols no
-+@c @set config-aandcttables no
-+@c @set config-ac3dsp no
-+@set config-adts-header yes
-+@set config-atsc-a53 yes
-+@c @set config-audio-frame-queue no
-+@c @set config-audiodsp no
-+@c @set config-blockdsp no
-+@c @set config-bswapdsp no
-+@set config-cabac yes
-+@c @set config-cbs no
-+@c @set config-cbs-apv no
-+@c @set config-cbs-av1 no
-+@c @set config-cbs-h264 no
-+@c @set config-cbs-h265 no
-+@c @set config-cbs-h266 no
-+@c @set config-cbs-jpeg no
-+@c @set config-cbs-mpeg2 no
-+@c @set config-cbs-vp8 no
-+@c @set config-cbs-vp9 no
-+@c @set config-celp-math no
-+@c @set config-d3d12va-encode no
-+@c @set config-deflate-wrapper no
-+@set config-dirac-parse yes
-+@c @set config-dnn no
-+@c @set config-dovi-rpudec no
-+@c @set config-dovi-rpuenc no
-+@c @set config-dvprofile no
-+@c @set config-evcparse no
-+@c @set config-exif no
-+@c @set config-faandct no
-+@c @set config-faanidct no
-+@c @set config-fdctdsp no
-+@c @set config-fmtconvert no
-+@c @set config-frame-thread-encoder no
-+@c @set config-g722dsp no
-+@set config-golomb yes
-+@c @set config-gplv3 no
-+@c @set config-h263dsp no
-+@set config-h264chroma yes
-+@set config-h264dsp yes
-+@set config-h264parse yes
-+@set config-h264pred yes
-+@set config-h264qpel yes
-+@set config-h264-sei yes
-+@c @set config-hevcparse no
-+@c @set config-hevc-sei no
-+@c @set config-hpeldsp no
-+@c @set config-huffman no
-+@c @set config-huffyuvdsp no
-+@c @set config-huffyuvencdsp no
-+@c @set config-iamfdec no
-+@c @set config-iamfenc no
-+@c @set config-idctdsp no
-+@c @set config-inflate-wrapper no
-+@c @set config-intrax8 no
-+@set config-iso-media yes
-+@c @set config-iso-writer no
-+@c @set config-ividsp no
-+@c @set config-jpegtables no
-+@c @set config-lgplv3 no
-+@c @set config-libx262 no
-+@c @set config-libx264-hdr10 no
-+@c @set config-llauddsp no
-+@c @set config-llviddsp no
-+@c @set config-llvidencdsp no
-+@c @set config-lpc no
-+@c @set config-lzf no
-+@c @set config-me-cmp no
-+@c @set config-mpeg-er no
-+@set config-mpegaudio yes
-+@set config-mpegaudiodsp yes
-+@set config-mpegaudioheader yes
-+@set config-mpeg4audio yes
-+@c @set config-mpegvideo no
-+@c @set config-mpegvideodec no
-+@c @set config-mpegvideoenc no
-+@c @set config-mpegvideoencdsp no
-+@c @set config-msmpeg4dec no
-+@c @set config-msmpeg4enc no
-+@c @set config-mss34dsp no
-+@c @set config-pixblockdsp no
-+@c @set config-qpeldsp no
-+@c @set config-qsv no
-+@c @set config-qsvdec no
-+@c @set config-qsvenc no
-+@c @set config-qsvvpp no
-+@c @set config-rangecoder no
-+@set config-riffdec yes
-+@c @set config-riffenc no
-+@c @set config-rtpdec no
-+@c @set config-rtpenc-chain no
-+@c @set config-rv34dsp no
-+@c @set config-scene-sad no
-+@set config-sinewin yes
-+@c @set config-smpte-436m no
-+@c @set config-snappy no
-+@c @set config-srtp no
-+@set config-startcode yes
-+@c @set config-texturedsp no
-+@c @set config-texturedspenc no
-+@c @set config-tpeldsp no
-+@c @set config-vaapi-1 no
-+@c @set config-vaapi-encode no
-+@c @set config-vulkan-1-4 no
-+@c @set config-vc1dsp no
-+@set config-videodsp yes
-+@c @set config-vp3dsp no
-+@c @set config-vp56dsp no
-+@c @set config-vp8dsp no
-+@c @set config-vulkan-encode no
-+@c @set config-vvc-sei no
-+@c @set config-wma-freqs no
-+@c @set config-wmv2dsp no
-+@c @set config-aac-adtstoasc-bsf no
-+@c @set config-apv-metadata-bsf no
-+@c @set config-av1-frame-merge-bsf no
-+@c @set config-av1-frame-split-bsf no
-+@c @set config-av1-metadata-bsf no
-+@c @set config-chomp-bsf no
-+@c @set config-dump-extradata-bsf no
-+@c @set config-dca-core-bsf no
-+@c @set config-dovi-rpu-bsf no
-+@c @set config-dts2pts-bsf no
-+@c @set config-dv-error-marker-bsf no
-+@c @set config-eac3-core-bsf no
-+@c @set config-eia608-to-smpte436m-bsf no
-+@c @set config-evc-frame-merge-bsf no
-+@c @set config-extract-extradata-bsf no
-+@c @set config-filter-units-bsf no
-+@c @set config-h264-metadata-bsf no
-+@c @set config-h264-mp4toannexb-bsf no
-+@c @set config-h264-redundant-pps-bsf no
-+@c @set config-hapqa-extract-bsf no
-+@c @set config-hevc-metadata-bsf no
-+@c @set config-hevc-mp4toannexb-bsf no
-+@c @set config-imx-dump-header-bsf no
-+@c @set config-media100-to-mjpegb-bsf no
-+@c @set config-mjpeg2jpeg-bsf no
-+@c @set config-mjpega-dump-header-bsf no
-+@c @set config-mpeg2-metadata-bsf no
-+@c @set config-mpeg4-unpack-bframes-bsf no
-+@c @set config-mov2textsub-bsf no
-+@c @set config-noise-bsf no
-+@c @set config-null-bsf no
-+@c @set config-opus-metadata-bsf no
-+@c @set config-pcm-rechunk-bsf no
-+@c @set config-pgs-frame-merge-bsf no
-+@c @set config-prores-metadata-bsf no
-+@c @set config-remove-extradata-bsf no
-+@c @set config-setts-bsf no
-+@c @set config-showinfo-bsf no
-+@c @set config-smpte436m-to-eia608-bsf no
-+@c @set config-text2movsub-bsf no
-+@c @set config-trace-headers-bsf no
-+@c @set config-truehd-core-bsf no
-+@c @set config-vp9-metadata-bsf no
-+@c @set config-vp9-raw-reorder-bsf no
-+@c @set config-vp9-superframe-bsf no
-+@c @set config-vp9-superframe-split-bsf no
-+@c @set config-vvc-metadata-bsf no
-+@c @set config-vvc-mp4toannexb-bsf no
-+@c @set config-aasc-decoder no
-+@c @set config-aic-decoder no
-+@c @set config-alias-pix-decoder no
-+@c @set config-agm-decoder no
-+@c @set config-amv-decoder no
-+@c @set config-anm-decoder no
-+@c @set config-ansi-decoder no
-+@c @set config-apng-decoder no
-+@c @set config-apv-decoder no
-+@c @set config-arbc-decoder no
-+@c @set config-argo-decoder no
-+@c @set config-asv1-decoder no
-+@c @set config-asv2-decoder no
-+@c @set config-aura-decoder no
-+@c @set config-aura2-decoder no
-+@c @set config-avrp-decoder no
-+@c @set config-avrn-decoder no
-+@c @set config-avs-decoder no
-+@c @set config-avui-decoder no
-+@c @set config-bethsoftvid-decoder no
-+@c @set config-bfi-decoder no
-+@c @set config-bink-decoder no
-+@c @set config-bitpacked-decoder no
-+@c @set config-bmp-decoder no
-+@c @set config-bmv-video-decoder no
-+@c @set config-brender-pix-decoder no
-+@c @set config-c93-decoder no
-+@c @set config-cavs-decoder no
-+@c @set config-cdgraphics-decoder no
-+@c @set config-cdtoons-decoder no
-+@c @set config-cdxl-decoder no
-+@c @set config-cfhd-decoder no
-+@c @set config-cinepak-decoder no
-+@c @set config-clearvideo-decoder no
-+@c @set config-cljr-decoder no
-+@c @set config-cllc-decoder no
-+@c @set config-comfortnoise-decoder no
-+@c @set config-cpia-decoder no
-+@c @set config-cri-decoder no
-+@c @set config-cscd-decoder no
-+@c @set config-cyuv-decoder no
-+@c @set config-dds-decoder no
-+@c @set config-dfa-decoder no
-+@c @set config-dirac-decoder no
-+@c @set config-dnxhd-decoder no
-+@c @set config-dpx-decoder no
-+@c @set config-dsicinvideo-decoder no
-+@c @set config-dvaudio-decoder no
-+@c @set config-dvvideo-decoder no
-+@c @set config-dxa-decoder no
-+@c @set config-dxtory-decoder no
-+@c @set config-dxv-decoder no
-+@c @set config-eacmv-decoder no
-+@c @set config-eamad-decoder no
-+@c @set config-eatgq-decoder no
-+@c @set config-eatgv-decoder no
-+@c @set config-eatqi-decoder no
-+@c @set config-eightbps-decoder no
-+@c @set config-eightsvx-exp-decoder no
-+@c @set config-eightsvx-fib-decoder no
-+@c @set config-escape124-decoder no
-+@c @set config-escape130-decoder no
-+@c @set config-exr-decoder no
-+@c @set config-ffv1-decoder no
-+@c @set config-ffvhuff-decoder no
-+@c @set config-fic-decoder no
-+@c @set config-fits-decoder no
-+@c @set config-flashsv-decoder no
-+@c @set config-flashsv2-decoder no
-+@c @set config-flic-decoder no
-+@c @set config-flv-decoder no
-+@c @set config-fmvc-decoder no
-+@c @set config-fourxm-decoder no
-+@c @set config-fraps-decoder no
-+@c @set config-frwu-decoder no
-+@c @set config-g2m-decoder no
-+@c @set config-gdv-decoder no
-+@c @set config-gem-decoder no
-+@c @set config-gif-decoder no
-+@c @set config-h261-decoder no
-+@c @set config-h263-decoder no
-+@c @set config-h263i-decoder no
-+@c @set config-h263p-decoder no
-+@c @set config-h263-v4l2m2m-decoder no
-+@set config-h264-decoder yes
-+@c @set config-h264-v4l2m2m-decoder no
-+@c @set config-h264-mediacodec-decoder no
-+@c @set config-h264-mmal-decoder no
-+@c @set config-h264-qsv-decoder no
-+@c @set config-h264-rkmpp-decoder no
-+@c @set config-hap-decoder no
-+@c @set config-hevc-decoder no
-+@c @set config-hevc-qsv-decoder no
-+@c @set config-hevc-rkmpp-decoder no
-+@c @set config-hevc-v4l2m2m-decoder no
-+@c @set config-hnm4-video-decoder no
-+@c @set config-hq-hqa-decoder no
-+@c @set config-hqx-decoder no
-+@c @set config-huffyuv-decoder no
-+@c @set config-hymt-decoder no
-+@c @set config-idcin-decoder no
-+@c @set config-iff-ilbm-decoder no
-+@c @set config-imm4-decoder no
-+@c @set config-imm5-decoder no
-+@c @set config-indeo2-decoder no
-+@c @set config-indeo3-decoder no
-+@c @set config-indeo4-decoder no
-+@c @set config-indeo5-decoder no
-+@c @set config-interplay-video-decoder no
-+@c @set config-ipu-decoder no
-+@c @set config-jpeg2000-decoder no
-+@c @set config-jpegls-decoder no
-+@c @set config-jv-decoder no
-+@c @set config-kgv1-decoder no
-+@c @set config-kmvc-decoder no
-+@c @set config-lagarith-decoder no
-+@c @set config-lead-decoder no
-+@c @set config-loco-decoder no
-+@c @set config-lscr-decoder no
-+@c @set config-m101-decoder no
-+@c @set config-magicyuv-decoder no
-+@c @set config-mdec-decoder no
-+@c @set config-media100-decoder no
-+@c @set config-mimic-decoder no
-+@c @set config-mjpeg-decoder no
-+@c @set config-mjpegb-decoder no
-+@c @set config-mmvideo-decoder no
-+@c @set config-mobiclip-decoder no
-+@c @set config-motionpixels-decoder no
-+@c @set config-mpeg1video-decoder no
-+@c @set config-mpeg2video-decoder no
-+@c @set config-mpeg4-decoder no
-+@c @set config-mpeg4-v4l2m2m-decoder no
-+@c @set config-mpeg4-mmal-decoder no
-+@c @set config-mpegvideo-decoder no
-+@c @set config-mpeg1-v4l2m2m-decoder no
-+@c @set config-mpeg2-mmal-decoder no
-+@c @set config-mpeg2-v4l2m2m-decoder no
-+@c @set config-mpeg2-qsv-decoder no
-+@c @set config-mpeg2-mediacodec-decoder no
-+@c @set config-msa1-decoder no
-+@c @set config-mscc-decoder no
-+@c @set config-msmpeg4v1-decoder no
-+@c @set config-msmpeg4v2-decoder no
-+@c @set config-msmpeg4v3-decoder no
-+@c @set config-msp2-decoder no
-+@c @set config-msrle-decoder no
-+@c @set config-mss1-decoder no
-+@c @set config-mss2-decoder no
-+@c @set config-msvideo1-decoder no
-+@c @set config-mszh-decoder no
-+@c @set config-mts2-decoder no
-+@c @set config-mv30-decoder no
-+@c @set config-mvc1-decoder no
-+@c @set config-mvc2-decoder no
-+@c @set config-mvdv-decoder no
-+@c @set config-mvha-decoder no
-+@c @set config-mwsc-decoder no
-+@c @set config-mxpeg-decoder no
-+@c @set config-notchlc-decoder no
-+@c @set config-nuv-decoder no
-+@c @set config-paf-video-decoder no
-+@c @set config-pam-decoder no
-+@c @set config-pbm-decoder no
-+@c @set config-pcx-decoder no
-+@c @set config-pdv-decoder no
-+@c @set config-pfm-decoder no
-+@c @set config-pgm-decoder no
-+@c @set config-pgmyuv-decoder no
-+@c @set config-pgx-decoder no
-+@c @set config-phm-decoder no
-+@c @set config-photocd-decoder no
-+@c @set config-pictor-decoder no
-+@c @set config-pixlet-decoder no
-+@c @set config-png-decoder no
-+@c @set config-ppm-decoder no
-+@c @set config-prores-decoder no
-+@c @set config-prores-raw-decoder no
-+@c @set config-prosumer-decoder no
-+@c @set config-psd-decoder no
-+@c @set config-ptx-decoder no
-+@c @set config-qdraw-decoder no
-+@c @set config-qoi-decoder no
-+@c @set config-qpeg-decoder no
-+@c @set config-qtrle-decoder no
-+@c @set config-r10k-decoder no
-+@c @set config-r210-decoder no
-+@c @set config-rasc-decoder no
-+@c @set config-rawvideo-decoder no
-+@c @set config-rka-decoder no
-+@c @set config-rl2-decoder no
-+@c @set config-roq-decoder no
-+@c @set config-rpza-decoder no
-+@c @set config-rscc-decoder no
-+@c @set config-rtv1-decoder no
-+@c @set config-rv10-decoder no
-+@c @set config-rv20-decoder no
-+@c @set config-rv30-decoder no
-+@c @set config-rv40-decoder no
-+@c @set config-rv60-decoder no
-+@c @set config-s302m-decoder no
-+@c @set config-sanm-decoder no
-+@c @set config-scpr-decoder no
-+@c @set config-screenpresso-decoder no
-+@c @set config-sga-decoder no
-+@c @set config-sgi-decoder no
-+@c @set config-sgirle-decoder no
-+@c @set config-sheervideo-decoder no
-+@c @set config-simbiosis-imx-decoder no
-+@c @set config-smacker-decoder no
-+@c @set config-smc-decoder no
-+@c @set config-smvjpeg-decoder no
-+@c @set config-snow-decoder no
-+@c @set config-sp5x-decoder no
-+@c @set config-speedhq-decoder no
-+@c @set config-speex-decoder no
-+@c @set config-srgc-decoder no
-+@c @set config-sunrast-decoder no
-+@c @set config-svq1-decoder no
-+@c @set config-svq3-decoder no
-+@c @set config-targa-decoder no
-+@c @set config-targa-y216-decoder no
-+@c @set config-tdsc-decoder no
-+@c @set config-theora-decoder no
-+@c @set config-thp-decoder no
-+@c @set config-tiertexseqvideo-decoder no
-+@c @set config-tiff-decoder no
-+@c @set config-tmv-decoder no
-+@c @set config-truemotion1-decoder no
-+@c @set config-truemotion2-decoder no
-+@c @set config-truemotion2rt-decoder no
-+@c @set config-tscc-decoder no
-+@c @set config-tscc2-decoder no
-+@c @set config-txd-decoder no
-+@c @set config-ulti-decoder no
-+@c @set config-utvideo-decoder no
-+@c @set config-v210-decoder no
-+@c @set config-v210x-decoder no
-+@c @set config-v308-decoder no
-+@c @set config-v408-decoder no
-+@c @set config-v410-decoder no
-+@c @set config-vb-decoder no
-+@c @set config-vbn-decoder no
-+@c @set config-vble-decoder no
-+@c @set config-vc1-decoder no
-+@c @set config-vc1image-decoder no
-+@c @set config-vc1-mmal-decoder no
-+@c @set config-vc1-qsv-decoder no
-+@c @set config-vc1-v4l2m2m-decoder no
-+@c @set config-vcr1-decoder no
-+@c @set config-vmdvideo-decoder no
-+@c @set config-vmix-decoder no
-+@c @set config-vmnc-decoder no
-+@c @set config-vp3-decoder no
-+@c @set config-vp4-decoder no
-+@c @set config-vp5-decoder no
-+@c @set config-vp6-decoder no
-+@c @set config-vp6a-decoder no
-+@c @set config-vp6f-decoder no
-+@c @set config-vp7-decoder no
-+@c @set config-vp8-decoder no
-+@c @set config-vp8-rkmpp-decoder no
-+@c @set config-vp8-v4l2m2m-decoder no
-+@c @set config-vp9-decoder no
-+@c @set config-vp9-rkmpp-decoder no
-+@c @set config-vp9-v4l2m2m-decoder no
-+@c @set config-vqa-decoder no
-+@c @set config-vqc-decoder no
-+@c @set config-vvc-decoder no
-+@c @set config-wbmp-decoder no
-+@c @set config-webp-decoder no
-+@c @set config-wcmv-decoder no
-+@c @set config-wrapped-avframe-decoder no
-+@c @set config-wmv1-decoder no
-+@c @set config-wmv2-decoder no
-+@c @set config-wmv3-decoder no
-+@c @set config-wmv3image-decoder no
-+@c @set config-wnv1-decoder no
-+@c @set config-xan-wc3-decoder no
-+@c @set config-xan-wc4-decoder no
-+@c @set config-xbm-decoder no
-+@c @set config-xface-decoder no
-+@c @set config-xl-decoder no
-+@c @set config-xpm-decoder no
-+@c @set config-xwd-decoder no
-+@c @set config-y41p-decoder no
-+@c @set config-ylc-decoder no
-+@c @set config-yop-decoder no
-+@c @set config-yuv4-decoder no
-+@c @set config-zero12v-decoder no
-+@c @set config-zerocodec-decoder no
-+@c @set config-zlib-decoder no
-+@c @set config-zmbv-decoder no
-+@set config-aac-decoder yes
-+@c @set config-aac-fixed-decoder no
-+@c @set config-aac-latm-decoder no
-+@c @set config-ac3-decoder no
-+@c @set config-ac3-fixed-decoder no
-+@c @set config-acelp-kelvin-decoder no
-+@c @set config-alac-decoder no
-+@c @set config-als-decoder no
-+@c @set config-amrnb-decoder no
-+@c @set config-amrwb-decoder no
-+@c @set config-apac-decoder no
-+@c @set config-ape-decoder no
-+@c @set config-aptx-decoder no
-+@c @set config-aptx-hd-decoder no
-+@c @set config-atrac1-decoder no
-+@c @set config-atrac3-decoder no
-+@c @set config-atrac3al-decoder no
-+@c @set config-atrac3p-decoder no
-+@c @set config-atrac3pal-decoder no
-+@c @set config-atrac9-decoder no
-+@c @set config-binkaudio-dct-decoder no
-+@c @set config-binkaudio-rdft-decoder no
-+@c @set config-bmv-audio-decoder no
-+@c @set config-bonk-decoder no
-+@c @set config-cook-decoder no
-+@c @set config-dca-decoder no
-+@c @set config-dfpwm-decoder no
-+@c @set config-dolby-e-decoder no
-+@c @set config-dsd-lsbf-decoder no
-+@c @set config-dsd-msbf-decoder no
-+@c @set config-dsd-lsbf-planar-decoder no
-+@c @set config-dsd-msbf-planar-decoder no
-+@c @set config-dsicinaudio-decoder no
-+@c @set config-dss-sp-decoder no
-+@c @set config-dst-decoder no
-+@c @set config-eac3-decoder no
-+@c @set config-evrc-decoder no
-+@c @set config-fastaudio-decoder no
-+@c @set config-ffwavesynth-decoder no
-+@set config-flac-decoder yes
-+@c @set config-ftr-decoder no
-+@c @set config-g723-1-decoder no
-+@c @set config-g728-decoder no
-+@c @set config-g729-decoder no
-+@c @set config-gsm-decoder no
-+@c @set config-gsm-ms-decoder no
-+@c @set config-hca-decoder no
-+@c @set config-hcom-decoder no
-+@c @set config-hdr-decoder no
-+@c @set config-iac-decoder no
-+@c @set config-ilbc-decoder no
-+@c @set config-imc-decoder no
-+@c @set config-interplay-acm-decoder no
-+@c @set config-mace3-decoder no
-+@c @set config-mace6-decoder no
-+@c @set config-metasound-decoder no
-+@c @set config-misc4-decoder no
-+@c @set config-mlp-decoder no
-+@c @set config-mp1-decoder no
-+@c @set config-mp1float-decoder no
-+@c @set config-mp2-decoder no
-+@c @set config-mp2float-decoder no
-+@c @set config-mp3float-decoder no
-+@set config-mp3-decoder yes
-+@c @set config-mp3adufloat-decoder no
-+@c @set config-mp3adu-decoder no
-+@c @set config-mp3on4float-decoder no
-+@c @set config-mp3on4-decoder no
-+@c @set config-mpc7-decoder no
-+@c @set config-mpc8-decoder no
-+@c @set config-msnsiren-decoder no
-+@c @set config-nellymoser-decoder no
-+@c @set config-on2avc-decoder no
-+@c @set config-opus-decoder no
-+@c @set config-osq-decoder no
-+@c @set config-paf-audio-decoder no
-+@c @set config-qcelp-decoder no
-+@c @set config-qdm2-decoder no
-+@c @set config-qdmc-decoder no
-+@c @set config-qoa-decoder no
-+@c @set config-ra-144-decoder no
-+@c @set config-ra-288-decoder no
-+@c @set config-ralf-decoder no
-+@c @set config-sbc-decoder no
-+@c @set config-shorten-decoder no
-+@c @set config-sipr-decoder no
-+@c @set config-siren-decoder no
-+@c @set config-smackaud-decoder no
-+@c @set config-sonic-decoder no
-+@c @set config-tak-decoder no
-+@c @set config-truehd-decoder no
-+@c @set config-truespeech-decoder no
-+@c @set config-tta-decoder no
-+@c @set config-twinvq-decoder no
-+@c @set config-vmdaudio-decoder no
-+@set config-vorbis-decoder yes
-+@c @set config-wavarc-decoder no
-+@c @set config-wavpack-decoder no
-+@c @set config-wmalossless-decoder no
-+@c @set config-wmapro-decoder no
-+@c @set config-wmav1-decoder no
-+@c @set config-wmav2-decoder no
-+@c @set config-wmavoice-decoder no
-+@c @set config-ws-snd1-decoder no
-+@c @set config-xma1-decoder no
-+@c @set config-xma2-decoder no
-+@set config-pcm-alaw-decoder yes
-+@c @set config-pcm-bluray-decoder no
-+@c @set config-pcm-dvd-decoder no
-+@c @set config-pcm-f16le-decoder no
-+@c @set config-pcm-f24le-decoder no
-+@c @set config-pcm-f32be-decoder no
-+@set config-pcm-f32le-decoder yes
-+@c @set config-pcm-f64be-decoder no
-+@c @set config-pcm-f64le-decoder no
-+@c @set config-pcm-lxf-decoder no
-+@set config-pcm-mulaw-decoder yes
-+@c @set config-pcm-s8-decoder no
-+@c @set config-pcm-s8-planar-decoder no
-+@set config-pcm-s16be-decoder yes
-+@c @set config-pcm-s16be-planar-decoder no
-+@set config-pcm-s16le-decoder yes
-+@c @set config-pcm-s16le-planar-decoder no
-+@set config-pcm-s24be-decoder yes
-+@c @set config-pcm-s24daud-decoder no
-+@set config-pcm-s24le-decoder yes
-+@c @set config-pcm-s24le-planar-decoder no
-+@c @set config-pcm-s32be-decoder no
-+@set config-pcm-s32le-decoder yes
-+@c @set config-pcm-s32le-planar-decoder no
-+@c @set config-pcm-s64be-decoder no
-+@c @set config-pcm-s64le-decoder no
-+@c @set config-pcm-sga-decoder no
-+@set config-pcm-u8-decoder yes
-+@c @set config-pcm-u16be-decoder no
-+@c @set config-pcm-u16le-decoder no
-+@c @set config-pcm-u24be-decoder no
-+@c @set config-pcm-u24le-decoder no
-+@c @set config-pcm-u32be-decoder no
-+@c @set config-pcm-u32le-decoder no
-+@c @set config-pcm-vidc-decoder no
-+@c @set config-cbd2-dpcm-decoder no
-+@c @set config-derf-dpcm-decoder no
-+@c @set config-gremlin-dpcm-decoder no
-+@c @set config-interplay-dpcm-decoder no
-+@c @set config-roq-dpcm-decoder no
-+@c @set config-sdx2-dpcm-decoder no
-+@c @set config-sol-dpcm-decoder no
-+@c @set config-xan-dpcm-decoder no
-+@c @set config-wady-dpcm-decoder no
-+@c @set config-adpcm-4xm-decoder no
-+@c @set config-adpcm-adx-decoder no
-+@c @set config-adpcm-afc-decoder no
-+@c @set config-adpcm-agm-decoder no
-+@c @set config-adpcm-aica-decoder no
-+@c @set config-adpcm-argo-decoder no
-+@c @set config-adpcm-ct-decoder no
-+@c @set config-adpcm-dtk-decoder no
-+@c @set config-adpcm-ea-decoder no
-+@c @set config-adpcm-ea-maxis-xa-decoder no
-+@c @set config-adpcm-ea-r1-decoder no
-+@c @set config-adpcm-ea-r2-decoder no
-+@c @set config-adpcm-ea-r3-decoder no
-+@c @set config-adpcm-ea-xas-decoder no
-+@c @set config-adpcm-g722-decoder no
-+@c @set config-adpcm-g726-decoder no
-+@c @set config-adpcm-g726le-decoder no
-+@c @set config-adpcm-ima-acorn-decoder no
-+@c @set config-adpcm-ima-amv-decoder no
-+@c @set config-adpcm-ima-alp-decoder no
-+@c @set config-adpcm-ima-apc-decoder no
-+@c @set config-adpcm-ima-apm-decoder no
-+@c @set config-adpcm-ima-cunning-decoder no
-+@c @set config-adpcm-ima-dat4-decoder no
-+@c @set config-adpcm-ima-dk3-decoder no
-+@c @set config-adpcm-ima-dk4-decoder no
-+@c @set config-adpcm-ima-ea-eacs-decoder no
-+@c @set config-adpcm-ima-ea-sead-decoder no
-+@c @set config-adpcm-ima-iss-decoder no
-+@c @set config-adpcm-ima-moflex-decoder no
-+@c @set config-adpcm-ima-mtf-decoder no
-+@c @set config-adpcm-ima-oki-decoder no
-+@c @set config-adpcm-ima-qt-decoder no
-+@c @set config-adpcm-ima-rad-decoder no
-+@c @set config-adpcm-ima-ssi-decoder no
-+@c @set config-adpcm-ima-smjpeg-decoder no
-+@c @set config-adpcm-ima-wav-decoder no
-+@c @set config-adpcm-ima-ws-decoder no
-+@c @set config-adpcm-ima-xbox-decoder no
-+@c @set config-adpcm-ms-decoder no
-+@c @set config-adpcm-mtaf-decoder no
-+@c @set config-adpcm-psx-decoder no
-+@c @set config-adpcm-sanyo-decoder no
-+@c @set config-adpcm-sbpro-2-decoder no
-+@c @set config-adpcm-sbpro-3-decoder no
-+@c @set config-adpcm-sbpro-4-decoder no
-+@c @set config-adpcm-swf-decoder no
-+@c @set config-adpcm-thp-decoder no
-+@c @set config-adpcm-thp-le-decoder no
-+@c @set config-adpcm-vima-decoder no
-+@c @set config-adpcm-xa-decoder no
-+@c @set config-adpcm-xmd-decoder no
-+@c @set config-adpcm-yamaha-decoder no
-+@c @set config-adpcm-zork-decoder no
-+@c @set config-ssa-decoder no
-+@c @set config-ass-decoder no
-+@c @set config-ccaption-decoder no
-+@c @set config-dvbsub-decoder no
-+@c @set config-dvdsub-decoder no
-+@c @set config-jacosub-decoder no
-+@c @set config-microdvd-decoder no
-+@c @set config-movtext-decoder no
-+@c @set config-mpl2-decoder no
-+@c @set config-pgssub-decoder no
-+@c @set config-pjs-decoder no
-+@c @set config-realtext-decoder no
-+@c @set config-sami-decoder no
-+@c @set config-srt-decoder no
-+@c @set config-stl-decoder no
-+@c @set config-subrip-decoder no
-+@c @set config-subviewer-decoder no
-+@c @set config-subviewer1-decoder no
-+@c @set config-text-decoder no
-+@c @set config-vplayer-decoder no
-+@c @set config-webvtt-decoder no
-+@c @set config-xsub-decoder no
-+@c @set config-aac-at-decoder no
-+@c @set config-ac3-at-decoder no
-+@c @set config-adpcm-ima-qt-at-decoder no
-+@c @set config-alac-at-decoder no
-+@c @set config-amr-nb-at-decoder no
-+@c @set config-eac3-at-decoder no
-+@c @set config-gsm-ms-at-decoder no
-+@c @set config-ilbc-at-decoder no
-+@c @set config-mp1-at-decoder no
-+@c @set config-mp2-at-decoder no
-+@c @set config-mp3-at-decoder no
-+@c @set config-pcm-alaw-at-decoder no
-+@c @set config-pcm-mulaw-at-decoder no
-+@c @set config-qdmc-at-decoder no
-+@c @set config-qdm2-at-decoder no
-+@c @set config-libaribcaption-decoder no
-+@c @set config-libaribb24-decoder no
-+@c @set config-libcelt-decoder no
-+@c @set config-libcodec2-decoder no
-+@c @set config-libdav1d-decoder no
-+@c @set config-libdavs2-decoder no
-+@c @set config-libfdk-aac-decoder no
-+@c @set config-libgsm-decoder no
-+@c @set config-libgsm-ms-decoder no
-+@c @set config-libilbc-decoder no
-+@c @set config-libjxl-anim-decoder no
-+@c @set config-libjxl-decoder no
-+@c @set config-liblc3-decoder no
-+@c @set config-libopencore-amrnb-decoder no
-+@c @set config-libopencore-amrwb-decoder no
-+@set config-libopus-decoder yes
-+@c @set config-librsvg-decoder no
-+@c @set config-libspeex-decoder no
-+@c @set config-libuavs3d-decoder no
-+@c @set config-libvorbis-decoder no
-+@c @set config-libvpx-vp8-decoder no
-+@c @set config-libvpx-vp9-decoder no
-+@c @set config-libxevd-decoder no
-+@c @set config-libzvbi-teletext-decoder no
-+@c @set config-bintext-decoder no
-+@c @set config-xbin-decoder no
-+@c @set config-idf-decoder no
-+@c @set config-aac-mediacodec-decoder no
-+@c @set config-amrnb-mediacodec-decoder no
-+@c @set config-amrwb-mediacodec-decoder no
-+@c @set config-libaom-av1-decoder no
-+@c @set config-av1-decoder no
-+@c @set config-av1-cuvid-decoder no
-+@c @set config-av1-mediacodec-decoder no
-+@c @set config-av1-qsv-decoder no
-+@c @set config-av1-amf-decoder no
-+@c @set config-libopenh264-decoder no
-+@c @set config-h264-amf-decoder no
-+@c @set config-h264-cuvid-decoder no
-+@c @set config-h264-oh-decoder no
-+@c @set config-hevc-amf-decoder no
-+@c @set config-hevc-cuvid-decoder no
-+@c @set config-hevc-mediacodec-decoder no
-+@c @set config-hevc-oh-decoder no
-+@c @set config-mjpeg-cuvid-decoder no
-+@c @set config-mjpeg-qsv-decoder no
-+@c @set config-mp3-mediacodec-decoder no
-+@c @set config-mpeg1-cuvid-decoder no
-+@c @set config-mpeg2-cuvid-decoder no
-+@c @set config-mpeg4-cuvid-decoder no
-+@c @set config-mpeg4-mediacodec-decoder no
-+@c @set config-vc1-cuvid-decoder no
-+@c @set config-vp8-cuvid-decoder no
-+@c @set config-vp8-mediacodec-decoder no
-+@c @set config-vp8-qsv-decoder no
-+@c @set config-vp9-amf-decoder no
-+@c @set config-vp9-cuvid-decoder no
-+@c @set config-vp9-mediacodec-decoder no
-+@c @set config-vp9-qsv-decoder no
-+@c @set config-vvc-qsv-decoder no
-+@c @set config-vnull-decoder no
-+@c @set config-anull-decoder no
-+@c @set config-a64multi-encoder no
-+@c @set config-a64multi5-encoder no
-+@c @set config-alias-pix-encoder no
-+@c @set config-amv-encoder no
-+@c @set config-apng-encoder no
-+@c @set config-asv1-encoder no
-+@c @set config-asv2-encoder no
-+@c @set config-avrp-encoder no
-+@c @set config-avui-encoder no
-+@c @set config-bitpacked-encoder no
-+@c @set config-bmp-encoder no
-+@c @set config-cfhd-encoder no
-+@c @set config-cinepak-encoder no
-+@c @set config-cljr-encoder no
-+@c @set config-comfortnoise-encoder no
-+@c @set config-dnxhd-encoder no
-+@c @set config-dpx-encoder no
-+@c @set config-dvvideo-encoder no
-+@c @set config-dxv-encoder no
-+@c @set config-exr-encoder no
-+@c @set config-ffv1-encoder no
-+@c @set config-ffv1-vulkan-encoder no
-+@c @set config-ffvhuff-encoder no
-+@c @set config-fits-encoder no
-+@c @set config-flashsv-encoder no
-+@c @set config-flashsv2-encoder no
-+@c @set config-flv-encoder no
-+@c @set config-gif-encoder no
-+@c @set config-h261-encoder no
-+@c @set config-h263-encoder no
-+@c @set config-h263p-encoder no
-+@c @set config-h264-mediacodec-encoder no
-+@c @set config-hap-encoder no
-+@c @set config-huffyuv-encoder no
-+@c @set config-jpeg2000-encoder no
-+@c @set config-jpegls-encoder no
-+@c @set config-ljpeg-encoder no
-+@c @set config-magicyuv-encoder no
-+@c @set config-mjpeg-encoder no
-+@c @set config-mpeg1video-encoder no
-+@c @set config-mpeg2video-encoder no
-+@c @set config-mpeg4-encoder no
-+@c @set config-msmpeg4v2-encoder no
-+@c @set config-msmpeg4v3-encoder no
-+@c @set config-msrle-encoder no
-+@c @set config-msvideo1-encoder no
-+@c @set config-pam-encoder no
-+@c @set config-pbm-encoder no
-+@c @set config-pcx-encoder no
-+@c @set config-pfm-encoder no
-+@c @set config-pgm-encoder no
-+@c @set config-pgmyuv-encoder no
-+@c @set config-phm-encoder no
-+@c @set config-png-encoder no
-+@c @set config-ppm-encoder no
-+@c @set config-prores-encoder no
-+@c @set config-prores-aw-encoder no
-+@c @set config-prores-ks-encoder no
-+@c @set config-qoi-encoder no
-+@c @set config-qtrle-encoder no
-+@c @set config-r10k-encoder no
-+@c @set config-r210-encoder no
-+@c @set config-rawvideo-encoder no
-+@c @set config-roq-encoder no
-+@c @set config-rpza-encoder no
-+@c @set config-rv10-encoder no
-+@c @set config-rv20-encoder no
-+@c @set config-s302m-encoder no
-+@c @set config-sgi-encoder no
-+@c @set config-smc-encoder no
-+@c @set config-snow-encoder no
-+@c @set config-speedhq-encoder no
-+@c @set config-sunrast-encoder no
-+@c @set config-svq1-encoder no
-+@c @set config-targa-encoder no
-+@c @set config-tiff-encoder no
-+@c @set config-utvideo-encoder no
-+@c @set config-v210-encoder no
-+@c @set config-v308-encoder no
-+@c @set config-v408-encoder no
-+@c @set config-v410-encoder no
-+@c @set config-vbn-encoder no
-+@c @set config-vc2-encoder no
-+@c @set config-wbmp-encoder no
-+@c @set config-wrapped-avframe-encoder no
-+@c @set config-wmv1-encoder no
-+@c @set config-wmv2-encoder no
-+@c @set config-xbm-encoder no
-+@c @set config-xface-encoder no
-+@c @set config-xwd-encoder no
-+@c @set config-y41p-encoder no
-+@c @set config-yuv4-encoder no
-+@c @set config-zlib-encoder no
-+@c @set config-zmbv-encoder no
-+@c @set config-aac-encoder no
-+@c @set config-ac3-encoder no
-+@c @set config-ac3-fixed-encoder no
-+@c @set config-alac-encoder no
-+@c @set config-aptx-encoder no
-+@c @set config-aptx-hd-encoder no
-+@c @set config-dca-encoder no
-+@c @set config-dfpwm-encoder no
-+@c @set config-eac3-encoder no
-+@c @set config-flac-encoder no
-+@c @set config-g723-1-encoder no
-+@c @set config-hdr-encoder no
-+@c @set config-mlp-encoder no
-+@c @set config-mp2-encoder no
-+@c @set config-mp2fixed-encoder no
-+@c @set config-nellymoser-encoder no
-+@c @set config-opus-encoder no
-+@c @set config-ra-144-encoder no
-+@c @set config-sbc-encoder no
-+@c @set config-sonic-encoder no
-+@c @set config-sonic-ls-encoder no
-+@c @set config-truehd-encoder no
-+@c @set config-tta-encoder no
-+@c @set config-vorbis-encoder no
-+@c @set config-wavpack-encoder no
-+@c @set config-wmav1-encoder no
-+@c @set config-wmav2-encoder no
-+@c @set config-pcm-alaw-encoder no
-+@c @set config-pcm-bluray-encoder no
-+@c @set config-pcm-dvd-encoder no
-+@c @set config-pcm-f32be-encoder no
-+@c @set config-pcm-f32le-encoder no
-+@c @set config-pcm-f64be-encoder no
-+@c @set config-pcm-f64le-encoder no
-+@c @set config-pcm-mulaw-encoder no
-+@c @set config-pcm-s8-encoder no
-+@c @set config-pcm-s8-planar-encoder no
-+@c @set config-pcm-s16be-encoder no
-+@c @set config-pcm-s16be-planar-encoder no
-+@c @set config-pcm-s16le-encoder no
-+@c @set config-pcm-s16le-planar-encoder no
-+@c @set config-pcm-s24be-encoder no
-+@c @set config-pcm-s24daud-encoder no
-+@c @set config-pcm-s24le-encoder no
-+@c @set config-pcm-s24le-planar-encoder no
-+@c @set config-pcm-s32be-encoder no
-+@c @set config-pcm-s32le-encoder no
-+@c @set config-pcm-s32le-planar-encoder no
-+@c @set config-pcm-s64be-encoder no
-+@c @set config-pcm-s64le-encoder no
-+@c @set config-pcm-u8-encoder no
-+@c @set config-pcm-u16be-encoder no
-+@c @set config-pcm-u16le-encoder no
-+@c @set config-pcm-u24be-encoder no
-+@c @set config-pcm-u24le-encoder no
-+@c @set config-pcm-u32be-encoder no
-+@c @set config-pcm-u32le-encoder no
-+@c @set config-pcm-vidc-encoder no
-+@c @set config-roq-dpcm-encoder no
-+@c @set config-adpcm-adx-encoder no
-+@c @set config-adpcm-argo-encoder no
-+@c @set config-adpcm-g722-encoder no
-+@c @set config-adpcm-g726-encoder no
-+@c @set config-adpcm-g726le-encoder no
-+@c @set config-adpcm-ima-amv-encoder no
-+@c @set config-adpcm-ima-alp-encoder no
-+@c @set config-adpcm-ima-apm-encoder no
-+@c @set config-adpcm-ima-qt-encoder no
-+@c @set config-adpcm-ima-ssi-encoder no
-+@c @set config-adpcm-ima-wav-encoder no
-+@c @set config-adpcm-ima-ws-encoder no
-+@c @set config-adpcm-ms-encoder no
-+@c @set config-adpcm-swf-encoder no
-+@c @set config-adpcm-yamaha-encoder no
-+@c @set config-ssa-encoder no
-+@c @set config-ass-encoder no
-+@c @set config-dvbsub-encoder no
-+@c @set config-dvdsub-encoder no
-+@c @set config-movtext-encoder no
-+@c @set config-srt-encoder no
-+@c @set config-subrip-encoder no
-+@c @set config-text-encoder no
-+@c @set config-ttml-encoder no
-+@c @set config-webvtt-encoder no
-+@c @set config-xsub-encoder no
-+@c @set config-aac-at-encoder no
-+@c @set config-alac-at-encoder no
-+@c @set config-ilbc-at-encoder no
-+@c @set config-pcm-alaw-at-encoder no
-+@c @set config-pcm-mulaw-at-encoder no
-+@c @set config-libaom-av1-encoder no
-+@c @set config-libcodec2-encoder no
-+@c @set config-libfdk-aac-encoder no
-+@c @set config-libgsm-encoder no
-+@c @set config-libgsm-ms-encoder no
-+@c @set config-libilbc-encoder no
-+@c @set config-libjxl-anim-encoder no
-+@c @set config-libjxl-encoder no
-+@c @set config-liblc3-encoder no
-+@c @set config-libmp3lame-encoder no
-+@c @set config-liboapv-encoder no
-+@c @set config-libopencore-amrnb-encoder no
-+@c @set config-libopenjpeg-encoder no
-+@c @set config-libopus-encoder no
-+@c @set config-librav1e-encoder no
-+@c @set config-libshine-encoder no
-+@c @set config-libspeex-encoder no
-+@c @set config-libsvtav1-encoder no
-+@c @set config-libtheora-encoder no
-+@c @set config-libtwolame-encoder no
-+@c @set config-libvo-amrwbenc-encoder no
-+@c @set config-libvorbis-encoder no
-+@c @set config-libvpx-vp8-encoder no
-+@c @set config-libvpx-vp9-encoder no
-+@c @set config-libvvenc-encoder no
-+@c @set config-libwebp-anim-encoder no
-+@c @set config-libwebp-encoder no
-+@c @set config-libx262-encoder no
-+@c @set config-libx264-encoder no
-+@c @set config-libx264rgb-encoder no
-+@c @set config-libx265-encoder no
-+@c @set config-libxeve-encoder no
-+@c @set config-libxavs-encoder no
-+@c @set config-libxavs2-encoder no
-+@c @set config-libxvid-encoder no
-+@c @set config-aac-mf-encoder no
-+@c @set config-ac3-mf-encoder no
-+@c @set config-h263-v4l2m2m-encoder no
-+@c @set config-av1-mediacodec-encoder no
-+@c @set config-av1-nvenc-encoder no
-+@c @set config-av1-qsv-encoder no
-+@c @set config-av1-amf-encoder no
-+@c @set config-av1-mf-encoder no
-+@c @set config-av1-vaapi-encoder no
-+@c @set config-av1-vulkan-encoder no
-+@c @set config-libopenh264-encoder no
-+@c @set config-h264-amf-encoder no
-+@c @set config-h264-mf-encoder no
-+@c @set config-h264-nvenc-encoder no
-+@c @set config-h264-oh-encoder no
-+@c @set config-h264-omx-encoder no
-+@c @set config-h264-qsv-encoder no
-+@c @set config-h264-v4l2m2m-encoder no
-+@c @set config-h264-vaapi-encoder no
-+@c @set config-h264-videotoolbox-encoder no
-+@c @set config-h264-vulkan-encoder no
-+@c @set config-hevc-amf-encoder no
-+@c @set config-hevc-d3d12va-encoder no
-+@c @set config-hevc-mediacodec-encoder no
-+@c @set config-hevc-mf-encoder no
-+@c @set config-hevc-nvenc-encoder no
-+@c @set config-hevc-oh-encoder no
-+@c @set config-hevc-qsv-encoder no
-+@c @set config-hevc-v4l2m2m-encoder no
-+@c @set config-hevc-vaapi-encoder no
-+@c @set config-hevc-videotoolbox-encoder no
-+@c @set config-hevc-vulkan-encoder no
-+@c @set config-libkvazaar-encoder no
-+@c @set config-mjpeg-qsv-encoder no
-+@c @set config-mjpeg-vaapi-encoder no
-+@c @set config-mp3-mf-encoder no
-+@c @set config-mpeg2-qsv-encoder no
-+@c @set config-mpeg2-vaapi-encoder no
-+@c @set config-mpeg4-mediacodec-encoder no
-+@c @set config-mpeg4-omx-encoder no
-+@c @set config-mpeg4-v4l2m2m-encoder no
-+@c @set config-prores-videotoolbox-encoder no
-+@c @set config-vp8-mediacodec-encoder no
-+@c @set config-vp8-v4l2m2m-encoder no
-+@c @set config-vp8-vaapi-encoder no
-+@c @set config-vp9-mediacodec-encoder no
-+@c @set config-vp9-vaapi-encoder no
-+@c @set config-vp9-qsv-encoder no
-+@c @set config-vnull-encoder no
-+@c @set config-anull-encoder no
-+@c @set config-av1-d3d11va-hwaccel no
-+@c @set config-av1-d3d11va2-hwaccel no
-+@c @set config-av1-d3d12va-hwaccel no
-+@c @set config-av1-dxva2-hwaccel no
-+@c @set config-av1-nvdec-hwaccel no
-+@c @set config-av1-vaapi-hwaccel no
-+@c @set config-av1-vdpau-hwaccel no
-+@c @set config-av1-videotoolbox-hwaccel no
-+@c @set config-av1-vulkan-hwaccel no
-+@c @set config-ffv1-vulkan-hwaccel no
-+@c @set config-h263-vaapi-hwaccel no
-+@c @set config-h263-videotoolbox-hwaccel no
-+@c @set config-h264-d3d11va-hwaccel no
-+@c @set config-h264-d3d11va2-hwaccel no
-+@c @set config-h264-d3d12va-hwaccel no
-+@c @set config-h264-dxva2-hwaccel no
-+@c @set config-h264-nvdec-hwaccel no
-+@c @set config-h264-vaapi-hwaccel no
-+@c @set config-h264-vdpau-hwaccel no
-+@c @set config-h264-videotoolbox-hwaccel no
-+@c @set config-h264-vulkan-hwaccel no
-+@c @set config-hevc-d3d11va-hwaccel no
-+@c @set config-hevc-d3d11va2-hwaccel no
-+@c @set config-hevc-d3d12va-hwaccel no
-+@c @set config-hevc-dxva2-hwaccel no
-+@c @set config-hevc-nvdec-hwaccel no
-+@c @set config-hevc-vaapi-hwaccel no
-+@c @set config-hevc-vdpau-hwaccel no
-+@c @set config-hevc-videotoolbox-hwaccel no
-+@c @set config-hevc-vulkan-hwaccel no
-+@c @set config-mjpeg-nvdec-hwaccel no
-+@c @set config-mjpeg-vaapi-hwaccel no
-+@c @set config-mpeg1-nvdec-hwaccel no
-+@c @set config-mpeg1-vdpau-hwaccel no
-+@c @set config-mpeg1-videotoolbox-hwaccel no
-+@c @set config-mpeg2-d3d11va-hwaccel no
-+@c @set config-mpeg2-d3d11va2-hwaccel no
-+@c @set config-mpeg2-d3d12va-hwaccel no
-+@c @set config-mpeg2-dxva2-hwaccel no
-+@c @set config-mpeg2-nvdec-hwaccel no
-+@c @set config-mpeg2-vaapi-hwaccel no
-+@c @set config-mpeg2-vdpau-hwaccel no
-+@c @set config-mpeg2-videotoolbox-hwaccel no
-+@c @set config-mpeg4-nvdec-hwaccel no
-+@c @set config-mpeg4-vaapi-hwaccel no
-+@c @set config-mpeg4-vdpau-hwaccel no
-+@c @set config-mpeg4-videotoolbox-hwaccel no
-+@c @set config-prores-videotoolbox-hwaccel no
-+@c @set config-prores-raw-vulkan-hwaccel no
-+@c @set config-vc1-d3d11va-hwaccel no
-+@c @set config-vc1-d3d11va2-hwaccel no
-+@c @set config-vc1-d3d12va-hwaccel no
-+@c @set config-vc1-dxva2-hwaccel no
-+@c @set config-vc1-nvdec-hwaccel no
-+@c @set config-vc1-vaapi-hwaccel no
-+@c @set config-vc1-vdpau-hwaccel no
-+@c @set config-vp8-nvdec-hwaccel no
-+@c @set config-vp8-vaapi-hwaccel no
-+@c @set config-vp9-d3d11va-hwaccel no
-+@c @set config-vp9-d3d11va2-hwaccel no
-+@c @set config-vp9-d3d12va-hwaccel no
-+@c @set config-vp9-dxva2-hwaccel no
-+@c @set config-vp9-nvdec-hwaccel no
-+@c @set config-vp9-vaapi-hwaccel no
-+@c @set config-vp9-vdpau-hwaccel no
-+@c @set config-vp9-videotoolbox-hwaccel no
-+@c @set config-vp9-vulkan-hwaccel no
-+@c @set config-vvc-vaapi-hwaccel no
-+@c @set config-wmv3-d3d11va-hwaccel no
-+@c @set config-wmv3-d3d11va2-hwaccel no
-+@c @set config-wmv3-d3d12va-hwaccel no
-+@c @set config-wmv3-dxva2-hwaccel no
-+@c @set config-wmv3-nvdec-hwaccel no
-+@c @set config-wmv3-vaapi-hwaccel no
-+@c @set config-wmv3-vdpau-hwaccel no
-+@set config-aac-parser yes
-+@c @set config-aac-latm-parser no
-+@c @set config-ac3-parser no
-+@c @set config-adx-parser no
-+@c @set config-amr-parser no
-+@c @set config-apv-parser no
-+@c @set config-av1-parser no
-+@c @set config-avs2-parser no
-+@c @set config-avs3-parser no
-+@c @set config-bmp-parser no
-+@c @set config-cavsvideo-parser no
-+@c @set config-cook-parser no
-+@c @set config-cri-parser no
-+@c @set config-dca-parser no
-+@c @set config-dirac-parser no
-+@c @set config-dnxhd-parser no
-+@c @set config-dnxuc-parser no
-+@c @set config-dolby-e-parser no
-+@c @set config-dpx-parser no
-+@c @set config-dvaudio-parser no
-+@c @set config-dvbsub-parser no
-+@c @set config-dvdsub-parser no
-+@c @set config-dvd-nav-parser no
-+@c @set config-evc-parser no
-+@set config-flac-parser yes
-+@c @set config-ftr-parser no
-+@c @set config-ffv1-parser no
-+@c @set config-g723-1-parser no
-+@c @set config-g729-parser no
-+@c @set config-gif-parser no
-+@c @set config-gsm-parser no
-+@c @set config-h261-parser no
-+@c @set config-h263-parser no
-+@set config-h264-parser yes
-+@c @set config-hevc-parser no
-+@c @set config-hdr-parser no
-+@c @set config-ipu-parser no
-+@c @set config-jpeg2000-parser no
-+@c @set config-jpegxl-parser no
-+@c @set config-misc4-parser no
-+@c @set config-mjpeg-parser no
-+@c @set config-mlp-parser no
-+@c @set config-mpeg4video-parser no
-+@set config-mpegaudio-parser yes
-+@c @set config-mpegvideo-parser no
-+@set config-opus-parser yes
-+@c @set config-png-parser no
-+@c @set config-pnm-parser no
-+@c @set config-prores-raw-parser no
-+@c @set config-qoi-parser no
-+@c @set config-rv34-parser no
-+@c @set config-sbc-parser no
-+@c @set config-sipr-parser no
-+@c @set config-tak-parser no
-+@c @set config-vc1-parser no
-+@set config-vorbis-parser yes
-+@c @set config-vp3-parser no
-+@c @set config-vp8-parser no
-+@set config-vp9-parser yes
-+@c @set config-vvc-parser no
-+@c @set config-webp-parser no
-+@c @set config-xbm-parser no
-+@c @set config-xma-parser no
-+@c @set config-xwd-parser no
-+@c @set config-alsa-indev no
-+@c @set config-android-camera-indev no
-+@c @set config-avfoundation-indev no
-+@c @set config-decklink-indev no
-+@c @set config-dshow-indev no
-+@c @set config-fbdev-indev no
-+@c @set config-gdigrab-indev no
-+@c @set config-iec61883-indev no
-+@c @set config-jack-indev no
-+@c @set config-kmsgrab-indev no
-+@c @set config-lavfi-indev no
-+@c @set config-openal-indev no
-+@c @set config-oss-indev no
-+@c @set config-pulse-indev no
-+@c @set config-sndio-indev no
-+@c @set config-v4l2-indev no
-+@c @set config-vfwcap-indev no
-+@c @set config-xcbgrab-indev no
-+@c @set config-libcdio-indev no
-+@c @set config-libdc1394-indev no
-+@c @set config-alsa-outdev no
-+@c @set config-audiotoolbox-outdev no
-+@c @set config-caca-outdev no
-+@c @set config-decklink-outdev no
-+@c @set config-fbdev-outdev no
-+@c @set config-oss-outdev no
-+@c @set config-pulse-outdev no
-+@c @set config-sndio-outdev no
-+@c @set config-v4l2-outdev no
-+@c @set config-xv-outdev no
-+@c @set config-aap-filter no
-+@c @set config-abench-filter no
-+@c @set config-acompressor-filter no
-+@c @set config-acontrast-filter no
-+@c @set config-acopy-filter no
-+@c @set config-acue-filter no
-+@c @set config-acrossfade-filter no
-+@c @set config-acrossover-filter no
-+@c @set config-acrusher-filter no
-+@c @set config-adeclick-filter no
-+@c @set config-adeclip-filter no
-+@c @set config-adecorrelate-filter no
-+@c @set config-adelay-filter no
-+@c @set config-adenorm-filter no
-+@c @set config-aderivative-filter no
-+@c @set config-adrc-filter no
-+@c @set config-adynamicequalizer-filter no
-+@c @set config-adynamicsmooth-filter no
-+@c @set config-aecho-filter no
-+@c @set config-aemphasis-filter no
-+@c @set config-aeval-filter no
-+@c @set config-aexciter-filter no
-+@c @set config-afade-filter no
-+@c @set config-afftdn-filter no
-+@c @set config-afftfilt-filter no
-+@c @set config-afir-filter no
-+@c @set config-aformat-filter no
-+@c @set config-afreqshift-filter no
-+@c @set config-afwtdn-filter no
-+@c @set config-agate-filter no
-+@c @set config-aiir-filter no
-+@c @set config-aintegral-filter no
-+@c @set config-ainterleave-filter no
-+@c @set config-alatency-filter no
-+@c @set config-alimiter-filter no
-+@c @set config-allpass-filter no
-+@c @set config-aloop-filter no
-+@c @set config-amerge-filter no
-+@c @set config-ametadata-filter no
-+@c @set config-amix-filter no
-+@c @set config-amultiply-filter no
-+@c @set config-anequalizer-filter no
-+@c @set config-anlmdn-filter no
-+@c @set config-anlmf-filter no
-+@c @set config-anlms-filter no
-+@c @set config-anull-filter no
-+@c @set config-apad-filter no
-+@c @set config-aperms-filter no
-+@c @set config-aphaser-filter no
-+@c @set config-aphaseshift-filter no
-+@c @set config-apsnr-filter no
-+@c @set config-apsyclip-filter no
-+@c @set config-apulsator-filter no
-+@c @set config-arealtime-filter no
-+@c @set config-aresample-filter no
-+@c @set config-areverse-filter no
-+@c @set config-arls-filter no
-+@c @set config-arnndn-filter no
-+@c @set config-asdr-filter no
-+@c @set config-asegment-filter no
-+@c @set config-aselect-filter no
-+@c @set config-asendcmd-filter no
-+@c @set config-asetnsamples-filter no
-+@c @set config-asetpts-filter no
-+@c @set config-asetrate-filter no
-+@c @set config-asettb-filter no
-+@c @set config-ashowinfo-filter no
-+@c @set config-asidedata-filter no
-+@c @set config-asisdr-filter no
-+@c @set config-asoftclip-filter no
-+@c @set config-aspectralstats-filter no
-+@c @set config-asplit-filter no
-+@c @set config-asr-filter no
-+@c @set config-astats-filter no
-+@c @set config-astreamselect-filter no
-+@c @set config-asubboost-filter no
-+@c @set config-asubcut-filter no
-+@c @set config-asupercut-filter no
-+@c @set config-asuperpass-filter no
-+@c @set config-asuperstop-filter no
-+@c @set config-atempo-filter no
-+@c @set config-atilt-filter no
-+@c @set config-atrim-filter no
-+@c @set config-axcorrelate-filter no
-+@c @set config-azmq-filter no
-+@c @set config-bandpass-filter no
-+@c @set config-bandreject-filter no
-+@c @set config-bass-filter no
-+@c @set config-biquad-filter no
-+@c @set config-bs2b-filter no
-+@c @set config-channelmap-filter no
-+@c @set config-channelsplit-filter no
-+@c @set config-chorus-filter no
-+@c @set config-compand-filter no
-+@c @set config-compensationdelay-filter no
-+@c @set config-crossfeed-filter no
-+@c @set config-crystalizer-filter no
-+@c @set config-dcshift-filter no
-+@c @set config-deesser-filter no
-+@c @set config-dialoguenhance-filter no
-+@c @set config-drmeter-filter no
-+@c @set config-dynaudnorm-filter no
-+@c @set config-earwax-filter no
-+@c @set config-ebur128-filter no
-+@c @set config-equalizer-filter no
-+@c @set config-extrastereo-filter no
-+@c @set config-firequalizer-filter no
-+@c @set config-flanger-filter no
-+@c @set config-haas-filter no
-+@c @set config-hdcd-filter no
-+@c @set config-headphone-filter no
-+@c @set config-highpass-filter no
-+@c @set config-highshelf-filter no
-+@c @set config-join-filter no
-+@c @set config-ladspa-filter no
-+@c @set config-loudnorm-filter no
-+@c @set config-lowpass-filter no
-+@c @set config-lowshelf-filter no
-+@c @set config-lv2-filter no
-+@c @set config-mcompand-filter no
-+@c @set config-pan-filter no
-+@c @set config-replaygain-filter no
-+@c @set config-rubberband-filter no
-+@c @set config-sidechaincompress-filter no
-+@c @set config-sidechaingate-filter no
-+@c @set config-silencedetect-filter no
-+@c @set config-silenceremove-filter no
-+@c @set config-sofalizer-filter no
-+@c @set config-speechnorm-filter no
-+@c @set config-stereotools-filter no
-+@c @set config-stereowiden-filter no
-+@c @set config-superequalizer-filter no
-+@c @set config-surround-filter no
-+@c @set config-tiltshelf-filter no
-+@c @set config-treble-filter no
-+@c @set config-tremolo-filter no
-+@c @set config-vibrato-filter no
-+@c @set config-virtualbass-filter no
-+@c @set config-volume-filter no
-+@c @set config-volumedetect-filter no
-+@c @set config-whisper-filter no
-+@c @set config-aevalsrc-filter no
-+@c @set config-afdelaysrc-filter no
-+@c @set config-afireqsrc-filter no
-+@c @set config-afirsrc-filter no
-+@c @set config-anoisesrc-filter no
-+@c @set config-anullsrc-filter no
-+@c @set config-flite-filter no
-+@c @set config-hilbert-filter no
-+@c @set config-sinc-filter no
-+@c @set config-sine-filter no
-+@c @set config-anullsink-filter no
-+@c @set config-addroi-filter no
-+@c @set config-alphaextract-filter no
-+@c @set config-alphamerge-filter no
-+@c @set config-amplify-filter no
-+@c @set config-ass-filter no
-+@c @set config-atadenoise-filter no
-+@c @set config-avgblur-filter no
-+@c @set config-avgblur-opencl-filter no
-+@c @set config-avgblur-vulkan-filter no
-+@c @set config-backgroundkey-filter no
-+@c @set config-bbox-filter no
-+@c @set config-bench-filter no
-+@c @set config-bilateral-filter no
-+@c @set config-bilateral-cuda-filter no
-+@c @set config-bitplanenoise-filter no
-+@c @set config-blackdetect-filter no
-+@c @set config-blackdetect-vulkan-filter no
-+@c @set config-blackframe-filter no
-+@c @set config-blend-filter no
-+@c @set config-blend-vulkan-filter no
-+@c @set config-blockdetect-filter no
-+@c @set config-blurdetect-filter no
-+@c @set config-bm3d-filter no
-+@c @set config-boxblur-filter no
-+@c @set config-boxblur-opencl-filter no
-+@c @set config-bwdif-filter no
-+@c @set config-bwdif-cuda-filter no
-+@c @set config-bwdif-vulkan-filter no
-+@c @set config-cas-filter no
-+@c @set config-ccrepack-filter no
-+@c @set config-chromaber-vulkan-filter no
-+@c @set config-chromahold-filter no
-+@c @set config-chromakey-filter no
-+@c @set config-chromakey-cuda-filter no
-+@c @set config-chromanr-filter no
-+@c @set config-chromashift-filter no
-+@c @set config-ciescope-filter no
-+@c @set config-codecview-filter no
-+@c @set config-colorbalance-filter no
-+@c @set config-colorchannelmixer-filter no
-+@c @set config-colorcontrast-filter no
-+@c @set config-colorcorrect-filter no
-+@c @set config-colordetect-filter no
-+@c @set config-colorize-filter no
-+@c @set config-colorkey-filter no
-+@c @set config-colorkey-opencl-filter no
-+@c @set config-colorhold-filter no
-+@c @set config-colorlevels-filter no
-+@c @set config-colormap-filter no
-+@c @set config-colormatrix-filter no
-+@c @set config-colorspace-filter no
-+@c @set config-colorspace-cuda-filter no
-+@c @set config-colortemperature-filter no
-+@c @set config-convolution-filter no
-+@c @set config-convolution-opencl-filter no
-+@c @set config-convolve-filter no
-+@c @set config-copy-filter no
-+@c @set config-coreimage-filter no
-+@c @set config-corr-filter no
-+@c @set config-cover-rect-filter no
-+@c @set config-crop-filter no
-+@c @set config-cropdetect-filter no
-+@c @set config-cue-filter no
-+@c @set config-curves-filter no
-+@c @set config-datascope-filter no
-+@c @set config-dblur-filter no
-+@c @set config-dctdnoiz-filter no
-+@c @set config-deband-filter no
-+@c @set config-deblock-filter no
-+@c @set config-decimate-filter no
-+@c @set config-deconvolve-filter no
-+@c @set config-dedot-filter no
-+@c @set config-deflate-filter no
-+@c @set config-deflicker-filter no
-+@c @set config-deinterlace-qsv-filter no
-+@c @set config-deinterlace-vaapi-filter no
-+@c @set config-dejudder-filter no
-+@c @set config-delogo-filter no
-+@c @set config-denoise-vaapi-filter no
-+@c @set config-derain-filter no
-+@c @set config-deshake-filter no
-+@c @set config-deshake-opencl-filter no
-+@c @set config-despill-filter no
-+@c @set config-detelecine-filter no
-+@c @set config-dilation-filter no
-+@c @set config-dilation-opencl-filter no
-+@c @set config-displace-filter no
-+@c @set config-dnn-classify-filter no
-+@c @set config-dnn-detect-filter no
-+@c @set config-dnn-processing-filter no
-+@c @set config-doubleweave-filter no
-+@c @set config-drawbox-filter no
-+@c @set config-drawgraph-filter no
-+@c @set config-drawgrid-filter no
-+@c @set config-drawtext-filter no
-+@c @set config-edgedetect-filter no
-+@c @set config-elbg-filter no
-+@c @set config-entropy-filter no
-+@c @set config-epx-filter no
-+@c @set config-eq-filter no
-+@c @set config-erosion-filter no
-+@c @set config-erosion-opencl-filter no
-+@c @set config-estdif-filter no
-+@c @set config-exposure-filter no
-+@c @set config-extractplanes-filter no
-+@c @set config-fade-filter no
-+@c @set config-feedback-filter no
-+@c @set config-fftdnoiz-filter no
-+@c @set config-fftfilt-filter no
-+@c @set config-field-filter no
-+@c @set config-fieldhint-filter no
-+@c @set config-fieldmatch-filter no
-+@c @set config-fieldorder-filter no
-+@c @set config-fillborders-filter no
-+@c @set config-find-rect-filter no
-+@c @set config-flip-vulkan-filter no
-+@c @set config-floodfill-filter no
-+@c @set config-format-filter no
-+@c @set config-fps-filter no
-+@c @set config-framepack-filter no
-+@c @set config-framerate-filter no
-+@c @set config-framestep-filter no
-+@c @set config-freezedetect-filter no
-+@c @set config-freezeframes-filter no
-+@c @set config-frei0r-filter no
-+@c @set config-fspp-filter no
-+@c @set config-fsync-filter no
-+@c @set config-gblur-filter no
-+@c @set config-gblur-vulkan-filter no
-+@c @set config-geq-filter no
-+@c @set config-gradfun-filter no
-+@c @set config-graphmonitor-filter no
-+@c @set config-grayworld-filter no
-+@c @set config-greyedge-filter no
-+@c @set config-guided-filter no
-+@c @set config-haldclut-filter no
-+@c @set config-hflip-filter no
-+@c @set config-hflip-vulkan-filter no
-+@c @set config-histeq-filter no
-+@c @set config-histogram-filter no
-+@c @set config-hqdn3d-filter no
-+@c @set config-hqx-filter no
-+@c @set config-hstack-filter no
-+@c @set config-hsvhold-filter no
-+@c @set config-hsvkey-filter no
-+@c @set config-hue-filter no
-+@c @set config-huesaturation-filter no
-+@c @set config-hwdownload-filter no
-+@c @set config-hwmap-filter no
-+@c @set config-hwupload-filter no
-+@c @set config-hwupload-cuda-filter no
-+@c @set config-hysteresis-filter no
-+@c @set config-iccdetect-filter no
-+@c @set config-iccgen-filter no
-+@c @set config-identity-filter no
-+@c @set config-idet-filter no
-+@c @set config-il-filter no
-+@c @set config-inflate-filter no
-+@c @set config-interlace-filter no
-+@c @set config-interlace-vulkan-filter no
-+@c @set config-interleave-filter no
-+@c @set config-kerndeint-filter no
-+@c @set config-kirsch-filter no
-+@c @set config-lagfun-filter no
-+@c @set config-latency-filter no
-+@c @set config-lcevc-filter no
-+@c @set config-lenscorrection-filter no
-+@c @set config-lensfun-filter no
-+@c @set config-libplacebo-filter no
-+@c @set config-libvmaf-filter no
-+@c @set config-libvmaf-cuda-filter no
-+@c @set config-limitdiff-filter no
-+@c @set config-limiter-filter no
-+@c @set config-loop-filter no
-+@c @set config-lumakey-filter no
-+@c @set config-lut-filter no
-+@c @set config-lut1d-filter no
-+@c @set config-lut2-filter no
-+@c @set config-lut3d-filter no
-+@c @set config-lutrgb-filter no
-+@c @set config-lutyuv-filter no
-+@c @set config-maskedclamp-filter no
-+@c @set config-maskedmax-filter no
-+@c @set config-maskedmerge-filter no
-+@c @set config-maskedmin-filter no
-+@c @set config-maskedthreshold-filter no
-+@c @set config-maskfun-filter no
-+@c @set config-mcdeint-filter no
-+@c @set config-median-filter no
-+@c @set config-mergeplanes-filter no
-+@c @set config-mestimate-filter no
-+@c @set config-metadata-filter no
-+@c @set config-midequalizer-filter no
-+@c @set config-minterpolate-filter no
-+@c @set config-mix-filter no
-+@c @set config-monochrome-filter no
-+@c @set config-morpho-filter no
-+@c @set config-mpdecimate-filter no
-+@c @set config-msad-filter no
-+@c @set config-multiply-filter no
-+@c @set config-negate-filter no
-+@c @set config-nlmeans-filter no
-+@c @set config-nlmeans-opencl-filter no
-+@c @set config-nlmeans-vulkan-filter no
-+@c @set config-nnedi-filter no
-+@c @set config-noformat-filter no
-+@c @set config-noise-filter no
-+@c @set config-normalize-filter no
-+@c @set config-null-filter no
-+@c @set config-ocr-filter no
-+@c @set config-ocv-filter no
-+@c @set config-oscilloscope-filter no
-+@c @set config-overlay-filter no
-+@c @set config-overlay-opencl-filter no
-+@c @set config-overlay-qsv-filter no
-+@c @set config-overlay-vaapi-filter no
-+@c @set config-overlay-vulkan-filter no
-+@c @set config-overlay-cuda-filter no
-+@c @set config-owdenoise-filter no
-+@c @set config-pad-filter no
-+@c @set config-pad-cuda-filter no
-+@c @set config-pad-opencl-filter no
-+@c @set config-palettegen-filter no
-+@c @set config-paletteuse-filter no
-+@c @set config-perms-filter no
-+@c @set config-perspective-filter no
-+@c @set config-phase-filter no
-+@c @set config-photosensitivity-filter no
-+@c @set config-pixdesctest-filter no
-+@c @set config-pixelize-filter no
-+@c @set config-pixscope-filter no
-+@c @set config-pp7-filter no
-+@c @set config-premultiply-filter no
-+@c @set config-prewitt-filter no
-+@c @set config-prewitt-opencl-filter no
-+@c @set config-procamp-vaapi-filter no
-+@c @set config-program-opencl-filter no
-+@c @set config-pseudocolor-filter no
-+@c @set config-psnr-filter no
-+@c @set config-pullup-filter no
-+@c @set config-qp-filter no
-+@c @set config-qrencode-filter no
-+@c @set config-quirc-filter no
-+@c @set config-random-filter no
-+@c @set config-readeia608-filter no
-+@c @set config-readvitc-filter no
-+@c @set config-realtime-filter no
-+@c @set config-remap-filter no
-+@c @set config-remap-opencl-filter no
-+@c @set config-removegrain-filter no
-+@c @set config-removelogo-filter no
-+@c @set config-repeatfields-filter no
-+@c @set config-reverse-filter no
-+@c @set config-rgbashift-filter no
-+@c @set config-roberts-filter no
-+@c @set config-roberts-opencl-filter no
-+@c @set config-rotate-filter no
-+@c @set config-sab-filter no
-+@c @set config-scale-filter no
-+@c @set config-vpp-amf-filter no
-+@c @set config-sr-amf-filter no
-+@c @set config-scale-cuda-filter no
-+@c @set config-scale-d3d11-filter no
-+@c @set config-scale-npp-filter no
-+@c @set config-scale-qsv-filter no
-+@c @set config-scale-vaapi-filter no
-+@c @set config-scale-vt-filter no
-+@c @set config-scale-vulkan-filter no
-+@c @set config-scale2ref-filter no
-+@c @set config-scale2ref-npp-filter no
-+@c @set config-scdet-filter no
-+@c @set config-scdet-vulkan-filter no
-+@c @set config-scharr-filter no
-+@c @set config-scroll-filter no
-+@c @set config-segment-filter no
-+@c @set config-select-filter no
-+@c @set config-selectivecolor-filter no
-+@c @set config-sendcmd-filter no
-+@c @set config-separatefields-filter no
-+@c @set config-setdar-filter no
-+@c @set config-setfield-filter no
-+@c @set config-setparams-filter no
-+@c @set config-setpts-filter no
-+@c @set config-setrange-filter no
-+@c @set config-setsar-filter no
-+@c @set config-settb-filter no
-+@c @set config-sharpen-npp-filter no
-+@c @set config-sharpness-vaapi-filter no
-+@c @set config-shear-filter no
-+@c @set config-showinfo-filter no
-+@c @set config-showpalette-filter no
-+@c @set config-shuffleframes-filter no
-+@c @set config-shufflepixels-filter no
-+@c @set config-shuffleplanes-filter no
-+@c @set config-sidedata-filter no
-+@c @set config-signalstats-filter no
-+@c @set config-signature-filter no
-+@c @set config-siti-filter no
-+@c @set config-smartblur-filter no
-+@c @set config-sobel-filter no
-+@c @set config-sobel-opencl-filter no
-+@c @set config-split-filter no
-+@c @set config-spp-filter no
-+@c @set config-sr-filter no
-+@c @set config-ssim-filter no
-+@c @set config-ssim360-filter no
-+@c @set config-stereo3d-filter no
-+@c @set config-streamselect-filter no
-+@c @set config-subtitles-filter no
-+@c @set config-super2xsai-filter no
-+@c @set config-swaprect-filter no
-+@c @set config-swapuv-filter no
-+@c @set config-tblend-filter no
-+@c @set config-telecine-filter no
-+@c @set config-thistogram-filter no
-+@c @set config-threshold-filter no
-+@c @set config-thumbnail-filter no
-+@c @set config-thumbnail-cuda-filter no
-+@c @set config-tile-filter no
-+@c @set config-tiltandshift-filter no
-+@c @set config-tinterlace-filter no
-+@c @set config-tlut2-filter no
-+@c @set config-tmedian-filter no
-+@c @set config-tmidequalizer-filter no
-+@c @set config-tmix-filter no
-+@c @set config-tonemap-filter no
-+@c @set config-tonemap-opencl-filter no
-+@c @set config-tonemap-vaapi-filter no
-+@c @set config-tpad-filter no
-+@c @set config-transpose-filter no
-+@c @set config-transpose-npp-filter no
-+@c @set config-transpose-opencl-filter no
-+@c @set config-transpose-vaapi-filter no
-+@c @set config-transpose-vt-filter no
-+@c @set config-transpose-vulkan-filter no
-+@c @set config-trim-filter no
-+@c @set config-unpremultiply-filter no
-+@c @set config-unsharp-filter no
-+@c @set config-unsharp-opencl-filter no
-+@c @set config-untile-filter no
-+@c @set config-uspp-filter no
-+@c @set config-v360-filter no
-+@c @set config-vaguedenoiser-filter no
-+@c @set config-varblur-filter no
-+@c @set config-vectorscope-filter no
-+@c @set config-vflip-filter no
-+@c @set config-vflip-vulkan-filter no
-+@c @set config-vfrdet-filter no
-+@c @set config-vibrance-filter no
-+@c @set config-vidstabdetect-filter no
-+@c @set config-vidstabtransform-filter no
-+@c @set config-vif-filter no
-+@c @set config-vignette-filter no
-+@c @set config-vmafmotion-filter no
-+@c @set config-vpp-qsv-filter no
-+@c @set config-vstack-filter no
-+@c @set config-w3fdif-filter no
-+@c @set config-waveform-filter no
-+@c @set config-weave-filter no
-+@c @set config-xbr-filter no
-+@c @set config-xcorrelate-filter no
-+@c @set config-xfade-filter no
-+@c @set config-xfade-opencl-filter no
-+@c @set config-xfade-vulkan-filter no
-+@c @set config-xmedian-filter no
-+@c @set config-xpsnr-filter no
-+@c @set config-xstack-filter no
-+@c @set config-yadif-filter no
-+@c @set config-yadif-cuda-filter no
-+@c @set config-yadif-videotoolbox-filter no
-+@c @set config-yaepblur-filter no
-+@c @set config-zmq-filter no
-+@c @set config-zoompan-filter no
-+@c @set config-zscale-filter no
-+@c @set config-hstack-vaapi-filter no
-+@c @set config-vstack-vaapi-filter no
-+@c @set config-xstack-vaapi-filter no
-+@c @set config-hstack-qsv-filter no
-+@c @set config-vstack-qsv-filter no
-+@c @set config-xstack-qsv-filter no
-+@c @set config-pad-vaapi-filter no
-+@c @set config-drawbox-vaapi-filter no
-+@c @set config-allrgb-filter no
-+@c @set config-allyuv-filter no
-+@c @set config-cellauto-filter no
-+@c @set config-color-filter no
-+@c @set config-color-vulkan-filter no
-+@c @set config-colorchart-filter no
-+@c @set config-colorspectrum-filter no
-+@c @set config-coreimagesrc-filter no
-+@c @set config-ddagrab-filter no
-+@c @set config-frei0r-src-filter no
-+@c @set config-gradients-filter no
-+@c @set config-haldclutsrc-filter no
-+@c @set config-life-filter no
-+@c @set config-mandelbrot-filter no
-+@c @set config-mptestsrc-filter no
-+@c @set config-nullsrc-filter no
-+@c @set config-openclsrc-filter no
-+@c @set config-qrencodesrc-filter no
-+@c @set config-pal75bars-filter no
-+@c @set config-pal100bars-filter no
-+@c @set config-perlin-filter no
-+@c @set config-rgbtestsrc-filter no
-+@c @set config-sierpinski-filter no
-+@c @set config-smptebars-filter no
-+@c @set config-smptehdbars-filter no
-+@c @set config-testsrc-filter no
-+@c @set config-testsrc2-filter no
-+@c @set config-yuvtestsrc-filter no
-+@c @set config-zoneplate-filter no
-+@c @set config-nullsink-filter no
-+@c @set config-a3dscope-filter no
-+@c @set config-abitscope-filter no
-+@c @set config-adrawgraph-filter no
-+@c @set config-agraphmonitor-filter no
-+@c @set config-ahistogram-filter no
-+@c @set config-aphasemeter-filter no
-+@c @set config-avectorscope-filter no
-+@c @set config-concat-filter no
-+@c @set config-showcqt-filter no
-+@c @set config-showcwt-filter no
-+@c @set config-showfreqs-filter no
-+@c @set config-showspatial-filter no
-+@c @set config-showspectrum-filter no
-+@c @set config-showspectrumpic-filter no
-+@c @set config-showvolume-filter no
-+@c @set config-showwaves-filter no
-+@c @set config-showwavespic-filter no
-+@c @set config-spectrumsynth-filter no
-+@c @set config-avsynctest-filter no
-+@c @set config-amovie-filter no
-+@c @set config-movie-filter no
-+@c @set config-aa-demuxer no
-+@set config-aac-demuxer yes
-+@c @set config-aax-demuxer no
-+@c @set config-ac3-demuxer no
-+@c @set config-ac4-demuxer no
-+@c @set config-ace-demuxer no
-+@c @set config-acm-demuxer no
-+@c @set config-act-demuxer no
-+@c @set config-adf-demuxer no
-+@c @set config-adp-demuxer no
-+@c @set config-ads-demuxer no
-+@c @set config-adx-demuxer no
-+@c @set config-aea-demuxer no
-+@c @set config-afc-demuxer no
-+@c @set config-aiff-demuxer no
-+@c @set config-aix-demuxer no
-+@c @set config-alp-demuxer no
-+@c @set config-amr-demuxer no
-+@c @set config-amrnb-demuxer no
-+@c @set config-amrwb-demuxer no
-+@c @set config-anm-demuxer no
-+@c @set config-apac-demuxer no
-+@c @set config-apc-demuxer no
-+@c @set config-ape-demuxer no
-+@c @set config-apm-demuxer no
-+@c @set config-apng-demuxer no
-+@c @set config-aptx-demuxer no
-+@c @set config-aptx-hd-demuxer no
-+@c @set config-apv-demuxer no
-+@c @set config-aqtitle-demuxer no
-+@c @set config-argo-asf-demuxer no
-+@c @set config-argo-brp-demuxer no
-+@c @set config-argo-cvg-demuxer no
-+@c @set config-asf-demuxer no
-+@c @set config-asf-o-demuxer no
-+@c @set config-ass-demuxer no
-+@c @set config-ast-demuxer no
-+@c @set config-au-demuxer no
-+@c @set config-av1-demuxer no
-+@c @set config-avi-demuxer no
-+@c @set config-avr-demuxer no
-+@c @set config-avs-demuxer no
-+@c @set config-avs2-demuxer no
-+@c @set config-avs3-demuxer no
-+@c @set config-bethsoftvid-demuxer no
-+@c @set config-bfi-demuxer no
-+@c @set config-bintext-demuxer no
-+@c @set config-bink-demuxer no
-+@c @set config-binka-demuxer no
-+@c @set config-bit-demuxer no
-+@c @set config-bitpacked-demuxer no
-+@c @set config-bmv-demuxer no
-+@c @set config-bfstm-demuxer no
-+@c @set config-brstm-demuxer no
-+@c @set config-boa-demuxer no
-+@c @set config-bonk-demuxer no
-+@c @set config-c93-demuxer no
-+@c @set config-caf-demuxer no
-+@c @set config-cavsvideo-demuxer no
-+@c @set config-cdg-demuxer no
-+@c @set config-cdxl-demuxer no
-+@c @set config-cine-demuxer no
-+@c @set config-codec2-demuxer no
-+@c @set config-codec2raw-demuxer no
-+@c @set config-concat-demuxer no
-+@c @set config-dash-demuxer no
-+@c @set config-data-demuxer no
-+@c @set config-daud-demuxer no
-+@c @set config-dcstr-demuxer no
-+@c @set config-derf-demuxer no
-+@c @set config-dfa-demuxer no
-+@c @set config-dfpwm-demuxer no
-+@c @set config-dhav-demuxer no
-+@c @set config-dirac-demuxer no
-+@c @set config-dnxhd-demuxer no
-+@c @set config-dsf-demuxer no
-+@c @set config-dsicin-demuxer no
-+@c @set config-dss-demuxer no
-+@c @set config-dts-demuxer no
-+@c @set config-dtshd-demuxer no
-+@c @set config-dv-demuxer no
-+@c @set config-dvbsub-demuxer no
-+@c @set config-dvbtxt-demuxer no
-+@c @set config-dxa-demuxer no
-+@c @set config-ea-demuxer no
-+@c @set config-ea-cdata-demuxer no
-+@c @set config-eac3-demuxer no
-+@c @set config-epaf-demuxer no
-+@c @set config-evc-demuxer no
-+@c @set config-ffmetadata-demuxer no
-+@c @set config-filmstrip-demuxer no
-+@c @set config-fits-demuxer no
-+@set config-flac-demuxer yes
-+@c @set config-flic-demuxer no
-+@c @set config-flv-demuxer no
-+@c @set config-live-flv-demuxer no
-+@c @set config-fourxm-demuxer no
-+@c @set config-frm-demuxer no
-+@c @set config-fsb-demuxer no
-+@c @set config-fwse-demuxer no
-+@c @set config-g722-demuxer no
-+@c @set config-g723-1-demuxer no
-+@c @set config-g726-demuxer no
-+@c @set config-g726le-demuxer no
-+@c @set config-g728-demuxer no
-+@c @set config-g729-demuxer no
-+@c @set config-gdv-demuxer no
-+@c @set config-genh-demuxer no
-+@c @set config-gif-demuxer no
-+@c @set config-gsm-demuxer no
-+@c @set config-gxf-demuxer no
-+@c @set config-h261-demuxer no
-+@c @set config-h263-demuxer no
-+@c @set config-h264-demuxer no
-+@c @set config-hca-demuxer no
-+@c @set config-hcom-demuxer no
-+@c @set config-hevc-demuxer no
-+@c @set config-hls-demuxer no
-+@c @set config-hnm-demuxer no
-+@c @set config-iamf-demuxer no
-+@c @set config-ico-demuxer no
-+@c @set config-idcin-demuxer no
-+@c @set config-idf-demuxer no
-+@c @set config-iff-demuxer no
-+@c @set config-ifv-demuxer no
-+@c @set config-ilbc-demuxer no
-+@c @set config-image2-demuxer no
-+@c @set config-image2pipe-demuxer no
-+@c @set config-image2-alias-pix-demuxer no
-+@c @set config-image2-brender-pix-demuxer no
-+@c @set config-imf-demuxer no
-+@c @set config-ingenient-demuxer no
-+@c @set config-ipmovie-demuxer no
-+@c @set config-ipu-demuxer no
-+@c @set config-ircam-demuxer no
-+@c @set config-iss-demuxer no
-+@c @set config-iv8-demuxer no
-+@c @set config-ivf-demuxer no
-+@c @set config-ivr-demuxer no
-+@c @set config-jacosub-demuxer no
-+@c @set config-jv-demuxer no
-+@c @set config-jpegxl-anim-demuxer no
-+@c @set config-kux-demuxer no
-+@c @set config-kvag-demuxer no
-+@c @set config-laf-demuxer no
-+@c @set config-lc3-demuxer no
-+@c @set config-lmlm4-demuxer no
-+@c @set config-loas-demuxer no
-+@c @set config-luodat-demuxer no
-+@c @set config-lrc-demuxer no
-+@c @set config-lvf-demuxer no
-+@c @set config-lxf-demuxer no
-+@c @set config-m4v-demuxer no
-+@c @set config-mca-demuxer no
-+@c @set config-mcc-demuxer no
-+@set config-matroska-demuxer yes
-+@c @set config-mgsts-demuxer no
-+@c @set config-microdvd-demuxer no
-+@c @set config-mjpeg-demuxer no
-+@c @set config-mjpeg-2000-demuxer no
-+@c @set config-mlp-demuxer no
-+@c @set config-mlv-demuxer no
-+@c @set config-mm-demuxer no
-+@c @set config-mmf-demuxer no
-+@c @set config-mods-demuxer no
-+@c @set config-moflex-demuxer no
-+@set config-mov-demuxer yes
-+@set config-mp3-demuxer yes
-+@c @set config-mpc-demuxer no
-+@c @set config-mpc8-demuxer no
-+@c @set config-mpegps-demuxer no
-+@c @set config-mpegts-demuxer no
-+@c @set config-mpegtsraw-demuxer no
-+@c @set config-mpegvideo-demuxer no
-+@c @set config-mpjpeg-demuxer no
-+@c @set config-mpl2-demuxer no
-+@c @set config-mpsub-demuxer no
-+@c @set config-msf-demuxer no
-+@c @set config-msnwc-tcp-demuxer no
-+@c @set config-msp-demuxer no
-+@c @set config-mtaf-demuxer no
-+@c @set config-mtv-demuxer no
-+@c @set config-musx-demuxer no
-+@c @set config-mv-demuxer no
-+@c @set config-mvi-demuxer no
-+@c @set config-mxf-demuxer no
-+@c @set config-mxg-demuxer no
-+@c @set config-nc-demuxer no
-+@c @set config-nistsphere-demuxer no
-+@c @set config-nsp-demuxer no
-+@c @set config-nsv-demuxer no
-+@c @set config-nut-demuxer no
-+@c @set config-nuv-demuxer no
-+@c @set config-obu-demuxer no
-+@set config-ogg-demuxer yes
-+@c @set config-oma-demuxer no
-+@c @set config-osq-demuxer no
-+@c @set config-paf-demuxer no
-+@c @set config-pcm-alaw-demuxer no
-+@c @set config-pcm-mulaw-demuxer no
-+@c @set config-pcm-vidc-demuxer no
-+@c @set config-pcm-f64be-demuxer no
-+@c @set config-pcm-f64le-demuxer no
-+@c @set config-pcm-f32be-demuxer no
-+@c @set config-pcm-f32le-demuxer no
-+@c @set config-pcm-s32be-demuxer no
-+@c @set config-pcm-s32le-demuxer no
-+@c @set config-pcm-s24be-demuxer no
-+@c @set config-pcm-s24le-demuxer no
-+@c @set config-pcm-s16be-demuxer no
-+@c @set config-pcm-s16le-demuxer no
-+@c @set config-pcm-s8-demuxer no
-+@c @set config-pcm-u32be-demuxer no
-+@c @set config-pcm-u32le-demuxer no
-+@c @set config-pcm-u24be-demuxer no
-+@c @set config-pcm-u24le-demuxer no
-+@c @set config-pcm-u16be-demuxer no
-+@c @set config-pcm-u16le-demuxer no
-+@c @set config-pcm-u8-demuxer no
-+@c @set config-pdv-demuxer no
-+@c @set config-pjs-demuxer no
-+@c @set config-pmp-demuxer no
-+@c @set config-pp-bnk-demuxer no
-+@c @set config-pva-demuxer no
-+@c @set config-pvf-demuxer no
-+@c @set config-qcp-demuxer no
-+@c @set config-qoa-demuxer no
-+@c @set config-r3d-demuxer no
-+@c @set config-rawvideo-demuxer no
-+@c @set config-rcwt-demuxer no
-+@c @set config-realtext-demuxer no
-+@c @set config-redspark-demuxer no
-+@c @set config-rka-demuxer no
-+@c @set config-rl2-demuxer no
-+@c @set config-rm-demuxer no
-+@c @set config-roq-demuxer no
-+@c @set config-rpl-demuxer no
-+@c @set config-rsd-demuxer no
-+@c @set config-rso-demuxer no
-+@c @set config-rtp-demuxer no
-+@c @set config-rtsp-demuxer no
-+@c @set config-s337m-demuxer no
-+@c @set config-sami-demuxer no
-+@c @set config-sap-demuxer no
-+@c @set config-sbc-demuxer no
-+@c @set config-sbg-demuxer no
-+@c @set config-scc-demuxer no
-+@c @set config-scd-demuxer no
-+@c @set config-sdns-demuxer no
-+@c @set config-sdp-demuxer no
-+@c @set config-sdr2-demuxer no
-+@c @set config-sds-demuxer no
-+@c @set config-sdx-demuxer no
-+@c @set config-segafilm-demuxer no
-+@c @set config-ser-demuxer no
-+@c @set config-sga-demuxer no
-+@c @set config-shorten-demuxer no
-+@c @set config-siff-demuxer no
-+@c @set config-simbiosis-imx-demuxer no
-+@c @set config-sln-demuxer no
-+@c @set config-smacker-demuxer no
-+@c @set config-smjpeg-demuxer no
-+@c @set config-smush-demuxer no
-+@c @set config-sol-demuxer no
-+@c @set config-sox-demuxer no
-+@c @set config-spdif-demuxer no
-+@c @set config-srt-demuxer no
-+@c @set config-str-demuxer no
-+@c @set config-stl-demuxer no
-+@c @set config-subviewer1-demuxer no
-+@c @set config-subviewer-demuxer no
-+@c @set config-sup-demuxer no
-+@c @set config-svag-demuxer no
-+@c @set config-svs-demuxer no
-+@c @set config-swf-demuxer no
-+@c @set config-tak-demuxer no
-+@c @set config-tedcaptions-demuxer no
-+@c @set config-thp-demuxer no
-+@c @set config-threedostr-demuxer no
-+@c @set config-tiertexseq-demuxer no
-+@c @set config-tmv-demuxer no
-+@c @set config-truehd-demuxer no
-+@c @set config-tta-demuxer no
-+@c @set config-txd-demuxer no
-+@c @set config-tty-demuxer no
-+@c @set config-ty-demuxer no
-+@c @set config-usm-demuxer no
-+@c @set config-v210-demuxer no
-+@c @set config-v210x-demuxer no
-+@c @set config-vag-demuxer no
-+@c @set config-vc1-demuxer no
-+@c @set config-vc1t-demuxer no
-+@c @set config-vividas-demuxer no
-+@c @set config-vivo-demuxer no
-+@c @set config-vmd-demuxer no
-+@c @set config-vobsub-demuxer no
-+@c @set config-voc-demuxer no
-+@c @set config-vpk-demuxer no
-+@c @set config-vplayer-demuxer no
-+@c @set config-vqf-demuxer no
-+@c @set config-vvc-demuxer no
-+@c @set config-w64-demuxer no
-+@c @set config-wady-demuxer no
-+@c @set config-wavarc-demuxer no
-+@set config-wav-demuxer yes
-+@c @set config-wc3-demuxer no
-+@c @set config-webm-dash-manifest-demuxer no
-+@c @set config-webvtt-demuxer no
-+@c @set config-wsaud-demuxer no
-+@c @set config-wsd-demuxer no
-+@c @set config-wsvqa-demuxer no
-+@c @set config-wtv-demuxer no
-+@c @set config-wve-demuxer no
-+@c @set config-wv-demuxer no
-+@c @set config-xa-demuxer no
-+@c @set config-xbin-demuxer no
-+@c @set config-xmd-demuxer no
-+@c @set config-xmv-demuxer no
-+@c @set config-xvag-demuxer no
-+@c @set config-xwma-demuxer no
-+@c @set config-yop-demuxer no
-+@c @set config-yuv4mpegpipe-demuxer no
-+@c @set config-image-bmp-pipe-demuxer no
-+@c @set config-image-cri-pipe-demuxer no
-+@c @set config-image-dds-pipe-demuxer no
-+@c @set config-image-dpx-pipe-demuxer no
-+@c @set config-image-exr-pipe-demuxer no
-+@c @set config-image-gem-pipe-demuxer no
-+@c @set config-image-gif-pipe-demuxer no
-+@c @set config-image-hdr-pipe-demuxer no
-+@c @set config-image-j2k-pipe-demuxer no
-+@c @set config-image-jpeg-pipe-demuxer no
-+@c @set config-image-jpegls-pipe-demuxer no
-+@c @set config-image-jpegxl-pipe-demuxer no
-+@c @set config-image-pam-pipe-demuxer no
-+@c @set config-image-pbm-pipe-demuxer no
-+@c @set config-image-pcx-pipe-demuxer no
-+@c @set config-image-pfm-pipe-demuxer no
-+@c @set config-image-pgmyuv-pipe-demuxer no
-+@c @set config-image-pgm-pipe-demuxer no
-+@c @set config-image-pgx-pipe-demuxer no
-+@c @set config-image-phm-pipe-demuxer no
-+@c @set config-image-photocd-pipe-demuxer no
-+@c @set config-image-pictor-pipe-demuxer no
-+@c @set config-image-png-pipe-demuxer no
-+@c @set config-image-ppm-pipe-demuxer no
-+@c @set config-image-psd-pipe-demuxer no
-+@c @set config-image-qdraw-pipe-demuxer no
-+@c @set config-image-qoi-pipe-demuxer no
-+@c @set config-image-sgi-pipe-demuxer no
-+@c @set config-image-svg-pipe-demuxer no
-+@c @set config-image-sunrast-pipe-demuxer no
-+@c @set config-image-tiff-pipe-demuxer no
-+@c @set config-image-vbn-pipe-demuxer no
-+@c @set config-image-webp-pipe-demuxer no
-+@c @set config-image-xbm-pipe-demuxer no
-+@c @set config-image-xpm-pipe-demuxer no
-+@c @set config-image-xwd-pipe-demuxer no
-+@c @set config-avisynth-demuxer no
-+@c @set config-dvdvideo-demuxer no
-+@c @set config-libgme-demuxer no
-+@c @set config-libmodplug-demuxer no
-+@c @set config-libopenmpt-demuxer no
-+@c @set config-vapoursynth-demuxer no
-+@c @set config-a64-muxer no
-+@c @set config-ac3-muxer no
-+@c @set config-ac4-muxer no
-+@c @set config-adts-muxer no
-+@c @set config-adx-muxer no
-+@c @set config-aea-muxer no
-+@c @set config-aiff-muxer no
-+@c @set config-alp-muxer no
-+@c @set config-amr-muxer no
-+@c @set config-amv-muxer no
-+@c @set config-apm-muxer no
-+@c @set config-apng-muxer no
-+@c @set config-aptx-muxer no
-+@c @set config-aptx-hd-muxer no
-+@c @set config-apv-muxer no
-+@c @set config-argo-asf-muxer no
-+@c @set config-argo-cvg-muxer no
-+@c @set config-asf-muxer no
-+@c @set config-ass-muxer no
-+@c @set config-ast-muxer no
-+@c @set config-asf-stream-muxer no
-+@c @set config-au-muxer no
-+@c @set config-avi-muxer no
-+@c @set config-avif-muxer no
-+@c @set config-avm2-muxer no
-+@c @set config-avs2-muxer no
-+@c @set config-avs3-muxer no
-+@c @set config-bit-muxer no
-+@c @set config-caf-muxer no
-+@c @set config-cavsvideo-muxer no
-+@c @set config-codec2-muxer no
-+@c @set config-codec2raw-muxer no
-+@c @set config-crc-muxer no
-+@c @set config-dash-muxer no
-+@c @set config-data-muxer no
-+@c @set config-daud-muxer no
-+@c @set config-dfpwm-muxer no
-+@c @set config-dirac-muxer no
-+@c @set config-dnxhd-muxer no
-+@c @set config-dts-muxer no
-+@c @set config-dv-muxer no
-+@c @set config-eac3-muxer no
-+@c @set config-evc-muxer no
-+@c @set config-f4v-muxer no
-+@c @set config-ffmetadata-muxer no
-+@c @set config-fifo-muxer no
-+@c @set config-filmstrip-muxer no
-+@c @set config-fits-muxer no
-+@c @set config-flac-muxer no
-+@c @set config-flv-muxer no
-+@c @set config-framecrc-muxer no
-+@c @set config-framehash-muxer no
-+@c @set config-framemd5-muxer no
-+@c @set config-g722-muxer no
-+@c @set config-g723-1-muxer no
-+@c @set config-g726-muxer no
-+@c @set config-g726le-muxer no
-+@c @set config-gif-muxer no
-+@c @set config-gsm-muxer no
-+@c @set config-gxf-muxer no
-+@c @set config-h261-muxer no
-+@c @set config-h263-muxer no
-+@c @set config-h264-muxer no
-+@c @set config-hash-muxer no
-+@c @set config-hds-muxer no
-+@c @set config-hevc-muxer no
-+@c @set config-hls-muxer no
-+@c @set config-iamf-muxer no
-+@c @set config-ico-muxer no
-+@c @set config-ilbc-muxer no
-+@c @set config-image2-muxer no
-+@c @set config-image2pipe-muxer no
-+@c @set config-ipod-muxer no
-+@c @set config-ircam-muxer no
-+@c @set config-ismv-muxer no
-+@c @set config-ivf-muxer no
-+@c @set config-jacosub-muxer no
-+@c @set config-kvag-muxer no
-+@c @set config-latm-muxer no
-+@c @set config-lc3-muxer no
-+@c @set config-lrc-muxer no
-+@c @set config-m4v-muxer no
-+@c @set config-mcc-muxer no
-+@c @set config-md5-muxer no
-+@c @set config-matroska-muxer no
-+@c @set config-matroska-audio-muxer no
-+@c @set config-microdvd-muxer no
-+@c @set config-mjpeg-muxer no
-+@c @set config-mlp-muxer no
-+@c @set config-mmf-muxer no
-+@c @set config-mov-muxer no
-+@c @set config-mp2-muxer no
-+@c @set config-mp3-muxer no
-+@c @set config-mp4-muxer no
-+@c @set config-mpeg1system-muxer no
-+@c @set config-mpeg1vcd-muxer no
-+@c @set config-mpeg1video-muxer no
-+@c @set config-mpeg2dvd-muxer no
-+@c @set config-mpeg2svcd-muxer no
-+@c @set config-mpeg2video-muxer no
-+@c @set config-mpeg2vob-muxer no
-+@c @set config-mpegts-muxer no
-+@c @set config-mpjpeg-muxer no
-+@c @set config-mxf-muxer no
-+@c @set config-mxf-d10-muxer no
-+@c @set config-mxf-opatom-muxer no
-+@c @set config-null-muxer no
-+@c @set config-nut-muxer no
-+@c @set config-obu-muxer no
-+@c @set config-oga-muxer no
-+@c @set config-ogg-muxer no
-+@c @set config-ogv-muxer no
-+@c @set config-oma-muxer no
-+@c @set config-opus-muxer no
-+@c @set config-pcm-alaw-muxer no
-+@c @set config-pcm-mulaw-muxer no
-+@c @set config-pcm-vidc-muxer no
-+@c @set config-pcm-f64be-muxer no
-+@c @set config-pcm-f64le-muxer no
-+@c @set config-pcm-f32be-muxer no
-+@c @set config-pcm-f32le-muxer no
-+@c @set config-pcm-s32be-muxer no
-+@c @set config-pcm-s32le-muxer no
-+@c @set config-pcm-s24be-muxer no
-+@c @set config-pcm-s24le-muxer no
-+@c @set config-pcm-s16be-muxer no
-+@c @set config-pcm-s16le-muxer no
-+@c @set config-pcm-s8-muxer no
-+@c @set config-pcm-u32be-muxer no
-+@c @set config-pcm-u32le-muxer no
-+@c @set config-pcm-u24be-muxer no
-+@c @set config-pcm-u24le-muxer no
-+@c @set config-pcm-u16be-muxer no
-+@c @set config-pcm-u16le-muxer no
-+@c @set config-pcm-u8-muxer no
-+@c @set config-psp-muxer no
-+@c @set config-rawvideo-muxer no
-+@c @set config-rcwt-muxer no
-+@c @set config-rm-muxer no
-+@c @set config-roq-muxer no
-+@c @set config-rso-muxer no
-+@c @set config-rtp-muxer no
-+@c @set config-rtp-mpegts-muxer no
-+@c @set config-rtsp-muxer no
-+@c @set config-sap-muxer no
-+@c @set config-sbc-muxer no
-+@c @set config-scc-muxer no
-+@c @set config-segafilm-muxer no
-+@c @set config-segment-muxer no
-+@c @set config-stream-segment-muxer no
-+@c @set config-smjpeg-muxer no
-+@c @set config-smoothstreaming-muxer no
-+@c @set config-sox-muxer no
-+@c @set config-spx-muxer no
-+@c @set config-spdif-muxer no
-+@c @set config-srt-muxer no
-+@c @set config-streamhash-muxer no
-+@c @set config-sup-muxer no
-+@c @set config-swf-muxer no
-+@c @set config-tee-muxer no
-+@c @set config-tg2-muxer no
-+@c @set config-tgp-muxer no
-+@c @set config-mkvtimestamp-v2-muxer no
-+@c @set config-truehd-muxer no
-+@c @set config-tta-muxer no
-+@c @set config-ttml-muxer no
-+@c @set config-uncodedframecrc-muxer no
-+@c @set config-vc1-muxer no
-+@c @set config-vc1t-muxer no
-+@c @set config-voc-muxer no
-+@c @set config-vvc-muxer no
-+@c @set config-w64-muxer no
-+@c @set config-wav-muxer no
-+@c @set config-webm-muxer no
-+@c @set config-webm-dash-manifest-muxer no
-+@c @set config-webm-chunk-muxer no
-+@c @set config-webp-muxer no
-+@c @set config-webvtt-muxer no
-+@c @set config-whip-muxer no
-+@c @set config-wsaud-muxer no
-+@c @set config-wtv-muxer no
-+@c @set config-wv-muxer no
-+@c @set config-yuv4mpegpipe-muxer no
-+@c @set config-chromaprint-muxer no
-+@c @set config-android-content-protocol no
-+@c @set config-async-protocol no
-+@c @set config-bluray-protocol no
-+@c @set config-cache-protocol no
-+@c @set config-concat-protocol no
-+@c @set config-concatf-protocol no
-+@c @set config-crypto-protocol no
-+@c @set config-data-protocol no
-+@c @set config-fd-protocol no
-+@c @set config-ffrtmpcrypt-protocol no
-+@c @set config-ffrtmphttp-protocol no
-+@c @set config-file-protocol no
-+@c @set config-ftp-protocol no
-+@c @set config-gopher-protocol no
-+@c @set config-gophers-protocol no
-+@c @set config-hls-protocol no
-+@c @set config-http-protocol no
-+@c @set config-httpproxy-protocol no
-+@c @set config-https-protocol no
-+@c @set config-icecast-protocol no
-+@c @set config-mmsh-protocol no
-+@c @set config-mmst-protocol no
-+@c @set config-md5-protocol no
-+@c @set config-pipe-protocol no
-+@c @set config-prompeg-protocol no
-+@c @set config-rtmp-protocol no
-+@c @set config-rtmpe-protocol no
-+@c @set config-rtmps-protocol no
-+@c @set config-rtmpt-protocol no
-+@c @set config-rtmpte-protocol no
-+@c @set config-rtmpts-protocol no
-+@c @set config-rtp-protocol no
-+@c @set config-sctp-protocol no
-+@c @set config-srtp-protocol no
-+@c @set config-subfile-protocol no
-+@c @set config-tee-protocol no
-+@c @set config-tcp-protocol no
-+@c @set config-tls-protocol no
-+@c @set config-dtls-protocol no
-+@c @set config-udp-protocol no
-+@c @set config-udplite-protocol no
-+@c @set config-unix-protocol no
-+@c @set config-libamqp-protocol no
-+@c @set config-librist-protocol no
-+@c @set config-librtmp-protocol no
-+@c @set config-librtmpe-protocol no
-+@c @set config-librtmps-protocol no
-+@c @set config-librtmpt-protocol no
-+@c @set config-librtmpte-protocol no
-+@c @set config-libsrt-protocol no
-+@c @set config-libssh-protocol no
-+@c @set config-libsmbclient-protocol no
-+@c @set config-libzmq-protocol no
-+@c @set config-ipfs-gateway-protocol no
-+@c @set config-ipns-gateway-protocol no
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
+new file mode 100644
+index 0000000000..7d9debfe61
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
+@@ -0,0 +1,15 @@
++static const FFCodec * const codec_list[] = {
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
+new file mode 100644
+index 0000000000..fdc533b38f
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
+@@ -0,0 +1,7 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_flac_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp9_parser,
++    NULL };
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
+new file mode 100644
+index 0000000000..570a6441d3
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
+@@ -0,0 +1,8 @@
++static const FFInputFormat * const demuxer_list[] = {
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
+new file mode 100644
+index 0000000000..ae54c39f23
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
+new file mode 100644
+index 0000000000..247e1e4c3a
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
+new file mode 100644
+index 0000000000..c289fbb551
+--- /dev/null
++++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 1
++#endif /* AVUTIL_AVCONFIG_H */
 diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni
 index b92f3f6631..ae678336ab 100644
 --- a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/ffmpeg_generated.gni
@@ -19279,123 +9750,122 @@ index b92f3f6631..ae678336ab 100644
  if ((is_android && current_cpu == "arm" && arm_use_neon) ||
      (use_linux_config && current_cpu == "arm" && arm_use_neon) ||
      (use_linux_config && current_cpu == "arm")) {
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/bsf_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/bsf_list.c
-new file mode 100644
-index 0000000000..7ff70c6e2d
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/bsf_list.c
-@@ -0,0 +1,2 @@
-+static const FFBitStreamFilter * const bitstream_filters[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/codec_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/codec_list.c
-new file mode 100644
-index 0000000000..fe5adb0d92
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/codec_list.c
-@@ -0,0 +1,17 @@
-+static const FFCodec * const codec_list[] = {
-+    &ff_h264_decoder,
-+    &ff_aac_decoder,
-+    &ff_flac_decoder,
-+    &ff_mp3_decoder,
-+    &ff_vorbis_decoder,
-+    &ff_pcm_alaw_decoder,
-+    &ff_pcm_f32le_decoder,
-+    &ff_pcm_mulaw_decoder,
-+    &ff_pcm_s16be_decoder,
-+    &ff_pcm_s16le_decoder,
-+    &ff_pcm_s24be_decoder,
-+    &ff_pcm_s24le_decoder,
-+    &ff_pcm_s32le_decoder,
-+    &ff_pcm_u8_decoder,
-+    &ff_libopus_decoder,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/parser_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/parser_list.c
-new file mode 100644
-index 0000000000..3e4fa9c320
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavcodec/parser_list.c
-@@ -0,0 +1,9 @@
-+static const AVCodecParser * const parser_list[] = {
-+    &ff_aac_parser,
-+    &ff_flac_parser,
-+    &ff_h264_parser,
-+    &ff_mpegaudio_parser,
-+    &ff_opus_parser,
-+    &ff_vorbis_parser,
-+    &ff_vp9_parser,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/indev_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/indev_list.c
-new file mode 100644
-index 0000000000..7c31d1d44b
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/indev_list.c
-@@ -0,0 +1,2 @@
-+static const FFInputFormat * const indev_list[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/outdev_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/outdev_list.c
-new file mode 100644
-index 0000000000..d15f210cbc
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavdevice/outdev_list.c
-@@ -0,0 +1,2 @@
-+static const FFOutputFormat * const outdev_list[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavfilter/filter_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavfilter/filter_list.c
-new file mode 100644
-index 0000000000..9df38a6ed5
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavfilter/filter_list.c
-@@ -0,0 +1,6 @@
-+static const FFFilter * const filter_list[] = {
-+    &ff_asrc_abuffer,
-+    &ff_vsrc_buffer,
-+    &ff_asink_abuffer,
-+    &ff_vsink_buffer,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/demuxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/demuxer_list.c
-new file mode 100644
-index 0000000000..29f1f59381
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/demuxer_list.c
-@@ -0,0 +1,9 @@
-+static const FFInputFormat * const demuxer_list[] = {
-+    &ff_aac_demuxer,
-+    &ff_flac_demuxer,
-+    &ff_matroska_demuxer,
-+    &ff_mov_demuxer,
-+    &ff_mp3_demuxer,
-+    &ff_ogg_demuxer,
-+    &ff_wav_demuxer,
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/muxer_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/muxer_list.c
-new file mode 100644
-index 0000000000..ae54c39f23
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/muxer_list.c
-@@ -0,0 +1,2 @@
-+static const FFOutputFormat * const muxer_list[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/protocol_list.c b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/protocol_list.c
-new file mode 100644
-index 0000000000..247e1e4c3a
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavformat/protocol_list.c
-@@ -0,0 +1,2 @@
-+static const URLProtocol * const url_protocols[] = {
-+    NULL };
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavutil/avconfig.h b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavutil/avconfig.h
-new file mode 100644
-index 0000000000..c289fbb551
---- /dev/null
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/ffmpeg/libavutil/avconfig.h
-@@ -0,0 +1,6 @@
-+/* Generated by ffmpeg configure */
-+#ifndef AVUTIL_AVCONFIG_H
-+#define AVUTIL_AVCONFIG_H
-+#define AV_HAVE_BIGENDIAN 0
-+#define AV_HAVE_FAST_UNALIGNED 1
-+#endif /* AVUTIL_AVCONFIG_H */
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/skia/gn/core.gni b/qtwebengine/src/3rdparty/chromium/third_party/skia/gn/core.gni
+index f16403f93c..8e8d879cdc 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/skia/gn/core.gni
++++ b/qtwebengine/src/3rdparty/chromium/third_party/skia/gn/core.gni
+@@ -283,7 +283,7 @@ skia_core_sources = [
+   "$_src/core/SkBitmapProcState.h",
+   "$_src/core/SkBitmapProcState_matrixProcs.cpp",
+   "$_src/core/SkBitmapProcState_opts.cpp",
+-  "$_src/core/SkBitmapProcState_opts_lasx.cpp",
++  #"$_src/core/SkBitmapProcState_opts_lasx.cpp",
+   "$_src/core/SkBitmapProcState_opts_ssse3.cpp",
+   "$_src/core/SkBlendMode.cpp",
+   "$_src/core/SkBlendModeBlender.cpp",
+@@ -298,7 +298,7 @@ skia_core_sources = [
+   "$_src/core/SkBlitRow_D32.cpp",
+   "$_src/core/SkBlitRow_opts.cpp",
+   "$_src/core/SkBlitRow_opts_hsw.cpp",
+-  "$_src/core/SkBlitRow_opts_lasx.cpp",
++  #"$_src/core/SkBlitRow_opts_lasx.cpp",
+   "$_src/core/SkBlitter.cpp",
+   "$_src/core/SkBlitter.h",
+   "$_src/core/SkBlitter_A8.cpp",
+@@ -593,7 +593,7 @@ skia_core_sources = [
+   "$_src/core/SkSwizzlePriv.h",
+   "$_src/core/SkSwizzler_opts.cpp",
+   "$_src/core/SkSwizzler_opts_hsw.cpp",
+-  "$_src/core/SkSwizzler_opts_lasx.cpp",
++  #"$_src/core/SkSwizzler_opts_lasx.cpp",
+   "$_src/core/SkSwizzler_opts_ssse3.cpp",
+   "$_src/core/SkSynchronizedResourceCache.cpp",
+   "$_src/core/SkSynchronizedResourceCache.h",
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/skia/include/private/base/SkFeatures.h b/qtwebengine/src/3rdparty/chromium/third_party/skia/include/private/base/SkFeatures.h
+index 2452386cf9..6ed28d0639 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/skia/include/private/base/SkFeatures.h
++++ b/qtwebengine/src/3rdparty/chromium/third_party/skia/include/private/base/SkFeatures.h
+@@ -125,9 +125,9 @@
+ #endif
+ 
+ #ifndef SK_CPU_LSX_LEVEL
+-    #if defined(__loongarch_asx)
++    #if defined(__loongarch_asx) && 0
+         #define SK_CPU_LSX_LEVEL    SK_CPU_LSX_LEVEL_LASX
+-    #elif defined(__loongarch_sx)
++    #elif defined(__loongarch_sx) && 0
+         #define SK_CPU_LSX_LEVEL    SK_CPU_LSX_LEVEL_LSX
+     #endif
+ #endif
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBitmapProcState_opts.cpp b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBitmapProcState_opts.cpp
+index 3961d720bb..bf7494eb47 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBitmapProcState_opts.cpp
++++ b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBitmapProcState_opts.cpp
+@@ -22,7 +22,6 @@ namespace SkOpts {
+     DEFINE_DEFAULT(S32_alpha_D32_filter_DXDY);
+ 
+     void Init_BitmapProcState_ssse3();
+-    void Init_BitmapProcState_lasx();
+ 
+     static bool init() {
+     #if defined(SK_ENABLE_OPTIMIZE_SIZE)
+@@ -31,10 +30,6 @@ namespace SkOpts {
+         #if SK_CPU_SSE_LEVEL < SK_CPU_SSE_LEVEL_SSSE3
+             if (SkCpu::Supports(SkCpu::SSSE3)) { Init_BitmapProcState_ssse3(); }
+         #endif
+-    #elif defined(SK_CPU_LOONGARCH)
+-        #if SK_CPU_LSX_LEVEL < SK_CPU_LSX_LEVEL_LASX
+-            if (SkCpu::Supports(SkCpu::LOONGARCH_ASX)) { Init_BitmapProcState_lasx(); }
+-        #endif
+     #endif
+       return true;
+     }
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBlitRow_opts.cpp b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBlitRow_opts.cpp
+index 6b125ac834..e49b625df1 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBlitRow_opts.cpp
++++ b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkBlitRow_opts.cpp
+@@ -22,7 +22,6 @@ namespace SkOpts {
+     DEFINE_DEFAULT(blit_row_s32a_opaque);
+ 
+     void Init_BlitRow_hsw();
+-    void Init_BlitRow_lasx();
+ 
+     static bool init() {
+     #if defined(SK_ENABLE_OPTIMIZE_SIZE)
+@@ -31,10 +30,6 @@ namespace SkOpts {
+         #if SK_CPU_SSE_LEVEL < SK_CPU_SSE_LEVEL_AVX2
+             if (SkCpu::Supports(SkCpu::HSW)) { Init_BlitRow_hsw(); }
+         #endif
+-    #elif defined(SK_CPU_LOONGARCH)
+-        #if SK_CPU_LSX_LEVEL < SK_CPU_LSX_LEVEL_LASX
+-            if (SkCpu::Supports(SkCpu::LOONGARCH_ASX)) { Init_BlitRow_lasx(); }
+-        #endif
+     #endif
+       return true;
+     }
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkSwizzler_opts.cpp b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkSwizzler_opts.cpp
+index 0665a19fbb..c8efe53e74 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkSwizzler_opts.cpp
++++ b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/core/SkSwizzler_opts.cpp
+@@ -33,7 +33,6 @@ namespace SkOpts {
+ 
+     void Init_Swizzler_ssse3();
+     void Init_Swizzler_hsw();
+-    void Init_Swizzler_lasx();
+ 
+     static bool init() {
+     #if defined(SK_ENABLE_OPTIMIZE_SIZE)
+@@ -46,10 +45,6 @@ namespace SkOpts {
+         #if SK_CPU_SSE_LEVEL < SK_CPU_SSE_LEVEL_AVX2
+             if (SkCpu::Supports(SkCpu::HSW)) { Init_Swizzler_hsw(); }
+         #endif
+-    #elif defined(SK_CPU_LOONGARCH)
+-        #if SK_CPU_LSX_LEVEL < SK_CPU_LSX_LEVEL_LASX
+-            if (SkCpu::Supports(SkCpu::LOONGARCH_ASX)) { Init_Swizzler_lasx(); }
+-        #endif
+     #endif
+       return true;
+     }
 diff --git a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/opts/SkOpts_SetTarget.h b/qtwebengine/src/3rdparty/chromium/third_party/skia/src/opts/SkOpts_SetTarget.h
 index f2debc0444..48c0b9de83 100644
 --- a/qtwebengine/src/3rdparty/chromium/third_party/skia/src/opts/SkOpts_SetTarget.h
@@ -19429,7518 +9899,31 @@ index 67dfeb0ec8..c9683912e7 100644
  
      deps = [
        ":swiftshader_reactor_base",
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/BUILD.gn
-index 3d51cd29bc..15c42128c6 100644
---- a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/BUILD.gn
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/BUILD.gn
-@@ -1835,6 +1835,262 @@ if (current_cpu == "x64" || current_cpu == "x86") {
-       ":xx-transposev_riscv64_standalone",
-     ]
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/src/Vulkan/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/src/Vulkan/BUILD.gn
+index 852068cade..fb6618f9d3 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/src/Vulkan/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/src/Vulkan/BUILD.gn
+@@ -229,6 +229,7 @@ swiftshader_shared_library("swiftshader_libvulkan") {
    }
-+} else if (current_cpu == "loong64") {
-+  if (build_with_chromium) {
-+    xnnpack_deps = [
-+      ":configs_loong64",
-+      ":enums_loong64",
-+      ":f16-f32-vcvt_loong64",
-+      ":f16-qs8-vcvt_loong64",
-+      ":f16-qu8-vcvt_loong64",
-+      ":f16-rdminmax_loong64",
-+      ":f16-rminmax_loong64",
-+      ":f16-vapproxgelu_loong64",
-+      ":f16-vcos_loong64",
-+      ":f16-vexp_loong64",
-+      ":f16-vgelu_loong64",
-+      ":f16-vsin_loong64",
-+      ":f32-argmaxpool_loong64",
-+      ":f32-avgpool_loong64",
-+      ":f32-conv-hwc2chw_loong64",
-+      ":f32-dwconv2d-chw_loong64",
-+      ":f32-dwconv_loong64",
-+      ":f32-f16-vcvt_loong64",
-+      ":f32-gemm_loong64",
-+      ":f32-ibilinear-chw_loong64",
-+      ":f32-ibilinear_loong64",
-+      ":f32-igemm_loong64",
-+      ":f32-maxpool_loong64",
-+      ":f32-qc4w-gemm_loong64",
-+      ":f32-qc8w-gemm_loong64",
-+      ":f32-qs8-vcvt_loong64",
-+      ":f32-qu8-vcvt_loong64",
-+      ":f32-raddstoreexpminusmax_loong64",
-+      ":f32-rdminmax_loong64",
-+      ":f32-rdsum2_loong64",
-+      ":f32-rdsum_loong64",
-+      ":f32-rminmax_loong64",
-+      ":f32-rsum2_loong64",
-+      ":f32-rsum_loong64",
-+      ":f32-spmm_loong64",
-+      ":f32-vapproxgelu_loong64",
-+      ":f32-vbinary_loong64",
-+      ":f32-vclamp_loong64",
-+      ":f32-vcmul_loong64",
-+      ":f32-vcopysign_loong64",
-+      ":f32-vcos_loong64",
-+      ":f32-velu_loong64",
-+      ":f32-vexp_loong64",
-+      ":f32-vgelu_loong64",
-+      ":f32-vhswish_loong64",
-+      ":f32-vlog_loong64",
-+      ":f32-vlrelu_loong64",
-+      ":f32-vmulcaddc_loong64",
-+      ":f32-vrnd_loong64",
-+      ":f32-vrsqrt_loong64",
-+      ":f32-vsigmoid_loong64",
-+      ":f32-vsin_loong64",
-+      ":f32-vsqrt_loong64",
-+      ":f32-vtanh_loong64",
-+      ":f32-vunary_loong64",
-+      ":operators_loong64",
-+      ":qd8-f32-qb4w-gemm_loong64",
-+      ":qd8-f32-qc4w-gemm_loong64",
-+      ":qd8-f32-qc8w-gemm_loong64",
-+      ":qd8-f32-qc8w-igemm_loong64",
-+      ":qs8-dwconv_loong64",
-+      ":qs8-f32-vcvt_loong64",
-+      ":qs8-packw_loong64",
-+      ":qs8-qc4w-gemm_loong64",
-+      ":qs8-qc8w-dwconv_loong64",
-+      ":qs8-qc8w-gemm_loong64",
-+      ":qs8-qc8w-igemm_loong64",
-+      ":qs8-qu8-packw_loong64",
-+      ":qs8-rdsum_loong64",
-+      ":qs8-rsum_loong64",
-+      ":qs8-vadd_loong64",
-+      ":qs8-vaddc_loong64",
-+      ":qs8-vcvt_loong64",
-+      ":qs8-vlrelu_loong64",
-+      ":qs8-vmul_loong64",
-+      ":qs8-vmulc_loong64",
-+      ":qs8-vprelu_loong64",
-+      ":qs8-vpreluc_loong64",
-+      ":qs8-vrpreluc_loong64",
-+      ":qu8-dwconv_loong64",
-+      ":qu8-f32-vcvt_loong64",
-+      ":qu8-gemm_loong64",
-+      ":qu8-igemm_loong64",
-+      ":qu8-rdsum_loong64",
-+      ":qu8-rsum_loong64",
-+      ":qu8-vadd_loong64",
-+      ":qu8-vaddc_loong64",
-+      ":qu8-vcvt_loong64",
-+      ":qu8-vlrelu_loong64",
-+      ":qu8-vmul_loong64",
-+      ":qu8-vmulc_loong64",
-+      ":qu8-vprelu_loong64",
-+      ":qu8-vpreluc_loong64",
-+      ":qu8-vrpreluc_loong64",
-+      ":reference_loong64",
-+      ":s8-ibilinear_loong64",
-+      ":s8-maxpool_loong64",
-+      ":s8-rdminmax_loong64",
-+      ":s8-rminmax_loong64",
-+      ":s8-vclamp_loong64",
-+      ":subgraph_loong64",
-+      ":tables_loong64",
-+      ":u8-ibilinear_loong64",
-+      ":u8-lut32norm_loong64",
-+      ":u8-maxpool_loong64",
-+      ":u8-rdminmax_loong64",
-+      ":u8-rminmax_loong64",
-+      ":u8-vclamp_loong64",
-+      ":x16-transposec_loong64",
-+      ":x16-x32-packw_loong64",
-+      ":x24-transposec_loong64",
-+      ":x32-packw_loong64",
-+      ":x32-transposec_loong64",
-+      ":x32-unpool_loong64",
-+      ":x64-transposec_loong64",
-+      ":x8-lut_loong64",
-+      ":x8-packq_loong64",
-+      ":x8-packw_loong64",
-+      ":x8-transposec_loong64",
-+      ":xx-copy_loong64",
-+      ":xx-fill_loong64",
-+      ":xx-pad_loong64",
-+      ":xx-transposev_loong64",
-+    ]
-+  }
-+
-+  if (build_with_internal_optimization_guide) {
-+    xnnpack_standalone_deps = [
-+      ":configs_loong64_standalone",
-+      ":enums_loong64_standalone",
-+      ":f16-f32-vcvt_loong64_standalone",
-+      ":f16-qs8-vcvt_loong64_standalone",
-+      ":f16-qu8-vcvt_loong64_standalone",
-+      ":f16-rdminmax_loong64_standalone",
-+      ":f16-rminmax_loong64_standalone",
-+      ":f16-vapproxgelu_loong64_standalone",
-+      ":f16-vcos_loong64_standalone",
-+      ":f16-vexp_loong64_standalone",
-+      ":f16-vgelu_loong64_standalone",
-+      ":f16-vsin_loong64_standalone",
-+      ":f32-argmaxpool_loong64_standalone",
-+      ":f32-avgpool_loong64_standalone",
-+      ":f32-conv-hwc2chw_loong64_standalone",
-+      ":f32-dwconv2d-chw_loong64_standalone",
-+      ":f32-dwconv_loong64_standalone",
-+      ":f32-f16-vcvt_loong64_standalone",
-+      ":f32-gemm_loong64_standalone",
-+      ":f32-ibilinear-chw_loong64_standalone",
-+      ":f32-ibilinear_loong64_standalone",
-+      ":f32-igemm_loong64_standalone",
-+      ":f32-maxpool_loong64_standalone",
-+      ":f32-qc4w-gemm_loong64_standalone",
-+      ":f32-qc8w-gemm_loong64_standalone",
-+      ":f32-qs8-vcvt_loong64_standalone",
-+      ":f32-qu8-vcvt_loong64_standalone",
-+      ":f32-raddstoreexpminusmax_loong64_standalone",
-+      ":f32-rdminmax_loong64_standalone",
-+      ":f32-rdsum2_loong64_standalone",
-+      ":f32-rdsum_loong64_standalone",
-+      ":f32-rminmax_loong64_standalone",
-+      ":f32-rsum2_loong64_standalone",
-+      ":f32-rsum_loong64_standalone",
-+      ":f32-spmm_loong64_standalone",
-+      ":f32-vapproxgelu_loong64_standalone",
-+      ":f32-vbinary_loong64_standalone",
-+      ":f32-vclamp_loong64_standalone",
-+      ":f32-vcmul_loong64_standalone",
-+      ":f32-vcopysign_loong64_standalone",
-+      ":f32-vcos_loong64_standalone",
-+      ":f32-velu_loong64_standalone",
-+      ":f32-vexp_loong64_standalone",
-+      ":f32-vgelu_loong64_standalone",
-+      ":f32-vhswish_loong64_standalone",
-+      ":f32-vlog_loong64_standalone",
-+      ":f32-vlrelu_loong64_standalone",
-+      ":f32-vmulcaddc_loong64_standalone",
-+      ":f32-vrnd_loong64_standalone",
-+      ":f32-vrsqrt_loong64_standalone",
-+      ":f32-vsigmoid_loong64_standalone",
-+      ":f32-vsin_loong64_standalone",
-+      ":f32-vsqrt_loong64_standalone",
-+      ":f32-vtanh_loong64_standalone",
-+      ":f32-vunary_loong64_standalone",
-+      ":operators_loong64_standalone",
-+      ":qd8-f32-qb4w-gemm_loong64_standalone",
-+      ":qd8-f32-qc4w-gemm_loong64_standalone",
-+      ":qd8-f32-qc8w-gemm_loong64_standalone",
-+      ":qd8-f32-qc8w-igemm_loong64_standalone",
-+      ":qs8-dwconv_loong64_standalone",
-+      ":qs8-f32-vcvt_loong64_standalone",
-+      ":qs8-packw_loong64_standalone",
-+      ":qs8-qc4w-gemm_loong64_standalone",
-+      ":qs8-qc8w-dwconv_loong64_standalone",
-+      ":qs8-qc8w-gemm_loong64_standalone",
-+      ":qs8-qc8w-igemm_loong64_standalone",
-+      ":qs8-qu8-packw_loong64_standalone",
-+      ":qs8-rdsum_loong64_standalone",
-+      ":qs8-rsum_loong64_standalone",
-+      ":qs8-vadd_loong64_standalone",
-+      ":qs8-vaddc_loong64_standalone",
-+      ":qs8-vcvt_loong64_standalone",
-+      ":qs8-vlrelu_loong64_standalone",
-+      ":qs8-vmul_loong64_standalone",
-+      ":qs8-vmulc_loong64_standalone",
-+      ":qs8-vprelu_loong64_standalone",
-+      ":qs8-vpreluc_loong64_standalone",
-+      ":qs8-vrpreluc_loong64_standalone",
-+      ":qu8-dwconv_loong64_standalone",
-+      ":qu8-f32-vcvt_loong64_standalone",
-+      ":qu8-gemm_loong64_standalone",
-+      ":qu8-igemm_loong64_standalone",
-+      ":qu8-rdsum_loong64_standalone",
-+      ":qu8-rsum_loong64_standalone",
-+      ":qu8-vadd_loong64_standalone",
-+      ":qu8-vaddc_loong64_standalone",
-+      ":qu8-vcvt_loong64_standalone",
-+      ":qu8-vlrelu_loong64_standalone",
-+      ":qu8-vmul_loong64_standalone",
-+      ":qu8-vmulc_loong64_standalone",
-+      ":qu8-vprelu_loong64_standalone",
-+      ":qu8-vpreluc_loong64_standalone",
-+      ":qu8-vrpreluc_loong64_standalone",
-+      ":reference_loong64_standalone",
-+      ":s8-ibilinear_loong64_standalone",
-+      ":s8-maxpool_loong64_standalone",
-+      ":s8-rdminmax_loong64_standalone",
-+      ":s8-rminmax_loong64_standalone",
-+      ":s8-vclamp_loong64_standalone",
-+      ":subgraph_loong64_standalone",
-+      ":tables_loong64_standalone",
-+      ":u8-ibilinear_loong64_standalone",
-+      ":u8-lut32norm_loong64_standalone",
-+      ":u8-maxpool_loong64_standalone",
-+      ":u8-rdminmax_loong64_standalone",
-+      ":u8-rminmax_loong64_standalone",
-+      ":u8-vclamp_loong64_standalone",
-+      ":x16-transposec_loong64_standalone",
-+      ":x16-x32-packw_loong64_standalone",
-+      ":x24-transposec_loong64_standalone",
-+      ":x32-packw_loong64_standalone",
-+      ":x32-transposec_loong64_standalone",
-+      ":x32-unpool_loong64_standalone",
-+      ":x64-transposec_loong64_standalone",
-+      ":x8-lut_loong64_standalone",
-+      ":x8-packq_loong64_standalone",
-+      ":x8-packw_loong64_standalone",
-+      ":x8-transposec_loong64_standalone",
-+      ":xx-copy_loong64_standalone",
-+      ":xx-fill_loong64_standalone",
-+      ":xx-pad_loong64_standalone",
-+      ":xx-transposev_loong64_standalone",
-+    ]
-+  }
- } else {
-   xnnpack_deps = []
-   if (build_with_internal_optimization_guide) {
-@@ -55097,3 +55353,7164 @@ if (current_cpu == "riscv64") {
-     }
-   }
+ 
+   deps = [ ":_swiftshader_libvulkan" ]
++  libs = [ "m" ]
  }
-+
-+if (current_cpu == "loong64") {
-+  if (build_with_chromium) {
-+    source_set("configs_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/configs/argmaxpool-config.c",
-+        "src/src/configs/avgpool-config.c",
-+        "src/src/configs/binary-elementwise-config.c",
-+        "src/src/configs/cmul-config.c",
-+        "src/src/configs/conv-hwc2chw-config.c",
-+        "src/src/configs/dwconv-config.c",
-+        "src/src/configs/dwconv2d-chw-config.c",
-+        "src/src/configs/gemm-config.c",
-+        "src/src/configs/hardware-config.c",
-+        "src/src/configs/ibilinear-chw-config.c",
-+        "src/src/configs/ibilinear-config.c",
-+        "src/src/configs/lut32norm-config.c",
-+        "src/src/configs/maxpool-config.c",
-+        "src/src/configs/pack-lh-config.c",
-+        "src/src/configs/raddstoreexpminusmax-config.c",
-+        "src/src/configs/reduce-config.c",
-+        "src/src/configs/spmm-config.c",
-+        "src/src/configs/transpose-config.c",
-+        "src/src/configs/unary-elementwise-config.c",
-+        "src/src/configs/unpool-config.c",
-+        "src/src/configs/vmulcaddc-config.c",
-+        "src/src/configs/x8-lut-config.c",
-+        "src/src/configs/xx-fill-config.c",
-+        "src/src/configs/xx-pad-config.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("configs_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/configs/argmaxpool-config.c",
-+        "src/src/configs/avgpool-config.c",
-+        "src/src/configs/binary-elementwise-config.c",
-+        "src/src/configs/cmul-config.c",
-+        "src/src/configs/conv-hwc2chw-config.c",
-+        "src/src/configs/dwconv-config.c",
-+        "src/src/configs/dwconv2d-chw-config.c",
-+        "src/src/configs/gemm-config.c",
-+        "src/src/configs/hardware-config.c",
-+        "src/src/configs/ibilinear-chw-config.c",
-+        "src/src/configs/ibilinear-config.c",
-+        "src/src/configs/lut32norm-config.c",
-+        "src/src/configs/maxpool-config.c",
-+        "src/src/configs/pack-lh-config.c",
-+        "src/src/configs/raddstoreexpminusmax-config.c",
-+        "src/src/configs/reduce-config.c",
-+        "src/src/configs/spmm-config.c",
-+        "src/src/configs/transpose-config.c",
-+        "src/src/configs/unary-elementwise-config.c",
-+        "src/src/configs/unpool-config.c",
-+        "src/src/configs/vmulcaddc-config.c",
-+        "src/src/configs/x8-lut-config.c",
-+        "src/src/configs/xx-fill-config.c",
-+        "src/src/configs/xx-pad-config.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("enums_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/enums/allocation-type.c",
-+        "src/src/enums/datatype-strings.c",
-+        "src/src/enums/microkernel-type.c",
-+        "src/src/enums/node-type.c",
-+        "src/src/enums/operator-type.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("enums_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/enums/allocation-type.c",
-+        "src/src/enums/datatype-strings.c",
-+        "src/src/enums/microkernel-type.c",
-+        "src/src/enums/node-type.c",
-+        "src/src/enums/operator-type.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-f32-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-f32-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-f32-vcvt/gen/f16-f32-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-qs8-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-qs8-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-qs8-vcvt/gen/f16-qs8-vcvt-scalar-imagic-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-qu8-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-qu8-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-qu8-vcvt/gen/f16-qu8-vcvt-scalar-imagic-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-rdminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
-+        "src/src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-rdminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-rdminmax/gen/f16-rdmax-2p2x-scalar-u2.c",
-+        "src/src/f16-rdminmax/gen/f16-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-rminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",
-+        "src/src/f16-rminmax/gen/f16-rmin-scalar-u2-acc2.c",
-+        "src/src/f16-rminmax/gen/f16-rminmax-scalar-u2-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-rminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-rminmax/gen/f16-rmax-scalar-u2-acc2.c",
-+        "src/src/f16-rminmax/gen/f16-rmin-scalar-u2-acc2.c",
-+        "src/src/f16-rminmax/gen/f16-rminmax-scalar-u2-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-vapproxgelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-vapproxgelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vapproxgelu/gen/f16-vapproxgelu-scalar-rational-6-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-vcos_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vcos/gen/f16-vcos-scalar-rational-3-2-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-vcos_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vcos/gen/f16-vcos-scalar-rational-3-2-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-vexp_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vexp/gen/f16-vexp-scalar-poly-3.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-vexp_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vexp/gen/f16-vexp-scalar-poly-3.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-vgelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vgelu/gen/f16-vgelu-scalar-rational-6-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-vgelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vgelu/gen/f16-vgelu-scalar-rational-6-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f16-vsin_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vsin/gen/f16-vsin-scalar-rational-3-2-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f16-vsin_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f16-vsin/gen/f16-vsin-scalar-rational-3-2-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-argmaxpool_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-argmaxpool/f32-argmaxpool-9p8x-scalar-c1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-argmaxpool_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-argmaxpool/f32-argmaxpool-9p8x-scalar-c1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-avgpool_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-avgpool/gen/f32-avgpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-avgpool_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-avgpool/gen/f32-avgpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-conv-hwc2chw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x4-scalar-1x1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-conv-hwc2chw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-conv-hwc2chw/f32-conv-hwc2chw-3x3s2p1c3x4-scalar-1x1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-dwconv2d-chw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-2x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-4x1.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-1x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-2x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-1x1-acc5.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-2x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-1x1-acc5.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-2x1-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-dwconv2d-chw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-2x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3p1-minmax-scalar-4x1.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-1x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-3x3s2p1-minmax-scalar-2x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-1x1-acc5.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5p2-minmax-scalar-2x1-acc2.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-1x1-acc5.c",
-+        "src/src/f32-dwconv2d-chw/gen/f32-dwconv2d-chw-5x5s2p2-minmax-scalar-2x1-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-dwconv_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-scalar-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-dwconv_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p1c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-25p2c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-3p1c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-4p1c-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-minmax-scalar-acc2.c",
-+        "src/src/f32-dwconv/gen/f32-dwconv-9p1c-scalar-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-f16-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-f16-vcvt/gen/f32-f16-vcvt-scalar-fabsf-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-f16-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-f16-vcvt/gen/f32-f16-vcvt-scalar-fabsf-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-gemm/gen/f32-gemm-1x4-minmax-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-1x4-relu-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-1x4-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x2-minmax-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x2-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x4-minmax-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x4-relu-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x4-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-gemm/gen/f32-gemm-1x4-minmax-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-1x4-relu-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-1x4-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x2-minmax-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x2-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x4-minmax-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x4-relu-scalar.c",
-+        "src/src/f32-gemm/gen/f32-gemm-4x4-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-ibilinear-chw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-ibilinear-chw/gen/f32-ibilinear-chw-scalar-p4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-ibilinear-chw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-ibilinear-chw/gen/f32-ibilinear-chw-scalar-p4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-ibilinear_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-ibilinear/gen/f32-ibilinear-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-ibilinear_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-ibilinear/gen/f32-ibilinear-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-igemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-igemm/gen/f32-igemm-1x4-minmax-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-1x4-relu-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-1x4-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x2-minmax-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x2-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x4-minmax-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x4-relu-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x4-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-igemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-igemm/gen/f32-igemm-1x4-minmax-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-1x4-relu-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-1x4-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x2-minmax-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x2-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x4-minmax-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x4-relu-scalar.c",
-+        "src/src/f32-igemm/gen/f32-igemm-4x4-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-maxpool_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-maxpool_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-maxpool/gen/f32-maxpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-qc4w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-1x4-minmax-scalar.c",
-+        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-qc4w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-1x4-minmax-scalar.c",
-+        "src/src/f32-qc4w-gemm/gen/f32-qc4w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-qc8w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-1x4-minmax-scalar.c",
-+        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-qc8w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-1x4-minmax-scalar.c",
-+        "src/src/f32-qc8w-gemm/gen/f32-qc8w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-qs8-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-imagic-u4.c",
-+        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-lrintf-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-qs8-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-imagic-u4.c",
-+        "src/src/f32-qs8-vcvt/gen/f32-qs8-vcvt-scalar-lrintf-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-qu8-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-imagic-u4.c",
-+        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-lrintf-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-qu8-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-imagic-u4.c",
-+        "src/src/f32-qu8-vcvt/gen/f32-qu8-vcvt-scalar-lrintf-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-raddstoreexpminusmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-raddstoreexpminusmax/gen/f32-raddstoreexpminusmax-scalar-rr2-p5-u4-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-raddstoreexpminusmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-raddstoreexpminusmax/gen/f32-raddstoreexpminusmax-scalar-rr2-p5-u4-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-rdminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rdminmax/gen/f32-rdmax-2p2x-scalar-u2.c",
-+        "src/src/f32-rdminmax/gen/f32-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-rdminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rdminmax/gen/f32-rdmax-2p2x-scalar-u2.c",
-+        "src/src/f32-rdminmax/gen/f32-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-rdsum2_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rdsum2/gen/f32-rdsum2-7p7x-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-rdsum2_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rdsum2/gen/f32-rdsum2-7p7x-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-rdsum_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rdsum/gen/f32-rdsum-7p7x-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-rdsum_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rdsum/gen/f32-rdsum-7p7x-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-rminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rminmax/gen/f32-rmax-scalar-u4-acc4.c",
-+        "src/src/f32-rminmax/gen/f32-rmin-scalar-u4-acc4.c",
-+        "src/src/f32-rminmax/gen/f32-rminmax-scalar-u4-acc4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-rminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rminmax/gen/f32-rmax-scalar-u4-acc4.c",
-+        "src/src/f32-rminmax/gen/f32-rmin-scalar-u4-acc4.c",
-+        "src/src/f32-rminmax/gen/f32-rminmax-scalar-u4-acc4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-rsum2_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rsum2/gen/f32-rsum2-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-rsum2_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rsum2/gen/f32-rsum2-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-rsum_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rsum/gen/f32-rsum-scalar-u4-acc4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-rsum_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-rsum/gen/f32-rsum-scalar-u4-acc4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-spmm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-spmm/gen/f32-spmm-8x1-minmax-scalar.c",
-+        "src/src/f32-spmm/gen/f32-spmm-8x2-minmax-scalar.c",
-+        "src/src/f32-spmm/gen/f32-spmm-8x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-spmm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-spmm/gen/f32-spmm-8x1-minmax-scalar.c",
-+        "src/src/f32-spmm/gen/f32-spmm-8x2-minmax-scalar.c",
-+        "src/src/f32-spmm/gen/f32-spmm-8x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vapproxgelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vapproxgelu/gen/f32-vapproxgelu-scalar-rational-12-10-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vapproxgelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vapproxgelu/gen/f32-vapproxgelu-scalar-rational-12-10-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vbinary_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vbinary/gen/f32-vadd-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vaddc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vdiv-scalar-u2.c",
-+        "src/src/f32-vbinary/gen/f32-vdivc-scalar-u2.c",
-+        "src/src/f32-vbinary/gen/f32-vmax-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmaxc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmin-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vminc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmul-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmulc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vprelu-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vpreluc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vrdivc-scalar-u2.c",
-+        "src/src/f32-vbinary/gen/f32-vrpreluc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vrsubc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsqrdiff-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsqrdiffc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsub-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsubc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vbinary_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vbinary/gen/f32-vadd-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vaddc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vdiv-scalar-u2.c",
-+        "src/src/f32-vbinary/gen/f32-vdivc-scalar-u2.c",
-+        "src/src/f32-vbinary/gen/f32-vmax-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmaxc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmin-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vminc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmul-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vmulc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vprelu-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vpreluc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vrdivc-scalar-u2.c",
-+        "src/src/f32-vbinary/gen/f32-vrpreluc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vrsubc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsqrdiff-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsqrdiffc-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsub-scalar-u8.c",
-+        "src/src/f32-vbinary/gen/f32-vsubc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vclamp_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vclamp/gen/f32-vclamp-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vclamp_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vclamp/gen/f32-vclamp-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vcmul_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vcmul/gen/f32-vcmul-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vcmul_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vcmul/gen/f32-vcmul-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vcopysign_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vcopysign/gen/f32-vcopysign-scalar.c",
-+        "src/src/f32-vcopysign/gen/f32-vcopysignc-scalar.c",
-+        "src/src/f32-vcopysign/gen/f32-vrcopysignc-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vcopysign_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vcopysign/gen/f32-vcopysign-scalar.c",
-+        "src/src/f32-vcopysign/gen/f32-vcopysignc-scalar.c",
-+        "src/src/f32-vcopysign/gen/f32-vrcopysignc-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vcos_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vcos/gen/f32-vcos-scalar-rational-5-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vcos_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vcos/gen/f32-vcos-scalar-rational-5-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-velu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-velu/gen/f32-velu-scalar-rr2-lut16-p3-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-velu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-velu/gen/f32-velu-scalar-rr2-lut16-p3-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vexp_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vexp/gen/f32-vexp-scalar-rational-3-2-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vexp_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vexp/gen/f32-vexp-scalar-rational-3-2-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vgelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vgelu/gen/f32-vgelu-scalar-rational-12-10-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vgelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vgelu/gen/f32-vgelu-scalar-rational-12-10-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vhswish_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vhswish/gen/f32-vhswish-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vhswish_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vhswish/gen/f32-vhswish-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vlog_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vlog/gen/f32-vlog-scalar-rational-3-3-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vlog_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vlog/gen/f32-vlog-scalar-rational-3-3-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vlrelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vlrelu/gen/f32-vlrelu-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vlrelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vlrelu/gen/f32-vlrelu-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vmulcaddc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vmulcaddc/gen/f32-vmulcaddc-c1-minmax-scalar-2x.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vmulcaddc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vmulcaddc/gen/f32-vmulcaddc-c1-minmax-scalar-2x.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vrnd_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vrnd/gen/f32-vrndd-scalar-libm-u1.c",
-+        "src/src/f32-vrnd/gen/f32-vrndne-scalar-libm-u1.c",
-+        "src/src/f32-vrnd/gen/f32-vrndu-scalar-libm-u1.c",
-+        "src/src/f32-vrnd/gen/f32-vrndz-scalar-libm-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vrnd_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vrnd/gen/f32-vrndd-scalar-libm-u1.c",
-+        "src/src/f32-vrnd/gen/f32-vrndne-scalar-libm-u1.c",
-+        "src/src/f32-vrnd/gen/f32-vrndu-scalar-libm-u1.c",
-+        "src/src/f32-vrnd/gen/f32-vrndz-scalar-libm-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vrsqrt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-rsqrt-u1.c",
-+        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-sqrt.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vrsqrt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-rsqrt-u1.c",
-+        "src/src/f32-vrsqrt/gen/f32-vrsqrt-scalar-sqrt.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vsigmoid_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vsigmoid/gen/f32-vsigmoid-scalar-rr2-lut64-p2-div-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vsigmoid_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vsigmoid/gen/f32-vsigmoid-scalar-rr2-lut64-p2-div-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vsin_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vsin/gen/f32-vsin-scalar-rational-5-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vsin_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vsin/gen/f32-vsin-scalar-rational-5-4-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vsqrt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vsqrt/gen/f32-vsqrt-scalar-sqrt.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vsqrt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vsqrt/gen/f32-vsqrt-scalar-sqrt.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vtanh_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vtanh/gen/f32-vtanh-scalar-rational-9-8-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vtanh_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vtanh/gen/f32-vtanh-scalar-rational-9-8-div.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("f32-vunary_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vunary/gen/f32-vabs-scalar.c",
-+        "src/src/f32-vunary/gen/f32-vneg-scalar.c",
-+        "src/src/f32-vunary/gen/f32-vsqr-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("f32-vunary_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/f32-vunary/gen/f32-vabs-scalar.c",
-+        "src/src/f32-vunary/gen/f32-vneg-scalar.c",
-+        "src/src/f32-vunary/gen/f32-vsqr-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("operators_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/operators/argmax-pooling-nhwc.c",
-+        "src/src/operators/average-pooling-nhwc.c",
-+        "src/src/operators/batch-matrix-multiply-nc.c",
-+        "src/src/operators/binary-elementwise-nd.c",
-+        "src/src/operators/constant-pad-nd.c",
-+        "src/src/operators/convolution-nchw.c",
-+        "src/src/operators/convolution-nhwc.c",
-+        "src/src/operators/deconvolution-nhwc.c",
-+        "src/src/operators/dynamic-fully-connected-nc.c",
-+        "src/src/operators/fully-connected-nc.c",
-+        "src/src/operators/max-pooling-nhwc.c",
-+        "src/src/operators/pack-lh.c",
-+        "src/src/operators/reduce-nd.c",
-+        "src/src/operators/resize-bilinear-nchw.c",
-+        "src/src/operators/resize-bilinear-nhwc.c",
-+        "src/src/operators/rope-nthc.c",
-+        "src/src/operators/slice-nd.c",
-+        "src/src/operators/softmax-nc.c",
-+        "src/src/operators/transpose-nd.c",
-+        "src/src/operators/unary-elementwise-nc.c",
-+        "src/src/operators/unpooling-nhwc.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("operators_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/operators/argmax-pooling-nhwc.c",
-+        "src/src/operators/average-pooling-nhwc.c",
-+        "src/src/operators/batch-matrix-multiply-nc.c",
-+        "src/src/operators/binary-elementwise-nd.c",
-+        "src/src/operators/constant-pad-nd.c",
-+        "src/src/operators/convolution-nchw.c",
-+        "src/src/operators/convolution-nhwc.c",
-+        "src/src/operators/deconvolution-nhwc.c",
-+        "src/src/operators/dynamic-fully-connected-nc.c",
-+        "src/src/operators/fully-connected-nc.c",
-+        "src/src/operators/max-pooling-nhwc.c",
-+        "src/src/operators/pack-lh.c",
-+        "src/src/operators/reduce-nd.c",
-+        "src/src/operators/resize-bilinear-nchw.c",
-+        "src/src/operators/resize-bilinear-nhwc.c",
-+        "src/src/operators/rope-nthc.c",
-+        "src/src/operators/slice-nd.c",
-+        "src/src/operators/softmax-nc.c",
-+        "src/src/operators/transpose-nd.c",
-+        "src/src/operators/unary-elementwise-nc.c",
-+        "src/src/operators/unpooling-nhwc.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qd8-f32-qb4w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qd8-f32-qb4w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qb4w-gemm/gen/qd8-f32-qb4w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qd8-f32-qc4w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qd8-f32-qc4w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qc4w-gemm/gen/qd8-f32-qc4w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qd8-f32-qc8w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x2-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qd8-f32-qc8w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x2-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-gemm/gen/qd8-f32-qc8w-gemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qd8-f32-qc8w-igemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x2-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qd8-f32-qc8w-igemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x2-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-1x4-minmax-scalar.c",
-+        "src/src/qd8-f32-qc8w-igemm/gen/qd8-f32-qc8w-igemm-4x4-minmax-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-dwconv_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-dwconv_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-dwconv/gen/qs8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-f32-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-f32-vcvt/gen/qs8-f32-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-f32-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-f32-vcvt/gen/qs8-f32-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-packw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-packw/gen/qs8-packw-x16c8-gemm-goi-scalar.c",
-+        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-gio-scalar.c",
-+        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-goi-scalar.c",
-+        "src/src/qs8-packw/gen/qs8-packw-x8c8-gemm-gio-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-packw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-packw/gen/qs8-packw-x16c8-gemm-goi-scalar.c",
-+        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-gio-scalar.c",
-+        "src/src/qs8-packw/gen/qs8-packw-x4c8-gemm-goi-scalar.c",
-+        "src/src/qs8-packw/gen/qs8-packw-x8c8-gemm-gio-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-qc4w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-1x4-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-3x4-minmax-fp32-scalar-fmagic.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-qc4w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-1x4-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc4w-gemm/gen/qs8-qc4w-gemm-3x4-minmax-fp32-scalar-fmagic.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-qc8w-dwconv_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-qc8w-dwconv_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-3p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qs8-qc8w-dwconv/gen/qs8-qc8w-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-qc8w-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-qc8w-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-gemm/gen/qs8-qc8w-gemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-qc8w-igemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-qc8w-igemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qs8-qc8w-igemm/gen/qs8-qc8w-igemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-qu8-packw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qu8-packw/gen/qs8-qu8-packw-x16c8-gemm-goi-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-qu8-packw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-qu8-packw/gen/qs8-qu8-packw-x16c8-gemm-goi-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-rdsum_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-rdsum/gen/qs8-rdsum-minmax-fp32-scalar-u1-acc1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-rdsum_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-rdsum/gen/qs8-rdsum-minmax-fp32-scalar-u1-acc1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-rsum_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-rsum/gen/qs8-rsum-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-rsum_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-rsum/gen/qs8-rsum-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vadd_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u1.c",
-+        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vadd_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u1.c",
-+        "src/src/qs8-vadd/gen/qs8-vadd-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vaddc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u1.c",
-+        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vaddc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u1.c",
-+        "src/src/qs8-vaddc/gen/qs8-vaddc-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vcvt/gen/qs8-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vcvt/gen/qs8-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vlrelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vlrelu/gen/qs8-vlrelu-scalar-andxor-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vlrelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vlrelu/gen/qs8-vlrelu-scalar-andxor-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vmul_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vmul/gen/qs8-vmul-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vmul_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vmul/gen/qs8-vmul-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vmulc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vmulc/gen/qs8-vmulc-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vmulc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vmulc/gen/qs8-vmulc-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vprelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vprelu/gen/qs8-vprelu-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vprelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vprelu/gen/qs8-vprelu-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vpreluc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vpreluc/gen/qs8-vpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vpreluc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vpreluc/gen/qs8-vpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qs8-vrpreluc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vrpreluc/gen/qs8-vrpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qs8-vrpreluc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qs8-vrpreluc/gen/qs8-vrpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-dwconv_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-dwconv_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-25p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-25p2c-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-9p1c-minmax-fp32-scalar-fmagic.c",
-+        "src/src/qu8-dwconv/gen/qu8-dwconv-9p2c-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-f32-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-f32-vcvt/gen/qu8-f32-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-f32-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-f32-vcvt/gen/qu8-f32-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-gemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-gemm/gen/qu8-gemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qu8-gemm/gen/qu8-gemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-gemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-gemm/gen/qu8-gemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qu8-gemm/gen/qu8-gemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-igemm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-igemm/gen/qu8-igemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qu8-igemm/gen/qu8-igemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-igemm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-igemm/gen/qu8-igemm-1x4-minmax-fp32-scalar-lrintf.c",
-+        "src/src/qu8-igemm/gen/qu8-igemm-3x4-minmax-fp32-scalar-lrintf.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-rdsum_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-rdsum/gen/qu8-rdsum-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-rdsum_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-rdsum/gen/qu8-rdsum-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-rsum_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-rsum/gen/qu8-rsum-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-rsum_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-rsum/gen/qu8-rsum-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vadd_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u1.c",
-+        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vadd_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u1.c",
-+        "src/src/qu8-vadd/gen/qu8-vadd-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vaddc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u1.c",
-+        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vaddc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u1.c",
-+        "src/src/qu8-vaddc/gen/qu8-vaddc-minmax-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vcvt_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vcvt/gen/qu8-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vcvt_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vcvt/gen/qu8-vcvt-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vlrelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vlrelu/gen/qu8-vlrelu-scalar-andxor-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vlrelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vlrelu/gen/qu8-vlrelu-scalar-andxor-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vmul_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vmul/gen/qu8-vmul-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vmul_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vmul/gen/qu8-vmul-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vmulc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vmulc/gen/qu8-vmulc-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vmulc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vmulc/gen/qu8-vmulc-minmax-fp32-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vprelu_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vprelu/gen/qu8-vprelu-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vprelu_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vprelu/gen/qu8-vprelu-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vpreluc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vpreluc/gen/qu8-vpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vpreluc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vpreluc/gen/qu8-vpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("qu8-vrpreluc_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vrpreluc/gen/qu8-vrpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("qu8-vrpreluc_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/qu8-vrpreluc/gen/qu8-vrpreluc-scalar-u8.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("reference_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/reference/binary-elementwise.cc",
-+        "src/src/reference/packing.cc",
-+        "src/src/reference/unary-elementwise.cc",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("reference_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/reference/binary-elementwise.cc",
-+        "src/src/reference/packing.cc",
-+        "src/src/reference/unary-elementwise.cc",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("s8-ibilinear_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-ibilinear/gen/s8-ibilinear-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("s8-ibilinear_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-ibilinear/gen/s8-ibilinear-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("s8-maxpool_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("s8-maxpool_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-maxpool/gen/s8-maxpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("s8-rdminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-rdminmax/gen/s8-rdmax-2p2x-scalar-u2.c",
-+        "src/src/s8-rdminmax/gen/s8-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("s8-rdminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-rdminmax/gen/s8-rdmax-2p2x-scalar-u2.c",
-+        "src/src/s8-rdminmax/gen/s8-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("s8-rminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-rminmax/gen/s8-rmax-scalar-u2-acc2.c",
-+        "src/src/s8-rminmax/gen/s8-rmin-scalar-u2-acc2.c",
-+        "src/src/s8-rminmax/gen/s8-rminmax-scalar-u2-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("s8-rminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-rminmax/gen/s8-rmax-scalar-u2-acc2.c",
-+        "src/src/s8-rminmax/gen/s8-rmin-scalar-u2-acc2.c",
-+        "src/src/s8-rminmax/gen/s8-rminmax-scalar-u2-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("s8-vclamp_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-vclamp/s8-vclamp-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("s8-vclamp_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/s8-vclamp/s8-vclamp-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("subgraph_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/subgraph/argmax-pooling-2d.c",
-+        "src/src/subgraph/average-pooling-2d.c",
-+        "src/src/subgraph/batch-matrix-multiply.c",
-+        "src/src/subgraph/binary.c",
-+        "src/src/subgraph/concatenate.c",
-+        "src/src/subgraph/convolution-2d.c",
-+        "src/src/subgraph/copy.c",
-+        "src/src/subgraph/deconvolution-2d.c",
-+        "src/src/subgraph/deprecated.c",
-+        "src/src/subgraph/depth-to-space-2d.c",
-+        "src/src/subgraph/depthwise-convolution-2d.c",
-+        "src/src/subgraph/even-split.c",
-+        "src/src/subgraph/fully-connected-sparse.c",
-+        "src/src/subgraph/fully-connected.c",
-+        "src/src/subgraph/max-pooling-2d.c",
-+        "src/src/subgraph/pack-lh.c",
-+        "src/src/subgraph/reshape-helpers.c",
-+        "src/src/subgraph/rope.c",
-+        "src/src/subgraph/softmax.c",
-+        "src/src/subgraph/space-to-depth-2d.c",
-+        "src/src/subgraph/static-constant-pad.c",
-+        "src/src/subgraph/static-reduce.c",
-+        "src/src/subgraph/static-resize-bilinear-2d.c",
-+        "src/src/subgraph/static-slice.c",
-+        "src/src/subgraph/static-transpose.c",
-+        "src/src/subgraph/subgraph-utils.c",
-+        "src/src/subgraph/unary.c",
-+        "src/src/subgraph/unpooling-2d.c",
-+        "src/src/subgraph/validation.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("subgraph_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/subgraph/argmax-pooling-2d.c",
-+        "src/src/subgraph/average-pooling-2d.c",
-+        "src/src/subgraph/batch-matrix-multiply.c",
-+        "src/src/subgraph/binary.c",
-+        "src/src/subgraph/concatenate.c",
-+        "src/src/subgraph/convolution-2d.c",
-+        "src/src/subgraph/copy.c",
-+        "src/src/subgraph/deconvolution-2d.c",
-+        "src/src/subgraph/deprecated.c",
-+        "src/src/subgraph/depth-to-space-2d.c",
-+        "src/src/subgraph/depthwise-convolution-2d.c",
-+        "src/src/subgraph/even-split.c",
-+        "src/src/subgraph/fully-connected-sparse.c",
-+        "src/src/subgraph/fully-connected.c",
-+        "src/src/subgraph/max-pooling-2d.c",
-+        "src/src/subgraph/pack-lh.c",
-+        "src/src/subgraph/reshape-helpers.c",
-+        "src/src/subgraph/rope.c",
-+        "src/src/subgraph/softmax.c",
-+        "src/src/subgraph/space-to-depth-2d.c",
-+        "src/src/subgraph/static-constant-pad.c",
-+        "src/src/subgraph/static-reduce.c",
-+        "src/src/subgraph/static-resize-bilinear-2d.c",
-+        "src/src/subgraph/static-slice.c",
-+        "src/src/subgraph/static-transpose.c",
-+        "src/src/subgraph/subgraph-utils.c",
-+        "src/src/subgraph/unary.c",
-+        "src/src/subgraph/unpooling-2d.c",
-+        "src/src/subgraph/validation.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("tables_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/tables/exp2-k-over-2048.c",
-+        "src/src/tables/exp2-k-over-64.c",
-+        "src/src/tables/exp2minus-k-over-16.c",
-+        "src/src/tables/exp2minus-k-over-2048.c",
-+        "src/src/tables/exp2minus-k-over-32.c",
-+        "src/src/tables/exp2minus-k-over-4.c",
-+        "src/src/tables/exp2minus-k-over-64.c",
-+        "src/src/tables/exp2minus-k-over-8.c",
-+        "src/src/tables/vlog.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("tables_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/tables/exp2-k-over-2048.c",
-+        "src/src/tables/exp2-k-over-64.c",
-+        "src/src/tables/exp2minus-k-over-16.c",
-+        "src/src/tables/exp2minus-k-over-2048.c",
-+        "src/src/tables/exp2minus-k-over-32.c",
-+        "src/src/tables/exp2minus-k-over-4.c",
-+        "src/src/tables/exp2minus-k-over-64.c",
-+        "src/src/tables/exp2minus-k-over-8.c",
-+        "src/src/tables/vlog.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("u8-ibilinear_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-ibilinear/gen/u8-ibilinear-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("u8-ibilinear_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-ibilinear/gen/u8-ibilinear-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("u8-lut32norm_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-lut32norm/u8-lut32norm-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("u8-lut32norm_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-lut32norm/u8-lut32norm-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("u8-maxpool_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("u8-maxpool_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-maxpool/gen/u8-maxpool-9p-minmax-scalar-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("u8-rdminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-rdminmax/gen/u8-rdmax-2p2x-scalar-u2.c",
-+        "src/src/u8-rdminmax/gen/u8-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("u8-rdminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-rdminmax/gen/u8-rdmax-2p2x-scalar-u2.c",
-+        "src/src/u8-rdminmax/gen/u8-rdmin-2p2x-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("u8-rminmax_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-rminmax/gen/u8-rmax-scalar-u2-acc2.c",
-+        "src/src/u8-rminmax/gen/u8-rmin-scalar-u2-acc2.c",
-+        "src/src/u8-rminmax/gen/u8-rminmax-scalar-u2-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("u8-rminmax_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-rminmax/gen/u8-rmax-scalar-u2-acc2.c",
-+        "src/src/u8-rminmax/gen/u8-rmin-scalar-u2-acc2.c",
-+        "src/src/u8-rminmax/gen/u8-rminmax-scalar-u2-acc2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("u8-vclamp_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-vclamp/u8-vclamp-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("u8-vclamp_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/u8-vclamp/u8-vclamp-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x16-transposec_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x16-transposec/gen/x16-transposec-2x4-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x16-transposec_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x16-transposec/gen/x16-transposec-2x4-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x16-x32-packw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-gio-scalar.c",
-+        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-goi-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x16-x32-packw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-gio-scalar.c",
-+        "src/src/x16-x32-packw/gen/x16-x32-packw-x32c2-gemm-goi-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x24-transposec_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x24-transposec/gen/x24-transposec-1x2-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x24-transposec_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x24-transposec/gen/x24-transposec-1x2-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x32-packw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x32-packw/gen/x32-packw-x2-gemm-gio-scalar.c",
-+        "src/src/x32-packw/gen/x32-packw-x2-gemm-goi-scalar-float-u4.c",
-+        "src/src/x32-packw/gen/x32-packw-x32-gemm-goi-scalar-int-u2.c",
-+        "src/src/x32-packw/gen/x32-packw-x4-gemm-gio-scalar.c",
-+        "src/src/x32-packw/gen/x32-packw-x4-gemm-goi-scalar-float-u4.c",
-+        "src/src/x32-packw/gen/x32-packw-x64-gemm-goi-scalar-int-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x32-packw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x32-packw/gen/x32-packw-x2-gemm-gio-scalar.c",
-+        "src/src/x32-packw/gen/x32-packw-x2-gemm-goi-scalar-float-u4.c",
-+        "src/src/x32-packw/gen/x32-packw-x32-gemm-goi-scalar-int-u2.c",
-+        "src/src/x32-packw/gen/x32-packw-x4-gemm-gio-scalar.c",
-+        "src/src/x32-packw/gen/x32-packw-x4-gemm-goi-scalar-float-u4.c",
-+        "src/src/x32-packw/gen/x32-packw-x64-gemm-goi-scalar-int-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x32-transposec_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x32-transposec/gen/x32-transposec-2x4-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x32-transposec_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x32-transposec/gen/x32-transposec-2x4-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x32-unpool_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x32-unpool/x32-unpool-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x32-unpool_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x32-unpool/x32-unpool-scalar.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x64-transposec_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x64-transposec/gen/x64-transposec-4x2-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x64-transposec_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x64-transposec/gen/x64-transposec-4x2-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x8-lut_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-lut/gen/x8-lut-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x8-lut_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-lut/gen/x8-lut-scalar-u4.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x8-packq_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-packq/x8-packq-scalar-f32qp8-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x8-packq_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-packq/x8-packq-scalar-f32qp8-u1.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x8-packw_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-packw/gen/x8-packw-x16-gemm-goi-scalar-u2.c",
-+        "src/src/x8-packw/gen/x8-packw-x32-gemm-goi-scalar-u2.c",
-+        "src/src/x8-packw/gen/x8-packw-x4-gemm-goi-scalar-u2.c",
-+        "src/src/x8-packw/gen/x8-packw-x8-gemm-goi-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x8-packw_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-packw/gen/x8-packw-x16-gemm-goi-scalar-u2.c",
-+        "src/src/x8-packw/gen/x8-packw-x32-gemm-goi-scalar-u2.c",
-+        "src/src/x8-packw/gen/x8-packw-x4-gemm-goi-scalar-u2.c",
-+        "src/src/x8-packw/gen/x8-packw-x8-gemm-goi-scalar-u2.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("x8-transposec_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-transposec/gen/x8-transposec-2x4-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("x8-transposec_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/x8-transposec/gen/x8-transposec-2x4-scalar-int.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("xx-copy_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-copy/xx-copy-scalar-memcpy.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("xx-copy_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-copy/xx-copy-scalar-memcpy.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("xx-fill_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-fill/xx-fill-scalar-u16.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("xx-fill_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-fill/xx-fill-scalar-u16.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("xx-pad_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-pad/xx-pad-p4-scalar-u16.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("xx-pad_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-pad/xx-pad-p4-scalar-u16.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+
-+  if (build_with_chromium) {
-+    source_set("xx-transposev_loong64") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+    }
-+  }
-+
-+  # This is a target that cannot depend on //base.
-+  if (build_with_internal_optimization_guide) {
-+    source_set("xx-transposev_loong64_standalone") {
-+      cflags = []
-+
-+      sources = [
-+        "src/include/xnnpack.h",
-+        "src/src/xx-transposev/xx-transposev-1x1-scalar-memcpy.c",
-+      ]
-+
-+      configs -= [ "//build/config/compiler:chromium_code" ]
-+      configs += [ "//build/config/compiler:no_chromium_code" ]
-+      configs += [ "//build/config/sanitizers:cfi_icall_generalize_pointers" ]
-+      configs += [ ":xnnpack_private_config" ]
-+
-+      deps = [
-+        "//third_party/cpuinfo",
-+        "//third_party/fp16",
-+        "//third_party/fxdiv",
-+        "//third_party/pthreadpool:pthreadpool_standalone",
-+      ]
-+
-+      public_configs = [ ":xnnpack_public_config" ]
-+
-+      if (!(is_android && use_order_profiling)) {
-+        assert_no_deps = [ "//base" ]
-+      }
-+    }
-+  }
-+}
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/bazelroot/BUILD b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/bazelroot/BUILD
-index 0e5e68c4e9..4958144ebc 100644
---- a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/bazelroot/BUILD
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/bazelroot/BUILD
-@@ -29,6 +29,19 @@ platform(
-     ],
- )
  
-+constraint_value(
-+    name = "loongarch64",
-+    constraint_setting = "@platforms//cpu:cpu",
-+)
-+
-+platform(
-+    name = "linux_loongarch64",
-+    constraint_values = [
-+        "@platforms//os:linux",
-+        ":loongarch64",
-+    ],
-+)
-+
- # A dummy clang toolchain for building them for any arch.
- 
- filegroup(name = "empty")
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/generate_build_gn.py b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/generate_build_gn.py
-index e9fbe00225..739327dded 100644
---- a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/generate_build_gn.py
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/generate_build_gn.py
-@@ -232,7 +232,10 @@ _PLATFORMS = [
-               bazel_platform='//:linux_aarch64'),
-     _Platform(gn_cpu='riscv64',
-               bazel_cpu='riscv64',
--              bazel_platform='//:linux_riscv64')
-+              bazel_platform='//:linux_riscv64'),
-+_Platform(gn_cpu='loong64',
-+              bazel_cpu='loongarch64',
-+              bazel_platform='//:linux_loongarch64')
- ]
- 
- 
-@@ -345,7 +348,7 @@ def _run_bazel_cmd(args: list[str]) -> str:
-       Exception if the command failed.
-     """
-     # Use standard Bazel install instead of the one included with depot_tools.
--    exec_path = "/usr/bin/bazel"
-+    exec_path = os.getenv("BAZEL_PATH_OVERRIDE") or "/usr/bin/bazel"
-     if not exec_path:
-         raise Exception(
-             "bazel is not installed. Please run `sudo apt-get install " +
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/common.h b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/common.h
-index fac0ff4ca2..3cd41cfce6 100644
---- a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/common.h
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/common.h
-@@ -80,6 +80,12 @@
- #define XNN_ARCH_WASMRELAXEDSIMD 0
- #endif
- 
-+#if defined(__loongarch__)
-+#define XNN_ARCH_LOONGARCH 1
-+#else
-+#define XNN_ARCH_LOONGARCH 0
-+#endif
-+
- // Define platform identification macros
- 
- #if defined(__ANDROID__)
-diff --git a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/hardware-config.h b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/hardware-config.h
-index ca0183be89..a425827298 100644
---- a/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/hardware-config.h
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/xnnpack/src/src/xnnpack/hardware-config.h
-@@ -63,6 +63,9 @@ enum xnn_arch_flags {
-   xnn_arch_vsx = 1 << 0,
-   xnn_arch_vsx3 = 1 << 1,
-   xnn_arch_mma = 1 << 2,
-+#elif XNN_ARCH_LOONGARCH
-+  xnn_arch_lsx = 1 << 0,
-+  xnn_arch_lasx = 1 << 1,
- #elif XNN_ARCH_WASM || XNN_ARCH_WASMSIMD || XNN_ARCH_WASMRELAXEDSIMD
-   xnn_arch_wasm_is_x86 = 1 << 0,
- #if XNN_ARCH_WASMRELAXEDSIMD
+ swiftshader_static_library("swiftshader_libvulkan_static") {
+diff --git a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
+index f99abba377..7b2e285795 100644
+--- a/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
++++ b/qtwebengine/src/3rdparty/chromium/third_party/swiftshader/third_party/llvm-10.0/BUILD.gn
+@@ -159,6 +159,8 @@ swiftshader_llvm_source_set("swiftshader_llvm") {
+     deps += [ ":swiftshader_llvm_ppc" ]
+   } else if (current_cpu == "riscv64") {
+     deps += [ ":swiftshader_llvm_riscv64" ]
++  } else if (current_cpu == "loong64") {
++    # swiftshader unused in qt6-webengine
+   } else if (current_cpu == "x86" || current_cpu == "x64") {
+     deps += [ ":swiftshader_llvm_x86" ]
+   } else {
 -- 
 2.52.0
 

--- a/runtime-desktop/qt-6/01-runtime/patches/0005-AOSCOS-qtdeclarative-fallback-to-QThreadStorage-for-.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0005-AOSCOS-qtdeclarative-fallback-to-QThreadStorage-for-.patch
@@ -1,4 +1,4 @@
-From eac157ff7417decb6a67deb060a36d71912a8e3f Mon Sep 17 00:00:00 2001
+From b32718f2e94abd8d50a4a99f9d60fc8989971c4d Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Tue, 11 Nov 2025 13:28:35 +0800
 Subject: [PATCH 5/6] AOSCOS: qtdeclarative: fallback to QThreadStorage for

--- a/runtime-desktop/qt-6/01-runtime/patches/0006-Linux-accessibility-let-org.a11y.Status-win-over-XCB.patch
+++ b/runtime-desktop/qt-6/01-runtime/patches/0006-Linux-accessibility-let-org.a11y.Status-win-over-XCB.patch
@@ -1,4 +1,4 @@
-From 75cfffbd641d4a7894aabe6200a67119309c2e6b Mon Sep 17 00:00:00 2001
+From 1da7c76e57924d534473c906475c8a3e9d183990 Mon Sep 17 00:00:00 2001
 From: Matthew Aura <matthewaura075@gmail.com>
 Date: Sat, 18 Apr 2026 17:12:14 +0300
 Subject: [PATCH 6/6] Linux accessibility: let org.a11y.Status win over XCB

--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,7 +1,6 @@
-VER=6.11.0
-REL=4
+VER=6.11.1
 SRCS="https://download.qt.io/official_releases/qt/${VER%.*}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::acf3b3db04c9e5d0820e8324b097320388954c297cee83d2bd698789234f68a4"
+CHKSUMS="sha256::252acef8c5ae68074d91cadba2ee4a83465051bbb970dd26e8f0daa0f3904e03"
 CHKUPDATE="anitya::id=7927"
 # Note: Prefer larger RAM.
 ENVREQ="total_mem=60"

--- a/runtime-desktop/quickshell/spec
+++ b/runtime-desktop/quickshell/spec
@@ -2,3 +2,4 @@ VER=0.3.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/quickshell-mirror/quickshell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378649"
+REL=1

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,5 +1,5 @@
 VER=0.7.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"

--- a/runtime-doc/poppler/spec
+++ b/runtime-doc/poppler/spec
@@ -2,4 +2,4 @@ VER=25.07.0
 SRCS="tbl::https://poppler.freedesktop.org/poppler-$VER.tar.xz"
 CHKSUMS="sha256::c504a9066dbdfebe377ad53cec641fd971ee96c4e1e8ca74e6c9c03d46d817ae"
 CHKUPDATE="anitya::id=3686"
-REL=5
+REL=6

--- a/runtime-imaging/soqt/spec
+++ b/runtime-imaging/soqt/spec
@@ -2,4 +2,4 @@ VER=1.6.3
 SRCS="git::commit=tags/v$VER::https://github.com/coin3d/soqt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242371"
-REL=3
+REL=4

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.28.1
-REL=4
+REL=5
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-scientific/opencv/spec
+++ b/runtime-scientific/opencv/spec
@@ -5,4 +5,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="opencv"
 CHKUPDATE="anitya::id=6615"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: update to 6.11.1
    Track patches at AOSC-Tracking/qt-6 @ aosc/v6.11.1
    \(HEAD: 1de47e1a93b79c6a57db3f1f90fc6d1c516480ff\).

Package(s) Affected
-------------------

- qt-6: 6.11.1
- qt-6-doc: 6.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6 groups/qt6-rebuilds
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
