### PR TITLE
miniupnpd: security update to 2.3.10

### DIFF
--- a/app-network/miniupnpd/autobuild/build
+++ b/app-network/miniupnpd/autobuild/build
@@ -6,7 +6,7 @@ make -f Makefile.linux
 
 abinfo "Installing miniupnpd ..."
 mkdir -p "$PKGDIR/usr/share/man/man8"
-make PREFIX="$PKGDIR/" SBININSTALLDIR="$PKGDIR/usr/bin" STRIP="echo" -f Makefile.linux install
+make PREFIX="$PKGDIR/" SBINDIR="$PKGDIR/usr/bin" STRIP="echo" -f Makefile.linux install
 
 abinfo "Removing legacy openrc files ..."
 rm -r "$PKGDIR/etc/init.d"

--- a/app-network/miniupnpd/spec
+++ b/app-network/miniupnpd/spec
@@ -1,4 +1,4 @@
-VER=2.3.5
+VER=2.3.10
 SRCS="tbl::http://miniupnp.free.fr/files/miniupnpd-$VER.tar.gz"
-CHKSUMS="sha256::9637a412c33d2778cdae561058933b4e0b67465ff134e96761a7b19751b2fa0f"
+CHKSUMS="sha256::f9c34ed3632fb60cd248dd5897bd98479a103a75688b056ca2f069e68ab32987"
 CHKUPDATE="anitya::id=14608"

--- a/topics/miniupnpd-2.3.10.toml
+++ b/topics/miniupnpd-2.3.10.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "miniupnpd 2.3.10"
+
+[caution]
+default = "Fixes an Integer Underflow vulnerability (CVE-2026-5720, Severity: Critical)"
+zh_CN = "修复一个整数下溢漏洞（漏洞编号 CVE-2026-5720，严重性：严重）"
+
+[packages-v2]
+"miniupnpd" = "< 2.3.10"


### PR DESCRIPTION
Topic Description
-----------------

- miniupnpd: security update to 2.3.10
    - Model: Deepseek V4 Pro
    - Platform: Deepseek 开放平台
    - Agent platform: Claude Code
    - Prompt: 更新miniupnpd，写tum

Package(s) Affected
-------------------

- miniupnpd: 2.3.10

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit miniupnpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
