### PR TITLE
shfmt: new, 3.13.1

### DIFF
--- a/app-devel/shfmt/autobuild/beyond
+++ b/app-devel/shfmt/autobuild/beyond
@@ -1,0 +1,8 @@
+abinfo 'Installing shfmt license...'
+install -vDm644 -t "$PKGDIR"/usr/share/licenses/shfmt "$SRCDIR"/LICENSE
+
+abinfo 'Generating man pages for shfmt...'
+scdoc < "$SRCDIR"/cmd/shfmt/shfmt.1.scd > "$SRCDIR"/cmd/shfmt/shfmt.1
+
+abinfo 'Installing shfmt man pages...'
+install -vDm644 -t "$PKGDIR"/usr/share/man/man1 "$SRCDIR"/cmd/shfmt/shfmt.1

--- a/app-devel/shfmt/autobuild/defines
+++ b/app-devel/shfmt/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=shfmt
+PKGSEC=devel
+PKGDES='Parser, formatter and interpreter for sh/bash/mksh'
+BUILDDEP='go scdoc'
+AB_TYPE=gomod
+GO_PACKAGES=('cmd/shfmt')

--- a/app-devel/shfmt/spec
+++ b/app-devel/shfmt/spec
@@ -1,0 +1,4 @@
+VER=3.13.1
+SRCS="git::commit=tags/v${VER}::https://github.com/mvdan/sh"
+CHKSUMS='SKIP'
+CHKUPDATE='anitya::id=242179'


### PR DESCRIPTION
Topic Description
-----------------

- shfmt: new, 3.13.1

Package(s) Affected
-------------------

- shfmt: 3.13.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit shfmt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

---

Resolves #12613.