### PR TITLE
xmake:update to 3.0.9

### DIFF
--- a/app-devel/xmake/spec
+++ b/app-devel/xmake/spec
@@ -1,4 +1,4 @@
-VER=3.0.8
+VER=3.0.9
 SRCS="git::commit=tags/v$VER::https://github.com/xmake-io/xmake.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370249"


### PR DESCRIPTION
Topic Description
-----------------

- xmake: update to 3.0.9

Package(s) Affected
-------------------

- xmake: 3.0.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit xmake
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
