### PR TITLE
telegram-desktop: update to 6.8.2

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=6.7.2
+VER=6.8.2
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=26068e29bfa8d74a9dc9c8f7f94172fafbc262b8
 TDLIBVER=1677a0c77f30bbb337f91cf6627d62b2a62a8f87
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::b9e0c5fc1ec48debf2522b00a047d60e4f14167c646700ffb931f5fa766884d3 \
+CHKSUMS="sha256::cce1c196ef00703e9872d7072defd14860c970effc52d52d990745c8dca16cac \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.8.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- telegram-desktop: 6.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
