### PR TITLE
wireplumber: update to 0.5.14

### DIFF
--- a/app-multimedia/wireplumber/autobuild/beyond
+++ b/app-multimedia/wireplumber/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing HTML documentations ..."
+rm -rv "$PKGDIR"/usr/share/doc/wireplumber/html

--- a/app-multimedia/wireplumber/autobuild/defines
+++ b/app-multimedia/wireplumber/autobuild/defines
@@ -1,14 +1,16 @@
 PKGNAME=wireplumber
 PKGSEC=sound
-PKGDES="A modular session/policy manager for PipeWire"
-PKGDEP="glib pipewire lua-5.3 systemd"
+PKGDES="Modular session/policy manager for PipeWire"
+PKGDEP="glib pipewire lua-5.4 systemd"
 BUILDDEP="meson gobject-introspection lxml doxygen sphinx \
           sphinx-rtd-theme breathe"
 
 ABTYPE=meson
-MESON_AFTER="-Dsystem-lua=true \
-             -Ddoc=enabled \
-             -Dsystemd=enabled \
-             -Dsystemd-user-service=true \
-             -Dintrospection=enabled \
-             -Delogind=disabled"
+MESON_AFTER=(
+    '-Dsystem-lua=true'
+    '-Ddoc=enabled'
+    '-Dsystemd=enabled'
+    '-Dsystemd-user-service=true'
+    '-Dintrospection=enabled'
+    '-Delogind=disabled'
+)

--- a/app-multimedia/wireplumber/spec
+++ b/app-multimedia/wireplumber/spec
@@ -1,4 +1,4 @@
-VER=0.5.13
+VER=0.5.14
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/wireplumber"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235056"


### PR DESCRIPTION
Topic Description
-----------------

- wireplumber: update to 0.5.14
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wireplumber: 0.5.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireplumber
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
