### PR TITLE
ffmpeg: rework, update PKGBREAK

### DIFF
--- a/app-multimedia/ffmpeg/01-ffmpeg/defines
+++ b/app-multimedia/ffmpeg/01-ffmpeg/defines
@@ -32,12 +32,12 @@ PKGBREAK="akode<=14.1.5 alsa-plugins<=1.2.12-2 aubio<=0.4.9-7 \
           dragon<=23.08.5 fceux<=2.6.6+git20251111 ffmpegthumbnailer<=2.2.2-1 \
           ffmpegthumbs<=23.08.5-1 ffms2<=5.0 freerdp<=2:3.24.2 \
           gegl-0.4<=0.4.68-1 goldendict<=1:1.5.0-2 gpac<=2.2.1 \
-          gstreamer<=1.28.1-3 gtk-4<=4.14.2 guvcview<=2.1.0-1 \
+          gstreamer<=1.28.1-4 gtk-4<=4.14.2 guvcview<=2.1.0-1 \
           haruna<=0.12.3-3 harvid<=0.9.1-1 k3b<=23.08.5-5 \
           k3b-trinity<=14.1.5-1 k9copy-trinity<=14.1.5-1 kdenlive<=23.08.5 \
           kfilemetadata<=5.115.0-4 kid3<=3.9.5-2 kodi<=21.3-3 \
           kodi-inputstream-ffmpegdirect<=21.3.7 kpipewire<=5.27.12 \
-          libde265<=1.0.18 libplacebo<=7.351.0 localsearch<=3.10.2-2 \
+          libde265<=1.0.18-1 libplacebo<=7.351.0 localsearch<=3.10.2-2 \
           makemkv<=1.16.4-3 mgba<=0.10.5 mixxx<=2.5.2-1 mlt<=7.38.0-2 \
           mlt-6<=6.26.1-4 mocp<=2.6.0~svn.r3005-2 moonlight-embedded<=2.5.3-2 \
           moonlight-qt<=6.1.0-4 mpd<=0.24.12 mplayer<=1.5-4 mpv<=0.41.0-2 \
@@ -50,7 +50,7 @@ PKGBREAK="akode<=14.1.5 alsa-plugins<=1.2.12-2 aubio<=0.4.9-7 \
           qtav<=1.13.0-4 qtox<=1.17.6-1 replaysorcery<=0.6.0 \
           renpy<=8.5.2.26010301 scrcpy<=3.3.4 simplescreenrecorder<=0.4.4 \
           spek-x<=0.9.4-1 sunshine<=2025.924.154138 synfig<=1.5.3 \
-          stepmania<=1:5.0.12+git20221114 telegram-desktop<=6.8.2 \
+          stepmania<=1:5.0.12+git20221114 telegram-desktop<=6.8.2-2 \
           tigervnc<=1.16.2+xserver21.1.21 unpaper<=1:7.0.0 \
           vba-m<=2.2.3-1 vlc<=3.0.21-1 wine<=11.8+gecko2.47.4+mono11.1.0 \
           xine-lib<=1.2.13-10 xjadeo<=0.8.13-1 xpra<=5.0.8-1"

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,4 +1,5 @@
 VER=8.1.1
+REL=1
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"
 CHKUPDATE="anitya::id=5405"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=2
+REL=3
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=e0943d068ce90b5010f1aea946e6901e25b43bf6

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.28.1
-REL=4
+REL=5
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"

--- a/runtime-multimedia/libde265/spec
+++ b/runtime-multimedia/libde265/spec
@@ -1,5 +1,5 @@
 VER=1.0.18
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libde265"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11239"


### PR DESCRIPTION
Topic Description
-----------------

- libde265: rebuild for ffmpeg 8.1.1
- telegram-desktop: rebuild for ffmpeg 8.1.1
- gstreamer: bump REL due to ffmpeg update to 8.1.1
- ffmpeg: update PKGBREAK

Package(s) Affected
-------------------

- ffmpeg: 8.1.1-1
- ffmpeg-static-libs-for-sunshine: 8.1.1-1
- gstreamer: 1.28.1-5
- libde265: 1.0.18-2
- telegram-desktop: 6.8.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg:-pkgbreak libde265:+stage2 gstreamer:+stage2 libde265 gstreamer telegram-desktop ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
