### PR TITLE
.NET SDK 10.0.108

### DIFF
--- a/lang-dotnet/dotnet10/01-source-built-artifacts/defines
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/defines
@@ -2,7 +2,7 @@ PKGNAME=dotnet-sdk-10.0-source-built-artifacts
 PKGSEC=devel
 PKGDES="Microsoft .NET source-built artifacts (version 10)"
 PKGDEP=""
-BUILDDEP="dotnet-sdk-10.0-source-built-artifacts dotnet-sdk-10.0 llvm"
+BUILDDEP="dotnet-sdk-10.0-source-built-artifacts dotnet-sdk-10.0 llvm lttng-ust"
 
 # FIXME: could not scrape payload in src/runtime/artifacts/obj/coreclr/linux.x64.Release/
 # vm/datadescriptor/CMakeFiles/cdac_contract_descriptor_temp.dir/__/__/debug/datadescriptor-shared/datadescriptor.cpp.o

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/defines.stage2
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/defines.stage2
@@ -2,7 +2,7 @@ PKGNAME=dotnet-sdk-10.0-source-built-artifacts
 PKGSEC=devel
 PKGDES="Microsoft .NET source-built artifacts (version 10)"
 PKGDEP=""
-BUILDDEP="llvm"
+BUILDDEP="llvm lttng-ust"
 
 # FIXME: could not scrape payload in src/runtime/artifacts/obj/coreclr/linux.x64.Release/
 # vm/datadescriptor/CMakeFiles/cdac_contract_descriptor_temp.dir/__/__/debug/datadescriptor-shared/datadescriptor.cpp.o

--- a/lang-dotnet/dotnet10/spec
+++ b/lang-dotnet/dotnet10/spec
@@ -1,4 +1,4 @@
-VER=10.0.107
+VER=10.0.108
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/dotnet/dotnet.git"
 CHKSUMS="SKIP"
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(10\.0\.1.+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- dotnet10: update to 10.0.108

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-sdk-10.0-source-built-artifacts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
