### PR TITLE
arp-scan: set cap_net_raw for /usr/bin/arp-scan

### DIFF
--- a/app-network/arp-scan/autobuild/defines
+++ b/app-network/arp-scan/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=arp-scan
 PKGSEC=net
 PKGDEP="libpcap libwww-perl"
-PKGDES="A tool that uses ARP to discover and fingerprint IP hosts on local network"
+PKGDES="Utility to discover and fingerprint IP hosts on local network via ARP"
+
+ABTYPE=autotools

--- a/app-network/arp-scan/autobuild/postinst
+++ b/app-network/arp-scan/autobuild/postinst
@@ -1,0 +1,2 @@
+echo "Configuring capability of /usr/bin/arp-scan"
+setcap cap_net_raw+eip /usr/bin/arp-scan

--- a/app-network/arp-scan/spec
+++ b/app-network/arp-scan/spec
@@ -1,4 +1,5 @@
 VER=1.10.0
-SRCS="tbl::https://github.com/royhills/arp-scan/archive/$VER.tar.gz"
-CHKSUMS="sha256::204b13487158b8e46bf6dd207757a52621148fdd1d2467ebd104de17493bab25"
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/royhills/arp-scan"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=110"


### PR DESCRIPTION
Topic Description
-----------------

- arp-scan: set cap_net_raw for /usr/bin/arp-scan
    This should enable this utility to be used without root permission.

Package(s) Affected
-------------------

- arp-scan: 1.10.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit arp-scan
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
