### PR TITLE
exim: security update to 4.99.3

### DIFF
--- a/app-web/exim/autobuild/patches/0001-Set-exim-config.patch
+++ b/app-web/exim/autobuild/patches/0001-Set-exim-config.patch
@@ -1,32 +1,21 @@
-From 38fc98870f4d320b15262af655620b2ba66f0493 Mon Sep 17 00:00:00 2001
-From: CAB233 <yidaduizuoye@outlook.com>
-Date: Fri, 19 Sep 2025 12:29:47 +0800
-Subject: [PATCH] Set exim config
-
----
- src/scripts/Configure-Makefile |   2 +-
- src/src/EDITME                 | 103 ++++++++-------
- src/src/configure.default      | 233 +++++++++++++++++++++++++++++----
- 3 files changed, 260 insertions(+), 78 deletions(-)
-
 diff --git a/src/scripts/Configure-Makefile b/src/scripts/Configure-Makefile
-index dc5015f6f..07f8c2340 100755
+index 73737274e..6e934a81e 100755
 --- a/src/scripts/Configure-Makefile
 +++ b/src/scripts/Configure-Makefile
-@@ -319,7 +319,7 @@ if [ "${EXIM_PERL}" != "" ] ; then
+@@ -367,7 +367,7 @@ if [ "${EXIM_PERL}" != "" ] ; then
  
    mv $mft $mftt
-   echo "PERL_CC=`$PERL_COMMAND -MConfig -e 'print $Config{cc}'`" >>$mft
--  echo "PERL_CCOPTS=`$PERL_COMMAND -MExtUtils::Embed -e ccopts`" >>$mft
-+  echo "PERL_CCOPTS=`$PERL_COMMAND -MExtUtils::Embed -e ccopts` \$(CFLAGS)" >>$mft
-   echo "PERL_LIBS=`$PERL_COMMAND -MExtUtils::Embed -e ldopts`" >>$mft
-   echo "" >>$mft
-   cat $mftt >> $mft
+   echo "PERL_CC=${perl_cc}" >>$mft
+-  echo "PERL_CCOPTS=${perl_ccopts}" >>$mft
++  echo "PERL_CCOPTS=${perl_ccopts} \$(CFLAGS)" >>$mft
+   echo "PERL_LIBS=${perl_libs}" >>$mft
+   echo "PERL_CFLAGS=${perl_cflags}" >>$mft
+   echo "PERL_LFLAGS=${perl_lflags}" >>$mft
 diff --git a/src/src/EDITME b/src/src/EDITME
-index ebfaf640a..4d22cbc57 100644
+index 3a9b167de..e301d424a 100644
 --- a/src/src/EDITME
 +++ b/src/src/EDITME
-@@ -103,7 +103,7 @@
+@@ -104,7 +104,7 @@
  # /usr/local/sbin. The installation script will try to create this directory,
  # and any superior directories, if they do not exist.
  
@@ -35,7 +24,7 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -119,7 +119,7 @@ BIN_DIRECTORY=/usr/exim/bin
+@@ -120,7 +120,7 @@ BIN_DIRECTORY=/usr/exim/bin
  # don't exist. It will also install a default runtime configuration if this
  # file does not exist.
  
@@ -44,7 +33,7 @@ index ebfaf640a..4d22cbc57 100644
  
  # It is possible to specify a colon-separated list of files for CONFIGURE_FILE.
  # In this case, Exim will use the first of them that exists when it is run.
-@@ -136,7 +136,7 @@ CONFIGURE_FILE=/usr/exim/configure
+@@ -137,7 +137,7 @@ CONFIGURE_FILE=/usr/exim/configure
  # deliveries. (Local deliveries run as various non-root users, typically as the
  # owner of a local mailbox.) Specifying these values as root is not supported.
  
@@ -53,7 +42,7 @@ index ebfaf640a..4d22cbc57 100644
  
  # If you specify EXIM_USER as a name, this is looked up at build time, and the
  # uid number is built into the binary. However, you can specify that this
-@@ -214,10 +214,10 @@ SPOOL_DIRECTORY=/var/spool/exim
+@@ -215,10 +215,10 @@ SPOOL_DIRECTORY=/var/spool/exim
  # If you are building with TLS, the library configuration must be done:
  
  # Uncomment this if you are using OpenSSL
@@ -66,7 +55,7 @@ index ebfaf640a..4d22cbc57 100644
  # TLS_LIBS=-lssl -lcrypto
  # TLS_LIBS=-L/usr/local/openssl/lib -lssl -lcrypto
  
-@@ -344,7 +344,7 @@ TRANSPORT_SMTP=yes
+@@ -362,7 +362,7 @@ TRANSPORT_SMTP=yes
  # This one is special-purpose, and commonly not required, so it is not
  # included by default.
  
@@ -75,7 +64,7 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -353,9 +353,9 @@ TRANSPORT_SMTP=yes
+@@ -371,9 +371,9 @@ TRANSPORT_SMTP=yes
  # MBX, is included only when requested. If you do not know what this is about,
  # leave these settings commented out.
  
@@ -88,7 +77,7 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -377,7 +377,7 @@ TRANSPORT_SMTP=yes
+@@ -395,7 +395,7 @@ TRANSPORT_SMTP=yes
  # To build a module dynamically, you'll need to define CFLAGS_DYNAMIC for
  # your platform.  Eg:
  # CFLAGS_DYNAMIC=-shared -rdynamic
@@ -97,7 +86,7 @@ index ebfaf640a..4d22cbc57 100644
  
  #------------------------------------------------------------------------------
  # These settings determine which file and database lookup methods are included
-@@ -413,22 +413,28 @@ LOOKUP_DBM=yes
+@@ -434,22 +434,27 @@ LOOKUP_DBM=yes
  LOOKUP_LSEARCH=yes
  LOOKUP_DNSDB=yes
  
@@ -116,8 +105,8 @@ index ebfaf640a..4d22cbc57 100644
 -# LOOKUP_MYSQL=yes
 -# LOOKUP_MYSQL_PC=mariadb
 -# LOOKUP_NIS=yes
-+LOOKUP_MYSQL=2
-+LOOKUP_MYSQL_PC=libmariadb
++LOOKUP_MYSQL=yes
++LOOKUP_MYSQL_PC=mariadb
 +LOOKUP_NIS=yes
  # LOOKUP_NISPLUS=yes
 +CFLAGS+=-I/usr/include/nsl -I/usr/include/tirpc
@@ -125,26 +114,24 @@ index ebfaf640a..4d22cbc57 100644
 +
  # LOOKUP_ORACLE=yes
 -# LOOKUP_PASSWD=yes
--# LOOKUP_PGSQL=yes
 +LOOKUP_PASSWD=yes
-+LOOKUP_PGSQL=2
-+LOOKUP_PGSQL_LIBS=-lpq
+ # LOOKUP_PGSQL=yes
  # LOOKUP_REDIS=yes
 -# LOOKUP_SQLITE=yes
 +LOOKUP_SQLITE=yes
  # LOOKUP_SQLITE_PC=sqlite3
  # LOOKUP_WHOSON=yes
  
-@@ -441,7 +447,7 @@ LOOKUP_DNSDB=yes
+@@ -530,7 +535,7 @@ SUPPORT_DANE=yes
  
- 
+ # LOOKUP_LIBS=-L/usr/local/lib -lldap -llber
  # Some platforms may need this for LOOKUP_NIS:
--# LIBS += -lnsl
-+LIBS += -lnsl
+-#LOOKUP_LIBS += -lnsl
++LOOKUP_LIBS += -lnsl
+ #LOOKUP_LIBS += -ljansson
+ #LOOKUP_LIBS += -lhiredis
  
- #------------------------------------------------------------------------------
- # If you have set LOOKUP_LDAP=yes, you should set LDAP_LIB_TYPE to indicate
-@@ -515,7 +521,7 @@ SUPPORT_DANE=yes
+@@ -551,7 +556,7 @@ SUPPORT_DANE=yes
  # files are defaulted in the OS/Makefile-Default file, but can be overridden in
  # local OS-specific make files.
  
@@ -153,7 +140,7 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -525,7 +531,7 @@ SUPPORT_DANE=yes
+@@ -583,7 +588,7 @@ SUPPORT_DANE=yes
  # and the MIME ACL. Please read the documentation to learn more about these
  # features.
  
@@ -162,27 +149,27 @@ index ebfaf640a..4d22cbc57 100644
  
  # If you have content scanning you may wish to only include some of the scanner
  # interfaces.  Uncomment any of these lines to remove that code.
-@@ -614,7 +620,7 @@ DISABLE_MAL_MKS=yes
- # LDFLAGS += -lopendmarc
+@@ -683,7 +688,7 @@ DISABLE_MAL_MKS=yes
+ #
  # Uncomment the following if you need to change the default. You can
  # override it at runtime (main config option dmarc_tld_file)
 -# DMARC_TLD_FILE=/etc/exim/opendmarc.tlds
-+# DMARC_TLD_FILE=/usr/share/publicsuffix/public_suffix_list.dat
++DMARC_TLD_FILE=/usr/share/publicsuffix/public_suffix_list.dat
  #
  # Library version libopendmarc-1.4.1-1.fc33.x86_64  (on Fedora 33) is known broken;
  # 1.3.2-3 works.  It seems that the OpenDMARC project broke their API.
-@@ -749,7 +755,7 @@ FIXED_NEVER_USERS=root
+@@ -821,7 +826,7 @@ FIXED_NEVER_USERS=root
  # CONFIGURE_OWNER setting, to specify a configuration file which is listed in
  # the TRUSTED_CONFIG_LIST file, then root privileges are not dropped by Exim.
  
 -# TRUSTED_CONFIG_LIST=/usr/exim/trusted_configs
-+TRUSTED_CONFIG_LIST=/etc/exim/trusted-configs
++TRUSTED_CONFIG_LIST=/usr/exim/trusted_configs
  
  
  #------------------------------------------------------------------------------
-@@ -794,18 +800,18 @@ FIXED_NEVER_USERS=root
- # included in the Exim binary. You will then need to set up the run time
- # configuration to make use of the mechanism(s) selected.
+@@ -879,18 +884,18 @@ FIXED_NEVER_USERS=root
+ # core exim build.  This gets them linked with the module instead.
+ # The heimdal does build but we have no test coverage so it is not know to work.
  
 -# AUTH_CRAM_MD5=yes
 +AUTH_CRAM_MD5=yes
@@ -204,7 +191,7 @@ index ebfaf640a..4d22cbc57 100644
  
  # Heimdal through 1.5 required pkg-config 'heimdal-gssapi'; Heimdal 7.1
  # requires multiple pkg-config files to work with Exim, so the second example
-@@ -832,7 +838,7 @@ FIXED_NEVER_USERS=root
+@@ -917,7 +922,7 @@ FIXED_NEVER_USERS=root
  # one that is set in the headers_charset option. The default setting is
  # defined by this setting:
  
@@ -213,7 +200,7 @@ index ebfaf640a..4d22cbc57 100644
  
  # If you are going to make use of $header_xxx expansions in your configuration
  # file, or if your users are going to use them in filter files, and the normal
-@@ -852,7 +858,7 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -937,7 +942,7 @@ HEADERS_CHARSET="ISO-8859-1"
  # the Sieve filter support. For those OS where iconv() is known to be installed
  # as standard, the file in OS/Makefile-xxxx contains
  #
@@ -222,7 +209,7 @@ index ebfaf640a..4d22cbc57 100644
  #
  # If you are not using one of those systems, but have installed iconv(), you
  # need to uncomment that line above. In some cases, you may find that iconv()
-@@ -928,7 +934,7 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -1013,7 +1018,7 @@ HEADERS_CHARSET="ISO-8859-1"
  # Once you have done this, "make install" will build the info files and
  # install them in the directory you have defined.
  
@@ -231,25 +218,25 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -941,7 +947,7 @@ HEADERS_CHARSET="ISO-8859-1"
+@@ -1026,7 +1031,7 @@ HEADERS_CHARSET="ISO-8859-1"
  # %s. This will be replaced by one of the strings "main", "panic", or "reject"
  # to form the final file names. Some installations may want something like this:
  
 -# LOG_FILE_PATH=/var/log/exim_%slog
-+LOG_FILE_PATH=/var/log/exim/%s.log
++LOG_FILE_PATH=/var/log/exim_%slog
  
  # which results in files with names /var/log/exim_mainlog, etc. The directory
  # in which the log files are placed must exist; Exim does not try to create
-@@ -1013,7 +1019,7 @@ ZCAT_COMMAND=/usr/bin/zcat
- # (version 5.004 or later) installed, set EXIM_PERL to perl.o. Using embedded
+@@ -1099,7 +1104,7 @@ ZCAT_COMMAND=/usr/bin/zcat
  # Perl costs quite a lot of resources. Only do this if you really need it.
+ #
  
 -# EXIM_PERL=perl.o
 +EXIM_PERL=perl.o
  
- 
- #------------------------------------------------------------------------------
-@@ -1023,7 +1029,7 @@ ZCAT_COMMAND=/usr/bin/zcat
+ # For a dynamic module build add also SUPPORT_PERL=2 and SUPPORT_PAM_(INCLUED,LIBS)
+ #SUPPORT_PERL=2
+@@ -1114,7 +1119,7 @@ ZCAT_COMMAND=/usr/bin/zcat
  # that the local_scan API is made available by the linker. You may also need
  # to add -ldl to EXTRALIBS so that dlopen() is available to Exim.
  
@@ -258,9 +245,9 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -1033,7 +1039,8 @@ ZCAT_COMMAND=/usr/bin/zcat
- # support, which is intended for use in conjunction with the SMTP AUTH
- # facilities, is included only when requested by the following setting:
+@@ -1126,7 +1131,8 @@ ZCAT_COMMAND=/usr/bin/zcat
+ #
+ # For a dynamic module build add SUPPORT_PAM=2 and SUPPORT_PAM_LIBS=-lpam
  
 -# SUPPORT_PAM=yes
 +SUPPORT_PAM=yes
@@ -268,7 +255,7 @@ index ebfaf640a..4d22cbc57 100644
  
  # You probably need to add -lpam to EXTRALIBS, and in some releases of
  # GNU/Linux -ldl is also needed.
-@@ -1045,12 +1052,12 @@ ZCAT_COMMAND=/usr/bin/zcat
+@@ -1138,12 +1144,12 @@ ZCAT_COMMAND=/usr/bin/zcat
  # If you may want to use outbound (client-side) proxying, using Socks5,
  # uncomment the line below.
  
@@ -283,7 +270,7 @@ index ebfaf640a..4d22cbc57 100644
  
  
  #------------------------------------------------------------------------------
-@@ -1208,7 +1215,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
+@@ -1288,7 +1294,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
  # is "yes", as well as supporting line editing, a history of input lines in the
  # current run is maintained.
  
@@ -292,7 +279,7 @@ index ebfaf640a..4d22cbc57 100644
  
  # You may need to add -ldl to EXTRALIBS when you set USE_READLINE=yes.
  # Note that this option adds to the size of the Exim binary, because the
-@@ -1225,7 +1232,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
+@@ -1305,7 +1311,7 @@ SYSTEM_ALIASES_FILE=/etc/aliases
  #------------------------------------------------------------------------------
  # Uncomment this setting to include IPv6 support.
  
@@ -301,7 +288,7 @@ index ebfaf640a..4d22cbc57 100644
  
  ###############################################################################
  #              THINGS YOU ALMOST NEVER NEED TO MENTION                        #
-@@ -1246,13 +1253,13 @@ SYSTEM_ALIASES_FILE=/etc/aliases
+@@ -1326,13 +1332,13 @@ SYSTEM_ALIASES_FILE=/etc/aliases
  # haven't got Perl, Exim will still build and run; you just won't be able to
  # use those utilities.
  
@@ -315,14 +302,14 @@ index ebfaf640a..4d22cbc57 100644
 +CHOWN_COMMAND=/usr/bin/chown
 +CHGRP_COMMAND=/usr/bin/chgrp
 +CHMOD_COMMAND=/usr/bin/chmod
-+MV_COMMAND=/usr/bin/mv
-+RM_COMMAND=/usr/bin/rm
++MV_COMMAND=/bin/mv
++RM_COMMAND=/bin/rm
 +TOUCH_COMMAND=/usr/bin/touch
 +PERL_COMMAND=/usr/bin/perl
  
  
  #------------------------------------------------------------------------------
-@@ -1454,7 +1461,7 @@ EXIM_TMPDIR="/tmp"
+@@ -1534,7 +1540,7 @@ EXIM_TMPDIR="/tmp"
  # (process id) to a file so that it can easily be identified. The path of the
  # file can be specified here. Some installations may want something like this:
  
@@ -332,7 +319,7 @@ index ebfaf640a..4d22cbc57 100644
  # If PID_FILE_PATH is not defined, Exim writes a file in its spool directory
  # using the name "exim-daemon.pid".
 diff --git a/src/src/configure.default b/src/src/configure.default
-index 633c6539e..6245a3134 100644
+index 633c6539e..7dcd9b42d 100644
 --- a/src/src/configure.default
 +++ b/src/src/configure.default
 @@ -67,7 +67,7 @@
@@ -395,8 +382,8 @@ index 633c6539e..6245a3134 100644
  
 -# tls_certificate = /etc/ssl/exim.crt
 -# tls_privatekey = /etc/ssl/exim.pem
-+tls_certificate = /etc/pki/tls/certs/exim.pem
-+tls_privatekey = /etc/pki/tls/private/exim.pem
++tls_certificate = /etc/ssl/exim.crt
++tls_privatekey = /etc/ssl/exim.pem
  
  # For OpenSSL, prefer EC- over RSA-authenticated ciphers
  .ifdef _HAVE_OPENSSL
@@ -411,9 +398,9 @@ index 633c6539e..6245a3134 100644
  
  
  # Specify the domain you want to be added to all unqualified addresses
-@@ -252,6 +260,24 @@ never_users = root
- 
+@@ -253,6 +261,26 @@ never_users = root
  host_lookup = *
+ 
  
 +# This setting, if uncommented, allows users to authenticate using
 +# their system passwords against saslauthd if they connect over a
@@ -433,10 +420,12 @@ index 633c6539e..6245a3134 100644
 +# saslauthd is actually running first?
 +#
 +auth_advertise_hosts =
- 
++
++
  # The setting below causes Exim to try to initialize the system resolver
  # library with DNSSEC support.  It has no effect if your library lacks
-@@ -382,8 +408,8 @@ timeout_frozen_after = 7d
+ # DNSSEC support.
+@@ -382,8 +410,8 @@ timeout_frozen_after = 7d
  # Note that TZ is handled separately by the timezone runtime option
  # and TIMEZONE_DEFAULT buildtime option.
  
@@ -447,11 +436,10 @@ index 633c6539e..6245a3134 100644
  
  
  
-@@ -394,6 +420,29 @@ timeout_frozen_after = 7d
+@@ -394,6 +422,26 @@ timeout_frozen_after = 7d
  
  begin acl
  
-+
 +# This access control list is used for the MAIL command in an incoming
 +# SMTP message.
 +
@@ -472,12 +460,10 @@ index 633c6539e..6245a3134 100644
 +
 +  accept
 +
-+
-+
  # This access control list is used for every RCPT command in an incoming
  # SMTP message. The tests are run in order until the address is either
  # accepted or denied.
-@@ -405,6 +454,7 @@ acl_check_rcpt:
+@@ -405,6 +453,7 @@ acl_check_rcpt:
  
    accept  hosts = :
            control = dkim_disable_verify
@@ -485,7 +471,7 @@ index 633c6539e..6245a3134 100644
  
    #############################################################################
    # The following section of the ACL is concerned with local parts that contain
-@@ -458,7 +508,8 @@ acl_check_rcpt:
+@@ -458,7 +507,8 @@ acl_check_rcpt:
    accept  local_parts   = postmaster
            domains       = +local_domains
  
@@ -495,7 +481,7 @@ index 633c6539e..6245a3134 100644
  
    require verify        = sender
  
-@@ -498,6 +549,7 @@ acl_check_rcpt:
+@@ -498,6 +548,7 @@ acl_check_rcpt:
    accept  hosts         = +relay_from_hosts
            control       = submission
            control       = dkim_disable_verify
@@ -503,7 +489,7 @@ index 633c6539e..6245a3134 100644
  
    # Accept if the message arrived over an authenticated connection, from
    # any host. Again, these messages are usually from MUAs, so recipient
-@@ -507,6 +559,7 @@ acl_check_rcpt:
+@@ -507,6 +558,7 @@ acl_check_rcpt:
    accept  authenticated = *
            control       = submission
            control       = dkim_disable_verify
@@ -511,7 +497,7 @@ index 633c6539e..6245a3134 100644
  
    # Insist that any other recipient address that we accept is either in one of
    # our local domains, or is in a domain for which we explicitly allow
-@@ -527,7 +580,8 @@ acl_check_rcpt:
+@@ -527,7 +579,8 @@ acl_check_rcpt:
    # There are no default checks on DNS black lists because the domains that
    # contain these lists are changing all the time. However, here are two
    # examples of how you can get Exim to perform a DNS black list lookup at this
@@ -521,7 +507,7 @@ index 633c6539e..6245a3134 100644
    #
    # deny    dnslists      = black.list.example
    #         message       = rejected because $sender_host_address is in a black list at $dnslist_domain\n$dnslist_text
-@@ -535,6 +589,10 @@ acl_check_rcpt:
+@@ -535,6 +588,10 @@ acl_check_rcpt:
    # warn    dnslists      = black.list.example
    #         add_header    = X-Warning: $sender_host_address is in a black list at $dnslist_domain
    #         log_message   = found in $dnslist_domain
@@ -532,7 +518,7 @@ index 633c6539e..6245a3134 100644
    #############################################################################
  
    #############################################################################
-@@ -561,6 +619,10 @@ acl_check_rcpt:
+@@ -561,6 +618,10 @@ acl_check_rcpt:
    #        set acl_m_content_filter = ${lookup PER_RCPT_CONTENT_FILTER}
    #############################################################################
  
@@ -543,7 +529,7 @@ index 633c6539e..6245a3134 100644
    # At this point, the address has passed all the checks that have been
    # configured, so we accept it unconditionally.
  
-@@ -610,21 +672,32 @@ acl_check_data:
+@@ -610,21 +671,32 @@ acl_check_data:
            message =     header syntax
            log_message = header syntax ($acl_verify_message)
  
@@ -584,7 +570,7 @@ index 633c6539e..6245a3134 100644
  
    #############################################################################
    # No more tests if PRDR was actively used.
-@@ -638,11 +711,63 @@ acl_check_data:
+@@ -638,11 +710,63 @@ acl_check_data:
    #           condition    = ...
    #############################################################################
  
@@ -614,9 +600,9 @@ index 633c6539e..6245a3134 100644
 +  #
 +  # warn    condition = ${if >{$spam_score_int}{5} {1}}
 +  #         set acl_m_greylistreasons = Message has $spam_score SpamAssassin points\n$acl_m_greylistreasons
-+
  
 -  # Accept the message.
++
 +  # If you want to greylist _all_ mail rather than only mail which looks like there
 +  # might be something wrong with it, then you can do this...
 +  #
@@ -632,10 +618,10 @@ index 633c6539e..6245a3134 100644
 +  # require acl = greylist_mail
  
    accept
- 
++ 
 +# To enable the greylisting, also uncomment this line:
 +# .include /etc/exim/exim-greylist.conf.inc
-+
+ 
 +acl_check_mime:
 +
 +  # File extension filtering.
@@ -649,7 +635,7 @@ index 633c6539e..6245a3134 100644
  
  
  ######################################################################
-@@ -721,9 +846,9 @@ dnslookup:
+@@ -721,9 +845,9 @@ dnslookup:
  
  
  # This router handles aliasing using a linearly searched alias file with the
@@ -661,7 +647,7 @@ index 633c6539e..6245a3134 100644
  # If you install this configuration by hand, you need to specify the correct
  # path in the "data" setting below.
  #
-@@ -744,7 +869,7 @@ system_aliases:
+@@ -744,7 +868,7 @@ system_aliases:
    driver = redirect
    allow_fail
    allow_defer
@@ -670,16 +656,16 @@ index 633c6539e..6245a3134 100644
  # user = exim
    file_transport = address_file
    pipe_transport = address_pipe
-@@ -782,7 +907,7 @@ userforward:
+@@ -782,7 +906,7 @@ userforward:
  # local_part_suffix = +* : -*
  # local_part_suffix_optional
    file = $home/.forward
 -# allow_filter
-+  allow_filter
++allow_filter
    no_verify
    no_expn
    check_ancestor
-@@ -790,6 +915,12 @@ userforward:
+@@ -790,6 +914,12 @@ userforward:
    pipe_transport = address_pipe
    reply_transport = address_reply
  
@@ -692,7 +678,7 @@ index 633c6539e..6245a3134 100644
  
  # This router matches local user mailboxes. If the router fails, the error
  # message is "Unknown user".
-@@ -830,6 +961,25 @@ remote_smtp:
+@@ -830,6 +960,25 @@ remote_smtp:
    tls_resumption_hosts = *
  .endif
  
@@ -718,18 +704,18 @@ index 633c6539e..6245a3134 100644
  
  # This transport is used for delivering messages to a smarthost, if the
  # smarthost router is enabled.  This starts from the same basis as
-@@ -884,8 +1034,8 @@ local_delivery:
+@@ -884,8 +1033,8 @@ local_delivery:
    delivery_date_add
    envelope_to_add
    return_path_add
 -# group = mail
 -# mode = 0660
-+  group = mail
-+  mode = 0660
++group = mail
++mode = 0660
  
  
  # This transport is used for handling pipe deliveries generated by alias or
-@@ -918,6 +1068,16 @@ address_reply:
+@@ -918,6 +1067,15 @@ address_reply:
    driver = autoreply
  
  
@@ -742,42 +728,10 @@ index 633c6539e..6245a3134 100644
 +#  command = "/usr/lib/cyrus-imapd/deliver -l"
 +#  batch_max = 20
 +#  user = cyrus
-+
  
  ######################################################################
  #                      RETRY CONFIGURATION                           #
-@@ -958,6 +1118,21 @@ begin rewrite
- #                   AUTHENTICATION CONFIGURATION                     #
- ######################################################################
- 
-+begin authenticators
-+
-+# This authenticator supports CRAM-MD5 username/password authentication
-+# with Exim acting as a _client_, as it might when sending its outgoing
-+# mail to a smarthost rather than directly to the final recipient.
-+# Replace SMTPAUTH_USERNAME and SMTPAUTH_PASSWORD as appropriate.
-+
-+#client_auth:
-+#  driver = cram_md5
-+#  public_name = CRAM-MD5
-+#  client_name = SMTPAUTH_USERNAME
-+#  client_secret = SMTPAUTH_PASSWORD
-+
-+#
-+
- # The following authenticators support plaintext username/password
- # authentication using the standard PLAIN mechanism and the traditional
- # but non-standard LOGIN mechanism, with Exim acting as the server.
-@@ -973,7 +1148,7 @@ begin rewrite
- # The default RCPT ACL checks for successful authentication, and will accept
- # messages from authenticated users from anywhere on the Internet.
- 
--begin authenticators
-+#
- 
- # PLAIN authentication has no server prompts. The client sends its
- # credentials in one lump, containing an authorization ID (which we do not
-@@ -987,7 +1162,7 @@ begin authenticators
+@@ -987,7 +1145,7 @@ begin authenticators
  #  driver                     = plaintext
  #  server_set_id              = $auth2
  #  server_prompts             = :
@@ -786,15 +740,12 @@ index 633c6539e..6245a3134 100644
  #  server_advertise_condition = ${if def:tls_in_cipher }
  
  # LOGIN authentication has traditional prompts and responses. There is no
-@@ -999,7 +1174,7 @@ begin authenticators
+@@ -999,7 +1157,7 @@ begin authenticators
  #  driver                     = plaintext
  #  server_set_id              = $auth1
  #  server_prompts             = <| Username: | Password:
 -#  server_condition           = Authentication is not yet configured
-+#  server_condition           = ${if saslauthd{{$1}{$2}{smtp}} {1}}
++#  server_condition           = ${if saslauthd{{$2}{$3}{smtp}} {1}}
  #  server_advertise_condition = ${if def:tls_in_cipher }
  
  
--- 
-2.51.0
-

--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,4 +1,4 @@
-VER=4.98.2
-SRCS="git::commit=tags/exim-$VER;copy-repo=true::https://github.com/Exim/exim"
+VER=4.99.3
+SRCS="git::commit=tags/exim-$VER;copy-repo=true::https://code.exim.org/exim/exim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=768"

--- a/topics/exim-4.99.3.toml
+++ b/topics/exim-4.99.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Exim 4.99.3"
+
+[caution]
+default = "Fixes 5 security vulnerabilities (including 3 of critical severity, 1 of high severity and 1 of medium severity)"
+zh_CN = "修复 5 个安全漏洞（含 3 个严重漏洞、1 个高危漏洞和 1 个中危漏洞）"
+
+[packages-v2]
+"exim" = "< 4.99.3"


### PR DESCRIPTION
Topic Description
-----------------

- exim: security update to 4.99.3

Package(s) Affected
-------------------

- exim: 4.99.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit exim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
