### PR TITLE
gst-plugins-rs: update to 0.15.2

### DIFF
--- a/runtime-multimedia/gst-plugins-rs/autobuild/defines
+++ b/runtime-multimedia/gst-plugins-rs/autobuild/defines
@@ -8,34 +8,39 @@ PKGDES="GStreamer plugins and elements written in Rust"
 ABTYPE=meson
 USECLANG=1
 
+# FIXME: ld.lld: error: ld-temp.o <inline asm>:1:21: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+NOLTO__RISCV64=1
+
 MESON_AFTER=(
     '-Ddoc=disabled'
     '-Dexamples=disabled'
     '-Dtests=disabled'
 )
 
-MESON_AFTER__NO_SKIA=(
+# FIXME: skia-bindings missing fetch_gn support on loongarch64, loongson3,
+# ppc64el, riscv64
+# FIXME: gstreamer-validate-1.0 is not available on loongarch64, see gstreamer's
+# defines file for more information
+MESON_AFTER__LOONGARCH64=(
+    "${MESON_AFTER[@]}"
+    '-Dskia=disabled'
+    '-Dvalidate=disabled'
+)
+MESON_AFTER__LOONGARCH64_NOSIMD=(
+    "${MESON_AFTER__LOONGARCH64[@]}"
+)
+MESON_AFTER__LOONGSON3=(
     "${MESON_AFTER[@]}"
     '-Dskia=disabled'
 )
-
-# FIXME: skia-bindings missing fetch_gn support on loongarch64, loongson3,
-# ppc64el, riscv64
-MESON_AFTER__LOONGARCH64=(
-    "${MESON_AFTER__NO_SKIA[@]}"
-)
-MESON_AFTER__LOONGARCH64_NOSIMD=(
-    "${MESON_AFTER__NO_SKIA[@]}"
-)
-MESON_AFTER__LOONGSON3=(
-    "${MESON_AFTER__NO_SKIA[@]}"
-)
 MESON_AFTER__PPC64EL=(
-    "${MESON_AFTER__NO_SKIA[@]}"
+    "${MESON_AFTER[@]}"
+    '-Dskia=disabled'
 )
 # FIXME: libsodium-sys Invalid configuration `riscv64gc-unknown-linux-gnu':
 # machine `riscv64gc-unknown' not recognized
 MESON_AFTER__RISCV64=(
-    "${MESON_AFTER__NO_SKIA[@]}"
+    "${MESON_AFTER[@]}"
+    '-Dskia=disabled'
     '-Dsodium=disabled'
 )

--- a/runtime-multimedia/gst-plugins-rs/spec
+++ b/runtime-multimedia/gst-plugins-rs/spec
@@ -1,4 +1,4 @@
-VER=0.14.4
+VER=0.15.2
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328366"


### PR DESCRIPTION
Topic Description
-----------------

- gst-plugins-rs: update to 0.15.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gst-plugins-rs: 0.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gst-plugins-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
