### PR TITLE
wireshark: update to 4.6.6

### DIFF
--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,5 +1,4 @@
-VER=4.6.4
-REL=2
+VER=4.6.6
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::fbeab3d85c6c8a5763c8d9b7fe20b5c69ca9f9e7f2b824bedc73135bdca332e2"
+CHKSUMS="sha256::27e7ff780cd68a7466082be82ca26c06a002e74a71646ef3a6e4683e444c1a86"
 CHKUPDATE="anitya::id=5137"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: update to 4.6.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireshark: 4.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
