### PR TITLE
expat: security update to 2.8.1

### DIFF
--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,4 @@
-VER=2.8.0
+VER=2.8.1
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/runtime-optenv32/expat+32/spec
+++ b/runtime-optenv32/expat+32/spec
@@ -1,4 +1,4 @@
-VER=2.8.0
+VER=2.8.1
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/topics/expat-2.8.1.toml
+++ b/topics/expat-2.8.1.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = true
+
+[name]
+default = "Expat 2.8.1"
+
+[caution]
+default = "Fixes an Inefficient Algorithmic Complexity vulnerability (CVE-2026-45186, Severity: High)"
+zh_CN = "修复一个算法复杂度不足漏洞（CVE-2026-45186，严重性：高）"
+
+[packages-v2]
+"expat" = "< 2.8.1"
+"expat+32" = "< 2.8.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add expat-2.8.1.toml
- expat+32: security update to 2.8.1
- expat: security update to 2.8.1

Package(s) Affected
-------------------

- expat: 2.8.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
