### PR TITLE
mergiraf: update to 0.17.0

### DIFF
--- a/app-devel/mergiraf/spec
+++ b/app-devel/mergiraf/spec
@@ -1,4 +1,4 @@
-VER=0.16.3
+VER=0.17.0
 SRCS="git::commit=tags/v$VER::https://codeberg.org/mergiraf/mergiraf.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=386476"


### PR DESCRIPTION
Topic Description
-----------------

- mergiraf: update to 0.17.0
    Co-authored-by: Rong "Mantle" Bao \(@CSharperMantle\) <rong.bao@csmantle.top>

Package(s) Affected
-------------------

- mergiraf: 0.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mergiraf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
