### PR TITLE
deno: update to 2.8.0

### DIFF
--- a/app-devel/gn/autobuild/defines
+++ b/app-devel/gn/autobuild/defines
@@ -4,4 +4,4 @@ PKGDEP="gcc-runtime"
 BUILDDEP="llvm ninja"
 PKGDES="Meta-build system that generates build files for Ninja"
 
-PKGEPOCH=1
+ABTYPE=self

--- a/app-devel/gn/spec
+++ b/app-devel/gn/spec
@@ -1,3 +1,4 @@
-VER=0+git20260226
-SRCS="git::commit=1a310e88443018837759c952b113846b0096f65b;copy-repo=true::https://gn.googlesource.com/gn"
+EPOCH=1
+VER=0+git20260521
+SRCS="git::commit=e44942b445d9376451f7d519965dae036efde5bc;copy-repo=true::https://gn.googlesource.com/gn"
 CHKSUMS="SKIP"

--- a/lang-js/deno/autobuild/defines
+++ b/lang-js/deno/autobuild/defines
@@ -3,9 +3,10 @@ PKGSEC=devel
 PKGDEP="gcc-runtime glibc zlib"
 PKGSUG="mesa"
 BUILDDEP="rustc llvm protobuf python-3 gn ninja"
-# Note: There is no pre-generated bindgen for aws-lc-rs on loongarch64.
+# Note: There is no pre-generated bindgen for aws-lc-rs on loongarch64 and ppc64el.
 BUILDDEP__LOONGARCH64="${BUILDDEP} rust-bindgen"
 BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP__LOONGARCH64}"
+BUILDDEP__PPC64EL="${BUILDDEP__LOONGARCH64}"
 PKGDES="JavaScript and TypeScript runtime"
 
 ABTYPE=rust
@@ -16,12 +17,7 @@ CARGO_AFTER=(
 )
 
 # loongson3: Missing libclang_rt.builtins.a.
-#
-# ppc64el:
-# error: failed to run custom build command for `deno_snapshots v0.55.0 (/var/cache/acbs/build/acbs.h3yo3m9_/deno/cli/snapshot)`
-# Caused by:
-# process didn't exit successfully: `/var/cache/acbs/build/acbs.h3yo3m9_/deno/target/release/build/deno_snapshots-2d102cf42a87b00e/build-script-build` (signal: 4, SIGILL: illegal instruction) 
-FAIL_ARCH="(ppc64el|loongson3)"
+FAIL_ARCH="(loongson3)"
 
 # FIXME:
 # ld.lld: error: undefined symbol: aws_lc_0_26_0_EVP_parse_private_key

--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,6 +1,6 @@
-From 5655e5ae6348f57709bb87b59061c7a56325acb8 Mon Sep 17 00:00:00 2001
+From 8ecf71079aaef11bb4f4dcb5908eb9cbf74fc380 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Wed, 4 Mar 2026 20:16:58 +0800
+Date: Sat, 23 May 2026 00:33:21 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
 
 ---
@@ -9,23 +9,23 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 77a5e6474..06911ea73 100644
+index 4651851f3..c28575193 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -11266,8 +11266,6 @@ dependencies = [
+@@ -11336,8 +11336,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "147.4.0"
+ version = "149.0.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
+-checksum = "55897294cf631f99d5ff57c6a0611648861645ed7c8f251579161e0768812840"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index 401fc3c0a..f4167b1ef 100644
+index 2be6c83cc..982a10cdd 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -610,3 +610,6 @@ opt-level = 3
+@@ -612,3 +612,6 @@ opt-level = 3
  opt-level = 3
  [profile.release.package.twox-hash]
  opt-level = 3

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loongarch64
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loongarch64
@@ -1,6 +1,6 @@
-From f30f47e6b225db90e8492586c540e5751154b178 Mon Sep 17 00:00:00 2001
+From 83eca17782c26361276b065d056ada714cbaed9e Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Fri, 20 Mar 2026 09:45:58 +0800
+Date: Sat, 23 May 2026 00:37:00 +0800
 Subject: [PATCH 2/2] AOSCOS: add more architectures support
 
 After cranelift 0.117.1, it can support more unknown architectures.
@@ -9,14 +9,14 @@ Ref: https://github.com/bytecodealliance/wasmtime/pull/10107
 ---
  Cargo.lock                             | 67 ++++++++++++++++----------
  Cargo.toml                             |  4 +-
- ext/node/polyfills/_process/process.ts |  2 +
- 3 files changed, 46 insertions(+), 27 deletions(-)
+ ext/node/polyfills/_process/process.ts |  4 ++
+ 3 files changed, 48 insertions(+), 27 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 06911ea73..72f0e8ced 100644
+index c28575193..139fea1d9 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -1321,37 +1321,53 @@ dependencies = [
+@@ -1295,37 +1295,53 @@ dependencies = [
  
  [[package]]
  name = "cranelift"
@@ -78,7 +78,7 @@ index 06911ea73..72f0e8ced 100644
   "cranelift-bforest",
   "cranelift-bitset",
   "cranelift-codegen-meta",
-@@ -1360,7 +1376,7 @@ dependencies = [
+@@ -1334,7 +1350,7 @@ dependencies = [
   "cranelift-entity",
   "cranelift-isle",
   "gimli",
@@ -87,7 +87,7 @@ index 06911ea73..72f0e8ced 100644
   "log",
   "regalloc2",
   "rustc-hash 2.1.1",
-@@ -1371,42 +1387,43 @@ dependencies = [
+@@ -1345,42 +1361,43 @@ dependencies = [
  
  [[package]]
  name = "cranelift-codegen-meta"
@@ -141,7 +141,7 @@ index 06911ea73..72f0e8ced 100644
  dependencies = [
   "cranelift-codegen",
   "log",
-@@ -1416,15 +1433,15 @@ dependencies = [
+@@ -1390,15 +1407,15 @@ dependencies = [
  
  [[package]]
  name = "cranelift-isle"
@@ -161,7 +161,7 @@ index 06911ea73..72f0e8ced 100644
  dependencies = [
   "anyhow",
   "cranelift-codegen",
-@@ -1433,9 +1450,9 @@ dependencies = [
+@@ -1407,9 +1424,9 @@ dependencies = [
  
  [[package]]
  name = "cranelift-native"
@@ -174,10 +174,10 @@ index 06911ea73..72f0e8ced 100644
   "cranelift-codegen",
   "libc",
 diff --git a/Cargo.toml b/Cargo.toml
-index f4167b1ef..51a2428ee 100644
+index 982a10cdd..816aec223 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -428,8 +428,8 @@ x25519-dalek = "2.0.0"
+@@ -423,8 +423,8 @@ x25519-dalek = "2.0.0"
  x509-parser = "0.15.0"
  
  # ffi
@@ -187,17 +187,19 @@ index f4167b1ef..51a2428ee 100644
 +cranelift-native = "0.117"
  dlopen2 = "0.6.1"
  libffi = "=5.1.0"
- libffi-sys = "=4.1.0"
+ memmap2 = "0.9"
 diff --git a/ext/node/polyfills/_process/process.ts b/ext/node/polyfills/_process/process.ts
-index 9aa922709..04c64bf6f 100644
+index 1fb1968bf..049e2be5b 100644
 --- a/ext/node/polyfills/_process/process.ts
 +++ b/ext/node/polyfills/_process/process.ts
-@@ -41,6 +41,8 @@ export function arch(): string {
+@@ -44,6 +44,10 @@ function arch(): string {
      return "arm64";
    } else if (build.arch == "riscv64gc") {
      return "riscv64";
 +  } else if (build.arch == "loongarch64") {
 +    return "loong64";
++  } else if (build.arch == "powerpc64le") {
++    return "ppc64";
    } else {
      throw new Error("unreachable");
    }

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.ppc64el
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.ppc64el
@@ -1,0 +1,1 @@
+0002-AOSCOS-add-more-architectures-support.patch.loongarch64

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,4 +1,4 @@
-From 19b099baf17f611b7681ebda212bfa7ca471f388 Mon Sep 17 00:00:00 2001
+From 9b468c951884ad6c559e247baa7c76950808baa2 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 29 Apr 2026 19:29:06 +0800
 Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup on arm64
@@ -9,10 +9,10 @@ Because we have native linux arm64 CI :)
  1 file changed, 16 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index b7a71b26..3cf8f023 100644
+index a2a2e4596..8a0d0e16d 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -379,22 +379,6 @@ fn build_v8(is_asan: bool) {
+@@ -381,22 +381,6 @@ fn build_v8(is_asan: bool) {
    if needs_tls_define && !tls_define_injected {
      gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
    }

--- a/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,4 +1,4 @@
-From cba75642b38a0dd58a73fba1f60c8b92770f48c2 Mon Sep 17 00:00:00 2001
+From c361eee641e489088d96badb55601bfbaccc5b82 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
 Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
@@ -11,10 +11,10 @@ Correct the builtins path accordingly.
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index e05032c0..67092527 100644
+index f429120f4..d75fbc007 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -185,22 +185,23 @@ template("clang_lib") {
+@@ -188,22 +188,23 @@ template("clang_lib") {
        } else if (is_apple) {
          _dir = "darwin"
        } else if (is_linux || is_chromeos) {
@@ -46,7 +46,7 @@ index e05032c0..67092527 100644
          } else {
            assert(false)  # Unhandled cpu type
          }
-@@ -231,7 +232,7 @@ template("clang_lib") {
+@@ -234,7 +235,7 @@ template("clang_lib") {
          assert(false)  # Unhandled target platform
        }
  

--- a/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,17 +1,32 @@
-From 307723a74fc208fe64c0cbfb3a0348f9885cfc50 Mon Sep 17 00:00:00 2001
+From 39a105d73e2a1f2f886349ef4d95d25fcfa35809 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Sun, 29 Mar 2026 18:50:37 +0800
+Date: Sat, 23 May 2026 00:26:17 +0800
 Subject: [PATCH 5/5] AOSCOS: drop unknown argument
 
+Ref: https://github.com/cions/termux-deno/blob/7068f1fc4d8817045cbe4c65934df9646cd78368/rusty_v8-fix-unknown-options.patch
 ---
- build/config/compiler/BUILD.gn | 19 -------------------
- 1 file changed, 19 deletions(-)
+ build/config/compiler/BUILD.gn         | 13 -------------
+ build/config/sanitizers/sanitizers.gni |  7 -------
+ 2 files changed, 20 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index ff8022f0..9721cdd9 100644
+index 1b53cb1d4..53b6092b7 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -625,13 +625,6 @@ config("compiler") {
+@@ -600,12 +600,6 @@ config("compiler") {
+   if (is_clang) {
+     # Flags for diagnostics.
+     cflags += [ "-fcolor-diagnostics" ]
+-    if (!is_win) {
+-      cflags += [ "-fdiagnostics-show-inlining-chain" ]
+-    } else {
+-      # Combine after https://github.com/llvm/llvm-project/pull/192241
+-      cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+-    }
+     if (diagnostics_print_source_range_info && !is_win) {
+       cflags += [ "-fdiagnostics-print-source-range-info" ]
+     }
+@@ -636,13 +630,6 @@ config("compiler") {
        ]
      }
  
@@ -25,25 +40,24 @@ index ff8022f0..9721cdd9 100644
      # TODO(hans): Remove this once Clang generates better optimized debug info
      # by default. https://crbug.com/765793
      cflags += [
-@@ -1892,18 +1885,6 @@ config("sanitize_c_array_bounds") {
-     cflags = [
-       "-fsanitize=array-bounds",
-       "-fsanitize-trap=array-bounds",
+diff --git a/build/config/sanitizers/sanitizers.gni b/build/config/sanitizers/sanitizers.gni
+index 329a2fc8b..903b87c7b 100644
+--- a/build/config/sanitizers/sanitizers.gni
++++ b/build/config/sanitizers/sanitizers.gni
+@@ -534,13 +534,6 @@ template("ubsan_hardening") {
+       cflags = [
+         "-fsanitize=${invoker.sanitizer}",
+         "-fsanitize-trap=${invoker.sanitizer}",
 -
--      # Some code users feature detection to determine if UBSAN (or any
--      # sanitizer) is enabled, they then do expensive debug like operations. We
--      # want to suppress this behaviour since we want to keep performance costs
--      # as low as possible while having these checks.
--      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
--
--      # Because we've enabled array-bounds sanitizing we also want to suppress
--      # the related warning about "unsafe-buffer-usage-in-static-sized-array",
--      # since we know that the array bounds sanitizing will catch any out-of-
--      # bounds accesses.
--      "-Wno-unsafe-buffer-usage-in-static-sized-array",
-     ]
-   }
- }
+-        # Prevents `__has_feature(undefined_behavior_sanitizer)`
+-        # from evaluating true. Configs defined here are intended to
+-        # be usable even in release builds, i.e. as widely as possible.
+-        # It's important not to have full-on UBSan workarounds activate
+-        # just because we built support for a specific sanitizer.
+-        "-fsanitize-ignore-for-ubsan-feature=${invoker.sanitizer}",
+       ]
+       if (defined(invoker.cflags)) {
+         cflags += invoker.cflags
 -- 
 2.54.0
 

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,10 +1,11 @@
-VER=2.7.14
+VER=2.8.0
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=147.4.0
+RUSTY_V8_VER=149.0.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::617bc7247da4c8b031e3f155e10bfcb085ddd8f51625a73318dfd02fa5e939d0 \
+CHKSUMS="sha256::63873c643e516f10f20d5708e271ed55186a02cef04f5df632c987a91fbd25ac \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"
 ENVREQ__ARM64="total_mem=30"
+ENVREQ__PPC64EL="total_mem_per_core=1"


### PR DESCRIPTION
Topic Description
-----------------

- gn: update to 0+git20260521
- deno: update to 2.8.0

Package(s) Affected
-------------------

- deno: 2.8.0
- gn: 0+git20260521

Security Update?
----------------

No

Build Order
-----------

```
#buildit gn deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
