### PR TITLE
pluma: rebuild for libxml2 2.15.1

### DIFF
--- a/desktop-mate/pluma/spec
+++ b/desktop-mate/pluma/spec
@@ -1,4 +1,5 @@
 VER=1.28.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/mate-desktop/pluma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=198621"


### PR DESCRIPTION
Topic Description
-----------------

- pluma: rebuild for libxml2 2.15.1

Package(s) Affected
-------------------

- pluma: 1.28.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pluma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
