### PR TITLE
mpd: update to 0.24.12

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,4 @@
-VER=0.24.8
+VER=0.24.12
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
-CHKSUMS="sha256::1868aded6aabe6a02a6427ef1d3856b11370612afc53d28184533db53991d2f7"
+CHKSUMS="sha256::14223ca883c35fbf711994bcf745726cecc9d898e3d3964265cf3a2c7519a360"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.24.12
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- mpd: 0.24.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
