### PR TITLE
topics: fix package name in postgresql-18-18.3.toml

### DIFF
--- a/topics/postgresql-18-18.3.toml
+++ b/topics/postgresql-18-18.3.toml
@@ -8,4 +8,4 @@ default = "Fixes 7 security vulnerabilities (4 of high severity)"
 zh_CN = "修复 7 个安全漏洞（含 4 个高危漏洞）"
 
 [packages-v2]
-"postgresql-17" = "< 18.3"
+"postgresql-18" = "< 18.3"


### PR DESCRIPTION
Topic Description
-----------------

- topics: fix package name in postgresql-18-18.3.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
