### PR TITLE
wolfssl: security update to 5.9.1

### DIFF
--- a/runtime-cryptography/wolfssl/autobuild/defines
+++ b/runtime-cryptography/wolfssl/autobuild/defines
@@ -3,11 +3,12 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="TLS/SSL library for embedded and cloud environments"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
-    "--enable-all"
-    "--enable-dtls13"
-    "--enable-dtls-mtu"
-    "--disable-examples"
-    "--disable-static"
-    "--disable-armasm" # Error: selected processor does not support `sha256h2 q1,q25,v24.4s' 
+    '--enable-all'
+    '--enable-dtls13'
+    '--enable-dtls-mtu'
+    '--disable-examples'
+    '--disable-static'
+    '--disable-armasm'  # Error: selected processor does not support `sha256h2 q1,q25,v24.4s'
 )

--- a/runtime-cryptography/wolfssl/spec
+++ b/runtime-cryptography/wolfssl/spec
@@ -1,4 +1,4 @@
-VER=5.8.4
+VER=5.9.1
 SRCS="git::commit=tags/v${VER}-stable::https://github.com/wolfSSL/wolfssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21631"

--- a/topics/woflssl-5.9.1.toml
+++ b/topics/woflssl-5.9.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "wolfSSL 5.9.1"
+
+[caution]
+default = "Fixes 38 security vulnerabilities (including 9 of Critical severity, 14 of High, and 13 of Medium severity)"
+zh_CN = "修复 38 个安全漏洞（含 9 个严重漏洞、14 个高危漏洞和 13 个中危漏洞）"
+
+[packages-v2]
+"wolfssl" = "< 5.9.1"

--- a/topics/wolfssl-5.8.4.toml
+++ b/topics/wolfssl-5.8.4.toml
@@ -4,8 +4,8 @@ security = true
 default = "wolfSSL 5.8.4"
 
 [caution]
-default = "Fixes 5 security vulnerabilities (1 of critical severity, 1 high, 3 medium)"
-zh_CN = "修复 5 个安全漏洞（含 1 个严重漏洞，1 个高危漏洞，3 个中危漏洞）"
+default = "Fixes 5 security vulnerabilities (including 1 of Critical, 1 of High, and 3 of Medium severity)"
+zh_CN = "修复 5 个安全漏洞（含 1 个严重漏洞、1 个高危漏洞和 3 个中危漏洞）"
 
 [packages-v2]
 "wolfssl" = "< 5.8.4"


### PR DESCRIPTION
Topic Description
-----------------

- wolfssl: security update to 5.9.1

Package(s) Affected
-------------------

- wolfssl: 5.9.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit wolfssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
