### PR TITLE
libepoxy: rebuild for Spiral markers

### DIFF
--- a/runtime-display/libepoxy/spec
+++ b/runtime-display/libepoxy/spec
@@ -1,4 +1,5 @@
 VER=1.5.10
+REL=1
 SRCS="tbl::https://download.gnome.org/sources/libepoxy/${VER:0:3}/libepoxy-$VER.tar.xz"
 CHKSUMS="sha256::072cda4b59dd098bba8c2363a6247299db1fa89411dc221c8b81b8ee8192e623"
 CHKUPDATE="anitya::id=6090"


### PR DESCRIPTION
Topic Description
-----------------

- libepoxy: rebuild for Spiral markers

Package(s) Affected
-------------------

- libepoxy: 1.5.10-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libepoxy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
