### PR TITLE
xrdp: security update to 0.10.6

### DIFF
--- a/app-network/xrdp/autobuild/defines
+++ b/app-network/xrdp/autobuild/defines
@@ -3,26 +3,27 @@ PKGSEC=net
 PKGDEP="fuse libjpeg-turbo pulseaudio tigervnc lame linux-pam x264 fuse-3"
 PKGRECOM="xorgxrdp"
 BUILDDEP__AMD64="nasm"
-PKGDES="An open source remote desktop protocol (RDP) server"
+PKGDES="Open source remote desktop protocol (RDP) server"
 
 ABTYPE=autotools
-AUTOTOOLS_AFTER="--with-socketdir=/var/run/xrdp \
-                 --enable-pam \
-                 --enable-pam-config=arch \
-                 --enable-jpeg \
-                 --enable-tjpeg \
-                 --enable-fuse \
-                 --enable-opus \
-                 --enable-mp3lame \
-                 --enable-pixman \
-                 --enable-painter \
-                 --enable-rfxcodec \
-                 --enable-painter \
-                 --disable-neutrinordp \
-                 --disable-xrdpvr \
-                 --enable-ipv6 \
-                 --enable-static \
-                 --enable-x264"
+AUTOTOOLS_AFTER=(
+    '--with-socketdir=/var/run/xrdp'
+    '--enable-pam'
+    '--enable-pam-config=arch'
+    '--enable-jpeg'
+    '--enable-tjpeg'
+    '--enable-fuse'
+    '--enable-opus'
+    '--enable-mp3lame'
+    '--enable-pixman'
+    '--enable-painter'
+    '--enable-rfxcodec'
+    '--disable-neutrinordp'
+    '--disable-xrdpvr'
+    '--enable-ipv6'
+    '--enable-static'
+    '--enable-x264'
+)
 ABSHADOW=0
 # For subprojects that cannot understand many parameters
 AUTOTOOLS_STRICT=0

--- a/app-network/xrdp/spec
+++ b/app-network/xrdp/spec
@@ -1,4 +1,4 @@
-VER=0.10.3
+VER=0.10.6
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231006"

--- a/topics/xrdp-0.10.6.toml
+++ b/topics/xrdp-0.10.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "xrdp 0.10.6"
+
+[caution]
+default = "Fixes 9 security vulnerabilities (including 4 of Critical, 3 of High, and 2 of Medium severity)"
+zh_CN = "修复 9 个安全漏洞（含 4 个严重漏洞、3 个高危漏洞和 2 个中危漏洞）"
+
+[packages-v2]
+"xrdp" = "< 0.10.6"


### PR DESCRIPTION
Topic Description
-----------------

- xrdp: security update to 0.10.6

Package(s) Affected
-------------------

- xrdp: 0.10.6

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit xrdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
