### PR TITLE
libheif: security update to 1.22.0

### DIFF
--- a/runtime-imaging/libheif/spec
+++ b/runtime-imaging/libheif/spec
@@ -1,4 +1,4 @@
-VER=1.21.2
+VER=1.22.0
 SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libheif"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=64439"

--- a/topics/libheif-1.22.0.toml
+++ b/topics/libheif-1.22.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libheif 1.22.0"
+
+[caution]
+default = "Fixes 2 Out-of-Bounds Read vulnerabilities (CVE-2026-32738, CVE-2026-32740, Severity: Medium, High) and a Loop with Unreachable Exit Condition vulnerability (CVE-2026-32739, Severity: Medium)"
+zh_CN = "修复两个越界读取漏洞（漏洞编号 CVE-2026-32738、CVE-2026-32740，严重性：中、高）和一个无限循环漏洞（漏洞编号 CVE-2026-32739，严重性：中）"
+
+[packages-v2]
+"libheif" = "< 1.22.0"


### PR DESCRIPTION
Topic Description
-----------------

- libheif: security update to 1.22.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libheif: 1.22.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libheif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
