### PR TITLE
memcached: security update to 1.6.42

### DIFF
--- a/app-admin/memcached/autobuild/defines
+++ b/app-admin/memcached/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=memcached
 PKGSEC=admin
 PKGDEP="libevent perl"
-PKGDES="A distributed memory object caching system"
-
+PKGDES="Distributed memory object caching system"

--- a/app-admin/memcached/spec
+++ b/app-admin/memcached/spec
@@ -1,4 +1,4 @@
-VER=1.6.36
+VER=1.6.42
 SRCS="git::commit=$VER;copy-repo=true::https://github.com/memcached/memcached"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1965"

--- a/topics/memcached-1.6.42.toml
+++ b/topics/memcached-1.6.42.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Memcached 1.6.42"
+
+[caution]
+default = "Fixes 2 Observable Timing Discrepancy vulnerability (CVE-2026-47783 and CVE-2026-47784, Severity: High)"
+zh_CN = "修复 2 个可观察的计时差异漏洞（漏洞编号 CVE-2026-47783 及 CVE-2026-47784，严重性：高）"
+
+[packages-v2]
+"memcached" = "< 1.6.42"


### PR DESCRIPTION
Topic Description
-----------------

- memcached: security update to 1.6.42

Package(s) Affected
-------------------

- memcached: 1.6.42

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit memcached
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
