### PR TITLE
utterly-nord-plasma: update to 3.3+git20260108

### DIFF
--- a/desktop-themes/utterly-nord-plasma/spec
+++ b/desktop-themes/utterly-nord-plasma/spec
@@ -1,3 +1,3 @@
-VER=3.2+git20240505
-SRCS="git::commit=e513b4dfeddd587a34bfdd9ba6b1d1eac8ecadf5::https://github.com/HimDek/Utterly-Nord-Plasma.git"
+VER=3.3+git20260108
+SRCS="git::commit=ae0de9d555b518226627b2d10ee5df4a18073c60::https://github.com/HimDek/Utterly-Nord-Plasma.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
[Upstream]Fix: https://github.com/HimDek/Utterly-Nord-Plasma/issues/25

Topic Description
-----------------

- utterly-nord-plasma: update to 3.3+git20260108

Package(s) Affected
-------------------

- utterly-nord-plasma: 3.3+git20260108

Security Update?
----------------

No

Build Order
-----------

```
#buildit utterly-nord-plasma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
