### PR TITLE
praat: update to 6.4.67

### DIFF
--- a/app-scientific/praat/autobuild/defines
+++ b/app-scientific/praat/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=praat
 PKGSEC=science
 PKGDEP="gtk-3 alsa-lib pulseaudio"
-PKGDES="A speech analysis tool for phonetics"
+PKGDES="Speech analysis tool for phonetics"
+
+ABTYPE=self

--- a/app-scientific/praat/autobuild/prepare
+++ b/app-scientific/praat/autobuild/prepare
@@ -1,4 +1,0 @@
-abinfo "Copying the right makefile.defs (Little Endian, Linux with PulseAudio + GCC) ..."
-# NOTE: AOSC OS mainline currently only has little-endian architectures, we'll
-# default to use the LE variant here
-cp -v "$SRCDIR"/makefiles/makefile.defs.linux.pulse-gcc.LE "$SRCDIR"/makefile.defs

--- a/app-scientific/praat/spec
+++ b/app-scientific/praat/spec
@@ -1,4 +1,4 @@
-VER=6.4.60
+VER=6.4.67
 SRCS="git::commit=tags/v$VER::https://github.com/praat/praat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373832"


### PR DESCRIPTION
Topic Description
-----------------

- praat: update to 6.4.67
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- praat: 6.4.67

Security Update?
----------------

No

Build Order
-----------

```
#buildit praat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
