### PR TITLE
an-anime-game-launcher: update to 3.19.5

### DIFF
--- a/app-games/an-anime-game-launcher/autobuild/defines
+++ b/app-games/an-anime-game-launcher/autobuild/defines
@@ -1,11 +1,9 @@
 PKGNAME=an-anime-game-launcher
 PKGSEC=games
-PKGDES="An Anime Game launcher for Linux"
+PKGDES="Launcher for Genshin Impact"
 PKGDEP="libadwaita libwebp gtk-4 git p7zip xdg-desktop-portal"
 BUILDDEP="rustc llvm"
-
-# NOTE: only x86 and emu-x86 supported archs
-FAIL_ARCH="!(amd64|arm64|loongarch64)"
+ABTYPE=rust
 
 # FIXME: `ring` seems broken in LTO
 NOLTO=1

--- a/app-games/an-anime-game-launcher/autobuild/overrides/usr/share/applications/an-anime-game-launcher.desktop
+++ b/app-games/an-anime-game-launcher/autobuild/overrides/usr/share/applications/an-anime-game-launcher.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Name=An Anime Game Launcher
 Name[zh_CN]=某二次元游戏启动器
-Comment=An Launcher for a specific anime game with automatic updates, Discord RPC and time tracking
-Comment[zh_CN]=带有自动更新、Discord RPC 及游戏时间记录功能的某二次元游戏启动器
+Comment=Genshin Impact Launcher with telemetry disabling
+Comment[zh_CN]=带有禁用遥测功能的某二次元游戏启动器
 Exec=anime-game-launcher
 Terminal=false
 Type=Application

--- a/app-games/an-anime-game-launcher/spec
+++ b/app-games/an-anime-game-launcher/spec
@@ -1,4 +1,4 @@
-VER=3.18.0
+VER=3.19.5
 SRCS="git::commit=$VER::https://github.com/an-anime-team/an-anime-game-launcher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373631"


### PR DESCRIPTION
Topic Description
-----------------

- an-anime-game-launcher: update to 3.19.5

Package(s) Affected
-------------------

- an-anime-game-launcher: 3.19.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit an-anime-game-launcher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
