### PR TITLE
rsync: update to 3.4.3

### DIFF
--- a/app-network/rsync/spec
+++ b/app-network/rsync/spec
@@ -1,4 +1,4 @@
-VER=3.4.2
+VER=3.4.3
 SRCS="tbl::https://download.samba.org/pub/rsync/rsync-$VER.tar.gz"
-CHKSUMS="sha256::ff10aa2c151cd4b2dbbe6135126dbc854046113d2dfb49572a348233267eb315"
+CHKSUMS="sha256::c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3"
 CHKUPDATE="anitya::id=4217"

--- a/topics/rsync-3.4.3.toml
+++ b/topics/rsync-3.4.3.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "rsync 3.4.3"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (2 of high severity)"
+zh_CN = "修复 6 个的安全漏洞（含 2 个高危漏洞）"
+zh_TW = "修復 6 個的安全漏洞（含 2 個高危漏洞）"
+
+[packages-v2]
+"rsync" = "< 3.4.3"


### PR DESCRIPTION
Topic Description
-----------------

- rsync: update to 3.4.3
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- rsync: 3.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit rsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
