### PR TITLE
rustc: only enable frequently used rust tools components

### DIFF
--- a/lang-rust/rustc/autobuild/prepare
+++ b/lang-rust/rustc/autobuild/prepare
@@ -47,6 +47,7 @@ profiler = true
 vendor = true
 print-step-timings = true
 docs = false
+tools = ["cargo","clippy","rust-analyzer","rust-analysis","rustdoc","rustfmt","src"]
 EOF
 
 # FIXME: Uncomment this if we have the last version built and ready.

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,4 +1,5 @@
 VER=1.94.0
+REL=1
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
 CHKSUMS="sha256::0b53ae34f5c0c3612cfe1de139f9167a018cd5737bc2205664fd69ba9b25f600"


### PR DESCRIPTION
Topic Description
-----------------

- rustc: only enable frequently used rust tools components

Package(s) Affected
-------------------

- rustc: 1:1.94.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
