### PR TITLE
libreoffice: security update to 26.2.4.1

### DIFF
--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,4 @@
-VER=26.2.0.3
-REL=2
+VER=26.2.4.1
 SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://git.libreoffice.org/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"

--- a/topics/libreoffice-26.2.4.1.toml
+++ b/topics/libreoffice-26.2.4.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "LibreOffice 26.2.4.1"
+
+[caution]
+default = "Fixes an Out-of-Bounds Write vulnerability (CVE-2026-4430, Severity: High)"
+zh_CN = "修复一个越界写入漏洞（CVE-2026-4430，严重性：高）"
+
+[packages-v2]
+"LibreOffice" = "< 26.2.4.1"


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: security update to 26.2.4.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libreoffice: 26.2.4.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
