### PR TITLE
openvpn: update to 2.7.4

### DIFF
--- a/app-network/openvpn/spec
+++ b/app-network/openvpn/spec
@@ -1,4 +1,4 @@
-VER=2.6.17
+VER=2.7.4
 SRCS="tbl::https://swupdate.openvpn.net/community/releases/openvpn-$VER.tar.gz"
-CHKSUMS="sha256::4cc8e63f710d3001493b13d8a32cf22a214d5e4f71dd37d93831e2fd3208b370"
+CHKSUMS="sha256::18db05f3d5eee3663db1914590044e5f96ff5cd47b6e7846c6a350806c23dbce"
 CHKUPDATE="anitya::id=2567"


### PR DESCRIPTION
Topic Description
-----------------

- openvpn: update to 2.7.4
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- openvpn: 2.7.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit openvpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
