### PR TITLE
w3m: security update to 0.5.6

### DIFF
--- a/app-web/w3m/autobuild/defines
+++ b/app-web/w3m/autobuild/defines
@@ -1,37 +1,28 @@
 PKGNAME=w3m
 PKGSEC=web
-PKGDES="A text-based Web browser and pager"
-
+PKGDES="Text-based Web browser and pager"
 PKGDEP="openssl gc ncurses imlib2"
 PKGDEP__RETRO="openssl ncurses gc"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
 
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
-                 --enable-image=x11,fb \
-                 --with-imagelib=imlib2 \
-                 --with-termlib=ncurses \
-                 --disable-w3mmailer"
-AUTOTOOLS_AFTER__RETRO=" \
-                 --libexecdir=/usr/lib \
-                 --disable-image \
-                 --without-imagelib \
-                 --with-termlib=ncurses \
-                 --disable-w3mmailer"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="$AUTOTOOLS_AFTER__RETRO"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+ABTYPE=autotools
+
+# FIXME: Fails to re-generate.
+#
+# configure.ac:45: error: possibly undefined macro: AM_GNU_GETTEXT
+#       If this token and others are legitimate, please use m4_pattern_allow.
+#       See the Autoconf documentation.
+# autoreconf: error: /usr/bin/autoconf failed with exit status: 1
 RECONF=0
 
-PKGEPOCH=2
+AUTOTOOLS_AFTER=(
+    '--libexecdir=/usr/lib'
+    '--enable-image=x11,fb'
+    '--with-imagelib=imlib2'
+    '--with-termlib=ncurses'
+    '--disable-w3mmailer'
+)
+AUTOTOOLS_AFTER__RETRO=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--disable-image'
+    '--without-imagelib'
+)

--- a/app-web/w3m/spec
+++ b/app-web/w3m/spec
@@ -1,5 +1,5 @@
-VER=0.5.3+git20230121
-SRCS="git::commit=tags/v$VER::https://github.com/tats/w3m"
+VER=0.5.6
+EPOCH=2
+SRCS="git::commit=tags/v$VER::https://git.sr.ht/~rkta/w3m"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5115"
-REL=2

--- a/topics/w3m-0.5.6.toml
+++ b/topics/w3m-0.5.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "w3m 0.5.6"
+
+[caution]
+default = "Fixes 2 Out-of-Bounds Read vulnerability (CVE-2023-38252 and CVE-2023-38253, Severity: Medium)"
+zh_CN = "修复 2 个越界读取漏洞（漏洞编号 CVE-2023-38252、CVE-2023-38253，严重性：中）"
+
+[packages-v2]
+"w3m" = "< 0.5.6"


### PR DESCRIPTION
Topic Description
-----------------

- w3m: security update to 0.5.6
    - Model: Deepseek V4 Pro
    - Platform: Deepseek 开放平台
    - Agent platform: Claude Code
    - Prompt: 更新w3m，写tum

Package(s) Affected
-------------------

- w3m: 2:0.5.6

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit w3m
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
