### PR TITLE
libxml2-2: new, 2.13.9

### DIFF
--- a/runtime-common/libxml2-2/autobuild/beyond
+++ b/runtime-common/libxml2-2/autobuild/beyond
@@ -1,0 +1,18 @@
+abinfo "Installing files ..."
+mkdir -pv "$OLD_PKGDIR""$LIBDIR"
+# NOTE: install dereferences symbolic links.
+find "$PKGDIR""$LIBDIR" \( -type f -o -type l \) -executable -exec \
+	cp -av {} "$OLD_PKGDIR""$LIBDIR"/ \;
+
+abinfo "Removing non-versioned symlinks ..."
+unlink "$OLD_PKGDIR""$LIBDIR"/libxml2.so
+
+abinfo "Creating ld.so.conf ..."
+mkdir -pv "$OLD_PKGDIR"/etc/ld.so.conf.d
+cat > "$OLD_PKGDIR"/etc/ld.so.conf.d/"$PKGNAME".conf << EOF
+# libxml2-2 (libxml.so.2 ABI)
+$LIBDIR
+EOF
+
+abinfo "Restoring PKGDIR ..."
+export PKGDIR="$OLD_PKGDIR"

--- a/runtime-common/libxml2-2/autobuild/defines
+++ b/runtime-common/libxml2-2/autobuild/defines
@@ -1,0 +1,20 @@
+PKGNAME=libxml2-2
+PKGDES="Utilities and libraries for parsing XMLs (Legacy ABI)"
+PKGSEC=utils
+PKGDEP="zlib readline ncurses xz icu"
+
+# NOTE: Using Autotools
+# Their Meson build script does not instruct the linker to annotate the
+# symbols with versions from libxml2.syms.
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+	"--with-html"
+	"--with-http"
+	"--with-icu"
+	"--with-lzma"
+	"--without-python"
+	"--with-threads"
+	"--with-zlib"
+	"--with-legacy"
+	"--libdir=/usr/lib/legacy/$PKGNAME"
+)

--- a/runtime-common/libxml2-2/autobuild/prepare
+++ b/runtime-common/libxml2-2/autobuild/prepare
@@ -1,0 +1,7 @@
+abinfo "Overriding system paths ..."
+# NOTE: For convenience. This is overriden in MESON_AFTER.
+export LIBDIR=/usr/lib/legacy/"$PKGNAME"
+
+abinfo "Overriding PKGDIR ..."
+export OLD_PKGDIR="$PKGDIR"
+export PKGDIR="$PKGDIR"-legacy

--- a/runtime-common/libxml2-2/spec
+++ b/runtime-common/libxml2-2/spec
@@ -1,0 +1,4 @@
+VER=2.13.9
+SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/GNOME/libxml2"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1783"


### PR DESCRIPTION
Topic Description
-----------------

- libxml2-2: new, 2.13.9
    This is the last minor branch that bears the libxml2.so.2 SONAME. The
    library is installed to /usr/lib/legacy/libxml2-2, and ships a linker
    config that enables the linker to search this directory.

Package(s) Affected
-------------------

- libxml2-2: 2.13.9

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxml2-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
