### PR TITLE
dae: update to 1.1.0

### DIFF
--- a/app-proxy/dae/spec
+++ b/app-proxy/dae/spec
@@ -1,6 +1,5 @@
-VER=1.0.0
-REL=5
+VER=1.1.0
 SRCS="tbl::https://github.com/daeuniverse/dae/releases/download/v$VER/dae-full-src.zip"
-CHKSUMS="sha256::d933b93fc30cb4e9941cbb1be23557bd6caa2a33af212883505fec435d06fc13"
+CHKSUMS="sha256::e2e4207dc110ef21b07d9150272bcedb466ec93b435a6090fea3a946485f2328"
 CHKUPDATE="anitya::id=369479"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- dae: update to 1.1.0
    Co-authored-by: \(@MutsukiC\)

Package(s) Affected
-------------------

- dae: 1.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dae
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
