### PR TITLE
ouch: update to 0.8.0

### DIFF
--- a/app-utils/ouch/autobuild/defines
+++ b/app-utils/ouch/autobuild/defines
@@ -7,3 +7,9 @@ PKGSEC="util"
 USECLANG=1
 ABTYPE=rust
 CARGO_AFTER__I486=('--target=i486-unknown-linux-gnu')
+
+# FIXME: Build error before appending `-Clink-arg=-lc++ -Clink-arg=-lc++abi`.
+# cargo:warning=vendor/unrar/os.hpp:12:10: fatal error: 'new' file not found                                  
+# cargo:warning=   12 | #include <new>                                                                        
+# cargo:warning=      |          ^~~~~
+FAIL_ARCH="loongson3"

--- a/app-utils/ouch/autobuild/prepare
+++ b/app-utils/ouch/autobuild/prepare
@@ -1,3 +1,8 @@
 # Note: To generate manpage and completions.
 abinfo "Setting OUCH_ARTIFACTS_FOLDER ..."
 export OUCH_ARTIFACTS_FOLDER="$SRCDIR"/artifacts
+
+# FIXME: unrar-ng-sys may build UnRAR with libc++,
+# link libc++ explicitly.
+abinfo "Fixing build with unrar-ng-sys ..."
+export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-lc++ -Clink-arg=-lc++abi"

--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,5 +1,4 @@
-VER=0.7.1
-REL=1
+VER=0.8.0
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"


### PR DESCRIPTION
Topic Description
-----------------

- ouch: update to 0.8.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- ouch: 0.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
