### PR TITLE
bind: security update to 9.20.23

### DIFF
--- a/app-network/bind/spec
+++ b/app-network/bind/spec
@@ -1,6 +1,5 @@
-VER=9.20.18
-REL=2
+VER=9.20.23
 EPOCH=1
 SRCS="tbl::https://downloads.isc.org/isc/bind${VER:0:1}/${VER/.P/-P}/bind-${VER/.P/-P}.tar.xz"
-CHKSUMS="sha256::dfc546c990ac4515529cd45c4dd995862b18ae8a2d0cb29208e8896a5d325331"
+CHKSUMS="sha256::5d4475aed3f9e500ef554b2b14d972bdb83d33de214a9b3be92918ea46908371"
 CHKUPDATE="anitya::id=14923"

--- a/topics/bind-9.20.23.toml
+++ b/topics/bind-9.20.23.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Bind 9.20.23"
+
+[caution]
+default = "Fixes 10 security vulnerabilities (including 1 of Critical, 5 of High, and 4 of Medium severity)"
+zh_CN = "修复 10 个安全漏洞（含 1 个严重漏洞、5 个高危漏洞和 4 个中危漏洞）"
+
+[packages-v2]
+"bind" = "< 9.20.23"


### PR DESCRIPTION
Topic Description
-----------------

- bind: security update to 9.20.23

Package(s) Affected
-------------------

- bind: 9.20.23

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit bind
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
