### PR TITLE
cherrytree: new, 1.7.0

### DIFF
--- a/app-productivity/cherrytree/autobuild/defines
+++ b/app-productivity/cherrytree/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=cherrytree
+PKGSEC=doc
+PKGDES="Hierarchical note taking application"
+PKGDEP="gtkmm-3 gtksourceview-4 libxml++-2.6 sqlite gspell curl \
+        uchardet fribidi vte spdlog glibmm pangomm"
+BUILDDEP="ninja cmake fmt file"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_TESTING=OFF'
+)

--- a/app-productivity/cherrytree/spec
+++ b/app-productivity/cherrytree/spec
@@ -1,0 +1,4 @@
+VER=1.7.0
+SRCS="git::commit=tags/v$VER::https://github.com/giuspen/cherrytree"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=279"


### PR DESCRIPTION
Topic Description
-----------------

- cherrytree: new, 1.7.0

Package(s) Affected
-------------------

- cherrytree: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit cherrytree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
