### PR TITLE
vim: security update to 9.2.0502

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0478
+VER=9.2.0502
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0502.toml
+++ b/topics/vim-9.2.0502.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0502"
+
+[caution]
+default = "Fixes 4 Code Injection vulnerabilities"
+zh_CN = "修复 4 个代码注入漏洞"
+
+[packages-v2]
+"vim" = "< 9.2.0502"


### PR DESCRIPTION
Topic Description
-----------------

- vim: security update to 9.2.0502
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.0502
- vim: 9.2.0502

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
