### PR TITLE
vscode: update to 1.120.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.119.0
+VER=1.120.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::39be7a2c3f95bd933a8c804d12aa22a8053328b7cd04384e6af40e971c38e18b"
-CHKSUMS__ARM64="sha256::cd9a8885090484aa02bcb0cb4ce65b59bd5414aeaa8d3398fb3b66c958939f8b"
+CHKSUMS__AMD64="sha256::86a803d2dc8c019d589a7b6c3ee84f7242b53defd7d0344169a5ba2f9e917c70"
+CHKSUMS__ARM64="sha256::3c5b43b529f9082694c305f3e4e474a61714a5908791d9a4673bd934ad49a6d6"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.120.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.120.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
