### PR TITLE
virglrenderer: backport a patch to fix VM cursor orientation

### DIFF
--- a/app-virtualization/virglrenderer/autobuild/patches/0001-UPSTREAM-renderer-fix-cases-of-wrong-cursor-orientat.patch
+++ b/app-virtualization/virglrenderer/autobuild/patches/0001-UPSTREAM-renderer-fix-cases-of-wrong-cursor-orientat.patch
@@ -1,0 +1,30 @@
+From 30293d3bad33a4f9b35ccfd4444458b4faf4c2c9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Benno=20F=C3=BCnfst=C3=BCck?= <benno.fuenfstueck@neodyme.io>
+Date: Tue, 14 Apr 2026 12:29:30 +0200
+Subject: [PATCH] UPSTREAM: renderer: fix cases of wrong cursor orientation
+
+If Y_0_TOP is not set, we should not flip the cursor data. Downstream consumers like QEMU expect the returned buffer to be the cursor in a format where y=0 is bottom. This fixes a bug where QEMU renders an inverted mouse cursor if using a gl-accelerated display with certain wayland compositors (for example wl-roots based) in the guest.
+
+Part-of: <https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1611>
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ src/vrend/vrend_renderer.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/vrend/vrend_renderer.c b/src/vrend/vrend_renderer.c
+index 4bf88e09..3a9607a3 100644
+--- a/src/vrend/vrend_renderer.c
++++ b/src/vrend/vrend_renderer.c
+@@ -12967,7 +12967,8 @@ void *vrend_renderer_get_cursor_contents(struct pipe_resource *pres,
+    }
+ 
+    for (h = 0; h < res->base.height0; h++) {
+-      uint32_t doff = (res->base.height0 - h - 1) * res->base.width0 * blsize;
++      uint32_t dh = res->y_0_top ? (res->base.height0 - h - 1) : (h);
++      uint32_t doff = dh * res->base.width0 * blsize;
+       uint32_t soff = h * res->base.width0 * blsize;
+ 
+       memcpy(data2 + doff, data + soff, res->base.width0 * blsize);
+-- 
+2.52.0
+

--- a/app-virtualization/virglrenderer/spec
+++ b/app-virtualization/virglrenderer/spec
@@ -1,4 +1,5 @@
 VER=1.3.0
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/virgl/virglrenderer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15968"


### PR DESCRIPTION
Topic Description
-----------------

- virglrenderer: backport a patch to fix VM cursor orientation
    This patch fixes flipped cursor in VMs when running wlroots-based
    Wayland compositors.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- virglrenderer: 1.3.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit virglrenderer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
