### PR TITLE
squid: security update to 7.5

### DIFF
--- a/app-web/squid/spec
+++ b/app-web/squid/spec
@@ -1,4 +1,4 @@
-VER=7.3
+VER=7.5
 SRCS="tbl::https://github.com/squid-cache/squid/releases/download/SQUID_${VER//./_}/squid-$VER.tar.xz"
-CHKSUMS="sha256::dadc2a9a3926ce1b3babeaa7a7d7b21cbb089025876daa3f5c19e7eb6391ddcd"
+CHKSUMS="sha256::f6058907db0150d2f5d228482b5a9e5678920cf368ae0ccbcecceb2ff4c35106"
 CHKUPDATE="anitya::id=4880"

--- a/topics/squid-7.5.toml
+++ b/topics/squid-7.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Squid 7.5"
+
+[caution]
+default = "Fixes an Improper Resource Locking vulnerability (CVE-2026-32748, Severity: High), an Out-of-bounds Read vulnerability (CVE-2026-33515, Severity: Medium), and an Use After Free vulnerability (CVE-2026-33526, Severity: High)"
+zh_CN = "修复了一个资源加锁不恰当漏洞（CVE-2026-32748，严重性：高）、一个越界读取漏洞（CVE-2026-33515，严重性：中），以及一个释放后使用漏洞（CVE-2026-33526，严重性：高）"
+
+[packages-v2]
+"squid" = "< 7.5"


### PR DESCRIPTION
Topic Description
-----------------

- squid: security update to 7.5
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- squid: 7.5

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit squid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
