### PR TITLE
tsukimi: update to 26.5.3

### DIFF
--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=tsukimi
 PKGSEC=video
-PKGDES="A desktop client implementation for Emby"
+PKGDES="Third-party Jellyfin client"
 BUILDDEP="meson llvm rustc"
 PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv \
         openssl pango gtk-update-icon-cache"
@@ -8,7 +8,3 @@ PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv \
 ABTYPE=meson
 
 USECLANG=1
-
-# FIXME: ld.lld does not support loongson3
-NOLTO__LOONGSON3=1
-USECLANG__LOONGSON3=0

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,5 +1,4 @@
-VER=0.21.0
-REL=1
+VER=26.5.3
 SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376111"


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: update to 26.5.3
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- tsukimi: 26.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
