### PR TITLE
NVIDIA Legacy Drivers: Fix DKMS Build on Linux 7.0

### DIFF
--- a/runtime-display/nvidia+390/autobuild/patch
+++ b/runtime-display/nvidia+390/autobuild/patch
@@ -1,1 +1,0 @@
-# Explicitly do nothing

--- a/runtime-display/nvidia+390/autobuild/patches/0001-RPMFUSION-Change-NVKMS_USECS_TO_JIFFIES-to-pass-unsi.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0001-RPMFUSION-Change-NVKMS_USECS_TO_JIFFIES-to-pass-unsi.patch.deferred
@@ -1,0 +1,38 @@
+From f1989e2ae5212855b2d2d947a18a8dd46b8668ee Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 12:15:53 +0800
+Subject: [PATCH 01/90] RPMFUSION: Change NVKMS_USECS_TO_JIFFIES to pass
+ unsigned long long to do_div
+
+In kernel builds from 4.6 the compiler flags are more restrictive, and now
+Werror=incompatible-pointer-types is passed, which causes the build to fail on
+32bit. do_div expects a 64 bit unsigned integer, but the NVKMS_USECS_TO_JIFFIES
+macro passes an unsigned long. Use unsigned long long instead, and cast down
+the result before returning. This macro is passed to time_mod which takes an
+unsigned long as a parameter, so casting down is fine.
+
+Co-authored-by: Luca Boccassi <luca.boccassi@gmail.com>
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-modeset/nvidia-modeset-linux.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index f7f1def..e98c748 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -68,9 +68,9 @@
+  */
+ static inline unsigned long NVKMS_USECS_TO_JIFFIES(NvU64 usec)
+ {
+-    unsigned long result = usec * HZ;
++    unsigned long long result = usec * HZ;
+     do_div(result, 1000000);
+-    return result;
++    return (unsigned long)result;
+ }
+ 
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0002-RPMFUSION-backport-nv_install_notifier-changes-from-.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0002-RPMFUSION-backport-nv_install_notifier-changes-from-.patch.deferred
@@ -1,0 +1,127 @@
+From 2d6a497a22f19621dbcb5ddb455cbb0dcbb64314 Mon Sep 17 00:00:00 2001
+From: Andreas Beckmann <anbe@debian.org>
+Date: Wed, 19 Oct 2022 13:49:43 +0200
+Subject: [PATCH 02/90] RPMFUSION: backport nv_install_notifier changes from
+ 418.30
+
+---
+ kernel/nvidia/nv-acpi.c | 37 +++++++++++++++----------------------
+ 1 file changed, 15 insertions(+), 22 deletions(-)
+
+diff --git a/kernel/nvidia/nv-acpi.c b/kernel/nvidia/nv-acpi.c
+index da9fbc9..b37c9f3 100644
+--- a/kernel/nvidia/nv-acpi.c
++++ b/kernel/nvidia/nv-acpi.c
+@@ -502,19 +502,19 @@ static int nv_acpi_match(struct acpi_device *device, struct acpi_driver *driver)
+ #endif
+ 
+ /* Do the necessary allocations and install notifier "handler" on the device-node "device" */
+-static NV_STATUS nv_install_notifier(struct acpi_handle *handle, acpi_notify_handler handler)
+-{        
++static nv_acpi_t* nv_install_notifier(struct acpi_handle *handle, acpi_notify_handler handler)
++{
+     nvidia_stack_t *sp = NULL;
+     nv_acpi_t *pNvAcpiObject = NULL;
+     NV_STATUS rmStatus = NV_ERR_GENERIC;
+     acpi_status status = -1;
+ 
+     if (!handle)
+-        return NV_ERR_GENERIC;
++        return NULL;
+ 
+     if (nv_kmem_cache_alloc_stack(&sp) != 0)
+     {
+-        return NV_ERR_NO_MEMORY;
++        return NULL;
+     }
+ 
+     rmStatus = os_alloc_mem((void **) &pNvAcpiObject, sizeof(nv_acpi_t));
+@@ -532,32 +532,25 @@ static NV_STATUS nv_install_notifier(struct acpi_handle *handle, acpi_notify_han
+     if (!ACPI_FAILURE(status)) 
+     {
+         pNvAcpiObject->notify_handler_installed = 1;
+-        return NV_OK;
++        return pNvAcpiObject;
+     }
+ 
+-
+ return_error:
+-
+      nv_kmem_cache_free_stack(sp);
+      if (pNvAcpiObject)
+          os_free_mem((void *)pNvAcpiObject);
+-     return NV_ERR_GENERIC;
+ 
++     return NULL;
+ }
+ 
+ /* Tear-down and remove whatever nv_install_notifier did */ 
+-static void nv_uninstall_notifier(struct acpi_device *device, acpi_notify_handler handler)
++static void nv_uninstall_notifier(nv_acpi_t *pNvAcpiObject, acpi_notify_handler handler)
+ {
+     acpi_status status;
+-    nv_acpi_t *pNvAcpiObject = NULL;
+-
+-    if (!device)
+-        return;
+ 
+-    pNvAcpiObject = device->driver_data;
+     if (pNvAcpiObject && pNvAcpiObject->notify_handler_installed)
+     {
+-        status = acpi_remove_notify_handler(device->handle, ACPI_DEVICE_NOTIFY, handler);
++        status = acpi_remove_notify_handler(pNvAcpiObject->handle, ACPI_DEVICE_NOTIFY, handler);
+         if (ACPI_FAILURE(status))
+         {
+             nv_printf(NV_DBG_INFO,
+@@ -567,14 +560,12 @@ static void nv_uninstall_notifier(struct acpi_device *device, acpi_notify_handle
+         {
+             nv_kmem_cache_free_stack(pNvAcpiObject->sp);
+             os_free_mem((void *)pNvAcpiObject);
+-            device->driver_data = NULL;
+         }
+     }
+-   
++
+     return;
+ }
+ 
+-
+ /*
+  * acpi methods init function.
+  * check if the NVIF, _DSM and WMMX methods are present in the acpi namespace.
+@@ -585,7 +576,6 @@ void NV_API_CALL nv_acpi_methods_init(NvU32 *handlesPresent)
+ {
+ #if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+     struct acpi_device *device = NULL;
+-    NV_STATUS rmStatus;
+     int retVal = -1;
+ #endif
+ 
+@@ -618,8 +608,10 @@ void NV_API_CALL nv_acpi_methods_init(NvU32 *handlesPresent)
+                            nodes' structures. So nothing more to be done */
+             }
+ 
+-            rmStatus = nv_install_notifier(device->handle, nv_acpi_event);
+-            if (rmStatus != NV_OK)
++            device->driver_data  = nv_install_notifier(device->handle, nv_acpi_event);
++
++
++            if (!device->driver_data)
+                 nvif_parent_gpu_handle = NULL;
+ 
+         } while (0);
+@@ -684,9 +676,10 @@ void NV_API_CALL nv_acpi_methods_uninit(void)
+ #if defined(NV_ACPI_BUS_GET_DEVICE_PRESENT)
+     acpi_bus_get_device(nvif_parent_gpu_handle, &device);
+ 
+-    nv_uninstall_notifier(device, nv_acpi_event);
++    nv_uninstall_notifier(device->driver_data, nv_acpi_event);
+ #endif
+ 
++    device->driver_data = NULL;
+     nvif_parent_gpu_handle = NULL;
+ 
+     return;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0003-RPMFUSION-kernel-4.16-memory-encryption.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0003-RPMFUSION-kernel-4.16-memory-encryption.patch.deferred
@@ -1,0 +1,47 @@
+From 24ca81c786782c2f823287abaca3c91722ef1c01 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 12:29:06 +0800
+Subject: [PATCH 03/90] RPMFUSION: kernel 4.16+ memory encryption
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/common/inc/nv-linux.h | 4 ++++
+ kernel/conftest.sh           | 5 +++++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index 2bb311c..2c4cb7b 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -174,7 +174,11 @@ static inline uid_t __kuid_val(kuid_t uid)
+ 
+ #if defined(NV_VM_INSERT_PAGE_PRESENT)
+ #include <linux/pagemap.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+ #include <linux/dma-mapping.h>
++#else
++#include <linux/dma-direct.h>
++#endif
+ 
+ #if defined(NV_LINUX_DMA_MAP_OPS_H_PRESENT)
+ #include <linux/dma-map-ops.h>
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 24daa85..093704c 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -2074,7 +2074,12 @@ compile_test() {
+             # Determine if the phys_to_dma function is present.
+             #
+             CODE="
++            #include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+             #include <linux/dma-mapping.h>
++#else
++            #include <linux/dma-direct.h>
++#endif
+             void conftest_phys_to_dma(void) {
+                 phys_to_dma();
+             }"
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0004-RPMFUSION-Fix-build-for-kernel-6.2.x.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0004-RPMFUSION-Fix-build-for-kernel-6.2.x.patch.deferred
@@ -1,0 +1,173 @@
+From 0c8473004a746bdb2717a57d702227ff3f1399ca Mon Sep 17 00:00:00 2001
+From: NVieville <nicolas.vieville@uphf.fr>
+Date: Wed, 12 Apr 2023 12:14:39 +0200
+Subject: [PATCH 04/90] RPMFUSION: Fix build for kernel 6.2.x
+
+Signed-off-by: NVieville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-connector.c | 21 +++++++++++++++++++++
+ kernel/nvidia-drm/nvidia-drm-drv.c       |  4 ++++
+ kernel/nvidia-drm/nvidia-drm-fb.c        |  1 +
+ kernel/nvidia/nv-acpi.c                  | 19 +++++++++++++++++++
+ 4 files changed, 45 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-connector.c b/kernel/nvidia-drm/nvidia-drm-connector.c
+index 54167a7..9585840 100644
+--- a/kernel/nvidia-drm/nvidia-drm-connector.c
++++ b/kernel/nvidia-drm/nvidia-drm-connector.c
+@@ -20,6 +20,8 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
++#include <drm/drm_edid.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+@@ -98,6 +100,7 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
+             break;
+     }
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0))
+     if (connector->override_edid) {
+         const struct drm_property_blob *edid = connector->edid_blob_ptr;
+ 
+@@ -110,6 +113,24 @@ __nv_drm_detect_encoder(struct NvKmsKapiDynamicDisplayParams *pDetectParams,
+                     sizeof(pDetectParams->edid.buffer));
+         }
+     }
++#else
++    // Rel. commit "drm/edid: detach debugfs EDID override from EDID property update" (Jani Nikula, 24 Oct 2022)
++    // NOTE: HUGE HACK!
++    mutex_lock(&connector->edid_override_mutex);
++    if (connector->edid_override) {
++        const struct edid *edid = drm_edid_raw(connector->edid_override);
++        size_t edid_length = EDID_LENGTH * (edid->extensions + 1);
++        if (edid_length <= sizeof(pDetectParams->edid.buffer)) {
++            memcpy(pDetectParams->edid.buffer, edid, edid_length);
++            pDetectParams->edid.bufferSize = edid_length;
++            pDetectParams->overrideEdid = NV_TRUE;
++        } else {
++            WARN_ON(edid_length >
++                    sizeof(pDetectParams->edid.buffer));
++        }
++    }
++    mutex_unlock(&connector->edid_override_mutex);
++#endif
+ 
+     if (!nvKms->getDynamicDisplayInfo(nv_dev->pDevice, pDetectParams)) {
+         NV_DRM_DEV_LOG_ERR(
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index 1289cb3..ca03978 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -20,6 +20,7 @@
+  * DEALINGS IN THE SOFTWARE.
+  */
+ 
++#include <linux/version.h>
+ #include "nvidia-drm-conftest.h" /* NV_DRM_AVAILABLE and NV_DRM_DRM_GEM_H_PRESENT */
+ 
+ #include "nvidia-drm-priv.h"
+@@ -239,9 +240,12 @@ nv_drm_init_mode_config(struct nv_drm_device *nv_dev,
+     dev->mode_config.preferred_depth = 24;
+     dev->mode_config.prefer_shadow = 1;
+ 
++// Rel. commit "drm: Remove drm_mode_config::fb_base" (Zack Rusin, 18 Oct 2022)
++#if defined(CONFIG_FB) && (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0))
+     /* Currently unused. Update when needed. */
+ 
+     dev->mode_config.fb_base = 0;
++#endif
+ 
+     dev->mode_config.async_page_flip = false;
+ 
+diff --git a/kernel/nvidia-drm/nvidia-drm-fb.c b/kernel/nvidia-drm/nvidia-drm-fb.c
+index 725164a..e0b94f2 100644
+--- a/kernel/nvidia-drm/nvidia-drm-fb.c
++++ b/kernel/nvidia-drm/nvidia-drm-fb.c
+@@ -31,6 +31,7 @@
+ #include "nvidia-drm-gem.h"
+ 
+ #include <drm/drm_crtc_helper.h>
++#include <drm/drm_modeset_helper.h>
+ 
+ static void nv_drm_framebuffer_destroy(struct drm_framebuffer *fb)
+ {
+diff --git a/kernel/nvidia/nv-acpi.c b/kernel/nvidia/nv-acpi.c
+index b37c9f3..06056a4 100644
+--- a/kernel/nvidia/nv-acpi.c
++++ b/kernel/nvidia/nv-acpi.c
+@@ -8,6 +8,7 @@
+  * _NVRM_COPYRIGHT_END_
+  */
+ 
++#include <linux/version.h>
+ #define  __NO_VERSION__
+ 
+ #include "nv-misc.h"
+@@ -23,11 +24,16 @@ static NV_STATUS   nv_acpi_extract_object  (const union acpi_object *, void *, N
+ 
+ static int         nv_acpi_add             (struct acpi_device *);
+ 
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
++static void        nv_acpi_remove_one_arg_void(struct acpi_device *device);
++#else
+ #if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+ static int         nv_acpi_remove_two_args(struct acpi_device *device, int type);
+ #else
+ static int         nv_acpi_remove_one_arg(struct acpi_device *device);
+ #endif
++#endif
+ 
+ static void        nv_acpi_event           (acpi_handle, u32, void *);
+ static acpi_status nv_acpi_find_methods    (acpi_handle, u32, void *, void **);
+@@ -73,11 +79,16 @@ static const struct acpi_driver nv_acpi_driver_template = {
+ #endif
+     .ops = {
+         .add = nv_acpi_add,
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
++        .remove = nv_acpi_remove_one_arg_void,
++#else
+ #if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+         .remove = nv_acpi_remove_two_args,
+ #else
+         .remove = nv_acpi_remove_one_arg,
+ #endif
++#endif
+ #if defined(NV_ACPI_DEVICE_OPS_HAS_MATCH)
+         .match = nv_acpi_match,
+ #endif
+@@ -331,11 +342,16 @@ static int nv_acpi_add(struct acpi_device *device)
+     return 0;
+ }
+ 
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0))
++static void nv_acpi_remove_one_arg_void(struct acpi_device *device)
++#else
+ #if !defined(NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT) || (NV_ACPI_DEVICE_OPS_REMOVE_ARGUMENT_COUNT == 2)
+ static int nv_acpi_remove_two_args(struct acpi_device *device, int type)
+ #else
+ static int nv_acpi_remove_one_arg(struct acpi_device *device)
+ #endif
++#endif
+ {
+     /*
+      * This function will cause RM to relinquish control of the VGA ACPI device.
+@@ -385,7 +401,10 @@ static int nv_acpi_remove_one_arg(struct acpi_device *device)
+         device->driver_data = NULL;
+     }
+ 
++// Rel. commit "ACPI: make remove callback of ACPI driver void" (Dawei Li, 14 Nov 2022)
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0))
+     return status;
++#endif
+ }
+ 
+ static void nv_acpi_event(acpi_handle handle, u32 event_type, void *data)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0005-RPMFUSION-Fix-build-for-kernel-6.3.x.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0005-RPMFUSION-Fix-build-for-kernel-6.3.x.patch.deferred
@@ -1,0 +1,84 @@
+From bb357667be200ea089755f1e1d16a9050b3f6e72 Mon Sep 17 00:00:00 2001
+From: NVieville <nicolas.vieville@uphf.fr>
+Date: Tue, 9 May 2023 12:37:27 +0200
+Subject: [PATCH 05/90] RPMFUSION: Fix build for kernel 6.3.x
+
+Signed-off-by: NVieville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-uvm/uvm8.c |  4 ++++
+ kernel/nvidia/nv-mmap.c  | 18 ++++++++++++++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8.c b/kernel/nvidia-uvm/uvm8.c
+index 11cb373..c68d471 100644
+--- a/kernel/nvidia-uvm/uvm8.c
++++ b/kernel/nvidia-uvm/uvm8.c
+@@ -658,7 +658,11 @@ static int uvm_mmap(struct file *filp, struct vm_area_struct *vma)
+     // Using VM_DONTCOPY would be nice, but madvise(MADV_DOFORK) can reset that
+     // so we have to handle vm_open on fork anyway. We could disable MADV_DOFORK
+     // with VM_IO, but that causes other mapping issues.
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+     vma->vm_flags |= VM_MIXEDMAP | VM_DONTEXPAND;
++#else
++    vm_flags_set(vma, VM_MIXEDMAP | VM_DONTEXPAND);
++#endif
+ 
+     vma->vm_ops = &uvm_vm_ops_managed;
+ 
+diff --git a/kernel/nvidia/nv-mmap.c b/kernel/nvidia/nv-mmap.c
+index 0b0a6f2..dcb8b89 100644
+--- a/kernel/nvidia/nv-mmap.c
++++ b/kernel/nvidia/nv-mmap.c
+@@ -447,7 +447,11 @@ int nvidia_mmap_helper(
+             addr  = mmap_start;
+             
+             // Needed for the linux kernel for mapping compound pages
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+             vma->vm_flags |= VM_MIXEDMAP;
++#else
++            vm_flags_set(vma, VM_MIXEDMAP);
++#endif
+ 
+             for (j = 0; j < pages; j++)
+             {
+@@ -471,7 +475,11 @@ int nvidia_mmap_helper(
+             }
+         }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+         vma->vm_flags |= VM_IO;
++#else
++        vm_flags_set(vma, VM_IO);
++#endif
+     }
+     else
+     {
+@@ -533,15 +541,25 @@ int nvidia_mmap_helper(
+ 
+         NV_PRINT_AT(NV_DBG_MEMINFO, at);
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+         vma->vm_flags |= (VM_IO | VM_LOCKED | VM_RESERVED);
+         vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
++#else
++        vm_flags_set(vma, VM_IO | VM_LOCKED | VM_RESERVED);
++        vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
++#endif
+     }
+ 
+     if ((prot & NV_PROTECT_WRITEABLE) == 0)
+     {
+         vma->vm_page_prot = NV_PGPROT_READ_ONLY(vma->vm_page_prot);
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+         vma->vm_flags &= ~VM_WRITE;
+         vma->vm_flags &= ~VM_MAYWRITE;
++#else
++        vm_flags_clear(vma, VM_WRITE);
++        vm_flags_clear(vma, VM_MAYWRITE);
++#endif
+     }
+ 
+     vma->vm_ops = &nv_vm_ops;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0006-RPMFUSION-Fix-build-for-kernel-6.4.x.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0006-RPMFUSION-Fix-build-for-kernel-6.4.x.patch.deferred
@@ -1,0 +1,27 @@
+From 8bbe4d4ad6a7ac8b805429371ddab2f4ad59d10e Mon Sep 17 00:00:00 2001
+From: NVieville <nicolas.vieville@uphf.fr>
+Date: Wed, 10 May 2023 14:41:09 +0200
+Subject: [PATCH 06/90] RPMFUSION: Fix build for kernel 6.4.x
+
+Signed-off-by: NVieville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index ca03978..36fa536 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -766,7 +766,9 @@ static void nv_drm_update_drm_driver_features(void)
+ 
+     nv_drm_driver.dumb_create      = nv_drm_dumb_create;
+     nv_drm_driver.dumb_map_offset  = nv_drm_dumb_map_offset;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+     nv_drm_driver.dumb_destroy     = nv_drm_dumb_destroy;
++#endif
+ 
+ #if defined(NV_DRM_DRIVER_HAS_GEM_PRIME_CALLBACKS)
+     nv_drm_driver.gem_vm_ops       = &nv_drm_gem_vma_ops;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0007-RPMFUSION-Linux-6.5-garbage-collect-all-references-t.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0007-RPMFUSION-Linux-6.5-garbage-collect-all-references-t.patch.deferred
@@ -1,0 +1,271 @@
+From 81937b2fb26572269b667d2c51b27e588c1e640c Mon Sep 17 00:00:00 2001
+From: Paolo Pisati <paolo.pisati@canonical.com>
+Date: Tue, 18 Jul 2023 12:14:47 +0000
+Subject: [PATCH 07/90] RPMFUSION: Linux 6.5: garbage collect all references to
+ get_user_pages_remote()
+
+Upstream commit ca5e863233e8f6acd1792fd85d6bc2729a1b2c10 "mm/gup: remove
+vmas parameter from get_user_pages_remote()" changed the API: since we
+reference get_user_pages_remote() (but don't use it anywhere), garbage
+collect all reference.
+
+Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>
+---
+ kernel/common/inc/nv-mm.h |  99 -----------------------------
+ kernel/conftest.sh        | 130 --------------------------------------
+ 2 files changed, 229 deletions(-)
+
+diff --git a/kernel/common/inc/nv-mm.h b/kernel/common/inc/nv-mm.h
+index aec55b0..51d0df4 100644
+--- a/kernel/common/inc/nv-mm.h
++++ b/kernel/common/inc/nv-mm.h
+@@ -98,105 +98,6 @@ typedef int vm_fault_t;
+     #endif
+ #endif
+ 
+-/*
+- * get_user_pages_remote() was added by commit 1e9877902dc7
+- * ("mm/gup: Introduce get_user_pages_remote()") in v4.6 (2016-02-12).
+- *
+- * The very next commit cde70140fed8 ("mm/gup: Overload get_user_pages()
+- * functions") deprecated the 8-argument version of get_user_pages for the
+- * non-remote case (calling get_user_pages with current and current->mm).
+- *
+- * The guidelines are: call NV_GET_USER_PAGES_REMOTE if you need the 8-argument
+- * version that uses something other than current and current->mm. Use
+- * NV_GET_USER_PAGES if you are refering to current and current->mm.
+- *
+- * Note that get_user_pages_remote() requires the caller to hold a reference on
+- * the task_struct (if non-NULL and if this API has tsk argument) and the mm_struct.
+- * This will always be true when using current and current->mm. If the kernel passes
+- * the driver a vma via driver callback, the kernel holds a reference on vma->vm_mm
+- * over that callback.
+- *
+- * get_user_pages_remote() write/force parameters were replaced
+- * with gup_flags by commit 9beae1ea8930 ("mm: replace get_user_pages_remote()
+- * write/force parameters with gup_flags") in v4.9 (2016-10-13).
+- *
+- * get_user_pages_remote() added 'locked' parameter by commit 5b56d49fc31d
+- * ("mm: add locked parameter to get_user_pages_remote()") in
+- * v4.10 (2016-12-14).
+- *
+- * get_user_pages_remote() removed 'tsk' parameter by
+- * commit 64019a2e467a ("mm/gup: remove task_struct pointer for
+- * all gup code") in v5.9-rc1 (2020-08-11).
+- *
+- */
+-
+-#if defined(NV_GET_USER_PAGES_REMOTE_PRESENT)
+-    #if defined(NV_GET_USER_PAGES_REMOTE_HAS_WRITE_AND_FORCE_ARGS)
+-        #define NV_GET_USER_PAGES_REMOTE    get_user_pages_remote
+-    #else
+-        static inline long NV_GET_USER_PAGES_REMOTE(struct task_struct *tsk,
+-                                                    struct mm_struct *mm,
+-                                                    unsigned long start,
+-                                                    unsigned long nr_pages,
+-                                                    int write,
+-                                                    int force,
+-                                                    struct page **pages,
+-                                                    struct vm_area_struct **vmas)
+-        {
+-            unsigned int flags = 0;
+-
+-            if (write)
+-                flags |= FOLL_WRITE;
+-            if (force)
+-                flags |= FOLL_FORCE;
+-
+-        #if defined(NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG)
+-            #if defined (NV_GET_USER_PAGES_REMOTE_HAS_TSK_ARG)
+-               return get_user_pages_remote(tsk, mm, start, nr_pages, flags,
+-                                            pages, vmas, NULL);
+-            #else
+-               return get_user_pages_remote(mm, start, nr_pages, flags,
+-                                            pages, vmas, NULL);
+-            #endif
+-
+-        #else
+-
+-               return get_user_pages_remote(tsk, mm, start, nr_pages, flags,
+-                                            pages, vmas);
+-
+-        #endif
+-
+-        }
+-    #endif
+-#else
+-    #if defined(NV_GET_USER_PAGES_HAS_WRITE_AND_FORCE_ARGS)
+-        #define NV_GET_USER_PAGES_REMOTE    NV_GET_USER_PAGES
+-    #else
+-        #include <linux/mm.h>
+-        #include <linux/sched.h>
+-
+-        static inline long NV_GET_USER_PAGES_REMOTE(struct task_struct *tsk,
+-                                                    struct mm_struct *mm,
+-                                                    unsigned long start,
+-                                                    unsigned long nr_pages,
+-                                                    int write,
+-                                                    int force,
+-                                                    struct page **pages,
+-                                                    struct vm_area_struct **vmas)
+-        {
+-            unsigned int flags = 0;
+-
+-            if (write)
+-                flags |= FOLL_WRITE;
+-            if (force)
+-                flags |= FOLL_FORCE;
+-
+-            return get_user_pages(tsk, mm, start, nr_pages, flags, pages, vmas);
+-        }
+-    #endif
+-#endif
+-
+-
+ /*
+  * The .virtual_address field was effectively renamed to .address, by these
+  * two commits:
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 093704c..4673a63 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -3086,136 +3086,6 @@ compile_test() {
+             return
+         ;;
+ 
+-        get_user_pages_remote)
+-            #
+-            # Determine if the function get_user_pages_remote() is
+-            # present and has write/force/locked/tsk parameters.
+-            #
+-            # get_user_pages_remote() was added by:
+-            #   2016 Feb 12: 1e9877902dc7e11d2be038371c6fbf2dfcd469d7
+-            #
+-            # get_user_pages[_remote]() write/force parameters
+-            # replaced with gup_flags:
+-            #   2016 Oct 12: 768ae309a96103ed02eb1e111e838c87854d8b51
+-            #   2016 Oct 12: 9beae1ea89305a9667ceaab6d0bf46a045ad71e7
+-            #
+-            # get_user_pages_remote() added 'locked' parameter
+-            #   2016 Dec 14:5b56d49fc31dbb0487e14ead790fc81ca9fb2c99
+-            #
+-            # get_user_pages_remote() removed 'tsk' parameter by
+-            # commit 64019a2e467a ("mm/gup: remove task_struct pointer for
+-            # all gup code") in v5.9-rc1 (2020-08-11).
+-            #
+-            # conftest #1: check if get_user_pages_remote() is available
+-            # return if not available.
+-            # Fall through to conftest #2 if it is present
+-
+-            echo "$CONFTEST_PREAMBLE
+-            #include <linux/mm.h>
+-            void conftest_get_user_pages_remote(void) {
+-                get_user_pages_remote();
+-            }" > conftest$$.c
+-
+-            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
+-            rm -f conftest$$.c
+-
+-            if [ -f conftest$$.o ]; then
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_PRESENT" | append_conftest "functions"
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_TSK_ARG" | append_conftest "functions"
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_WRITE_AND_FORCE_ARGS" | append_conftest "functions"
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG" | append_conftest "functions"
+-                rm -f conftest$$.o
+-                return
+-            fi
+-
+-            # conftest #2: check if get_user_pages_remote() has write and
+-            # force arguments. Return if these arguments are present
+-            # Fall through to conftest #3 if these args are absent.
+-            echo "#define NV_GET_USER_PAGES_REMOTE_PRESENT" | append_conftest "functions"
+-            echo "$CONFTEST_PREAMBLE
+-            #include <linux/mm.h>
+-            long get_user_pages_remote(struct task_struct *tsk,
+-                                       struct mm_struct *mm,
+-                                       unsigned long start,
+-                                       unsigned long nr_pages,
+-                                       int write,
+-                                       int force,
+-                                       struct page **pages,
+-                                       struct vm_area_struct **vmas) {
+-                return 0;
+-            }" > conftest$$.c
+-
+-            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
+-            rm -f conftest$$.c
+-
+-            if [ -f conftest$$.o ]; then
+-                echo "#define NV_GET_USER_PAGES_REMOTE_HAS_TSK_ARG" | append_conftest "functions"
+-                echo "#define NV_GET_USER_PAGES_REMOTE_HAS_WRITE_AND_FORCE_ARGS" | append_conftest "functions"
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG" | append_conftest "functions"
+-                rm -f conftest$$.o
+-                return
+-            fi
+-
+-            echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_WRITE_AND_FORCE_ARGS" | append_conftest "functions"
+-
+-            #
+-            # conftest #3: check if get_user_pages_remote() has locked argument
+-            # Return if these arguments are present. Fall through to conftest #4
+-            # if these args are absent.
+-            #
+-            echo "$CONFTEST_PREAMBLE
+-            #include <linux/mm.h>
+-            long get_user_pages_remote(struct task_struct *tsk,
+-                                       struct mm_struct *mm,
+-                                       unsigned long start,
+-                                       unsigned long nr_pages,
+-                                       unsigned int gup_flags,
+-                                       struct page **pages,
+-                                       struct vm_area_struct **vmas,
+-                                       int *locked) {
+-                return 0;
+-            }" > conftest$$.c
+-
+-            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
+-            rm -f conftest$$.c
+-
+-            if [ -f conftest$$.o ]; then
+-                echo "#define NV_GET_USER_PAGES_REMOTE_HAS_TSK_ARG" | append_conftest "functions"
+-                echo "#define NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG" | append_conftest "functions"
+-                rm -f conftest$$.o
+-                return
+-            fi
+-
+-            #
+-            # conftest #4: check if get_user_pages_remote() does not take
+-            # tsk argument.
+-            #
+-            echo "$CONFTEST_PREAMBLE
+-            #include <linux/mm.h>
+-            long get_user_pages_remote(struct mm_struct *mm,
+-                                       unsigned long start,
+-                                       unsigned long nr_pages,
+-                                       unsigned int gup_flags,
+-                                       struct page **pages,
+-                                       struct vm_area_struct **vmas,
+-                                       int *locked) {
+-                return 0;
+-            }" > conftest$$.c
+-
+-            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
+-            rm -f conftest$$.c
+-
+-            if [ -f conftest$$.o ]; then
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_TSK_ARG" | append_conftest "functions"
+-                echo "#define NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG" | append_conftest "functions"
+-                rm -f conftest$$.o
+-            else
+-
+-                echo "#define NV_GET_USER_PAGES_REMOTE_HAS_TSK_ARG" | append_conftest "functions"
+-                echo "#undef NV_GET_USER_PAGES_REMOTE_HAS_LOCKED_ARG" | append_conftest "functions"
+-            fi
+-        ;;
+-
+         usleep_range)
+             #
+             # Determine if the function usleep_range() is present.
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0008-RPMFUSION-Linux-6.5-handle-get_user_pages-vmas-argum.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0008-RPMFUSION-Linux-6.5-handle-get_user_pages-vmas-argum.patch.deferred
@@ -1,0 +1,219 @@
+From 9eb2feed8950f3d37c1921894da59e7ca5d7d1ad Mon Sep 17 00:00:00 2001
+From: Paolo Pisati <paolo.pisati@canonical.com>
+Date: Thu, 13 Jul 2023 13:35:33 +0000
+Subject: [PATCH 08/90] RPMFUSION: Linux 6.5: handle get_user_pages() vmas
+ argument removal
+
+commit b2cac248191b7466c5819e0da617b0705a26e197 "mm/gup: removed vmas
+array from internal GUP functions" removed vmas arg from
+__get_user_pages_locked()[*], and to handle that we do two things:
+
+1) when caller vmas arg was NULL, blindly substitute the call with the new API.
+
+2) when caller vmas was a real array (and the caller expected it to be
+   populated upon return), reimplement the internal "for(;;) vma = vma_find(); vmas[i] = vma;"
+   loop that was partially removed.
+
+*: get_user_pages() is a wrapper around __get_user_pages_locked()
+
+Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>
+---
+ kernel/common/inc/nv-mm.h            | 56 +++++++++++++++++++---------
+ kernel/conftest.sh                   | 26 ++++++++++++-
+ kernel/nvidia-drm/nvidia-drm-linux.c |  5 +++
+ kernel/nvidia-uvm/uvm8_tools.c       | 24 ++++++++++++
+ kernel/nvidia/os-mlock.c             |  5 +++
+ 5 files changed, 97 insertions(+), 19 deletions(-)
+
+diff --git a/kernel/common/inc/nv-mm.h b/kernel/common/inc/nv-mm.h
+index 51d0df4..86bf603 100644
+--- a/kernel/common/inc/nv-mm.h
++++ b/kernel/common/inc/nv-mm.h
+@@ -77,24 +77,44 @@ typedef int vm_fault_t;
+     #if defined(NV_GET_USER_PAGES_HAS_WRITE_AND_FORCE_ARGS)
+         #define NV_GET_USER_PAGES get_user_pages
+     #else
+-        #include <linux/mm.h>
+-
+-        static inline long NV_GET_USER_PAGES(unsigned long start,
+-                                             unsigned long nr_pages,
+-                                             int write,
+-                                             int force,
+-                                             struct page **pages,
+-                                             struct vm_area_struct **vmas)
+-        {
+-            unsigned int flags = 0;
+-
+-            if (write)
+-                flags |= FOLL_WRITE;
+-            if (force)
+-                flags |= FOLL_FORCE;
+-
+-            return get_user_pages(start, nr_pages, flags, pages, vmas);
+-        }
++	#if defined(NV_GET_USER_PAGES_DROPPED_VMA)
++            #include <linux/mm.h>
++
++            static inline long NV_GET_USER_PAGES(unsigned long start,
++                                                 unsigned long nr_pages,
++                                                 int write,
++                                                 int force,
++                                                 struct page **pages)
++            {
++                unsigned int flags = 0;
++
++                if (write)
++                    flags |= FOLL_WRITE;
++                if (force)
++                    flags |= FOLL_FORCE;
++
++                return get_user_pages(start, nr_pages, flags, pages);
++            }
++	#else
++            #include <linux/mm.h>
++
++            static inline long NV_GET_USER_PAGES(unsigned long start,
++                                                 unsigned long nr_pages,
++                                                 int write,
++                                                 int force,
++                                                 struct page **pages,
++                                                 struct vm_area_struct **vmas)
++            {
++                unsigned int flags = 0;
++
++                if (write)
++                    flags |= FOLL_WRITE;
++                if (force)
++                    flags |= FOLL_FORCE;
++
++                return get_user_pages(start, nr_pages, flags, pages, vmas);
++            }
++	#endif
+     #endif
+ #endif
+ 
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 4673a63..268bca2 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -3056,7 +3056,6 @@ compile_test() {
+             # write and force parameters AND that gup has task_struct and
+             # mm_struct as its first arguments.
+             # Return if available.
+-            # Fall through to default case if absent.
+ 
+             echo "$CONFTEST_PREAMBLE
+             #include <linux/mm.h>
+@@ -3080,6 +3079,31 @@ compile_test() {
+                 return
+             fi
+ 
++            # Conftest #4: check if vma arg was dropped
++            # Return if available.
++            # Fall through to default case if absent.
++
++            echo "$CONFTEST_PREAMBLE
++            #include <linux/mm.h>
++            long get_user_pages(unsigned long start,
++                                unsigned long nr_pages,
++                                unsigned int gup_flags,
++                                struct page **pages) {
++                return 0;
++            }" > conftest$$.c
++
++            $CC $CFLAGS -c conftest$$.c > /dev/null 2>&1
++            rm -f conftest$$.c
++
++            if [ -f conftest$$.o ]; then
++                echo "#define NV_GET_USER_PAGES_DROPPED_VMA" | append_conftest "functions"
++                echo "#undef NV_GET_USER_PAGES_HAS_WRITE_AND_FORCE_ARGS" | append_conftest "functions"
++                echo "#undef NV_GET_USER_PAGES_HAS_TASK_STRUCT" | append_conftest "functions"
++                 rm -f conftest$$.o
++                return
++            fi
++
++
+             echo "#define NV_GET_USER_PAGES_HAS_WRITE_AND_FORCE_ARGS" | append_conftest "functions"
+             echo "#define NV_GET_USER_PAGES_HAS_TASK_STRUCT" | append_conftest "functions"
+ 
+diff --git a/kernel/nvidia-drm/nvidia-drm-linux.c b/kernel/nvidia-drm/nvidia-drm-linux.c
+index a4c5aeb..96c1661 100644
+--- a/kernel/nvidia-drm/nvidia-drm-linux.c
++++ b/kernel/nvidia-drm/nvidia-drm-linux.c
+@@ -115,8 +115,13 @@ int nv_drm_lock_user_pages(unsigned long address,
+ 
+     nv_mmap_read_lock(mm);
+ 
++#if defined(NV_GET_USER_PAGES_DROPPED_VMA)
++    pages_pinned = NV_GET_USER_PAGES(address, pages_count, write, force,
++		                     user_pages);
++#else
+     pages_pinned = NV_GET_USER_PAGES(address, pages_count, write, force,
+                                      user_pages, NULL);
++#endif
+     nv_mmap_read_unlock(mm);
+ 
+     if (pages_pinned < 0 || (unsigned)pages_pinned < pages_count) {
+diff --git a/kernel/nvidia-uvm/uvm8_tools.c b/kernel/nvidia-uvm/uvm8_tools.c
+index 1dc7c97..ea52194 100644
+--- a/kernel/nvidia-uvm/uvm8_tools.c
++++ b/kernel/nvidia-uvm/uvm8_tools.c
+@@ -251,13 +251,37 @@ static NV_STATUS map_user_pages(NvU64 user_va, NvU64 size, void **addr, struct p
+     }
+ 
+     nv_mmap_read_lock(current->mm);
++#if defined(NV_GET_USER_PAGES_DROPPED_VMA)
++    ret = NV_GET_USER_PAGES(user_va, num_pages, 1, 0, *pages);
++#else
+     ret = NV_GET_USER_PAGES(user_va, num_pages, 1, 0, *pages, vmas);
++#endif
+     nv_mmap_read_unlock(current->mm);
+     if (ret != num_pages) {
+         status = NV_ERR_INVALID_ARGUMENT;
+         goto fail;
+     }
+ 
++#if defined(NV_GET_USER_PAGES_DROPPED_VMA)
++    struct vm_area_struct *vma;
++    unsigned long start;
++
++    nv_mmap_read_lock(current->mm);
++    start = user_va;
++    for (i = 0; i < num_pages; i++) {
++        vma = find_vma(current->mm, start);
++        if (!vma) {
++	    nv_mmap_read_unlock(current->mm);
++	    status = NV_ERR_INVALID_ARGUMENT;
++	    goto fail;
++	}
++
++        vmas[i] = vma;
++        start = (start + PAGE_SIZE) & PAGE_MASK;
++    }
++    nv_mmap_read_unlock(current->mm);
++#endif
++
+     for (i = 0; i < num_pages; i++) {
+         if (page_count((*pages)[i]) > MAX_PAGE_COUNT || uvm_file_is_nvidia_uvm(vmas[i]->vm_file)) {
+             status = NV_ERR_INVALID_ARGUMENT;
+diff --git a/kernel/nvidia/os-mlock.c b/kernel/nvidia/os-mlock.c
+index f88daed..ad5cb9a 100644
+--- a/kernel/nvidia/os-mlock.c
++++ b/kernel/nvidia/os-mlock.c
+@@ -127,8 +127,13 @@ NV_STATUS NV_API_CALL os_lock_user_pages(
+     }
+ 
+     nv_mmap_read_lock(mm);
++#if defined(NV_GET_USER_PAGES_DROPPED_VMA)
++    ret = NV_GET_USER_PAGES((unsigned long)address,
++                            page_count, write, force, user_pages);
++#else
+     ret = NV_GET_USER_PAGES((unsigned long)address,
+                             page_count, write, force, user_pages, NULL);
++#endif
+     nv_mmap_read_unlock(mm);
+     pinned = ret;
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0009-RPMFUSION-backport-drm_gem_prime_handle_to_fd-change.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0009-RPMFUSION-backport-drm_gem_prime_handle_to_fd-change.patch.deferred
@@ -1,0 +1,50 @@
+From de72893d55090b88f290e556053a804f4dcf1b2e Mon Sep 17 00:00:00 2001
+From: Andreas Beckmann <anbe@debian.org>
+Date: Wed, 1 Nov 2023 10:31:40 +0100
+Subject: [PATCH 09/90] RPMFUSION: backport drm_gem_prime_handle_to_fd changes
+ from 470.223.02
+
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c  | 12 ++++++++++++
+ kernel/nvidia-drm/nvidia-drm.Kbuild |  1 +
+ 2 files changed, 13 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index 36fa536..7a1028d 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -705,7 +705,19 @@ static struct drm_driver nv_drm_driver = {
+     .ioctls                 = nv_drm_ioctls,
+     .num_ioctls             = ARRAY_SIZE(nv_drm_ioctls),
+ 
++/*
++ * linux-next commit 71a7974ac701 ("drm/prime: Unexport helpers for fd/handle
++ * conversion") unexports drm_gem_prime_handle_to_fd() and
++ * drm_gem_prime_fd_to_handle().
++ *
++ * Prior linux-next commit 6b85aa68d9d5 ("drm: Enable PRIME import/export for
++ * all drivers") made these helpers the default when .prime_handle_to_fd /
++ * .prime_fd_to_handle are unspecified, so it's fine to just skip specifying
++ * them if the helpers aren't present.
++ */
++#if NV_IS_EXPORT_SYMBOL_PRESENT_drm_gem_prime_handle_to_fd
+     .prime_handle_to_fd     = drm_gem_prime_handle_to_fd,
++#endif
+ 
+ #if defined(NV_DRM_DRIVER_HAS_GEM_PRIME_CALLBACKS)
+     .gem_prime_export       = nv_drm_gem_prime_export,
+diff --git a/kernel/nvidia-drm/nvidia-drm.Kbuild b/kernel/nvidia-drm/nvidia-drm.Kbuild
+index e283874..cb49130 100644
+--- a/kernel/nvidia-drm/nvidia-drm.Kbuild
++++ b/kernel/nvidia-drm/nvidia-drm.Kbuild
+@@ -51,6 +51,7 @@ NV_CONFTEST_GENERIC_COMPILE_TESTS += drm_available
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += drm_atomic_available
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += is_export_symbol_gpl_refcount_inc
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += is_export_symbol_gpl_refcount_dec_and_test
++NV_CONFTEST_GENERIC_COMPILE_TESTS += is_export_symbol_present_drm_gem_prime_handle_to_fd
+ 
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_dev_unref
+ NV_CONFTEST_FUNCTION_COMPILE_TESTS += drm_reinit_primary_mode_group
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0010-RPMFUSION-refuse-to-load-legacy-module-if-IBT-is-ena.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0010-RPMFUSION-refuse-to-load-legacy-module-if-IBT-is-ena.patch.deferred
@@ -1,0 +1,64 @@
+From bb6b9fcd8dca1f6dcaaf643ffa7738657b0f2de5 Mon Sep 17 00:00:00 2001
+From: Andreas Beckmann <anbe@debian.org>
+Date: Sat, 4 Nov 2023 00:44:56 +0100
+Subject: [PATCH 10/90] RPMFUSION: refuse to load legacy module if IBT is
+ enabled
+
+IBT (Indirect Branch Tracking) has been enabled by default (compiled in
+everywhere since it is effectively a no-op and enabled at runtime on
+supported CPUs, i.e. 11th gen. Intel Core processors (aka Tigerlake) or
+newer) since Linux 6.2, it can be disabled by booting with ibt=off.
+All entry points reachable from indirect JMP or CALL instructions need
+to contain the ENDBR instruction (actually just a NOP that is given a
+special meaning by enabling IBT) otherwise the CPU will raise a control
+flow exception.
+
+If the BLOB part of the NVIDIA module hasn't been built with IBT
+support, the module cannot be used if IBT is active. Check for that
+condition and abort module load to avoid kernel errors later.
+
+https://bugs.debian.org/1052069
+---
+ kernel/nvidia-modeset/nvidia-modeset-linux.c | 7 +++++++
+ kernel/nvidia/nv.c                           | 7 +++++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index e98c748..5bed9dd 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -1205,6 +1205,13 @@ static int __init nvkms_init(void)
+ {
+     int ret;
+ 
++#ifdef CONFIG_X86_KERNEL_IBT
++    if (cpu_feature_enabled(X86_FEATURE_IBT)) {
++        printk(KERN_ERR NVKMS_LOG_PREFIX "This NVIDIA driver version is incompatible with IBT. Try booting with ibt=off.");
++        return -EINVAL;
++    }
++#endif
++
+     ret = nvkms_alloc_rm();
+ 
+     if (ret != 0) {
+diff --git a/kernel/nvidia/nv.c b/kernel/nvidia/nv.c
+index 4fa9c23..ad64e88 100644
+--- a/kernel/nvidia/nv.c
++++ b/kernel/nvidia/nv.c
+@@ -776,6 +776,13 @@ int __init nvidia_init_module(void)
+     nv_state_t *nv = NV_STATE_PTR(&nv_ctl_device);
+     nvidia_stack_t *sp = NULL;
+ 
++#ifdef CONFIG_X86_KERNEL_IBT
++    if (cpu_feature_enabled(X86_FEATURE_IBT)) {
++        printk(KERN_ERR "NVRM: This NVIDIA driver version is incompatible with IBT. Try booting with ibt=off.");
++        return -EINVAL;
++    }
++#endif
++
+     if (nv_multiple_kernel_modules)
+     {
+         nv_printf(NV_DBG_INFO, "NVRM: nvidia module instance %d\n",
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0011-RPMFUSION-kernel-6.8-adaptation.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0011-RPMFUSION-kernel-6.8-adaptation.patch.deferred
@@ -1,0 +1,31 @@
+From a505a0b794f9120f6e0d80d5868eaa9003043d21 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:17:17 +0800
+Subject: [PATCH 11/90] RPMFUSION: kernel 6.8 adaptation
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index 7a1028d..f649202 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -654,6 +654,13 @@ static const struct file_operations nv_drm_fops = {
+     .llseek         = noop_llseek,
+ };
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
++// Rel. commit. "drm: Remove locking for legacy ioctls and DRM_UNLOCKED" (Thomas Zimmermann, 22 Nov 2023)
++// Mock this flag, which was already useless on any recent kernel, since it
++// only did something if the driver set DRIVER_LEGACY in driver_features.
++static const enum drm_ioctl_flags DRM_UNLOCKED = 0;
++#endif
++
+ static const struct drm_ioctl_desc nv_drm_ioctls[] = {
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+     DRM_IOCTL_DEF_DRV(NVIDIA_GEM_IMPORT_NVKMS_MEMORY,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0012-RPMFUSION-Linux-6.8-conftest.h-fix-wait_on_bit_lock-.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0012-RPMFUSION-Linux-6.8-conftest.h-fix-wait_on_bit_lock-.patch.deferred
@@ -1,0 +1,47 @@
+From 36d8140b684b06346e8d62545428902aa9b61eb2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Mon, 8 Apr 2024 15:43:34 +0200
+Subject: [PATCH 12/90] RPMFUSION: Linux 6.8: conftest.h fix wait_on_bit_lock
+ function not found
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/conftest.sh | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 268bca2..a46bc44 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -2792,7 +2792,12 @@ compile_test() {
+             #    2014-07-07  743162013d40ca612b4cb53d3a200dff2d9ab26e
+             #
+             echo "$CONFTEST_PREAMBLE
++            #include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+             #include <linux/wait.h>
++#else
++            #include <linux/wait_bit.h>
++#endif
+             void conftest_wait_on_bit_lock(void) {
+                 wait_on_bit_lock(NULL, 0, 0);
+             }" > conftest$$.c
+@@ -2807,7 +2812,12 @@ compile_test() {
+             fi
+ 
+             echo "$CONFTEST_PREAMBLE
++            #include <linux/version.h>
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+             #include <linux/wait.h>
++#else
++            #include <linux/wait_bit.h>
++#endif
+             void conftest_wait_on_bit_lock(void) {
+                 wait_on_bit_lock(NULL, 0, NULL, 0);
+             }" > conftest$$.c
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0013-RPMFUSION-Linux-5.6-nv-linux.h-ioremap_nocache-repla.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0013-RPMFUSION-Linux-5.6-nv-linux.h-ioremap_nocache-repla.patch.deferred
@@ -1,0 +1,33 @@
+From 591ba0dcbdeb27baca844185055804bbce29e1f4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Mon, 8 Apr 2024 16:04:49 +0200
+Subject: [PATCH 13/90] RPMFUSION: Linux 5.6: nv-linux.h ioremap_nocache
+ replaced with ioremap
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/common/inc/nv-linux.h | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index 2c4cb7b..295d5a8 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -565,7 +565,11 @@ static inline void *nv_ioremap(NvU64 phys, NvU64 size)
+ static inline void *nv_ioremap_nocache(NvU64 phys, NvU64 size)
+ {
+ #if defined(NV_IOREMAP_NOCACHE_PRESENT)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 6, 0)
+     void *ptr = ioremap_nocache(phys, size);
++#else
++    void *ptr = ioremap(phys, size);
++#endif
+ #else
+     void *ptr = ioremap(phys, size);
+ #endif
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0014-RPMFUSION-Linux-5.9-nv-linux.h-dma_is_direct-no-long.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0014-RPMFUSION-Linux-5.9-nv-linux.h-dma_is_direct-no-long.patch.deferred
@@ -1,0 +1,32 @@
+From 5272d4eb037bdc33235b5b7ad60ebb88fac2cdae Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Mon, 8 Apr 2024 17:42:05 +0200
+Subject: [PATCH 14/90] RPMFUSION: Linux 5.9: nv-linux.h dma_is_direct no
+ longer available
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/common/inc/nv-linux.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index 295d5a8..d35d064 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -1298,8 +1298,10 @@ static inline NvBool nv_is_dma_direct(struct device *dev)
+     NvBool is_direct = NV_FALSE;
+ 
+ #if defined(NV_DMA_IS_DIRECT_PRESENT)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
+     if (dma_is_direct(get_dma_ops(dev)))
+         is_direct = NV_TRUE;
++#endif
+ #endif
+ 
+     return is_direct;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0015-RPMFUSION-gcc14-no-previous-prototype-for-nv_load_dm.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0015-RPMFUSION-gcc14-no-previous-prototype-for-nv_load_dm.patch.deferred
@@ -1,0 +1,30 @@
+From 54f36a1edbf73ef9d887c334752f6adc12f7ebd0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Mon, 8 Apr 2024 17:48:38 +0200
+Subject: [PATCH 15/90] RPMFUSION: gcc14: no previous prototype for
+ nv_load_dma_map_scatterlist
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia/nv-dma.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/nv-dma.c b/kernel/nvidia/nv-dma.c
+index a06c12c..343e878 100644
+--- a/kernel/nvidia/nv-dma.c
++++ b/kernel/nvidia/nv-dma.c
+@@ -221,7 +221,7 @@ void nv_destroy_dma_map_scatterlist(nv_dma_map_t *dma_map)
+     os_free_mem(dma_map->mapping.discontig.submaps);
+ }
+ 
+-void nv_load_dma_map_scatterlist(
++static void nv_load_dma_map_scatterlist(
+     nv_dma_map_t *dma_map,
+     NvU64 *va_array
+ )
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0016-RPMFUSION-undef-NV_ACPI_BUS_GET_DEVICE_PRESENT-in-co.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0016-RPMFUSION-undef-NV_ACPI_BUS_GET_DEVICE_PRESENT-in-co.patch.deferred
@@ -1,0 +1,37 @@
+From 7fee0ae37c44e30f063e5a2efc7eaa32f788229e Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:18:14 +0800
+Subject: [PATCH 16/90] RPMFUSION: undef NV_ACPI_BUS_GET_DEVICE_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index a46bc44..95aa5e0 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -4451,12 +4451,13 @@ compile_test() {
+             # ("ACPI: bus: Eliminate acpi_bus_get_device()") in
+             # v5.18-rc2 (2022-04-05).
+             #
+-            CODE="
++            #CODE="
+             #include <linux/acpi.h>
+-            int conftest_acpi_bus_get_device(void) {
+-                return acpi_bus_get_device();
+-            }"
+-            compile_check_conftest "$CODE" "NV_ACPI_BUS_GET_DEVICE_PRESENT" "" "functions"
++            #int conftest_acpi_bus_get_device(void) {
++            #    return acpi_bus_get_device();
++            #}"
++            #compile_check_conftest "$CODE" "NV_ACPI_BUS_GET_DEVICE_PRESENT" "" "functions"
++            echo "#undef NV_ACPI_BUS_GET_DEVICE_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         dma_resv_add_fence)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0017-RPMFUSION-add-RPM_CFLAGS-setup-in-conftest.sh.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0017-RPMFUSION-add-RPM_CFLAGS-setup-in-conftest.sh.patch.deferred
@@ -1,0 +1,27 @@
+From f33504fdd8f27eb9bf42029c354944d9c8c8226b Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:19:01 +0800
+Subject: [PATCH 17/90] RPMFUSION: add RPM_CFLAGS setup in conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 95aa5e0..74afb2a 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -154,6 +154,9 @@ build_cflags() {
+     BASE_CFLAGS="-O2 -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"
++       if [ "x${RPM_CFLAGS}" != "x" ] ; then
++               BASE_CFLAGS="${BASE_CFLAGS} ${RPM_CFLAGS}"
++       fi
+ 
+     if [ "$OUTPUT" != "$SOURCES" ]; then
+         OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0018-RPMFUSION-workaround-NV_EFI_ENABLED-macro.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0018-RPMFUSION-workaround-NV_EFI_ENABLED-macro.patch.deferred
@@ -1,0 +1,26 @@
+From 7178994f9a6f56d5cba959cc0180ce6e3766f7b4 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:19:28 +0800
+Subject: [PATCH 18/90] RPMFUSION: workaround NV_EFI_ENABLED macro
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/common/inc/nv-linux.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index d35d064..ddbc68b 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -220,7 +220,7 @@ static inline uid_t __kuid_val(kuid_t uid)
+ #error "NV_EFI_ENABLED_ARGUMENT_COUNT value unrecognized!"
+ #endif
+ #elif (defined(NV_EFI_ENABLED_PRESENT) || defined(efi_enabled))
+-#define NV_EFI_ENABLED() efi_enabled
++#define NV_EFI_ENABLED() efi_enabled(0)
+ #else
+ #define NV_EFI_ENABLED() 0
+ #endif
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0019-RPMFUSION-incompatible-function-type-nv-gpu-numa.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0019-RPMFUSION-incompatible-function-type-nv-gpu-numa.c.patch.deferred
@@ -1,0 +1,46 @@
+From a5484db30f4605e07a72cd7f2f9e108cab7e03ae Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:20:11 +0800
+Subject: [PATCH 19/90] RPMFUSION: incompatible function type nv-gpu-numa.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-gpu-numa.c | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/nv-gpu-numa.c b/kernel/nvidia/nv-gpu-numa.c
+index 7916d35..a87df36 100644
+--- a/kernel/nvidia/nv-gpu-numa.c
++++ b/kernel/nvidia/nv-gpu-numa.c
+@@ -177,6 +177,19 @@ static int filldir_get_memblock_id(struct dir_context *ctx,
+     return 0;
+ }
+ 
++// Wrapper function to cast between incompatible function types from: 
++// int (*)(struct dir_context *, const char *, int,  loff_t,  u64,  unsigned int) to 
++// bool (*)(struct dir_context *, const char *, int,  loff_t,  u64,  unsigned int)
++static bool b_filldir_get_memblock_id(struct dir_context *ctx,
++                                   const char *name,
++                                   int name_len,
++                                   loff_t offset,
++                                   u64 ino,
++                                   unsigned int d_type)
++{
++    return filldir_get_memblock_id(ctx, name, name_len, offset, ino, d_type);
++}
++ 
+ /*
+  * Brings memory block online using the sysfs memory-hotplug interface
+  *   https://www.kernel.org/doc/Documentation/memory-hotplug.txt
+@@ -229,7 +242,7 @@ static NV_STATUS gather_memblock_ids_for_node
+     char numa_file_path[BUF_SIZE];
+     struct file *filp;
+     int err; 
+-    nv_dir_context_t ats_ctx = { .ctx.actor = (filldir_t)filldir_get_memblock_id };
++    nv_dir_context_t ats_ctx = { .ctx.actor = (filldir_t)b_filldir_get_memblock_id };
+ 
+     memset(numa_file_path, 0, sizeof(numa_file_path));
+     sprintf(numa_file_path, "%s%d", NID_PATH, node_id);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0020-RPMFUSION-fix-fallthrough-warning-nv-mmap.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0020-RPMFUSION-fix-fallthrough-warning-nv-mmap.c.patch.deferred
@@ -1,0 +1,25 @@
+From 30ca00ec8833b20ee20a8c7e94316d3c848cd6db Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:21:12 +0800
+Subject: [PATCH 20/90] RPMFUSION: fix fallthrough warning nv-mmap.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-mmap.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia/nv-mmap.c b/kernel/nvidia/nv-mmap.c
+index dcb8b89..392a5e4 100644
+--- a/kernel/nvidia/nv-mmap.c
++++ b/kernel/nvidia/nv-mmap.c
+@@ -261,6 +261,7 @@ int nv_encode_caching(
+         case NV_MEMORY_CACHED:
+             if (NV_ALLOW_CACHING(memory_type))
+                 break;
++            fallthrough;
+         default:
+             nv_printf(NV_DBG_ERRORS,
+                 "NVRM: VM: cache type %d not supported for memory type %d!\n",
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0021-RPMFUSION-no-previous-prototype-for-exercise_error_f.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0021-RPMFUSION-no-previous-prototype-for-exercise_error_f.patch.deferred
@@ -1,0 +1,27 @@
+From 46d561df3950e0c8e79d50f13fbb842af5952c59 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:29:04 +0800
+Subject: [PATCH 21/90] RPMFUSION: no previous prototype for
+ exercise_error_forwarding_va
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-procfs.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/nv-procfs.c b/kernel/nvidia/nv-procfs.c
+index 167b21f..aed7717 100644
+--- a/kernel/nvidia/nv-procfs.c
++++ b/kernel/nvidia/nv-procfs.c
+@@ -426,7 +426,7 @@ static nv_proc_ops_t nv_procfs_registry_fops = {
+ /*
+  * Forwards error to nv_log_error which exposes data to vendor callback
+  */
+-void
++static void
+ exercise_error_forwarding_va(
+     nv_state_t *nv,
+     NvU32 err,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0022-RPMFUSION-undef-NV_DO_GETTIMEOFDAY_PRESENT-in-confte.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0022-RPMFUSION-undef-NV_DO_GETTIMEOFDAY_PRESENT-in-confte.patch.deferred
@@ -1,0 +1,41 @@
+From a960ef1150955ed0d35f3cc81fbea32b39f81ba5 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:30:13 +0800
+Subject: [PATCH 22/90] RPMFUSION: undef NV_DO_GETTIMEOFDAY_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 74afb2a..e85173b 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -3717,16 +3717,17 @@ compile_test() {
+             # 97fc79f97b1111c80010d34ee66312b88f531e41 (2006-06-09) in v2.6.16,
+             # includes linux/time.h and/or linux/timekeeping.h.
+             #
+-            CODE="
++            #CODE="
+             #include <linux/time.h>
+             #if defined(NV_LINUX_KTIME_H_PRESENT)
+             #include <linux/ktime.h>
+             #endif
+-            void conftest_do_gettimeofday(void) {
+-                do_gettimeofday();
+-            }"
++            #void conftest_do_gettimeofday(void) {
++            #    do_gettimeofday();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_DO_GETTIMEOFDAY_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_DO_GETTIMEOFDAY_PRESENT" "" "functions"
++            echo "#undef NV_DO_GETTIMEOFDAY_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         drm_framebuffer_get)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0023-RPMFUSION-undef-NV_SET_MEMORY_ARRAY_UC_PRESENT-in-co.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0023-RPMFUSION-undef-NV_SET_MEMORY_ARRAY_UC_PRESENT-in-co.patch.deferred
@@ -1,0 +1,44 @@
+From 184c85cff71f976394cc03ebde69bcfbb3c719b7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:30:32 +0800
+Subject: [PATCH 23/90] RPMFUSION: undef NV_SET_MEMORY_ARRAY_UC_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index e85173b..cb7cb3c 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -453,7 +453,7 @@ compile_test() {
+             #
+             # Determine if the set_memory_array_uc() function is present.
+             #
+-            CODE="
++            #CODE="
+             #if defined(NV_ASM_SET_MEMORY_H_PRESENT)
+             #if defined(NV_ASM_PGTABLE_TYPES_H_PRESENT)
+             #include <asm/pgtable_types.h>
+@@ -462,11 +462,12 @@ compile_test() {
+             #else
+             #include <asm/cacheflush.h>
+             #endif
+-            void conftest_set_memory_array_uc(void) {
+-                set_memory_array_uc();
+-            }"
++            #void conftest_set_memory_array_uc(void) {
++            #    set_memory_array_uc();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_SET_MEMORY_ARRAY_UC_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_SET_MEMORY_ARRAY_UC_PRESENT" "" "functions"
++            echo "#undef NV_SET_MEMORY_ARRAY_UC_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         sysfs_slab_unlink)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0024-RPMFUSION-undef-NV_ACQUIRE_CONSOLE_SEM_PRESENT-in-co.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0024-RPMFUSION-undef-NV_ACQUIRE_CONSOLE_SEM_PRESENT-in-co.patch.deferred
@@ -1,0 +1,38 @@
+From 79de2b232fc2fa01b62699f2b4f502605a7d5843 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:30:50 +0800
+Subject: [PATCH 24/90] RPMFUSION: undef NV_ACQUIRE_CONSOLE_SEM_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index cb7cb3c..3f5cf30 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -895,13 +895,14 @@ compile_test() {
+             # Determine if the acquire_console_sem() function
+             # is present.
+             #
+-            CODE="
++            #CODE="
+             #include <linux/console.h>
+-            void conftest_acquire_console_sem(void) {
+-                acquire_console_sem(NULL);
+-            }"
++            #void conftest_acquire_console_sem(void) {
++            #    acquire_console_sem(NULL);
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_ACQUIRE_CONSOLE_SEM_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_ACQUIRE_CONSOLE_SEM_PRESENT" "" "functions"
++            echo "#undef NV_ACQUIRE_CONSOLE_SEM_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         console_lock)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0025-RPMFUSION-undef-NV_UNSAFE_FOLLOW_PFN_PRESENT-in-conf.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0025-RPMFUSION-undef-NV_UNSAFE_FOLLOW_PFN_PRESENT-in-conf.patch.deferred
@@ -1,0 +1,38 @@
+From 58cffb882c7f2bbdd8296a32a03ba6ef334edd78 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:31:15 +0800
+Subject: [PATCH 25/90] RPMFUSION: undef NV_UNSAFE_FOLLOW_PFN_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 3f5cf30..47800d8 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -4380,13 +4380,14 @@ compile_test() {
+             # unsafe_follow_pfn() was added by commit 69bacee7f9ad
+             # ("mm: Add unsafe_follow_pfn") in v5.13-rc1.
+             #
+-            CODE="
++            #CODE="
+             #include <linux/mm.h>
+-            void conftest_unsafe_follow_pfn(void) {
+-                unsafe_follow_pfn();
+-            }"
++            #void conftest_unsafe_follow_pfn(void) {
++            #    unsafe_follow_pfn();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_UNSAFE_FOLLOW_PFN_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_UNSAFE_FOLLOW_PFN_PRESENT" "" "functions"
++            echo "#undef NV_UNSAFE_FOLLOW_PFN_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         drm_plane_atomic_check_has_atomic_state_arg)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0026-RPMFUSION-undef-NV_JIFFIES_TO_TIMESPEC_PRESENT-in-co.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0026-RPMFUSION-undef-NV_JIFFIES_TO_TIMESPEC_PRESENT-in-co.patch.deferred
@@ -1,0 +1,37 @@
+From 7497f201000151f401664a9ea242c5400db9f469 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 13:31:38 +0800
+Subject: [PATCH 26/90] RPMFUSION: undef NV_JIFFIES_TO_TIMESPEC_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 47800d8..2078d00 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -2542,12 +2542,13 @@ compile_test() {
+             # removed by commit 751addac78b6
+             # ("y2038: remove obsolete jiffies conversion functions")
+             # in v5.6-rc1 (2019-12-13).
+-        CODE="
++        #CODE="
+         #include <linux/jiffies.h>
+-        void conftest_jiffies_to_timespec(void){
+-            jiffies_to_timespec();
+-        }"
+-            compile_check_conftest "$CODE" "NV_JIFFIES_TO_TIMESPEC_PRESENT" "" "functions"
++        #void conftest_jiffies_to_timespec(void){
++        #    jiffies_to_timespec();
++        #}"
++        #    compile_check_conftest "$CODE" "NV_JIFFIES_TO_TIMESPEC_PRESENT" "" "functions"
++            echo "#undef NV_JIFFIES_TO_TIMESPEC_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         drm_init_function_args)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0027-RPMFUSION-undef-NV_PNV_NPU2_INIT_CONTEXT_PRESENT-in-.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0027-RPMFUSION-undef-NV_PNV_NPU2_INIT_CONTEXT_PRESENT-in-.patch.deferred
@@ -1,0 +1,41 @@
+From ca57d5a6ab6b7c8a75b171a99a070ecbca4c6066 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:34:24 +0800
+Subject: [PATCH 27/90] RPMFUSION: undef NV_PNV_NPU2_INIT_CONTEXT_PRESENT in
+ conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 2078d00..6a7bf03 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -3312,16 +3312,17 @@ compile_test() {
+             # Determine if the pnv_npu2_init_context() function is
+             # present.
+             #
+-            CODE="
++            #CODE="
+             #if defined(NV_ASM_POWERNV_H_PRESENT)
+             #include <linux/pci.h>
+             #include <asm/powernv.h>
+             #endif
+-            void conftest_pnv_npu2_init_context(void) {
+-                pnv_npu2_init_context();
+-            }"
++            #void conftest_pnv_npu2_init_context(void) {
++            #    pnv_npu2_init_context();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_PNV_NPU2_INIT_CONTEXT_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_PNV_NPU2_INIT_CONTEXT_PRESENT" "" "functions"
++            echo "#undef NV_PNV_NPU2_INIT_CONTEXT_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         drm_driver_unload_has_int_return_type)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0028-RPMFUSION-fix-atomic64-include-in-conftest.sh.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0028-RPMFUSION-fix-atomic64-include-in-conftest.sh.patch.deferred
@@ -1,0 +1,30 @@
+From 2dee46b3a86149dc43e09bb22cf2649ef1d2199c Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:34:59 +0800
+Subject: [PATCH 28/90] RPMFUSION: fix atomic64 include in conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 6a7bf03..4e6bf27 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -1906,7 +1906,11 @@ compile_test() {
+         atomic64_type)
+             # Determine if atomic64_t and associated functions are defined
+             CODE="
+-            #include <asm/atomic.h>
++            #include <linux/init.h>
++            #include <linux/bug.h>
++            #include <linux/kernel.h>
++            #include <linux/atomic.h>
++            #include <linux/module.h>
+             void conftest_atomic64(void) {
+                 atomic64_t data;
+                 atomic64_read(&data);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0029-RPMFUSION-fix-dma_buf_map-renamed-to-iosys_map.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0029-RPMFUSION-fix-dma_buf_map-renamed-to-iosys_map.patch.deferred
@@ -1,0 +1,32 @@
+From fb2e64d3f9ab9374239a8feaa853983d29d4a9f8 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:35:25 +0800
+Subject: [PATCH 29/90] RPMFUSION: fix dma_buf_map renamed to iosys_map
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 4e6bf27..ae41aad 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -4371,8 +4371,13 @@ compile_test() {
+             #
+             CODE="
+             #include <drm/drm_gem.h>
++            #if defined(NV_LINUX_IOSYS_MAP_H_PRESENT)
++            typedef struct iosys_map nv_sysio_map_t;
++            #else
++            typedef struct dma_buf_map nv_sysio_map_t;
++            #endif
+             int conftest_drm_gem_object_vmap_has_map_arg(
+-                    struct drm_gem_object *obj, struct dma_buf_map *map) {
++                    struct drm_gem_object *obj, nv_sysio_map_t *map) {
+                 return obj->funcs->vmap(obj, map);
+             }"
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0030-RPMFUSION-no-previous-prototype-for-nv_pci_register_.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0030-RPMFUSION-no-previous-prototype-for-nv_pci_register_.patch.deferred
@@ -1,0 +1,26 @@
+From e19371939cbc67f0c870da7b77a9cac35ea2ea63 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:36:22 +0800
+Subject: [PATCH 30/90] RPMFUSION: no previous prototype for
+ nv_pci_register_driver
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-instance.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia/nv-instance.c b/kernel/nvidia/nv-instance.c
+index 33d39c2..2ebc0f5 100644
+--- a/kernel/nvidia/nv-instance.c
++++ b/kernel/nvidia/nv-instance.c
+@@ -13,6 +13,7 @@
+ #include "nv-linux.h"
+ #include "nv-frontend.h"
+ #include "nv-pci-table.h"
++#include "nv-instance.h"
+ 
+ #define MODULE_BASE_NAME "nvidia"
+ #define MODULE_INSTANCE_NUMBER 0
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0031-RPMFUSION-no-previous-prototype-for-nvidia_init_exit.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0031-RPMFUSION-no-previous-prototype-for-nvidia_init_exit.patch.deferred
@@ -1,0 +1,34 @@
+From 281df21b55c43f3efbb35e4f5032d4c87e0ec8f1 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:36:58 +0800
+Subject: [PATCH 31/90] RPMFUSION: no previous prototype for
+ nvidia_init_exit_module in nv.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel/nvidia/nv.c b/kernel/nvidia/nv.c
+index ad64e88..ef655d5 100644
+--- a/kernel/nvidia/nv.c
++++ b/kernel/nvidia/nv.c
+@@ -768,6 +768,7 @@ int nv_verify_cpa_interface(void)
+ }
+ #endif /* defined(NV_CHANGE_PAGE_ATTR_BUG_PRESENT) */
+ 
++int __init nvidia_init_module(void);
+ int __init nvidia_init_module(void)
+ {
+     NV_STATUS status;
+@@ -1165,6 +1166,7 @@ failed6:
+     return rc;
+ }
+ 
++void nvidia_exit_module(void);
+ void nvidia_exit_module(void)
+ {
+     nvidia_stack_t *sp = __nv_init_sp;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0032-RPMFUSION-no-previous-prototype-for-on_nv_assert.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0032-RPMFUSION-no-previous-prototype-for-on_nv_assert.patch.deferred
@@ -1,0 +1,26 @@
+From b269d1b24cc22553f5804aa3ca35ff64b5ea1b41 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:37:37 +0800
+Subject: [PATCH 32/90] RPMFUSION: no previous prototype for on_nv_assert
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-kthread-q-selftest.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/nv-kthread-q-selftest.c b/kernel/nvidia/nv-kthread-q-selftest.c
+index a8db326..61f01fb 100644
+--- a/kernel/nvidia/nv-kthread-q-selftest.c
++++ b/kernel/nvidia/nv-kthread-q-selftest.c
+@@ -71,7 +71,7 @@
+ #define NUM_Q_ITEMS_IN_MULTITHREAD_TEST (NUM_TEST_Q_ITEMS * NUM_TEST_KTHREADS)
+ 
+ // This exists in order to have a function to place a breakpoint on:
+-void on_nvq_assert(void)
++static void on_nvq_assert(void)
+ {
+     (void)NULL;
+ }
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0033-RPMFUSION-no-previous-prototype-for-_raw_q_flush.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0033-RPMFUSION-no-previous-prototype-for-_raw_q_flush.patch.deferred
@@ -1,0 +1,26 @@
+From 7b41631da7708299418ea9c70ac8bd472fd7ded7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:37:59 +0800
+Subject: [PATCH 33/90] RPMFUSION: no previous prototype for _raw_q_flush
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-kthread-q.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/nv-kthread-q.c b/kernel/nvidia/nv-kthread-q.c
+index 9c475b7..6e4e8a3 100644
+--- a/kernel/nvidia/nv-kthread-q.c
++++ b/kernel/nvidia/nv-kthread-q.c
+@@ -241,7 +241,7 @@ static void _q_flush_function(void *args)
+ }
+ 
+ 
+-void _raw_q_flush(nv_kthread_q_t *q)
++static void _raw_q_flush(nv_kthread_q_t *q)
+ {
+     nv_kthread_q_item_t q_item;
+     DECLARE_COMPLETION(completion);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0034-RPMFUSION-no-previous-prototype-for-nv-ibmnpu-functi.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0034-RPMFUSION-no-previous-prototype-for-nv-ibmnpu-functi.patch.deferred
@@ -1,0 +1,28 @@
+From 31de4764d3c02e32c35d723c23b02a54ab489ebe Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:39:21 +0800
+Subject: [PATCH 34/90] RPMFUSION: no previous prototype for nv-ibmnpu
+ functions
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nv-ibmnpu.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia/nv-ibmnpu.c b/kernel/nvidia/nv-ibmnpu.c
+index 50503e1..545d261 100644
+--- a/kernel/nvidia/nv-ibmnpu.c
++++ b/kernel/nvidia/nv-ibmnpu.c
+@@ -26,8 +26,8 @@
+  */
+ #include "nv-linux.h"
+ 
+-#if defined(NVCPU_PPC64LE)
+ #include "nv-ibmnpu.h"
++#if defined(NVCPU_PPC64LE)
+ 
+ #include "nvlink_common.h"
+ #include "nvlink_errors.h"
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0035-RPMFUSION-no-previous-prototype-for-uvm_tools_init_e.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0035-RPMFUSION-no-previous-prototype-for-uvm_tools_init_e.patch.deferred
@@ -1,0 +1,26 @@
+From 77480ba72f84695b0f8b1912f2b05946c36adf35 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:40:00 +0800
+Subject: [PATCH 35/90] RPMFUSION: no previous prototype for
+ uvm_tools_init_exit
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_tools.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_tools.c b/kernel/nvidia-uvm/uvm8_tools.c
+index ea52194..e1b72c3 100644
+--- a/kernel/nvidia-uvm/uvm8_tools.c
++++ b/kernel/nvidia-uvm/uvm8_tools.c
+@@ -33,6 +33,7 @@
+ #include "uvm8_forward_decl.h"
+ #include "uvm8_range_group.h"
+ #include "uvm8_mem.h"
++#include "uvm8_tools_init.h"
+ 
+ // We limit the number of times a page can be retained by the kernel
+ // to prevent the user from maliciously passing UVM tools the same page
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0036-RPMFUSION-no-previous-prototype-for-uvm8_test_set_pr.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0036-RPMFUSION-no-previous-prototype-for-uvm8_test_set_pr.patch.deferred
@@ -1,0 +1,26 @@
+From 8432bf0e147453792967d441c06082a357f5c360 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:40:22 +0800
+Subject: [PATCH 36/90] RPMFUSION: no previous prototype for
+ uvm8_test_set_prefetch_filtering
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_gpu.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_gpu.c b/kernel/nvidia-uvm/uvm8_gpu.c
+index 775dd09..66e2148 100644
+--- a/kernel/nvidia-uvm/uvm8_gpu.c
++++ b/kernel/nvidia-uvm/uvm8_gpu.c
+@@ -38,6 +38,7 @@
+ #include "ctrl2080mc.h"
+ #include "nv-kthread-q.h"
+ #include "uvm8_gpu_access_counters.h"
++#include "uvm8_test.h"
+ 
+ int uvm8_ats_mode = 0;
+ module_param(uvm8_ats_mode, int, S_IRUGO);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0037-RPMFUSION-no-previous-prototype-in-uvm8_va_space.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0037-RPMFUSION-no-previous-prototype-in-uvm8_va_space.c.patch.deferred
@@ -1,0 +1,26 @@
+From d37d1b71ac70f5041af24b9c33799e1cb341e03c Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:40:57 +0800
+Subject: [PATCH 37/90] RPMFUSION: no previous prototype in uvm8_va_space.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_va_space.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_va_space.c b/kernel/nvidia-uvm/uvm8_va_space.c
+index 42b7bb9..0744d6b 100644
+--- a/kernel/nvidia-uvm/uvm8_va_space.c
++++ b/kernel/nvidia-uvm/uvm8_va_space.c
+@@ -34,6 +34,8 @@
+ #include "uvm_common.h"
+ #include "nv_uvm_interface.h"
+ #include "nv-kthread-q.h"
++#include "uvm8_api.h"
++#include "uvm8_test.h"
+ 
+ static NV_STATUS enable_peers(uvm_va_space_t *va_space, uvm_gpu_t *gpu_1, uvm_gpu_t *gpu_2);
+ static void disable_peers(uvm_va_space_t *va_space,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0038-RPMFUSION-no-previous-prototype-for-uvm_channel_mana.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0038-RPMFUSION-no-previous-prototype-for-uvm_channel_mana.patch.deferred
@@ -1,0 +1,27 @@
+From c53f2b57846a2638ebca04875d66e38ae0f9730c Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:41:20 +0800
+Subject: [PATCH 38/90] RPMFUSION: no previous prototype for
+ uvm_channel_manager_print_pending_pushes
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_channel.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_channel.c b/kernel/nvidia-uvm/uvm8_channel.c
+index ed52910..7edede9 100644
+--- a/kernel/nvidia-uvm/uvm8_channel.c
++++ b/kernel/nvidia-uvm/uvm8_channel.c
+@@ -1137,7 +1137,7 @@ void uvm_channel_print_pending_pushes(uvm_channel_t *channel)
+     channel_print_pushes(channel, 0, NULL);
+ }
+ 
+-void uvm_channel_manager_print_pending_pushes(uvm_channel_manager_t *manager, struct seq_file *seq)
++static void uvm_channel_manager_print_pending_pushes(uvm_channel_manager_t *manager, struct seq_file *seq)
+ {
+     uvm_channel_t *channel;
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0039-RPMFUSION-no-previous-prototype-in-uvm8_va_range.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0039-RPMFUSION-no-previous-prototype-in-uvm8_va_range.c.patch.deferred
@@ -1,0 +1,26 @@
+From 2906657d4294def3bfdb9ac729f198ed7fae5f01 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:44:02 +0800
+Subject: [PATCH 39/90] RPMFUSION: no previous prototype in uvm8_va_range.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_va_range.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_va_range.c b/kernel/nvidia-uvm/uvm8_va_range.c
+index a1fb44c..08f8a05 100644
+--- a/kernel/nvidia-uvm/uvm8_va_range.c
++++ b/kernel/nvidia-uvm/uvm8_va_range.c
+@@ -559,7 +559,7 @@ NV_STATUS uvm_va_range_add_gpu_va_space(uvm_va_range_t *va_range, uvm_gpu_va_spa
+     }
+ }
+ 
+-void uvm_va_range_remove_gpu_va_space_managed(uvm_va_range_t *va_range, uvm_gpu_va_space_t *gpu_va_space)
++static void uvm_va_range_remove_gpu_va_space_managed(uvm_va_range_t *va_range, uvm_gpu_va_space_t *gpu_va_space)
+ {
+     uvm_va_block_t *va_block;
+     uvm_va_space_t *va_space = va_range->va_space;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0040-RPMFUSION-no-previous-prototype-in-uvm8_range_group..patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0040-RPMFUSION-no-previous-prototype-in-uvm8_range_group..patch.deferred
@@ -1,0 +1,50 @@
+From 0d4971ee3c9741586df3dafee979874817cf6de8 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:45:25 +0800
+Subject: [PATCH 40/90] RPMFUSION: no previous prototype in uvm8_range_group.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_range_group.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_range_group.c b/kernel/nvidia-uvm/uvm8_range_group.c
+index 307aaa2..19760b3 100644
+--- a/kernel/nvidia-uvm/uvm8_range_group.c
++++ b/kernel/nvidia-uvm/uvm8_range_group.c
+@@ -29,6 +29,7 @@
+ #include "uvm_ioctl.h"
+ #include "uvmtypes.h"
+ #include "uvm8_api.h"
++#include "uvm8_test.h"
+ 
+ static struct kmem_cache *g_uvm_range_group_cache __read_mostly;
+ static struct kmem_cache *g_uvm_range_group_range_cache __read_mostly;
+@@ -506,13 +507,13 @@ static uvm_range_group_range_t *range_group_range_container(uvm_range_tree_node_
+     return container_of(node, uvm_range_group_range_t, node);
+ }
+ 
+-uvm_range_group_range_t *uvm_range_group_range_prev(uvm_va_space_t *va_space, uvm_range_group_range_t *range)
++static uvm_range_group_range_t *uvm_range_group_range_prev(uvm_va_space_t *va_space, uvm_range_group_range_t *range)
+ {
+     uvm_range_tree_node_t *node = uvm_range_tree_prev(&va_space->range_group_ranges, &range->node);
+     return range_group_range_container(node);
+ }
+ 
+-uvm_range_group_range_t *uvm_range_group_range_next(uvm_va_space_t *va_space, uvm_range_group_range_t *range)
++static uvm_range_group_range_t *uvm_range_group_range_next(uvm_va_space_t *va_space, uvm_range_group_range_t *range)
+ {
+     uvm_range_tree_node_t *node = uvm_range_tree_next(&va_space->range_group_ranges, &range->node);
+     return range_group_range_container(node);
+@@ -664,7 +665,7 @@ uvm_range_group_range_t *uvm_range_group_range_iter_next(uvm_va_space_t *va_spac
+     return range_group_range_container(node);
+ }
+ 
+-void range_group_range_iter_advance(uvm_range_group_range_iter_t *iter, NvU64 end)
++static void range_group_range_iter_advance(uvm_range_group_range_iter_t *iter, NvU64 end)
+ {
+     if (iter->node == NULL) {
+         iter->end = end;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0041-RPMFUSION-no-previous-prototype-in-uvm8_gpu_replayab.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0041-RPMFUSION-no-previous-prototype-in-uvm8_gpu_replayab.patch.deferred
@@ -1,0 +1,26 @@
+From fb53801d5fbf35de3c28b89b02744c413902dc4c Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:47:35 +0800
+Subject: [PATCH 41/90] RPMFUSION: no previous prototype in
+ uvm8_gpu_replayable_faults.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c b/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c
+index f2279b6..9e1f468 100644
+--- a/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c
++++ b/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c
+@@ -35,6 +35,7 @@
+ #include "uvm8_procfs.h"
+ #include "uvm8_perf_thrashing.h"
+ #include "uvm8_gpu_non_replayable_faults.h"
++#include "uvm8_test.h"
+ 
+ // TODO: Bug 1881601: [uvm] Add fault handling overview for replayable and
+ // non-replayable faults
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0042-RPMFUSION-no-previous-prototype-for-block_map.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0042-RPMFUSION-no-previous-prototype-for-block_map.patch.deferred
@@ -1,0 +1,26 @@
+From e477c2288fda044e0fa55bd309c8d3eb1d20908f Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:47:55 +0800
+Subject: [PATCH 42/90] RPMFUSION: no previous prototype for block_map
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_va_block.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_va_block.c b/kernel/nvidia-uvm/uvm8_va_block.c
+index be6d873..6319251 100644
+--- a/kernel/nvidia-uvm/uvm8_va_block.c
++++ b/kernel/nvidia-uvm/uvm8_va_block.c
+@@ -6521,7 +6521,7 @@ static void map_get_allowed_destinations(uvm_va_block_t *block,
+     uvm_processor_mask_and(allowed_mask, allowed_mask, &va_space->can_access[id]);
+ }
+ 
+-NV_STATUS block_map(uvm_va_block_t *va_block,
++static NV_STATUS block_map(uvm_va_block_t *va_block,
+                     uvm_va_block_context_t *va_block_context,
+                     uvm_processor_id_t id,
+                     uvm_va_block_region_t region,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0043-RPMFUSION-no-previous-prototype-for-try_get_ptes.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0043-RPMFUSION-no-previous-prototype-for-try_get_ptes.patch.deferred
@@ -1,0 +1,26 @@
+From de078e2d1f555fbae251472da83371f3663bcece Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:48:12 +0800
+Subject: [PATCH 43/90] RPMFUSION: no previous prototype for try_get_ptes
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_mmu.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_mmu.c b/kernel/nvidia-uvm/uvm8_mmu.c
+index 2b90a3c..86518f5 100644
+--- a/kernel/nvidia-uvm/uvm8_mmu.c
++++ b/kernel/nvidia-uvm/uvm8_mmu.c
+@@ -695,7 +695,7 @@ NV_STATUS uvm_page_tree_wait(uvm_page_tree_t *tree)
+     return status;
+ }
+ 
+-NV_STATUS try_get_ptes(uvm_page_tree_t *tree,
++static NV_STATUS try_get_ptes(uvm_page_tree_t *tree,
+                        NvU32 page_size,
+                        NvU64 start,
+                        NvLength size,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0044-RPMFUSION-no-previous-prototype-in-uvm8_pushbuffer.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0044-RPMFUSION-no-previous-prototype-in-uvm8_pushbuffer.c.patch.deferred
@@ -1,0 +1,35 @@
+From 5fbc7725fdf26383f8202de93b9a693ca8af6ead Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:50:56 +0800
+Subject: [PATCH 44/90] RPMFUSION: no previous prototype in uvm8_pushbuffer.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_pushbuffer.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_pushbuffer.c b/kernel/nvidia-uvm/uvm8_pushbuffer.c
+index 3007f00..8eb686b 100644
+--- a/kernel/nvidia-uvm/uvm8_pushbuffer.c
++++ b/kernel/nvidia-uvm/uvm8_pushbuffer.c
+@@ -109,7 +109,7 @@ error:
+     return status;
+ }
+ 
+-NvLength uvm_pushbuffer_get_size(uvm_pushbuffer_t *pushbuffer)
++static NvLength uvm_pushbuffer_get_size(uvm_pushbuffer_t *pushbuffer)
+ {
+     return pushbuffer->memory->size;
+ }
+@@ -210,7 +210,7 @@ static NvU32 *chunk_get_next_push_start_addr(uvm_pushbuffer_t *pushbuffer, uvm_p
+     return (NvU32*)push_start;
+ }
+ 
+-void uvm_pushbuffer_update_progress(uvm_pushbuffer_t *pushbuffer)
++static void uvm_pushbuffer_update_progress(uvm_pushbuffer_t *pushbuffer)
+ {
+     uvm_channel_manager_update_progress(pushbuffer->channel_manager);
+ }
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0045-RPMFUSION-no-previous-prototype-in-uvm8_kepler_mmu.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0045-RPMFUSION-no-previous-prototype-in-uvm8_kepler_mmu.c.patch.deferred
@@ -1,0 +1,25 @@
+From dc53f0fcefcf1a99934d69e94f32526a6150e2d7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:51:16 +0800
+Subject: [PATCH 45/90] RPMFUSION: no previous prototype in uvm8_kepler_mmu.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_kepler_mmu.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_kepler_mmu.c b/kernel/nvidia-uvm/uvm8_kepler_mmu.c
+index ba46019..c9a1660 100644
+--- a/kernel/nvidia-uvm/uvm8_kepler_mmu.c
++++ b/kernel/nvidia-uvm/uvm8_kepler_mmu.c
+@@ -40,6 +40,7 @@
+ #include "uvm8_mmu.h"
+ #include "uvm8_push_macros.h"
+ #include "hwref/kepler/gk104/dev_mmu.h"
++#include "uvm8_hal.h"
+ 
+ #define MMU_BIG 0
+ #define MMU_SMALL 1
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0046-RPMFUSION-no-previous-prototype-in-uvm8_pascal_mmu.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0046-RPMFUSION-no-previous-prototype-in-uvm8_pascal_mmu.c.patch.deferred
@@ -1,0 +1,25 @@
+From 456f6542129b009d46373752fdfe9d4f503483e6 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:51:41 +0800
+Subject: [PATCH 46/90] RPMFUSION: no previous prototype in uvm8_pascal_mmu.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_pascal_mmu.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_pascal_mmu.c b/kernel/nvidia-uvm/uvm8_pascal_mmu.c
+index b3bf7b6..5719fa4 100644
+--- a/kernel/nvidia-uvm/uvm8_pascal_mmu.c
++++ b/kernel/nvidia-uvm/uvm8_pascal_mmu.c
+@@ -38,6 +38,7 @@
+ #include "uvm8_push_macros.h"
+ #include "hwref/pascal/gp100/dev_fb.h"
+ #include "hwref/pascal/gp100/dev_mmu.h"
++#include "uvm8_hal.h"
+ 
+ #define MMU_BIG 0
+ #define MMU_SMALL 1
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0047-RPMFUSION-no-previous-prototype-for-parse_fault_entr.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0047-RPMFUSION-no-previous-prototype-for-parse_fault_entr.patch.deferred
@@ -1,0 +1,27 @@
+From cf1c3d0c3fa4099c8699b6503985f5d9559fb26e Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:52:02 +0800
+Subject: [PATCH 47/90] RPMFUSION: no previous prototype for
+ parse_fault_entry_common
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_volta_fault_buffer.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_volta_fault_buffer.c b/kernel/nvidia-uvm/uvm8_volta_fault_buffer.c
+index 5ab6a81..b85352e 100644
+--- a/kernel/nvidia-uvm/uvm8_volta_fault_buffer.c
++++ b/kernel/nvidia-uvm/uvm8_volta_fault_buffer.c
+@@ -351,7 +351,7 @@ static NvU32 *get_fault_buffer_entry(uvm_gpu_t *gpu, NvU32 index)
+     return fault_entry;
+ }
+ 
+-void parse_fault_entry_common(uvm_gpu_t *gpu, NvU32 *fault_entry, uvm_fault_buffer_entry_t *buffer_entry)
++static void parse_fault_entry_common(uvm_gpu_t *gpu, NvU32 *fault_entry, uvm_fault_buffer_entry_t *buffer_entry)
+ {
+     NV_STATUS status;
+     NvU64 addr_hi, addr_lo;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0048-RPMFUSION-no-previous-prototype-in-uvm8_volta_access.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0048-RPMFUSION-no-previous-prototype-in-uvm8_volta_access.patch.deferred
@@ -1,0 +1,26 @@
+From ed7803a007e4dec31e00079e9408c06c86f6852f Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:52:20 +0800
+Subject: [PATCH 48/90] RPMFUSION: no previous prototype in
+ uvm8_volta_access_counter_buffer.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_volta_access_counter_buffer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_volta_access_counter_buffer.c b/kernel/nvidia-uvm/uvm8_volta_access_counter_buffer.c
+index 992cca5..3fedfc2 100644
+--- a/kernel/nvidia-uvm/uvm8_volta_access_counter_buffer.c
++++ b/kernel/nvidia-uvm/uvm8_volta_access_counter_buffer.c
+@@ -25,6 +25,7 @@
+ #include "uvm8_gpu.h"
+ #include "clc365.h"
+ #include "uvm8_volta_fault_buffer.h"
++#include "uvm8_hal.h"
+ 
+ typedef struct {
+     NvU8 bufferEntry[NVC365_NOTIFY_BUF_SIZE];
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0049-RPMFUSION-no-previous-prototype-for-va_block_set_rea.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0049-RPMFUSION-no-previous-prototype-for-va_block_set_rea.patch.deferred
@@ -1,0 +1,27 @@
+From 95366e275f92c0e0296cbf162d36e4e7ea31300d Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:53:32 +0800
+Subject: [PATCH 49/90] RPMFUSION: no previous prototype for
+ va_block_set_read_duplication_locked
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_policy.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_policy.c b/kernel/nvidia-uvm/uvm8_policy.c
+index 03b1a90..eb3523c 100644
+--- a/kernel/nvidia-uvm/uvm8_policy.c
++++ b/kernel/nvidia-uvm/uvm8_policy.c
+@@ -354,7 +354,7 @@ NV_STATUS uvm_api_unset_accessed_by(UVM_UNSET_ACCESSED_BY_PARAMS *params, struct
+     return accessed_by_set(va_space, params->requestedBase, params->length, &params->accessedByUuid, false);
+ }
+ 
+-NV_STATUS va_block_set_read_duplication_locked(uvm_va_block_t *va_block,
++static NV_STATUS va_block_set_read_duplication_locked(uvm_va_block_t *va_block,
+                                                uvm_va_block_retry_t *va_block_retry,
+                                                uvm_va_block_context_t *va_block_context)
+ {
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0050-RPMFUSION-no-previous-prototype-for-map_rm_pt_range.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0050-RPMFUSION-no-previous-prototype-for-map_rm_pt_range.patch.deferred
@@ -1,0 +1,26 @@
+From 364297f23c11b114f480c32b922be99932415313 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:54:50 +0800
+Subject: [PATCH 50/90] RPMFUSION: no previous prototype for map_rm_pt_range
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_map_external.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_map_external.c b/kernel/nvidia-uvm/uvm8_map_external.c
+index 67620a2..df5e8bd 100644
+--- a/kernel/nvidia-uvm/uvm8_map_external.c
++++ b/kernel/nvidia-uvm/uvm8_map_external.c
+@@ -275,7 +275,7 @@ static NV_STATUS copy_ptes(uvm_page_tree_t *tree,
+ //
+ // If the mapped range ends on va_range->node.end, a TLB invalidate for upgrade
+ // is also issued.
+-NV_STATUS map_rm_pt_range(uvm_va_range_t *va_range,
++static NV_STATUS map_rm_pt_range(uvm_va_range_t *va_range,
+                                  uvm_page_tree_t *tree,
+                                  uvm_page_table_range_t *pt_range,
+                                  uvm_pte_buffer_t *pte_buffer,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0051-RPMFUSION-no-previous-prototype-in-uvm8_user_channel.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0051-RPMFUSION-no-previous-prototype-in-uvm8_user_channel.patch.deferred
@@ -1,0 +1,25 @@
+From e70618d2c3ca5b7fa110c196c57204d0c32692b2 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:55:07 +0800
+Subject: [PATCH 51/90] RPMFUSION: no previous prototype in uvm8_user_channel.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_user_channel.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_user_channel.c b/kernel/nvidia-uvm/uvm8_user_channel.c
+index e8906f9..7e2d30a 100644
+--- a/kernel/nvidia-uvm/uvm8_user_channel.c
++++ b/kernel/nvidia-uvm/uvm8_user_channel.c
+@@ -36,6 +36,7 @@
+ #include "uvm8_map_external.h"
+ #include "uvm8_init.h"
+ #include "nv_uvm_interface.h"
++#include "uvm8_test.h"
+ 
+ #include <linux/sort.h>
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0052-RPMFUSION-no-previous-prototype-in-uvm8_perf_thrashi.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0052-RPMFUSION-no-previous-prototype-in-uvm8_perf_thrashi.patch.deferred
@@ -1,0 +1,26 @@
+From d0b78908d6000ebee326abd24dc9725f68df950b Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 15:56:18 +0800
+Subject: [PATCH 52/90] RPMFUSION: no previous prototype in
+ uvm8_perf_thrashing.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_perf_thrashing.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_perf_thrashing.c b/kernel/nvidia-uvm/uvm8_perf_thrashing.c
+index 0ed3b18..5d47b0e 100644
+--- a/kernel/nvidia-uvm/uvm8_perf_thrashing.c
++++ b/kernel/nvidia-uvm/uvm8_perf_thrashing.c
+@@ -29,6 +29,7 @@
+ #include "uvm8_va_range.h"
+ #include "uvm8_kvmalloc.h"
+ #include "uvm8_tools.h"
++#include "uvm8_test.h"
+ 
+ // Number of bits for page-granularity time stamps. Currently we ignore the first 6 bits
+ // of the timestamp (i.e. we have 64ns resolution, which is good enough)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0053-RPMFUSION-no-previous-prototype-in-uvm8_perf_prefetc.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0053-RPMFUSION-no-previous-prototype-in-uvm8_perf_prefetc.patch.deferred
@@ -1,0 +1,26 @@
+From 40025234b94933db1cc91efa3e5711a462ee5ba8 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:01:20 +0800
+Subject: [PATCH 53/90] RPMFUSION: no previous prototype in
+ uvm8_perf_prefetch.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_perf_prefetch.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia-uvm/uvm8_perf_prefetch.c b/kernel/nvidia-uvm/uvm8_perf_prefetch.c
+index 4f390ee..8206d63 100644
+--- a/kernel/nvidia-uvm/uvm8_perf_prefetch.c
++++ b/kernel/nvidia-uvm/uvm8_perf_prefetch.c
+@@ -28,6 +28,7 @@
+ #include "uvm8_kvmalloc.h"
+ #include "uvm8_va_block.h"
+ #include "uvm8_va_range.h"
++#include "uvm8_test.h"
+ 
+ // Global cache to allocate the per-VA block prefetch detection structures
+ static struct kmem_cache *g_prefetch_info_cache __read_mostly;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0054-RPMFUSION-no-previous-prototype-for-test_tracking.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0054-RPMFUSION-no-previous-prototype-for-test_tracking.patch.deferred
@@ -1,0 +1,26 @@
+From 2da10a9ed205671e8d42549789d54d0b55601dd0 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:01:35 +0800
+Subject: [PATCH 54/90] RPMFUSION: no previous prototype for test_tracking
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_gpu_semaphore_test.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_gpu_semaphore_test.c b/kernel/nvidia-uvm/uvm8_gpu_semaphore_test.c
+index 8b734b8..1523821 100644
+--- a/kernel/nvidia-uvm/uvm8_gpu_semaphore_test.c
++++ b/kernel/nvidia-uvm/uvm8_gpu_semaphore_test.c
+@@ -54,7 +54,7 @@ static NV_STATUS add_and_test(uvm_gpu_tracking_semaphore_t *tracking_sem, NvU32
+     return NV_OK;
+ }
+ 
+-NV_STATUS test_tracking(uvm_va_space_t *va_space)
++static NV_STATUS test_tracking(uvm_va_space_t *va_space)
+ {
+     NV_STATUS status;
+     uvm_gpu_tracking_semaphore_t tracking_sem;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0055-RPMFUSION-no-previous-prototype-in-uvm8_page_tree_te.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0055-RPMFUSION-no-previous-prototype-in-uvm8_page_tree_te.patch.deferred
@@ -1,0 +1,56 @@
+From 3d5a3e589df77e7d29901461b61607096cd467a8 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:01:52 +0800
+Subject: [PATCH 55/90] RPMFUSION: no previous prototype in
+ uvm8_page_tree_test.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_page_tree_test.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_page_tree_test.c b/kernel/nvidia-uvm/uvm8_page_tree_test.c
+index 91861b8..9a306b5 100644
+--- a/kernel/nvidia-uvm/uvm8_page_tree_test.c
++++ b/kernel/nvidia-uvm/uvm8_page_tree_test.c
+@@ -55,7 +55,7 @@ static void fake_ce_memset_8(uvm_push_t *push, uvm_gpu_address_t dst, NvU64 valu
+         *(NvU64 *)phys_to_virt(dst.address + i) = value;
+ }
+ 
+-void *cpu_addr_from_fake(uvm_gpu_address_t fake_gpu_addr)
++static void *cpu_addr_from_fake(uvm_gpu_address_t fake_gpu_addr)
+ {
+     if (fake_gpu_addr.is_virtual)
+         return (void*)fake_gpu_addr.address;
+@@ -69,16 +69,16 @@ static void fake_ce_memcopy(uvm_push_t *push, uvm_gpu_address_t dst, uvm_gpu_add
+     memcpy(cpu_addr_from_fake(dst), cpu_addr_from_fake(src), size);
+ }
+ 
+-void fake_wait_for_idle(uvm_push_t *push)
++static void fake_wait_for_idle(uvm_push_t *push)
+ {
+ }
+ 
+-void fake_noop(uvm_push_t *push, NvU32 size)
++static void fake_noop(uvm_push_t *push, NvU32 size)
+ {
+     push->next += size / 4;
+ }
+ 
+-void fake_membar(uvm_push_t *push)
++static void fake_membar(uvm_push_t *push)
+ {
+ }
+ 
+@@ -304,7 +304,7 @@ static NV_STATUS test_page_tree_get_entry(uvm_page_tree_t *tree, NvU32 page_size
+     return uvm_page_tree_get_entry(tree, page_size, start, UVM_PMM_ALLOC_FLAGS_NONE, single);
+ }
+ 
+-NV_STATUS test_page_tree_alloc_table(uvm_page_tree_t *tree, NvU32 page_size,
++static NV_STATUS test_page_tree_alloc_table(uvm_page_tree_t *tree, NvU32 page_size,
+         uvm_page_table_range_t *single, uvm_page_table_range_t *children)
+ {
+     return uvm_page_tree_alloc_table(tree, page_size, UVM_PMM_ALLOC_FLAGS_NONE, single, children);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0056-RPMFUSION-no-previous-prototype-in-uvm8_tracker_test.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0056-RPMFUSION-no-previous-prototype-in-uvm8_tracker_test.patch.deferred
@@ -1,0 +1,35 @@
+From 7fa3151f8355e60e15e897595269d075ad3ad988 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:03:06 +0800
+Subject: [PATCH 56/90] RPMFUSION: no previous prototype in uvm8_tracker_test.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_tracker_test.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_tracker_test.c b/kernel/nvidia-uvm/uvm8_tracker_test.c
+index 02ce1ce..9d3ea97 100644
+--- a/kernel/nvidia-uvm/uvm8_tracker_test.c
++++ b/kernel/nvidia-uvm/uvm8_tracker_test.c
+@@ -225,7 +225,7 @@ done:
+     return status;
+ }
+ 
+-NV_STATUS test_tracker_overwrite(uvm_va_space_t *va_space)
++static NV_STATUS test_tracker_overwrite(uvm_va_space_t *va_space)
+ {
+     uvm_gpu_t *gpu;
+     uvm_channel_t *channel;
+@@ -313,7 +313,7 @@ done:
+     return status;
+ }
+ 
+-NV_STATUS test_tracker_add_tracker(uvm_va_space_t *va_space)
++static NV_STATUS test_tracker_add_tracker(uvm_va_space_t *va_space)
+ {
+     uvm_gpu_t *gpu;
+     uvm_channel_t *channel;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0057-RPMFUSION-no-previous-prototype-in-uvm8_push_test.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0057-RPMFUSION-no-previous-prototype-in-uvm8_push_test.c.patch.deferred
@@ -1,0 +1,35 @@
+From eaa93327817ac0b1ce4b2a097c477467c85635a7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:03:23 +0800
+Subject: [PATCH 57/90] RPMFUSION: no previous prototype in uvm8_push_test.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_push_test.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_push_test.c b/kernel/nvidia-uvm/uvm8_push_test.c
+index 7eedb32..f00c661 100644
+--- a/kernel/nvidia-uvm/uvm8_push_test.c
++++ b/kernel/nvidia-uvm/uvm8_push_test.c
+@@ -355,7 +355,7 @@ done:
+ //
+ // Starting more than a single push is not safe to do outside of a test as if multiple threads tried doing so,
+ // it could easily deadlock.
+-NV_STATUS test_push_interleaving(uvm_va_space_t *va_space)
++static NV_STATUS test_push_interleaving(uvm_va_space_t *va_space)
+ {
+     NV_STATUS status;
+     uvm_gpu_t *gpu;
+@@ -584,7 +584,7 @@ typedef struct
+     NvU64 timestamp;
+ } timestamp_test_t;
+ 
+-void timestamp_on_complete(void *void_data)
++static void timestamp_on_complete(void *void_data)
+ {
+     timestamp_test_t *data = (timestamp_test_t *)void_data;
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0058-RPMFUSION-no-previous-prototype-in-uvm8_channel_test.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0058-RPMFUSION-no-previous-prototype-in-uvm8_channel_test.patch.deferred
@@ -1,0 +1,59 @@
+From 8f166a97645770c1936a2c206c708c79832baef4 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:03:34 +0800
+Subject: [PATCH 58/90] RPMFUSION: no previous prototype in uvm8_channel_test.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_channel_test.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_channel_test.c b/kernel/nvidia-uvm/uvm8_channel_test.c
+index eafcf85..0bd1540 100644
+--- a/kernel/nvidia-uvm/uvm8_channel_test.c
++++ b/kernel/nvidia-uvm/uvm8_channel_test.c
+@@ -40,7 +40,7 @@
+ // increment a counter into an adjacent memory location in a buffer. And then
+ // verify that all the values are correct on the CPU.
+ // GK110+ is required for the CE semaphore reduction method.
+-NV_STATUS test_ordering(uvm_va_space_t *va_space)
++static NV_STATUS test_ordering(uvm_va_space_t *va_space)
+ {
+     NV_STATUS status;
+     uvm_gpu_t *gpu;
+@@ -295,12 +295,12 @@ static void set_counter(uvm_push_t *push, uvm_rm_mem_t *counter_mem, NvU32 value
+     gpu->ce_hal->memset_v_4(push, counter_gpu_va, value, count * sizeof(NvU32));
+ }
+ 
+-uvm_channel_type_t random_channel_type(uvm_test_rng_t *rng)
++static uvm_channel_type_t random_channel_type(uvm_test_rng_t *rng)
+ {
+     return (uvm_channel_type_t)uvm_test_rng_range_32(rng, 0, UVM_CHANNEL_TYPE_COUNT - 1);
+ }
+ 
+-uvm_gpu_t *random_gpu(uvm_test_rng_t *rng, uvm_processor_mask_t *mask)
++static uvm_gpu_t *random_gpu(uvm_test_rng_t *rng, uvm_processor_mask_t *mask)
+ {
+     uvm_gpu_t *gpu;
+     NvU32 gpu_count = uvm_processor_mask_get_gpu_count(mask);
+@@ -314,7 +314,7 @@ uvm_gpu_t *random_gpu(uvm_test_rng_t *rng, uvm_processor_mask_t *mask)
+ }
+ 
+ 
+-void test_memset_rm_mem(uvm_push_t *push, uvm_rm_mem_t *rm_mem, NvU32 value)
++static void test_memset_rm_mem(uvm_push_t *push, uvm_rm_mem_t *rm_mem, NvU32 value)
+ {
+     uvm_gpu_t *gpu;
+     NvU64 gpu_va;
+@@ -336,7 +336,7 @@ void test_memset_rm_mem(uvm_push_t *push, uvm_rm_mem_t *rm_mem, NvU32 value)
+ // threads and contains some schedule() calls to help get as many threads
+ // through the init phase before other threads continue. It also has a random
+ // schedule() call in the main loop scheduling GPU work.
+-NV_STATUS stress_test_all_gpus_in_va(uvm_va_space_t *va_space, NvU32 num_streams, NvU32 iterations_per_stream,
++static NV_STATUS stress_test_all_gpus_in_va(uvm_va_space_t *va_space, NvU32 num_streams, NvU32 iterations_per_stream,
+                                      NvU32 seed, NvU32 verbose)
+ {
+     NV_STATUS status = NV_OK;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0059-RPMFUSION-no-previous-prototype-in-nvidia-modeset-li.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0059-RPMFUSION-no-previous-prototype-in-nvidia-modeset-li.patch.deferred
@@ -1,0 +1,45 @@
+From d91c213983f70a48727b82bcd31e2b50d1f8aaae Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:03:56 +0800
+Subject: [PATCH 59/90] RPMFUSION: no previous prototype in
+ nvidia-modeset-linux.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-modeset/nvidia-modeset-linux.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index 5bed9dd..3b2b26a 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -762,7 +762,7 @@ static void nvkms_kapi_event_kthread_q_callback(void *arg)
+     nvKmsKapiHandleEventQueueChange(device);
+ }
+ 
+-struct nvkms_per_open *nvkms_open_common(enum NvKmsClientType type,
++static struct nvkms_per_open *nvkms_open_common(enum NvKmsClientType type,
+                                          struct NvKmsKapiDevice *device,
+                                          int *status)
+ {
+@@ -814,7 +814,7 @@ failed:
+     return NULL;
+ }
+ 
+-void NVKMS_API_CALL nvkms_close_common(struct nvkms_per_open *popen)
++static void NVKMS_API_CALL nvkms_close_common(struct nvkms_per_open *popen)
+ {
+     /*
+      * Don't use down_interruptible(): we need to free resources
+@@ -852,7 +852,7 @@ void NVKMS_API_CALL nvkms_close_common(struct nvkms_per_open *popen)
+     nvkms_free(popen, sizeof(*popen));
+ }
+ 
+-int NVKMS_API_CALL nvkms_ioctl_common
++static int NVKMS_API_CALL nvkms_ioctl_common
+ (
+     struct nvkms_per_open *popen,
+     NvU32 cmd, NvU64 address, const size_t size
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0060-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0060-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
@@ -1,0 +1,27 @@
+From ea4d61a55d786532b2072a383e5ae3ea348bb3e7 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:05:01 +0800
+Subject: [PATCH 60/90] RPMFUSION: fix enum implicit conversion from
+ uvm_fault_type_t to uvm_fault_access_type_t in uvm8_va_range.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_va_range.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_va_range.c b/kernel/nvidia-uvm/uvm8_va_range.c
+index 08f8a05..a2e5e0e 100644
+--- a/kernel/nvidia-uvm/uvm8_va_range.c
++++ b/kernel/nvidia-uvm/uvm8_va_range.c
+@@ -1568,7 +1568,7 @@ NV_STATUS uvm_va_range_check_logical_permissions(uvm_va_range_t *va_range,
+         // example on mprotect) and here we are not guaranteed to have
+         // vma->vm_mm->mmap_lock. During tests we ensure that this scenario does
+         // not happen
+-        if (uvm_enable_builtin_tests && !fault_check_range_permission(va_range, access_type))
++        if (uvm_enable_builtin_tests && !fault_check_range_permission(va_range, (uvm_fault_access_type_t) access_type))
+             return NV_ERR_INVALID_ACCESS_TYPE;
+     }
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0061-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0061-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
@@ -1,0 +1,36 @@
+From e477fff51504840327b449bb7244da88b0e505f9 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:05:43 +0800
+Subject: [PATCH 61/90] RPMFUSION: fix enum implicit conversion from
+ uvm_fault_access_type_t to uvm_fault_type_t in uvm8_gpu_replayable_faults.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c b/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c
+index 9e1f468..390c7f6 100644
+--- a/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c
++++ b/kernel/nvidia-uvm/uvm8_gpu_replayable_faults.c
+@@ -972,7 +972,7 @@ static uvm_fault_access_type_t check_fault_access_permissions(uvm_gpu_t *gpu,
+ 
+     perm_status = uvm_va_range_check_logical_permissions(va_block->va_range,
+                                                          gpu->id,
+-                                                         fault_entry->fault_access_type,
++                                                         (uvm_fault_type_t)fault_entry->fault_access_type,
+                                                          allow_migration);
+     if (perm_status == NV_OK)
+         return fault_entry->fault_access_type;
+@@ -995,7 +995,7 @@ static uvm_fault_access_type_t check_fault_access_permissions(uvm_gpu_t *gpu,
+         if (uvm_fault_access_type_mask_test(fault_entry->access_type_mask, UVM_FAULT_ACCESS_TYPE_READ)) {
+             perm_status = uvm_va_range_check_logical_permissions(va_block->va_range,
+                                                                  gpu->id,
+-                                                                 UVM_FAULT_ACCESS_TYPE_READ,
++                                                                 (uvm_fault_type_t)UVM_FAULT_ACCESS_TYPE_READ,
+                                                                  allow_migration);
+             if (perm_status == NV_OK)
+                 return UVM_FAULT_ACCESS_TYPE_READ;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0062-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0062-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
@@ -1,0 +1,28 @@
+From fdfc4439b72922b63935a70e0980027f93b013a3 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:06:20 +0800
+Subject: [PATCH 62/90] RPMFUSION: fix enum implicit conversion from
+ uvm_fault_access_type_t to uvm_fault_type_t in
+ uvm8_gpu_non_replayable_faults.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_gpu_non_replayable_faults.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_gpu_non_replayable_faults.c b/kernel/nvidia-uvm/uvm8_gpu_non_replayable_faults.c
+index c78d0ff..728f7db 100644
+--- a/kernel/nvidia-uvm/uvm8_gpu_non_replayable_faults.c
++++ b/kernel/nvidia-uvm/uvm8_gpu_non_replayable_faults.c
+@@ -221,7 +221,7 @@ static NV_STATUS service_non_replayable_fault_block_locked(uvm_gpu_t *gpu,
+     // Check logical permissions
+     status = uvm_va_range_check_logical_permissions(va_block->va_range,
+                                                     gpu->id,
+-                                                    fault_entry->fault_access_type,
++                                                    (uvm_fault_type_t)fault_entry->fault_access_type,
+                                                     uvm_range_group_address_migratable(va_space,
+                                                                                        fault_entry->fault_address));
+     if (status != NV_OK) {
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0063-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0063-RPMFUSION-fix-enum-implicit-conversion-from-uvm_faul.patch.deferred
@@ -1,0 +1,27 @@
+From 622b50b1ea61761f7f15b08543d8465753988714 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:06:47 +0800
+Subject: [PATCH 63/90] RPMFUSION: fix enum implicit conversion from
+ uvm_fault_access_type_t to uvm_fault_type_t in uvm8_va_block.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_va_block.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_va_block.c b/kernel/nvidia-uvm/uvm8_va_block.c
+index 6319251..7af7c5c 100644
+--- a/kernel/nvidia-uvm/uvm8_va_block.c
++++ b/kernel/nvidia-uvm/uvm8_va_block.c
+@@ -9389,7 +9389,7 @@ static NV_STATUS block_cpu_fault_locked(uvm_va_block_t *va_block,
+     // Check logical permissions
+     status = uvm_va_range_check_logical_permissions(va_block->va_range,
+                                                     UVM_CPU_ID,
+-                                                    fault_access_type,
++                                                    (uvm_fault_type_t)fault_access_type,
+                                                     uvm_range_group_address_migratable(va_range->va_space, fault_addr));
+     if (status != NV_OK)
+         return status;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0064-RPMFUSION-no-previous-prototype-in-nvlink_linux.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0064-RPMFUSION-no-previous-prototype-in-nvlink_linux.c.patch.deferred
@@ -1,0 +1,25 @@
+From 6df94aaf88d23a9282aa062919a6d05c8590d099 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:07:09 +0800
+Subject: [PATCH 64/90] RPMFUSION: no previous prototype in nvlink_linux.c
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia/nvlink_linux.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel/nvidia/nvlink_linux.c b/kernel/nvidia/nvlink_linux.c
+index ba57b86..9f7d8c1 100644
+--- a/kernel/nvidia/nvlink_linux.c
++++ b/kernel/nvidia/nvlink_linux.c
+@@ -30,6 +30,7 @@
+ #include "nv-linux.h"
+ #include "nv-procfs.h"
+ #include "nv-time.h"
++#include "nvlink_proto.h"
+ 
+ #define MAX_ERROR_STRING           512
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0065-RPMFUSION-undef-NV_DRM_GEM_OBJECT_PUT_UNLOCK_PRESENT.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0065-RPMFUSION-undef-NV_DRM_GEM_OBJECT_PUT_UNLOCK_PRESENT.patch.deferred
@@ -1,0 +1,44 @@
+From 4b695bd2190847e3fe3dfad67dcab8364f869522 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:07:43 +0800
+Subject: [PATCH 65/90] RPMFUSION: undef NV_DRM_GEM_OBJECT_PUT_UNLOCK_PRESENT
+ in conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index ae41aad..b63a0c5 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -4152,7 +4152,7 @@ compile_test() {
+             # drm_gem_object_put_unlocked()") finally removes
+             # drm_gem_object_put_unlocked() macro.
+             #
+-            CODE="
++            #CODE="
+             #if defined(NV_DRM_DRMP_H_PRESENT)
+             #include <drm/drmP.h>
+             #endif
+@@ -4160,11 +4160,12 @@ compile_test() {
+             #if defined(NV_DRM_DRM_GEM_H_PRESENT)
+             #include <drm/drm_gem.h>
+             #endif
+-            void conftest_drm_gem_object_put_unlocked(void) {
+-                drm_gem_object_put_unlocked();
+-            }"
++            #void conftest_drm_gem_object_put_unlocked(void) {
++            #    drm_gem_object_put_unlocked();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_DRM_GEM_OBJECT_PUT_UNLOCK_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_DRM_GEM_OBJECT_PUT_UNLOCK_PRESENT" "" "functions"
++            echo "#undef NV_DRM_GEM_OBJECT_PUT_UNLOCK_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         drm_display_mode_has_vrefresh)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0066-RPMFUSION-undef-NV_DRM_CONNECTOR_FUNCS_HAVE_MODE_IN_.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0066-RPMFUSION-undef-NV_DRM_CONNECTOR_FUNCS_HAVE_MODE_IN_.patch.deferred
@@ -1,0 +1,38 @@
+From 1d068feb8c60eba5edb5fbbb98805a4ef54e33ef Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:08:15 +0800
+Subject: [PATCH 66/90] RPMFUSION: undef
+ NV_DRM_CONNECTOR_FUNCS_HAVE_MODE_IN_NAME in conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index b63a0c5..2154925 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -3669,13 +3669,14 @@ compile_test() {
+             #   2018-07-09  cde4c44d8769c1be16074c097592c46c7d64092b
+             #   2018-07-09  97e14fbeb53fe060c5f6a7a07e37fd24c087ed0c
+             #
+-            CODE="
++            #CODE="
+             #include <drm/drm_connector.h>
+-            void conftest_drm_connector_funcs_have_mode_in_name(void) {
+-                drm_mode_connector_attach_encoder();
+-            }"
++            #void conftest_drm_connector_funcs_have_mode_in_name(void) {
++            #    drm_mode_connector_attach_encoder();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_DRM_CONNECTOR_FUNCS_HAVE_MODE_IN_NAME" "" "functions"
++            #compile_check_conftest "$CODE" "NV_DRM_CONNECTOR_FUNCS_HAVE_MODE_IN_NAME" "" "functions"
++            echo "#undef NV_DRM_CONNECTOR_FUNCS_HAVE_MODE_IN_NAME" | append_conftest "functions"
+         ;;
+ 
+         vm_fault_t)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0067-RPMFUSION-undef-NV_DRM_REINIT_PRIMARY_MODE_GROUP_PRE.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0067-RPMFUSION-undef-NV_DRM_REINIT_PRIMARY_MODE_GROUP_PRE.patch.deferred
@@ -1,0 +1,40 @@
+From 6823e3182f23e819359a747f56f32fe7af9f6bf1 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:08:37 +0800
+Subject: [PATCH 67/90] RPMFUSION: undef
+ NV_DRM_REINIT_PRIMARY_MODE_GROUP_PRESENT in conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 2154925..47145e7 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -2783,15 +2783,16 @@ compile_test() {
+             # removed by commit:
+             #   2015-07-09  3fdefa399e4644399ce3e74e65a75122d52dba6a
+             #
+-            CODE="
++            #CODE="
+             #if defined(NV_DRM_DRM_CRTC_H_PRESENT)
+             #include <drm/drm_crtc.h>
+             #endif
+-            void conftest_drm_reinit_primary_mode_group(void) {
+-                drm_reinit_primary_mode_group();
+-            }"
++            #void conftest_drm_reinit_primary_mode_group(void) {
++            #    drm_reinit_primary_mode_group();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_DRM_REINIT_PRIMARY_MODE_GROUP_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_DRM_REINIT_PRIMARY_MODE_GROUP_PRESENT" "" "functions"
++            echo "#undef NV_DRM_REINIT_PRIMARY_MODE_GROUP_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         wait_on_bit_lock_argument_count)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0068-RPMFUSION-undef-NV_DRM_ATOMIC_HELPER_CONNECTOR_DPMS_.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0068-RPMFUSION-undef-NV_DRM_ATOMIC_HELPER_CONNECTOR_DPMS_.patch.deferred
@@ -1,0 +1,40 @@
+From 5c6af2cd3c08fd0a9de5afe2116f36e6b2f3ac0d Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:08:53 +0800
+Subject: [PATCH 68/90] RPMFUSION: undef
+ NV_DRM_ATOMIC_HELPER_CONNECTOR_DPMS_PRESENT in conftest.sh
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/conftest.sh | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 47145e7..d8c2826 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -3458,15 +3458,16 @@ compile_test() {
+             # drm_atomic_helper_connector_dpms() was removed by:
+             #   2017-07-25 7d902c05b480cc44033dcb56e12e51b082656b42
+             #
+-            CODE="
++            #CODE="
+             #if defined(NV_DRM_DRM_ATOMIC_HELPER_H_PRESENT)
+             #include <drm/drm_atomic_helper.h>
+             #endif
+-            void conftest_drm_atomic_helper_connector_dpms(void) {
+-                drm_atomic_helper_connector_dpms();
+-            }"
++            #void conftest_drm_atomic_helper_connector_dpms(void) {
++            #    drm_atomic_helper_connector_dpms();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_DRM_ATOMIC_HELPER_CONNECTOR_DPMS_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_DRM_ATOMIC_HELPER_CONNECTOR_DPMS_PRESENT" "" "functions"
++            echo "#undef NV_DRM_ATOMIC_HELPER_CONNECTOR_DPMS_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         backlight_device_register)
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0069-RPMFUSION-Linux-6.10-follow_pfn-function-removed-the.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0069-RPMFUSION-Linux-6.10-follow_pfn-function-removed-the.patch.deferred
@@ -1,0 +1,65 @@
+From 8e451e817b9b040bfa78f8952e95691751c131da Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Mon, 19 Aug 2024 13:55:15 +0200
+Subject: [PATCH 69/90] RPMFUSION: Linux 6.10: follow_pfn function removed,
+ then undef NV_FOLLOW_PFN_PRESENT
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/conftest.sh       | 18 +++++++++++++-----
+ kernel/nvidia/os-mlock.c |  4 +++-
+ 2 files changed, 16 insertions(+), 6 deletions(-)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index d8c2826..71c7d07 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -660,13 +660,21 @@ compile_test() {
+             # Determine if the follow_pfn() function is
+             # present.
+             #
+-            CODE="
++            # follow_pfn() was added by commit 3b6748e2dd69
++            # ("mm: introduce follow_pfn()") in v2.6.31-rc1, and removed
++            # by commit 233eb0bf3b94 ("mm: remove follow_pfn")
++            # from linux-next 233eb0bf3b94.
++            #
++            # Undefined for rpmfusion for fc40
++            #
++            #CODE="
+             #include <linux/mm.h>
+-            void conftest_follow_pfn(void) {
+-                follow_pfn();
+-            }"
++            #void conftest_follow_pfn(void) {
++            #    follow_pfn();
++            #}"
+ 
+-            compile_check_conftest "$CODE" "NV_FOLLOW_PFN_PRESENT" "" "functions"
++            #compile_check_conftest "$CODE" "NV_FOLLOW_PFN_PRESENT" "" "functions"
++            echo "#undef NV_FOLLOW_PFN_PRESENT" | append_conftest "functions"
+         ;;
+ 
+         i2c_adapter)
+diff --git a/kernel/nvidia/os-mlock.c b/kernel/nvidia/os-mlock.c
+index ad5cb9a..a59cb9f 100644
+--- a/kernel/nvidia/os-mlock.c
++++ b/kernel/nvidia/os-mlock.c
+@@ -20,8 +20,10 @@ static inline int nv_follow_pfn(struct vm_area_struct *vma,
+ {
+ #if defined(NV_UNSAFE_FOLLOW_PFN_PRESENT)
+     return unsafe_follow_pfn(vma, address, pfn);
+-#else
++##elif defined(NV_FOLLOW_PFN_PRESENT)
+     return follow_pfn(vma, address, pfn);
++#else
++    return -1;
+ #endif
+ }
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0070-RPMFUSION-fix-warning-old-style-declaration.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0070-RPMFUSION-fix-warning-old-style-declaration.patch.deferred
@@ -1,0 +1,49 @@
+From 2aa468f1d23d1635c86415962ce0f1bac52d94c8 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Tue, 26 May 2026 16:13:33 +0800
+Subject: [PATCH 70/90] RPMFUSION: fix warning old style declaration
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ kernel/nvidia-uvm/uvm8_pascal_mmu.c | 2 +-
+ kernel/nvidia/nv-mmap.c             | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_pascal_mmu.c b/kernel/nvidia-uvm/uvm8_pascal_mmu.c
+index 5719fa4..85a1018 100644
+--- a/kernel/nvidia-uvm/uvm8_pascal_mmu.c
++++ b/kernel/nvidia-uvm/uvm8_pascal_mmu.c
+@@ -169,7 +169,7 @@ static NvLength entry_size_pascal(NvU32 depth)
+ 
+ static NvU32 index_bits_pascal(NvU32 depth, NvU32 page_size)
+ {
+-    const static NvU32 bit_widths[] = {2, 9, 9, 8};
++    static const NvU32 bit_widths[] = {2, 9, 9, 8};
+     // some code paths keep on querying this until they get a 0, meaning only the page offset remains.
+     UVM_ASSERT(depth < 5);
+     if (depth < 4) {
+diff --git a/kernel/nvidia/nv-mmap.c b/kernel/nvidia/nv-mmap.c
+index 392a5e4..1888985 100644
+--- a/kernel/nvidia/nv-mmap.c
++++ b/kernel/nvidia/nv-mmap.c
+@@ -271,7 +271,7 @@ int nv_encode_caching(
+     return 0;
+ }
+ 
+-int static nvidia_mmap_peer_io(
++static int nvidia_mmap_peer_io(
+     struct vm_area_struct *vma,
+     nv_alloc_t *at,
+     NvU64 page_index,
+@@ -292,7 +292,7 @@ int static nvidia_mmap_peer_io(
+     return ret;
+ }
+ 
+-int static nvidia_mmap_sysmem(
++static int nvidia_mmap_sysmem(
+     struct vm_area_struct *vma,
+     nv_alloc_t *at,
+     NvU64 page_index,
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0071-RPMFUSION-Fix-for-index-0-is-out-of-range-for-type-u.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0071-RPMFUSION-Fix-for-index-0-is-out-of-range-for-type-u.patch.deferred
@@ -1,0 +1,47 @@
+From e139572a70041b765884ee1d111a40d31a38e808 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Thu, 3 Oct 2024 14:35:02 +0200
+Subject: [PATCH 71/90] RPMFUSION: Fix for 'index 0 is out of range for type
+ 'uvm_gpu_chunk_t *[*]' and uvm_page_directory_t *[*]' kernel 6.8.x traces.
+ Suggested by: https://forums.developer.nvidia.com/t/\
+ ubsan-array-index-out-of-bounds-complaints-in-newer-kernels/271705/5 Thanks
+ to Bruce Jerrick https://bugzilla.rpmfusion.org/show_bug.cgi?id=7069
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-uvm/uvm8_mmu.h     | 2 +-
+ kernel/nvidia-uvm/uvm8_pmm_gpu.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/nvidia-uvm/uvm8_mmu.h b/kernel/nvidia-uvm/uvm8_mmu.h
+index cddd43f..cf50c95 100644
+--- a/kernel/nvidia-uvm/uvm8_mmu.h
++++ b/kernel/nvidia-uvm/uvm8_mmu.h
+@@ -76,7 +76,7 @@ struct uvm_page_directory_struct
+ 
+     // pointers to child directories on the host.
+     // this array is variable length, so it needs to be last to allow it to take up extra space
+-    uvm_page_directory_t *entries[0];
++    uvm_page_directory_t *entries[];
+ };
+ 
+ struct uvm_mmu_mode_hal_struct
+diff --git a/kernel/nvidia-uvm/uvm8_pmm_gpu.c b/kernel/nvidia-uvm/uvm8_pmm_gpu.c
+index 602a286..6f0857e 100644
+--- a/kernel/nvidia-uvm/uvm8_pmm_gpu.c
++++ b/kernel/nvidia-uvm/uvm8_pmm_gpu.c
+@@ -209,7 +209,7 @@ struct uvm_pmm_gpu_chunk_suballoc_struct
+     // Array of all child subchunks
+     // TODO: Bug 1765461: Can the array be inlined? It could save the parent
+     //       pointer.
+-    uvm_gpu_chunk_t *subchunks[0];
++    uvm_gpu_chunk_t *subchunks[];
+ };
+ 
+ typedef enum
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0072-RPMFUSION-Linux-6.12-nvidia-drm-drv.c-adaptation-ins.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0072-RPMFUSION-Linux-6.12-nvidia-drm-drv.c-adaptation-ins.patch.deferred
@@ -1,0 +1,117 @@
+From dd452ceb9d03df8a91c000bcbdc4b95dcb0cab3b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Mon, 16 Dec 2024 17:43:36 +0100
+Subject: [PATCH 72/90] RPMFUSION: Linux 6.12: nvidia-drm-drv.c adaptation
+ inspired from Archlinux and Joan Bruguera gist repository
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 53 ++++++++++++++++++++++++++++++
+ 1 file changed, 53 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index f649202..a0887ff 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -84,6 +84,10 @@
+ #include <drm/drm_atomic_helper.h>
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++#include <drm/drm_client.h>
++#endif
++
+ static struct nv_drm_device *dev_list = NULL;
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+@@ -168,7 +172,15 @@ static const struct drm_mode_config_funcs nv_mode_config_funcs = {
+     .atomic_check  = nv_drm_atomic_check,
+     .atomic_commit = nv_drm_atomic_commit,
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
++    // Removed by commit 446d0f4849b101bfc35c0d00835c3e3a4804616d
++    // "drm: Remove struct drm_mode_config_funcs.output_poll_changed" in
++    // kernel 6.12 - Thomas Zimmermann, 12 Aug 2024.
++    // Hotplug event support is handled through the fbdev emulation interface
++    // going forward (required for for example /sys/class/drm/card*/modes
++    // to work).
+     .output_poll_changed = nv_drm_output_poll_changed,
++#endif
+ };
+ 
+ static void nv_drm_event_callback(const struct NvKmsKapiEvent *event)
+@@ -652,6 +664,13 @@ static const struct file_operations nv_drm_fops = {
+     .read           = drm_read,
+ 
+     .llseek         = noop_llseek,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++    // Removed by commit 641bb4394f405cba498b100b44541ffc0aed5be1
++    // "fs: move FMODE_UNSIGNED_OFFSET to fop_flags" the FMODE_UNSIGNED_OFFSET
++    // flag has been moved to fop_flags and renamed
++    // Christian Brauner, 9 Aug 2024.
++    .fop_flags      = FOP_UNSIGNED_OFFSET,
++#endif
+ };
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+@@ -796,6 +815,18 @@ static void nv_drm_update_drm_driver_features(void)
+ #endif /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++static int hotplug_helper_client_hotplug(struct drm_client_dev *client)
++{
++    nv_drm_output_poll_changed(client->dev);
++    return 0;
++}
++
++static const struct drm_client_funcs nv_hotplug_helper_client_funcs = {
++    .owner      = THIS_MODULE,
++    .hotplug    = hotplug_helper_client_hotplug,
++};
++#endif
+ 
+ 
+ /*
+@@ -850,6 +881,20 @@ static void nv_drm_register_drm_device(const nv_gpu_info_t *gpu_info)
+         goto failed_drm_register;
+     }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++    /* Register a DRM client for receiving hotplug events */
++    struct drm_client_dev *client = kzalloc(sizeof(*client), GFP_KERNEL);
++    if (client == NULL || drm_client_init(dev, client,
++        "nv-hotplug-helper", &nv_hotplug_helper_client_funcs)) {
++        printk(KERN_WARNING "Failed to initialize the nv-hotplug-helper DRM client"
++            " (ensure DRM kernel mode setting is enabled via nvidia-drm.modeset=1).\n");
++        goto failed_drm_client_init;
++    }
++
++    drm_client_register(client);
++    pr_info("Registered the nv-hotplug-helper DRM client.\n");
++#endif
++
+     /* Add NVIDIA-DRM device into list */
+ 
+     nv_dev->next = dev_list;
+@@ -857,6 +902,14 @@ static void nv_drm_register_drm_device(const nv_gpu_info_t *gpu_info)
+ 
+     return; /* Success */
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 12, 0)
++failed_drm_client_init:
++
++    kfree(client);
++    drm_dev_unregister(dev);
++
++#endif
++
+ failed_drm_register:
+ 
+     nv_drm_dev_free(dev);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0073-RPMFUSION-Linux-6.13-Kbuild-resolve-to-absolute-path.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0073-RPMFUSION-Linux-6.13-Kbuild-resolve-to-absolute-path.patch.deferred
@@ -1,0 +1,81 @@
+From ae678353c655e9e3b791d81069ebaa58ba2f793f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 16 Feb 2025 16:13:20 +0100
+Subject: [PATCH 73/90] RPMFUSION: Linux 6.13: Kbuild: resolve to absolute path
+ symlink command to abstract away the difference between Linux < 6.13 and
+ kernel >= 6.13 - Inspired from Eric Naim patch for CachyOS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/Kbuild                               | 14 ++++++++++++++
+ kernel/nvidia-modeset/nvidia-modeset.Kbuild |  7 ++++---
+ kernel/nvidia/nvidia.Kbuild                 |  7 ++++---
+ 3 files changed, 22 insertions(+), 6 deletions(-)
+
+diff --git a/kernel/Kbuild b/kernel/Kbuild
+index 85aa267..5dfb1eb 100644
+--- a/kernel/Kbuild
++++ b/kernel/Kbuild
+@@ -41,6 +41,20 @@ ASSIGN_PER_OBJ_CFLAGS = \
+  $(eval $(addprefix CFLAGS_,$(_cflags_variable)) += $(2)))
+ 
+ 
++#
++# Command to create a symbolic link, explicitly resolving the symlink target
++# to an absolute path to abstract away the difference between Linux < 6.13,
++# where the CWD is the Linux kernel source tree for Kbuild extmod builds, and
++# Linux >= 6.13, where the CWD is the external module source tree.
++#
++# This is used to create the nv*-kernel.o -> nv*-kernel.o_binary symlinks for
++# kernel modules which use precompiled binary object files.
++#
++
++quiet_cmd_symlink = SYMLINK $@
++ cmd_symlink = ln -sf $(abspath $<) $@
++
++
+ #
+ # Include the specifics of the individual NVIDIA kernel modules.
+ #
+diff --git a/kernel/nvidia-modeset/nvidia-modeset.Kbuild b/kernel/nvidia-modeset/nvidia-modeset.Kbuild
+index 8a7645d..09afa85 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset.Kbuild
++++ b/kernel/nvidia-modeset/nvidia-modeset.Kbuild
+@@ -38,9 +38,10 @@ NV_KERNEL_MODULE_TARGETS += $(NVIDIA_MODESET_KO)
+ NVIDIA_MODESET_BINARY_OBJECT := $(src)/nvidia-modeset/nv-modeset-kernel.o_binary
+ NVIDIA_MODESET_BINARY_OBJECT_O := nvidia-modeset/nv-modeset-kernel.o
+ 
+-quiet_cmd_symlink = SYMLINK $@
+-cmd_symlink = ln -sf $< $@
+-
++# Commented for kernel >= 6.13 - see root Kbuild file - Remove will append later
++#quiet_cmd_symlink = SYMLINK $@
++#cmd_symlink = ln -sf $< $@
++#
+ targets += $(NVIDIA_MODESET_BINARY_OBJECT_O)
+ 
+ $(obj)/$(NVIDIA_MODESET_BINARY_OBJECT_O): $(NVIDIA_MODESET_BINARY_OBJECT) FORCE
+diff --git a/kernel/nvidia/nvidia.Kbuild b/kernel/nvidia/nvidia.Kbuild
+index d6995ca..9805999 100644
+--- a/kernel/nvidia/nvidia.Kbuild
++++ b/kernel/nvidia/nvidia.Kbuild
+@@ -40,9 +40,10 @@ NVIDIA_KO = nvidia/nvidia.ko
+ NVIDIA_BINARY_OBJECT := $(src)/nvidia/nv-kernel.o_binary
+ NVIDIA_BINARY_OBJECT_O := nvidia/nv-kernel.o
+ 
+-quiet_cmd_symlink = SYMLINK $@
+- cmd_symlink = ln -sf $< $@
+-
++# Commented for kernel >= 6.13 - see root Kbuild file - Remove will append later
++#quiet_cmd_symlink = SYMLINK $@
++# cmd_symlink = ln -sf $< $@
++#
+ targets += $(NVIDIA_BINARY_OBJECT_O)
+ 
+ $(obj)/$(NVIDIA_BINARY_OBJECT_O): $(NVIDIA_BINARY_OBJECT) FORCE
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0074-RPMFUSION-Linux-6.14-nvidia-drm-drv.c-date-from-stru.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0074-RPMFUSION-Linux-6.14-nvidia-drm-drv.c-date-from-stru.patch.deferred
@@ -1,0 +1,32 @@
+From e1e06ee852d1a14a3c30bf772854df1ab6de575b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 16 Feb 2025 16:20:41 +0100
+Subject: [PATCH 74/90] RPMFUSION: Linux 6.14: nvidia-drm-drv.c: date from
+ struct drm_driver removed from all drivers in kernel 6.14 from commit
+ cb2e1c2136
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index a0887ff..e6f4a47 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -772,7 +772,9 @@ static struct drm_driver nv_drm_driver = {
+     .name                   = "nvidia-drm",
+ 
+     .desc                   = "NVIDIA DRM driver",
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 14, 0)
+     .date                   = "20160202",
++#endif
+ 
+ #if defined(NV_DRM_DRIVER_HAS_DEVICE_LIST)
+     .device_list            = LIST_HEAD_INIT(nv_drm_driver.device_list),
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0075-RPMFUSION-Linux-6.15-Kbuild-replace-EXTRA_CFLAGS-wit.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0075-RPMFUSION-Linux-6.15-Kbuild-replace-EXTRA_CFLAGS-wit.patch.deferred
@@ -1,0 +1,58 @@
+From b092cffa9c87c194e54001dc23be907b3354df9e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 18 Jun 2025 08:53:28 +0200
+Subject: [PATCH 75/90] RPMFUSION: Linux 6.15: Kbuild: replace EXTRA_CFLAGS
+ with ccflags-y from commit "kbuild: remove EXTRA_*FLAGS support" (Masahiro
+ Yamada, 6 Feb 2025) saying they have been deprecated since 2007
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/Kbuild | 21 +++++++++------------
+ 1 file changed, 9 insertions(+), 12 deletions(-)
+
+diff --git a/kernel/Kbuild b/kernel/Kbuild
+index 5dfb1eb..a3d7694 100644
+--- a/kernel/Kbuild
++++ b/kernel/Kbuild
+@@ -69,26 +69,23 @@ $(foreach _module, $(NV_KERNEL_MODULES), \
+ 
+ 
+ #
+-# Define CFLAGS that apply to all the NVIDIA kernel modules. EXTRA_CFLAGS
+-# is deprecated since 2.6.24 in favor of ccflags-y, but we need to support
+-# older kernels which do not have ccflags-y. Newer kernels append
+-# $(EXTRA_CFLAGS) to ccflags-y for compatibility.
++# Define ccflags-y that apply to all the NVIDIA kernel modules.
+ #
+ 
+-EXTRA_CFLAGS += -I$(src)/common/inc
+-EXTRA_CFLAGS += -I$(src)
+-EXTRA_CFLAGS += -Wall -MD $(DEFINES) $(INCLUDES) -Wsign-compare -Wno-cast-qual -Wno-error
+-EXTRA_CFLAGS += -D__KERNEL__ -DMODULE -DNVRM -DNV_VERSION_STRING=\"390.157\" -Wno-unused-function -Wuninitialized -fno-strict-aliasing -mno-red-zone -mcmodel=kernel -DNV_UVM_ENABLE -Wno-sign-compare -Wno-format-extra-args
+-EXTRA_CFLAGS += $(call cc-option,-Werror=undef,)
+-EXTRA_CFLAGS += -DNV_SPECTRE_V2=$(NV_SPECTRE_V2)
+-EXTRA_CFLAGS += -DNV_KERNEL_INTERFACE_LAYER
++ccflags-y += -I$(src)/common/inc
++ccflags-y += -I$(src)
++ccflags-y += -Wall -MD $(DEFINES) $(INCLUDES) -Wsign-compare -Wno-cast-qual -Wno-error
++ccflags-y += -D__KERNEL__ -DMODULE -DNVRM -DNV_VERSION_STRING=\"390.157\" -Wno-unused-function -Wuninitialized -fno-strict-aliasing -mno-red-zone -mcmodel=kernel -DNV_UVM_ENABLE -Wno-sign-compare -Wno-format-extra-args
++ccflags-y += $(call cc-option,-Werror=undef,)
++ccflags-y += -DNV_SPECTRE_V2=$(NV_SPECTRE_V2)
++ccflags-y += -DNV_KERNEL_INTERFACE_LAYER
+ 
+ #
+ # Detect SGI UV systems and apply system-specific optimizations.
+ #
+ 
+ ifneq ($(wildcard /proc/sgi_uv),)
+- EXTRA_CFLAGS += -DNV_CONFIG_X86_UV
++ ccflags-y += -DNV_CONFIG_X86_UV
+ endif
+ 
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0076-RPMFUSION-Linux-6.15-add-MODULE_DESCRIPTION-macro.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0076-RPMFUSION-Linux-6.15-add-MODULE_DESCRIPTION-macro.patch.deferred
@@ -1,0 +1,79 @@
+From 2cdbadc5e4ce6c2d0deca0e222bf9664fa13f2dd Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 18 Jun 2025 09:40:20 +0200
+Subject: [PATCH 76/90] RPMFUSION: Linux 6.15: add MODULE_DESCRIPTION macro
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-linux.c         | 1 +
+ kernel/nvidia-modeset/nvidia-modeset-linux.c | 1 +
+ kernel/nvidia-uvm/uvm_common.c               | 1 +
+ kernel/nvidia-uvm/uvm_unsupported.c          | 1 +
+ kernel/nvidia/nv-frontend.c                  | 1 +
+ 5 files changed, 5 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-linux.c b/kernel/nvidia-drm/nvidia-drm-linux.c
+index 96c1661..881f13c 100644
+--- a/kernel/nvidia-drm/nvidia-drm-linux.c
++++ b/kernel/nvidia-drm/nvidia-drm-linux.c
+@@ -189,6 +189,7 @@ static void __exit nv_linux_drm_exit(void)
+ module_init(nv_linux_drm_init);
+ module_exit(nv_linux_drm_exit);
+ 
++MODULE_DESCRIPTION("NVIDIA GPU DRM kernel module");
+ #if defined(MODULE_LICENSE)
+   MODULE_LICENSE("MIT");
+ #endif
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index 3b2b26a..d3d0900 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -1307,6 +1307,7 @@ restart:
+ module_init(nvkms_init);
+ module_exit(nvkms_exit);
+ 
++MODULE_DESCRIPTION("NVIDIA GPU modeset kernel module");
+ #if defined(MODULE_LICENSE)
+   MODULE_LICENSE("NVIDIA");
+ #endif
+diff --git a/kernel/nvidia-uvm/uvm_common.c b/kernel/nvidia-uvm/uvm_common.c
+index 0f4516a..85eea4e 100644
+--- a/kernel/nvidia-uvm/uvm_common.c
++++ b/kernel/nvidia-uvm/uvm_common.c
+@@ -379,5 +379,6 @@ module_param(uvm_enable_builtin_tests, int, S_IRUGO);
+ MODULE_PARM_DESC(uvm_enable_builtin_tests,
+                  "Enable the UVM built-in tests. (This is a security risk)");
+ 
++MODULE_DESCRIPTION("NVIDIA GPU UVM kernel module");
+ MODULE_LICENSE("MIT");
+ MODULE_INFO(supported, "external");
+diff --git a/kernel/nvidia-uvm/uvm_unsupported.c b/kernel/nvidia-uvm/uvm_unsupported.c
+index 0419121..105090a 100644
+--- a/kernel/nvidia-uvm/uvm_unsupported.c
++++ b/kernel/nvidia-uvm/uvm_unsupported.c
+@@ -171,6 +171,7 @@ static void __exit uvm_unsupported_exit(void)
+ module_init(uvm_unsupported_module_init);
+ module_exit(uvm_unsupported_exit);
+ 
++MODULE_DESCRIPTION("NVIDIA GPU unsupported UVM kernel module");
+ MODULE_LICENSE("MIT");
+ MODULE_INFO(supported, "external");
+ 
+diff --git a/kernel/nvidia/nv-frontend.c b/kernel/nvidia/nv-frontend.c
+index 59c69a0..157689a 100644
+--- a/kernel/nvidia/nv-frontend.c
++++ b/kernel/nvidia/nv-frontend.c
+@@ -14,6 +14,7 @@
+ #include "nv-reg.h"
+ #include "nv-frontend.h"
+ 
++MODULE_DESCRIPTION("NVIDIA GPU frontend kernel module");
+ #if defined(MODULE_LICENSE)
+ MODULE_LICENSE("NVIDIA");
+ #endif
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0077-RPMFUSION-Linux-6.15-fix-gcc-15-and-use-std-gnu17.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0077-RPMFUSION-Linux-6.15-fix-gcc-15-and-use-std-gnu17.patch.deferred
@@ -1,0 +1,42 @@
+From e14828fd12efec77507e3070e66b8631cd69fe70 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 18 Jun 2025 09:49:04 +0200
+Subject: [PATCH 77/90] RPMFUSION: Linux 6.15: fix gcc-15 and use std=gnu17
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/Kbuild      | 1 +
+ kernel/conftest.sh | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/kernel/Kbuild b/kernel/Kbuild
+index a3d7694..a96764a 100644
+--- a/kernel/Kbuild
++++ b/kernel/Kbuild
+@@ -72,6 +72,7 @@ $(foreach _module, $(NV_KERNEL_MODULES), \
+ # Define ccflags-y that apply to all the NVIDIA kernel modules.
+ #
+ 
++ccflags-y += -std=gnu17
+ ccflags-y += -I$(src)/common/inc
+ ccflags-y += -I$(src)
+ ccflags-y += -Wall -MD $(DEFINES) $(INCLUDES) -Wsign-compare -Wno-cast-qual -Wno-error
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 71c7d07..3e34333 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -151,7 +151,7 @@ test_headers() {
+ }
+ 
+ build_cflags() {
+-    BASE_CFLAGS="-O2 -D__KERNEL__ \
++    BASE_CFLAGS="-std=gnu17 -O2 -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM"
+        if [ "x${RPM_CFLAGS}" != "x" ] ; then
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0078-RPMFUSION-Linux-6.15-nvidia-drm-connector.c-modify-s.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0078-RPMFUSION-Linux-6.15-nvidia-drm-connector.c-modify-s.patch.deferred
@@ -1,0 +1,39 @@
+From fb024b5a9cc3b6d8a2b3b4ec9569981f0a88030d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 18 Jun 2025 12:02:10 +0200
+Subject: [PATCH 78/90] RPMFUSION: Linux 6.15: nvidia-drm-connector.c: modify
+ struct drm_display_mode to const, related to commit "drm/connector: make
+ mode_valid take a const struct drm_display_mode" (Dmitry Baryshkov, 14 Dec
+ 2024)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-connector.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-connector.c b/kernel/nvidia-drm/nvidia-drm-connector.c
+index 9585840..f48f1a8 100644
+--- a/kernel/nvidia-drm/nvidia-drm-connector.c
++++ b/kernel/nvidia-drm/nvidia-drm-connector.c
+@@ -312,8 +312,15 @@ static int nv_drm_connector_get_modes(struct drm_connector *connector)
+     return count;
+ }
+ 
++// Related to commit "drm/connector: make mode_valid take a const struct
++// drm_display_mode" (Dmitry Baryshkov, 14 Dec 2024)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++static int nv_drm_connector_mode_valid(struct drm_connector    *connector,
++                                       const struct drm_display_mode *mode)
++#else
+ static int nv_drm_connector_mode_valid(struct drm_connector    *connector,
+                                        struct drm_display_mode *mode)
++#endif
+ {
+     struct drm_device *dev = connector->dev;
+     struct nv_drm_device *nv_dev = to_nv_device(dev);
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0079-RPMFUSION-Linux-6.15-nvidia-modeset-linux.c-and-nv.c.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0079-RPMFUSION-Linux-6.15-nvidia-modeset-linux.c-and-nv.c.patch.deferred
@@ -1,0 +1,77 @@
+From 57af82903873b56bebed13f37d8424f1b65b2bac Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 18 Jun 2025 12:21:11 +0200
+Subject: [PATCH 79/90] RPMFUSION: Linux 6.15: nvidia-modeset-linux.c and nv.c:
+ convert del_timer_sync to timer_delete_sync, related to commit "treewide:
+ Switch/rename to timer_delete[_sync]()" (Thomas Gleixner, 5 Apr 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-modeset/nvidia-modeset-linux.c | 13 +++++++++++++
+ kernel/nvidia/nv.c                           |  6 ++++++
+ 2 files changed, 19 insertions(+)
+
+diff --git a/kernel/nvidia-modeset/nvidia-modeset-linux.c b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+index d3d0900..e3101fd 100644
+--- a/kernel/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel/nvidia-modeset/nvidia-modeset-linux.c
+@@ -8,6 +8,7 @@
+  * _NVRM_COPYRIGHT_END_
+  */
+ 
++#include <linux/version.h>
+ #include <linux/module.h>
+ #include <linux/kernel.h>
+ #include <linux/slab.h>
+@@ -495,7 +496,13 @@ static void nvkms_kthread_q_callback(void *arg)
+      * pending timers and than waiting for workqueue callbacks.
+      */
+     if (timer->kernel_timer_created) {
++// Related to commit "treewide: Switch/rename to timer_delete[_sync]()"
++// (Thomas Gleixner, 5 Apr 2025)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++        timer_delete_sync(&timer->kernel_timer);
++#else
+         del_timer_sync(&timer->kernel_timer);
++#endif
+     }
+ 
+     down(&nvkms_lock);
+@@ -1273,7 +1280,13 @@ restart:
+              * completion, and we wait for queue completion with
+              * nv_kthread_q_stop below.
+              */
++// Related to commit "treewide: Switch/rename to timer_delete[_sync]()"
++// (Thomas Gleixner, 5 Apr 2025)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++            if (timer_delete_sync(&timer->kernel_timer) == 1) {
++#else
+             if (del_timer_sync(&timer->kernel_timer) == 1) {
++#endif
+                 /*  We've deactivated timer so we need to clean after it */
+                 list_del(&timer->timers_list);
+                 
+diff --git a/kernel/nvidia/nv.c b/kernel/nvidia/nv.c
+index ef655d5..39ded51 100644
+--- a/kernel/nvidia/nv.c
++++ b/kernel/nvidia/nv.c
+@@ -3523,7 +3523,13 @@ int NV_API_CALL nv_stop_rc_timer(
+ 
+     nv_printf(NV_DBG_INFO, "NVRM: stopping rc timer\n");
+     nv->rc_timer_enabled = 0;
++// Related to commit "treewide: Switch/rename to timer_delete[_sync]()"
++// (Thomas Gleixner, 5 Apr 2025)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    timer_delete_sync(&nvl->rc_timer.kernel_timer);
++#else
+     del_timer_sync(&nvl->rc_timer.kernel_timer);
++#endif
+     nv_printf(NV_DBG_INFO, "NVRM: rc timer stopped\n");
+ 
+     return 0;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0080-RPMFUSION-Linux-6.15-switch-vm_flags_set-and-vm_flag.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0080-RPMFUSION-Linux-6.15-switch-vm_flags_set-and-vm_flag.patch.deferred
@@ -1,0 +1,123 @@
+From 7c535d12221528f1307220743fff5a08549e200e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Wed, 18 Jun 2025 13:00:15 +0200
+Subject: [PATCH 80/90] RPMFUSION: Linux 6.15: switch vm_flags_set and
+ vm_flags_clear calls which are GPL-only symbols to vm_flags_reset, related to
+ commit "mm: uninline the main body of vma_start_write()" (Suren Baghdasaryan,
+ 13 Feb 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/common/inc/nv-mm.h | 29 +++++++++++++++++++++++++++++
+ kernel/nvidia-uvm/uvm8.c  |  2 +-
+ kernel/nvidia/nv-mmap.c   | 12 ++++++------
+ 3 files changed, 36 insertions(+), 7 deletions(-)
+
+diff --git a/kernel/common/inc/nv-mm.h b/kernel/common/inc/nv-mm.h
+index 86bf603..a304080 100644
+--- a/kernel/common/inc/nv-mm.h
++++ b/kernel/common/inc/nv-mm.h
+@@ -23,6 +23,7 @@
+ #ifndef __NV_MM_H__
+ #define __NV_MM_H__
+ 
++#include <linux/version.h>
+ #include "conftest.h"
+ 
+ #if !defined(NV_VM_FAULT_T_IS_PRESENT)
+@@ -203,4 +204,32 @@ static inline struct rw_semaphore *nv_mmap_get_lock(struct mm_struct *mm)
+ #endif
+ }
+ 
++static inline void nv_vm_flags_set(struct vm_area_struct *vma, vm_flags_t flags)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    // Related to commit "mm: uninline the main body of vma_start_write()"
++    // (Suren Baghdasaryan, 13 Feb 2025)
++    // Since Linux 6.15, vm_flags_set and vm_flags_clear call a GPL-only symbol
++    // for locking (__vma_start_write), which can't be called from non-GPL code.
++    // However, it appears all uses on the driver are on VMAs being initially
++    // mapped and which are already locked, so we can use vm_flags_reset, which
++    // doesn't lock the VMA, but rather just asserts it is already write-locked.
++    vm_flags_reset(vma, vma->vm_flags | flags);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
++    vm_flags_set(vma, flags);
++#endif
++}
++
++static inline void nv_vm_flags_clear(struct vm_area_struct *vma, vm_flags_t flags)
++{
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++    // Rel. commit "mm: uninline the main body of vma_start_write()"
++    // (Suren Baghdasaryan, 13 Feb 2025)
++    // See above
++    vm_flags_reset(vma, vma->vm_flags & ~flags);
++#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
++    vm_flags_clear(vma, flags);
++#endif
++}
++
+ #endif // __NV_MM_H__
+diff --git a/kernel/nvidia-uvm/uvm8.c b/kernel/nvidia-uvm/uvm8.c
+index c68d471..3245521 100644
+--- a/kernel/nvidia-uvm/uvm8.c
++++ b/kernel/nvidia-uvm/uvm8.c
+@@ -661,7 +661,7 @@ static int uvm_mmap(struct file *filp, struct vm_area_struct *vma)
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+     vma->vm_flags |= VM_MIXEDMAP | VM_DONTEXPAND;
+ #else
+-    vm_flags_set(vma, VM_MIXEDMAP | VM_DONTEXPAND);
++    nv_vm_flags_set(vma, VM_MIXEDMAP | VM_DONTEXPAND);
+ #endif
+ 
+     vma->vm_ops = &uvm_vm_ops_managed;
+diff --git a/kernel/nvidia/nv-mmap.c b/kernel/nvidia/nv-mmap.c
+index 1888985..38d0105 100644
+--- a/kernel/nvidia/nv-mmap.c
++++ b/kernel/nvidia/nv-mmap.c
+@@ -451,7 +451,7 @@ int nvidia_mmap_helper(
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+             vma->vm_flags |= VM_MIXEDMAP;
+ #else
+-            vm_flags_set(vma, VM_MIXEDMAP);
++            nv_vm_flags_set(vma, VM_MIXEDMAP);
+ #endif
+ 
+             for (j = 0; j < pages; j++)
+@@ -479,7 +479,7 @@ int nvidia_mmap_helper(
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+         vma->vm_flags |= VM_IO;
+ #else
+-        vm_flags_set(vma, VM_IO);
++        nv_vm_flags_set(vma, VM_IO);
+ #endif
+     }
+     else
+@@ -546,8 +546,8 @@ int nvidia_mmap_helper(
+         vma->vm_flags |= (VM_IO | VM_LOCKED | VM_RESERVED);
+         vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
+ #else
+-        vm_flags_set(vma, VM_IO | VM_LOCKED | VM_RESERVED);
+-        vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
++        nv_vm_flags_set(vma, VM_IO | VM_LOCKED | VM_RESERVED);
++        nv_vm_flags_set(vma, VM_DONTEXPAND | VM_DONTDUMP);
+ #endif
+     }
+ 
+@@ -558,8 +558,8 @@ int nvidia_mmap_helper(
+         vma->vm_flags &= ~VM_WRITE;
+         vma->vm_flags &= ~VM_MAYWRITE;
+ #else
+-        vm_flags_clear(vma, VM_WRITE);
+-        vm_flags_clear(vma, VM_MAYWRITE);
++        nv_vm_flags_clear(vma, VM_WRITE);
++        nv_vm_flags_clear(vma, VM_MAYWRITE);
+ #endif
+     }
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0081-RPMFUSION-Linux-6.17-nvidia-drm-drv.c-add-drm_format.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0081-RPMFUSION-Linux-6.17-nvidia-drm-drv.c-add-drm_format.patch.deferred
@@ -1,0 +1,40 @@
+From c36b2de88f3158be49fd123950498e7a42213521 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Thu, 18 Sep 2025 16:36:47 +0200
+Subject: [PATCH 81/90] =?UTF-8?q?RPMFUSION:=20Linux=206.17:=20nvidia-drm-d?=
+ =?UTF-8?q?rv.c:=20add=20drm=5Fformat=5Finfo=20struct=20to=20drm=5Fframebu?=
+ =?UTF-8?q?ffer=20struct,=20related=20to=20commit=20"drm:=20Pass=20the=20f?=
+ =?UTF-8?q?ormat=20info=20to=20.fb=5Fcreate()"=20(Ville=20Syrj=C3=A4l?=
+ =?UTF-8?q?=C3=A4,=201=20Jul=202025)?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index e6f4a47..92ef959 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -139,6 +139,15 @@ static void nv_drm_output_poll_changed(struct drm_device *dev)
+ static struct drm_framebuffer *nv_drm_framebuffer_create(
+     struct drm_device *dev,
+     struct drm_file *file,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    // Added by commit 81112eaac559ccd451b3dce3bbb64d6b69083961
++    // "drm: Pass the format info to .fb_create()" in kernel 6.17 -
++    // Ville Syrjälä, 1 Jul 2025.
++    // Pass along the format information from the top to .fb_create()
++    // so that we can avoid redundant (and somewhat expensive) lookups
++    // in the drivers.
++    const struct drm_format_info *info,
++#endif
+     #if defined(NV_DRM_HELPER_MODE_FILL_FB_STRUCT_HAS_CONST_MODE_CMD_ARG)
+     const struct drm_mode_fb_cmd2 *cmd
+     #else
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0082-RPMFUSION-Linux-6.17-nvidia-drm-drv.c-nvidia-drm-fb..patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0082-RPMFUSION-Linux-6.17-nvidia-drm-drv.c-nvidia-drm-fb..patch.deferred
@@ -1,0 +1,135 @@
+From 95391fba6c7c3a89c953f6e2b01bbfbc67cee5e9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Thu, 18 Sep 2025 17:03:35 +0200
+Subject: [PATCH 82/90] =?UTF-8?q?RPMFUSION:=20Linux=206.17:=20nvidia-drm-d?=
+ =?UTF-8?q?rv.c,=20nvidia-drm-fb.c=20and=20nvidia-drm-fb.h,=20related=20to?=
+ =?UTF-8?q?=20commit=20"drm:=20Allow=20the=20caller=20to=20pass=20in=20the?=
+ =?UTF-8?q?=20format=20info=20to=20drm=5Fhelper=5Fmode=5Ffill=5Ffb=5Fstruc?=
+ =?UTF-8?q?t()"=20(Ville=20Syrj=C3=A4l=C3=A4,=201=20Jul=202025)?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-drv.c | 14 ++++++++++++++
+ kernel/nvidia-drm/nvidia-drm-fb.c  | 29 +++++++++++++++++++++++++++++
+ kernel/nvidia-drm/nvidia-drm-fb.h  | 16 ++++++++++++++++
+ 3 files changed, 59 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index 92ef959..cd0bcac 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -163,6 +163,20 @@ static struct drm_framebuffer *nv_drm_framebuffer_create(
+     fb = nv_drm_internal_framebuffer_create(
+             dev,
+             file,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++            // Added by commit a34cc7bf1034280904f9683e260f9d9e9fd4b84f
++            // "drm: Allow the caller to pass in the format info to
++            // drm_helper_mode_fill_fb_struct()" in kernel 6.17 - Ville Syrjälä,
++            // 1 Jul 2025.
++            // Soon all drivers should have the format info already available
++            // in the places where they call drm_helper_mode_fill_fb_struct().
++            // Allow it to be passed along into drm_helper_mode_fill_fb_struct()
++            // instead of doing yet another redundant lookup.
++            //
++            // Start by always passing in NULL and still doing the extra lookup.
++            // The actual changes to avoid the lookup will follow.
++            info,
++#endif
+             &local_cmd);
+ 
+     #if !defined(NV_DRM_HELPER_MODE_FILL_FB_STRUCT_HAS_CONST_MODE_CMD_ARG)
+diff --git a/kernel/nvidia-drm/nvidia-drm-fb.c b/kernel/nvidia-drm/nvidia-drm-fb.c
+index e0b94f2..a982c9a 100644
+--- a/kernel/nvidia-drm/nvidia-drm-fb.c
++++ b/kernel/nvidia-drm/nvidia-drm-fb.c
+@@ -32,6 +32,7 @@
+ 
+ #include <drm/drm_crtc_helper.h>
+ #include <drm/drm_modeset_helper.h>
++#include <linux/version.h>
+ 
+ static void nv_drm_framebuffer_destroy(struct drm_framebuffer *fb)
+ {
+@@ -157,6 +158,20 @@ static int nv_drm_framebuffer_init(
+ struct drm_framebuffer *nv_drm_internal_framebuffer_create(
+     struct drm_device *dev,
+     struct drm_file *file,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    // Added by commit a34cc7bf1034280904f9683e260f9d9e9fd4b84f
++    // "drm: Allow the caller to pass in the format info to
++    // drm_helper_mode_fill_fb_struct()" in kernel 6.17 - Ville Syrjälä,
++    // 1 Jul 2025.
++    // Soon all drivers should have the format info already available
++    // in the places where they call drm_helper_mode_fill_fb_struct().
++    // Allow it to be passed along into drm_helper_mode_fill_fb_struct()
++    // instead of doing yet another redundant lookup.
++    //
++    // Start by always passing in NULL and still doing the extra lookup.
++    // The actual changes to avoid the lookup will follow.
++    const struct drm_format_info *info,
++#endif
+     struct drm_mode_fb_cmd2 *cmd)
+ {
+     struct nv_drm_framebuffer *nv_fb;
+@@ -183,6 +198,20 @@ struct drm_framebuffer *nv_drm_internal_framebuffer_create(
+         dev,
+         #endif
+         &nv_fb->base,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++        // Added by commit a34cc7bf1034280904f9683e260f9d9e9fd4b84f
++        // "drm: Allow the caller to pass in the format info to
++        // drm_helper_mode_fill_fb_struct()" in kernel 6.17 - Ville Syrjälä,
++        // 1 Jul 2025.
++        // Soon all drivers should have the format info already available
++        // in the places where they call drm_helper_mode_fill_fb_struct().
++        // Allow it to be passed along into drm_helper_mode_fill_fb_struct()
++        // instead of doing yet another redundant lookup.
++        //
++        // Start by always passing in NULL and still doing the extra lookup.
++        // The actual changes to avoid the lookup will follow.
++        info,
++#endif
+         cmd);
+ 
+     /*
+diff --git a/kernel/nvidia-drm/nvidia-drm-fb.h b/kernel/nvidia-drm/nvidia-drm-fb.h
+index bfa93fd..51ad62d 100644
+--- a/kernel/nvidia-drm/nvidia-drm-fb.h
++++ b/kernel/nvidia-drm/nvidia-drm-fb.h
+@@ -35,6 +35,8 @@
+ #include <drm/drm_framebuffer.h>
+ #endif
+ 
++#include <linux/version.h>
++
+ #include "nvidia-drm-gem-nvkms-memory.h"
+ #include "nvkms-kapi.h"
+ 
+@@ -58,6 +60,20 @@ static inline struct nv_drm_framebuffer *to_nv_framebuffer(
+ struct drm_framebuffer *nv_drm_internal_framebuffer_create(
+     struct drm_device *dev,
+     struct drm_file *file,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
++    // Added by commit a34cc7bf1034280904f9683e260f9d9e9fd4b84f
++    // "drm: Allow the caller to pass in the format info to
++    // drm_helper_mode_fill_fb_struct()" in kernel 6.17 - Ville Syrjälä,
++    // 1 Jul 2025.
++    // Soon all drivers should have the format info already available
++    // in the places where they call drm_helper_mode_fill_fb_struct().
++    // Allow it to be passed along into drm_helper_mode_fill_fb_struct()
++    // instead of doing yet another redundant lookup.
++    //
++    // Start by always passing in NULL and still doing the extra lookup.
++    // The actual changes to avoid the lookup will follow.
++    const struct drm_format_info *info,
++#endif
+     struct drm_mode_fb_cmd2 *cmd);
+ 
+ #endif /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0083-RPMFUSION-nv-memdbg.h-fix-warnimg-Wempty-body.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0083-RPMFUSION-nv-memdbg.h-fix-warnimg-Wempty-body.patch.deferred
@@ -1,0 +1,32 @@
+From a3f130453d96e582fc4b953512024b140b18fc90 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 16:29:26 +0200
+Subject: [PATCH 83/90] RPMFUSION: nv-memdbg.h: fix warnimg -Wempty-body
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/common/inc/nv-memdbg.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/kernel/common/inc/nv-memdbg.h b/kernel/common/inc/nv-memdbg.h
+index c618ead..04bf6ac 100644
+--- a/kernel/common/inc/nv-memdbg.h
++++ b/kernel/common/inc/nv-memdbg.h
+@@ -28,8 +28,9 @@ void nv_memdbg_exit(void);
+ 
+ #else
+ 
+-#define NV_MEMDBG_ADD(ptr, size)
+-#define NV_MEMDBG_REMOVE(ptr, size)
++// Fix Wempty-body warnings: adding while(0)
++#define NV_MEMDBG_ADD(ptr, size) while(0)
++#define NV_MEMDBG_REMOVE(ptr, size) while(0)
+ 
+ #endif /* NV_MEM_LOGGER */
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0084-RPMFUSION-Linux-6.19-conftest.sh-Kbuild-enable-fms-e.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0084-RPMFUSION-Linux-6.19-conftest.sh-Kbuild-enable-fms-e.patch.deferred
@@ -1,0 +1,33 @@
+From 2918356dae2b313b3df2cca229f8f8c83bd32ad1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 16:51:47 +0200
+Subject: [PATCH 84/90] RPMFUSION: Linux 6.19: conftest.sh: Kbuild: enable
+ -fms-extensions in CFLAGS
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/conftest.sh | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/kernel/conftest.sh b/kernel/conftest.sh
+index 3e34333..dbc2877 100755
+--- a/kernel/conftest.sh
++++ b/kernel/conftest.sh
+@@ -258,6 +258,11 @@ build_cflags() {
+             CFLAGS="$CFLAGS -mfentry -DCC_USING_FENTRY"
+         fi
+     fi
++
++    # Related to commit "Kbuild: enable -fms-extensions" (Rasmus Villemoes, 20 Oct 2025)
++    # Enable the flags since the Linux headers use those extensions in some structs
++    # See https://www.phoronix.com/news/Linux-6.19-Patch-Would-MS-Ext
++    CFLAGS="$CFLAGS -fms-extensions"
+ }
+ 
+ CONFTEST_PREAMBLE="#include \"conftest/headers.h\"
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0085-RPMFUSION-Linux-6.19-nv-dma.c-replace-map_resource-w.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0085-RPMFUSION-Linux-6.19-nv-dma.c-replace-map_resource-w.patch.deferred
@@ -1,0 +1,44 @@
+From 95dcb50c194526282242577b383ed6b2ae98c676 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 17:18:16 +0200
+Subject: [PATCH 85/90] RPMFUSION: Linux 6.19: nv-dma.c: replace map_resource
+ with map_phys, related to commit "dma-mapping: remove unused mapping resource
+ callbacks" (Leon Romanovsky, 15 Oct 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia/nv-dma.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/kernel/nvidia/nv-dma.c b/kernel/nvidia/nv-dma.c
+index 343e878..4b942ed 100644
+--- a/kernel/nvidia/nv-dma.c
++++ b/kernel/nvidia/nv-dma.c
+@@ -13,6 +13,7 @@
+ 
+ #include "os-interface.h"
+ #include "nv-linux.h"
++#include <linux/version.h>
+ 
+ NV_STATUS   nv_create_dma_map_scatterlist (nv_dma_map_t *dma_map);
+ void        nv_destroy_dma_map_scatterlist(nv_dma_map_t *dma_map);
+@@ -619,7 +620,13 @@ static NvBool nv_dma_is_map_resource_implemented
+ #endif
+     }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    // Rel. commit "dma-mapping: remove unused mapping resource callbacks" (Leon Romanovsky, 15 Oct 2025)
++    // https://lore.kernel.org/all/20251015-remove-map-page-v5-0-3bbfe3a25cdf@kernel.org/
++    return (ops->map_phys != NULL);
++#else
+     return (ops->map_resource != NULL);
++#endif
+ #else
+     return NV_FALSE;
+ #endif
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0086-RPMFUSION-Linux-6.19-nvlink_linux.c-os-interface.c-r.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0086-RPMFUSION-Linux-6.19-nvlink_linux.c-os-interface.c-r.patch.deferred
@@ -1,0 +1,98 @@
+From 27c3e587d7233650454c6d82097006c3b8b51469 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 17:37:44 +0200
+Subject: [PATCH 86/90] RPMFUSION: Linux 6.19: nvlink_linux.c, os-interface.c:
+ replace in_irq with in_hardirq added in v5.11-rc1 (2020-12-15)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia/nvlink_linux.c |  9 +++++++++
+ kernel/nvidia/os-interface.c | 17 +++++++++++++++++
+ 2 files changed, 26 insertions(+)
+
+diff --git a/kernel/nvidia/nvlink_linux.c b/kernel/nvidia/nvlink_linux.c
+index 9f7d8c1..723ee8e 100644
+--- a/kernel/nvidia/nvlink_linux.c
++++ b/kernel/nvidia/nvlink_linux.c
+@@ -31,6 +31,11 @@
+ #include "nv-procfs.h"
+ #include "nv-time.h"
+ #include "nvlink_proto.h"
++#include <linux/version.h>
++
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++#include <linux/hardirq.h>
++#endif
+ 
+ #define MAX_ERROR_STRING           512
+ 
+@@ -571,7 +576,11 @@ void NVLINK_API_CALL nvlink_sleep(unsigned int ms)
+ 
+     nv_gettimeofday(&tm_aux);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    if (in_hardirq() && (ms > NV_MAX_ISR_DELAY_MS))
++#else
+     if (in_irq() && (ms > NV_MAX_ISR_DELAY_MS))
++#endif
+     {
+         return;
+     }
+diff --git a/kernel/nvidia/os-interface.c b/kernel/nvidia/os-interface.c
+index 262171f..c3e9da7 100644
+--- a/kernel/nvidia/os-interface.c
++++ b/kernel/nvidia/os-interface.c
+@@ -17,6 +17,11 @@
+ #include "nv-time.h"
+ #include "nv-gpu-numa.h"
+ 
++#include <linux/version.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++#include <linux/hardirq.h>
++#endif
++
+ #define MAX_ERROR_STRING 512
+ static char nv_error_string[MAX_ERROR_STRING];
+ nv_spinlock_t nv_error_string_lock;
+@@ -193,7 +198,11 @@ BOOL NV_API_CALL os_semaphore_may_sleep(void)
+ 
+ BOOL NV_API_CALL os_is_isr(void)
+ {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    return (in_hardirq());
++#else
+     return (in_irq());
++#endif
+ }
+ 
+ // return TRUE if the caller is the super-user
+@@ -510,7 +519,11 @@ NV_STATUS NV_API_CALL os_delay_us(NvU32 MicroSeconds)
+     nv_gettimeofday(&tm1);
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    if (in_hardirq() && (MicroSeconds > NV_MAX_ISR_DELAY_US))
++#else
+     if (in_irq() && (MicroSeconds > NV_MAX_ISR_DELAY_US))
++#endif
+         return NV_ERR_GENERIC;
+     
+     mdelay_safe_msec = MicroSeconds / 1000;
+@@ -555,7 +568,11 @@ NV_STATUS NV_API_CALL os_delay(NvU32 MilliSeconds)
+     tm_start = tm_aux;
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    if (in_hardirq() && (MilliSeconds > NV_MAX_ISR_DELAY_MS))
++#else
+     if (in_irq() && (MilliSeconds > NV_MAX_ISR_DELAY_MS))
++#endif
+         return NV_ERR_GENERIC;
+ 
+     if (!NV_MAY_SLEEP()) 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0087-RPMFUSION-Linux-6.19-nvidia-drm-priv.h-add-drm_print.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0087-RPMFUSION-Linux-6.19-nvidia-drm-priv.h-add-drm_print.patch.deferred
@@ -1,0 +1,32 @@
+From b1cd8562550243110d65d122ab03ce8e7173eed9 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 17:43:12 +0200
+Subject: [PATCH 87/90] RPMFUSION: Linux 6.19: nvidia-drm-priv.h: add
+ drm_print.h, Related to commit "drm/mm: replace drm_print.h include with a
+ forward declaration" (Jani Nikula, 29 Oct 2025)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-priv.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-priv.h b/kernel/nvidia-drm/nvidia-drm-priv.h
+index 4f1a0e7..953c2eb 100644
+--- a/kernel/nvidia-drm/nvidia-drm-priv.h
++++ b/kernel/nvidia-drm/nvidia-drm-priv.h
+@@ -39,6 +39,9 @@
+ #include <drm/drm_gem.h>
+ #endif
+ 
++// Rel. commit "drm/mm: replace drm_print.h include with a forward declaration" (Jani Nikula, 29 Oct 2025)
++#include <drm/drm_print.h>
++
+ #include "nvidia-drm-os-interface.h"
+ 
+ #include "nvkms-kapi.h"
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0088-RPMFUSION-Linux-6.19-nvidia-drm-drv.c-nvidia-drm-hel.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0088-RPMFUSION-Linux-6.19-nvidia-drm-drv.c-nvidia-drm-hel.patch.deferred
@@ -1,0 +1,227 @@
+From e81e62fd704ff025fdba6c7a00944c6a4241ba8f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 18:18:49 +0200
+Subject: [PATCH 88/90] RPMFUSION: Linux 6.19: nvidia-drm-drv.c,
+ nvidia-drm-helper.c, nvidia-drm-helper.h, nvidia-drm-modeset.c: replace
+ nv_drm_for_each_* with for_each_*
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/nvidia-drm/nvidia-drm-crtc.c    | 11 +++++++++++
+ kernel/nvidia-drm/nvidia-drm-drv.c     |  8 ++++++++
+ kernel/nvidia-drm/nvidia-drm-helper.c  |  3 +++
+ kernel/nvidia-drm/nvidia-drm-helper.h  |  3 +++
+ kernel/nvidia-drm/nvidia-drm-modeset.c | 23 +++++++++++++++++++++++
+ 5 files changed, 48 insertions(+)
+
+diff --git a/kernel/nvidia-drm/nvidia-drm-crtc.c b/kernel/nvidia-drm/nvidia-drm-crtc.c
+index 6d5478e..a099cb1 100644
+--- a/kernel/nvidia-drm/nvidia-drm-crtc.c
++++ b/kernel/nvidia-drm/nvidia-drm-crtc.c
+@@ -39,6 +39,8 @@
+ #include <drm/drm_atomic.h>
+ #include <drm/drm_atomic_helper.h>
+ 
++#include <linux/version.h>
++
+ static const u32 nv_default_supported_plane_drm_formats[] = {
+     DRM_FORMAT_ARGB1555,
+     DRM_FORMAT_XRGB1555,
+@@ -151,7 +153,11 @@ static int nv_drm_plane_atomic_check(struct drm_plane *plane,
+         goto done;
+     }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    for_each_new_crtc_in_state(plane_state->state, crtc, crtc_state, i) {
++#else
+     nv_drm_for_each_crtc_in_state(plane_state->state, crtc, crtc_state, i) {
++#endif
+         struct nv_drm_crtc_state *nv_crtc_state = to_nv_crtc_state(crtc_state);
+         struct NvKmsKapiHeadRequestedConfig *head_req_config =
+             &nv_crtc_state->req_config;
+@@ -368,8 +374,13 @@ static int nv_drm_crtc_atomic_check(struct drm_crtc *crtc,
+ 
+         req_config->flags.displaysChanged = NV_TRUE;
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++        for_each_new_connector_in_state(crtc_state->state,
++                                        connector, connector_state, j) {
++#else
+         nv_drm_for_each_connector_in_state(crtc_state->state,
+                                            connector, connector_state, j) {
++#endif
+             if (connector_state->crtc != crtc) {
+                 continue;
+             }
+diff --git a/kernel/nvidia-drm/nvidia-drm-drv.c b/kernel/nvidia-drm/nvidia-drm-drv.c
+index cd0bcac..3183ff7 100644
+--- a/kernel/nvidia-drm/nvidia-drm-drv.c
++++ b/kernel/nvidia-drm/nvidia-drm-drv.c
+@@ -558,13 +558,21 @@ void nv_drm_master_drop(struct drm_device *dev, struct drm_file *file_priv)
+ 
+     drm_modeset_lock_all(dev);
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    if ((err = drm_atomic_helper_disable_all(
++#else
+     if ((err = nv_drm_atomic_helper_disable_all(
++#endif
+             dev,
+             dev->mode_config.acquire_ctx)) != 0) {
+ 
+         NV_DRM_DEV_LOG_ERR(
+             nv_dev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++            "drm_atomic_helper_disable_all failed with error code %d !",
++#else
+             "nv_drm_atomic_helper_disable_all failed with error code %d !",
++#endif
+             err);
+     }
+ 
+diff --git a/kernel/nvidia-drm/nvidia-drm-helper.c b/kernel/nvidia-drm/nvidia-drm-helper.c
+index 8b89afe..5b4ed47 100644
+--- a/kernel/nvidia-drm/nvidia-drm-helper.c
++++ b/kernel/nvidia-drm/nvidia-drm-helper.c
+@@ -28,6 +28,7 @@
+  */
+ 
+ #include "nvidia-drm-helper.h"
++#include <linux/version.h>
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+ 
+@@ -62,6 +63,7 @@ static void __nv_drm_framebuffer_put(struct drm_framebuffer *fb)
+ 
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+ /*
+  * drm_atomic_helper_disable_all() has been added by commit
+  * 1494276000db789c6d2acd85747be4707051c801, which is Signed-off-by:
+@@ -199,4 +201,5 @@ free:
+     return ret;
+ }
+ 
++#endif /* kernel < 6.19 */
+ #endif /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
+diff --git a/kernel/nvidia-drm/nvidia-drm-helper.h b/kernel/nvidia-drm/nvidia-drm-helper.h
+index 831737d..bc61d7a 100644
+--- a/kernel/nvidia-drm/nvidia-drm-helper.h
++++ b/kernel/nvidia-drm/nvidia-drm-helper.h
+@@ -24,6 +24,7 @@
+ #define __NVIDIA_DRM_HELPER_H__
+ 
+ #include "nvidia-drm-conftest.h"
++#include <linux/version.h>
+ 
+ #if defined(NV_DRM_AVAILABLE)
+ 
+@@ -156,6 +157,7 @@ nv_drm_prime_pages_to_sg(struct drm_device *dev,
+ #include <drm/drm_atomic.h>
+ #include <drm/drm_atomic_helper.h>
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+ int nv_drm_atomic_helper_disable_all(struct drm_device *dev,
+                                      struct drm_modeset_acquire_ctx *ctx);
+ 
+@@ -277,6 +279,7 @@ int nv_drm_atomic_helper_disable_all(struct drm_device *dev,
+     for_each_plane_in_state(__state, plane, plane_state, __i)
+ #endif
+ 
++#endif /* Kernel < 6.19 */
+ static inline struct drm_crtc *nv_drm_crtc_find(struct drm_device *dev,
+     uint32_t id)
+ {
+diff --git a/kernel/nvidia-drm/nvidia-drm-modeset.c b/kernel/nvidia-drm/nvidia-drm-modeset.c
+index 3a57e8e..b6ef1e7 100644
+--- a/kernel/nvidia-drm/nvidia-drm-modeset.c
++++ b/kernel/nvidia-drm/nvidia-drm-modeset.c
+@@ -21,6 +21,7 @@
+  */
+ 
+ #include "nvidia-drm-conftest.h" /* NV_DRM_ATOMIC_MODESET_AVAILABLE */
++#include <linux/version.h>
+ 
+ #if defined(NV_DRM_ATOMIC_MODESET_AVAILABLE)
+ 
+@@ -112,12 +113,19 @@ nv_drm_atomic_apply_modeset_config(struct drm_device *dev,
+     struct NvKmsKapiRequestedModeSetConfig *requested_config =
+         &(to_nv_atomic_state(state)->config);
+     struct drm_crtc *crtc;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    struct drm_crtc_state *old_crtc_state, *new_crtc_state;
++#else
+     struct drm_crtc_state *crtc_state;
++#endif
+     int i;
+ 
+     memset(requested_config, 0, sizeof(*requested_config));
+ 
+     /* Loop over affected crtcs and construct NvKmsKapiRequestedModeSetConfig */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    for_each_oldnew_crtc_in_state(state, crtc, old_crtc_state, new_crtc_state, i) {
++#else
+     nv_drm_for_each_crtc_in_state(state, crtc, crtc_state, i) {
+         /*
+          * When commiting a state, the new state is already stored in
+@@ -126,6 +134,7 @@ nv_drm_atomic_apply_modeset_config(struct drm_device *dev,
+          */
+         struct drm_crtc_state *new_crtc_state =
+                                commit ? crtc->state : crtc_state;
++#endif
+         struct nv_drm_crtc *nv_crtc = to_nv_crtc(crtc);
+ 
+         requested_config->headRequestedConfig[nv_crtc->head] =
+@@ -134,7 +143,9 @@ nv_drm_atomic_apply_modeset_config(struct drm_device *dev,
+         requested_config->headsMask |= 1 << nv_crtc->head;
+ 
+         if (commit) {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+             struct drm_crtc_state *old_crtc_state = crtc_state;
++#endif
+             struct nv_drm_crtc_state *nv_new_crtc_state =
+                 to_nv_crtc_state(new_crtc_state);
+ 
+@@ -220,7 +231,11 @@ int nv_drm_atomic_commit(struct drm_device *dev,
+ 
+     int i;
+     struct drm_crtc *crtc = NULL;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++    struct drm_crtc_state *new_crtc_state = NULL;
++#else
+     struct drm_crtc_state *crtc_state = NULL;
++#endif
+     struct nv_drm_device *nv_dev = to_nv_device(dev);
+ 
+     /*
+@@ -230,7 +245,11 @@ int nv_drm_atomic_commit(struct drm_device *dev,
+      * updates to complete.
+      */
+     if (nonblock) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++        for_each_new_crtc_in_state(state, crtc, new_crtc_state, i) {
++#else
+         nv_drm_for_each_crtc_in_state(state, crtc, crtc_state, i) {
++#endif
+             struct nv_drm_crtc *nv_crtc = to_nv_crtc(crtc);
+ 
+             /*
+@@ -303,7 +322,11 @@ int nv_drm_atomic_commit(struct drm_device *dev,
+     }
+ 
+     if (ret == 0 && !nonblock) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
++        for_each_new_crtc_in_state(state, crtc, new_crtc_state, i) {
++#else
+         nv_drm_for_each_crtc_in_state(state, crtc, crtc_state, i) {
++#endif
+             struct nv_drm_crtc *nv_crtc = to_nv_crtc(crtc);
+ 
+             /*
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0089-RPMFUSION-Linux-6.18-Remove-flush_scheduled_work.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0089-RPMFUSION-Linux-6.18-Remove-flush_scheduled_work.patch.deferred
@@ -1,0 +1,72 @@
+From 4b45b82f8c60ddf64fcd8190860e665a765ae4b6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 22:59:35 +0200
+Subject: [PATCH 89/90] RPMFUSION: Linux 6.18: Remove flush_scheduled_work
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/common/inc/nv-linux.h               | 12 ++++++++++++
+ kernel/nvidia-drm/nvidia-drm-prime-fence.c |  3 +++
+ 2 files changed, 15 insertions(+)
+
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index ddbc68b..913aa9d 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -1133,7 +1133,14 @@ static inline void nv_kmem_ctor_dummy(void *arg)
+ {
+     (void)arg;
+ }
++/* Beginning with kernel 6.18 flushing system-wide workqueues was
++ * removed.
++*/
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
++#define NV_KMEM_CACHE_DESTROY_FLUSH ((void)0)
++#else
+ #define NV_KMEM_CACHE_DESTROY_FLUSH flush_scheduled_work
++#endif
+ #else
+ #define nv_kmem_ctor_dummy NULL
+ #define NV_KMEM_CACHE_DESTROY_FLUSH()
+@@ -1530,8 +1537,13 @@ typedef struct nv_work_s {
+ } nv_work_t;
+ 
+ #define NV_WORKQUEUE_SCHEDULE(work) schedule_work(work)
++// Remove system-wide workqueue flush
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 18, 0)
++#define NV_WORKQUEUE_FLUSH() do { } while (0)
++#else
+ #define NV_WORKQUEUE_FLUSH()                           \
+     flush_scheduled_work();
++#endif
+ #if (NV_INIT_WORK_ARGUMENT_COUNT == 2)
+ #define NV_WORKQUEUE_INIT(tq,handler,data)             \
+     {                                                  \
+diff --git a/kernel/nvidia-drm/nvidia-drm-prime-fence.c b/kernel/nvidia-drm/nvidia-drm-prime-fence.c
+index d7309cb..4b0c327 100644
+--- a/kernel/nvidia-drm/nvidia-drm-prime-fence.c
++++ b/kernel/nvidia-drm/nvidia-drm-prime-fence.c
+@@ -21,6 +21,7 @@
+  */
+ 
+ #include "nvidia-drm-conftest.h"
++#include <linux/version.h>
+ 
+ #if defined(NV_DRM_AVAILABLE)
+ 
+@@ -322,7 +323,9 @@ static void __nv_drm_fence_context_destroy(
+ 
+     /* Wait for all its already schedule callbacks to complete. */
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 0)
+     flush_scheduled_work();
++#endif
+ 
+     /* Free nvkms resources */
+ 
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/patches/0090-RPMFUSION-Linux-7.0-Replace-screen_info-with-sysfb_p.patch.deferred
+++ b/runtime-display/nvidia+390/autobuild/patches/0090-RPMFUSION-Linux-7.0-Replace-screen_info-with-sysfb_p.patch.deferred
@@ -1,0 +1,119 @@
+From a2a87da68f7b96279466277322a9ef4e75eeb8a3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Nicolas=20Vi=C3=A9ville?= <nicolas.vieville@uphf.fr>
+Date: Sun, 10 May 2026 23:40:12 +0200
+Subject: [PATCH 90/90] RPMFUSION: Linux 7.0: Replace screen_info with
+ sysfb_primary_display and dma-buf/dma-fence: Remove return code of
+ signaling-functions
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Nicolas Viéville <nicolas.vieville@uphf.fr>
+---
+ kernel/common/inc/nv-linux.h                |  3 +++
+ kernel/nvidia-drm/nvidia-dma-fence-helper.h | 14 ++++++++++++++
+ kernel/nvidia/os-interface.c                | 21 ++++++++++++++-------
+ 3 files changed, 31 insertions(+), 7 deletions(-)
+
+diff --git a/kernel/common/inc/nv-linux.h b/kernel/common/inc/nv-linux.h
+index 913aa9d..387cfcf 100644
+--- a/kernel/common/inc/nv-linux.h
++++ b/kernel/common/inc/nv-linux.h
+@@ -204,6 +204,9 @@ static inline uid_t __kuid_val(kuid_t uid)
+ #endif
+ #if defined(NV_LINUX_SCREEN_INFO_H_PRESENT)
+ #include <linux/screen_info.h>      /* screen_info                      */
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++#include <linux/sysfb.h>            /* sysfb_primary_display            */
++#endif
+ #else
+ #include <linux/tty.h>              /* screen_info                      */
+ #endif
+diff --git a/kernel/nvidia-drm/nvidia-dma-fence-helper.h b/kernel/nvidia-drm/nvidia-dma-fence-helper.h
+index a09ab76..ef2283e 100644
+--- a/kernel/nvidia-drm/nvidia-dma-fence-helper.h
++++ b/kernel/nvidia-drm/nvidia-dma-fence-helper.h
+@@ -24,6 +24,7 @@
+ #define __NVIDIA_DMA_FENCE_HELPER_H__
+ 
+ #include "nvidia-drm-conftest.h"
++#include <linux/version.h>
+ 
+ #if defined(NV_DRM_FENCE_AVAILABLE)
+ 
+@@ -89,12 +90,25 @@ nv_dma_fence_default_wait(nv_dma_fence_t *fence,
+ #endif
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++// Rel. commit "dma-buf/dma-fence: Remove return code of signaling-functions" (Philipp Stanner, 1 Dec 2025)
++static inline void nv_dma_fence_signal(nv_dma_fence_t *fence) {
++#else
+ static inline int nv_dma_fence_signal(nv_dma_fence_t *fence) {
++#endif
+ #if defined(NV_LINUX_FENCE_H_PRESENT)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++    fence_signal(fence);
++#else
+     return fence_signal(fence);
++#endif
++#else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++    dma_fence_signal(fence);
+ #else
+     return dma_fence_signal(fence);
+ #endif
++#endif
+ }
+ 
+ static inline u64 nv_dma_fence_context_alloc(unsigned num) {
+diff --git a/kernel/nvidia/os-interface.c b/kernel/nvidia/os-interface.c
+index c3e9da7..b503537 100644
+--- a/kernel/nvidia/os-interface.c
++++ b/kernel/nvidia/os-interface.c
+@@ -1141,6 +1141,13 @@ void NV_API_CALL os_get_screen_info(
+ )
+ {
+ #if (defined(NVCPU_X86) || defined(NVCPU_X86_64))
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++    // Rel. commit "sysfb: Replace screen_info with sysfb_primary_display" (Thomas Zimmermann, 26 Nov 2025)
++    const struct screen_info *si = &sysfb_primary_display.screen;
++#else
++    const struct screen_info *si = &screen_info;
++#endif
++
+     //
+     // If there is not a framebuffer console, return 0 size.
+     //
+@@ -1148,21 +1155,21 @@ void NV_API_CALL os_get_screen_info(
+     // initialization, and then will be set to a value, such as
+     // VIDEO_TYPE_VLFB or VIDEO_TYPE_EFI if an fbdev console is used.
+     //
+-    if (screen_info.orig_video_isVGA <= 1)
++    if (si->orig_video_isVGA <= 1)
+     {
+         *pPhysicalAddress = 0;
+         *pFbWidth = *pFbHeight = *pFbDepth = *pFbPitch = 0;
+         return;
+     }
+ 
+-    *pPhysicalAddress = screen_info.lfb_base;
++    *pPhysicalAddress = si->lfb_base;
+ #if defined(VIDEO_CAPABILITY_64BIT_BASE)
+-    *pPhysicalAddress |= (NvU64)screen_info.ext_lfb_base << 32;
++    *pPhysicalAddress |= (NvU64)si->ext_lfb_base << 32;
+ #endif
+-    *pFbWidth = screen_info.lfb_width;
+-    *pFbHeight = screen_info.lfb_height;
+-    *pFbDepth = screen_info.lfb_depth;
+-    *pFbPitch = screen_info.lfb_linelength;
++    *pFbWidth = si->lfb_width;
++    *pFbHeight = si->lfb_height;
++    *pFbDepth = si->lfb_depth;
++    *pFbPitch = si->lfb_linelength;
+ #else
+     *pPhysicalAddress = 0;
+     *pFbWidth = *pFbHeight = *pFbDepth = *pFbPitch = 0;
+-- 
+2.52.0
+

--- a/runtime-display/nvidia+390/autobuild/prepare
+++ b/runtime-display/nvidia+390/autobuild/prepare
@@ -5,3 +5,7 @@ abinfo "Generating postinst and prerm"
 for i in postinst prerm; do
 	sed -e "s/@DRV_VER@/${PKGVER}/g" ${SRCDIR}/autobuild/${i}.in > ${SRCDIR}/autobuild/${i}
 done
+
+abinfo "Applying patches"
+cd "$SRCDIR"/NVIDIA-Linux-x86_64-$PKGVER/
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.patch.deferred

--- a/runtime-display/nvidia+390/spec
+++ b/runtime-display/nvidia+390/spec
@@ -1,5 +1,5 @@
 VER=390.157
-REL=2
+REL=3
 SRCS="file::rename=NVIDIA-Linux-$VER.run::https://us.download.nvidia.com/XFree86/Linux-x86_64/${VER}/NVIDIA-Linux-x86_64-${VER}.run"
 CHKUPDATE="anitya::id=231058"
 CHKSUMS="sha256::5bebbca6e8fed5d6b9d81070fb9e351f18edc534952553cbdc71e8fd0b9b328a"

--- a/runtime-display/nvidia+580/01-utils/build
+++ b/runtime-display/nvidia+580/01-utils/build
@@ -113,10 +113,10 @@ install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-ml.so.$PKGVER
 install -Dvm755 "libnvidia-sandboxutils.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-sandboxutils.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.4" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.4
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.4" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.4
+install -Dvm755 "libnvidia-egl-xlib.so.1.0.5" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.5
+install -Dvm755 "libnvidia-egl-xcb.so.1.0.5" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.5
 install -Dvm644 "20_nvidia_xlib.json" \
     "$PKGDIR"/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json
 install -Dvm644 "20_nvidia_xcb.json" \
@@ -138,7 +138,7 @@ abinfo "Nvidia GPU control APIs"
 install_for_all 755 "libnvidia-api.so.1" "$PKGDIR"/usr/lib
 
 abinfo "Wayland support libraries and platform files..."
-install_for_all 755 "libnvidia-egl-gbm.so.1.1.2" "$PKGDIR"/usr/lib
+install_for_all 755 "libnvidia-egl-gbm.so.1.1.3" "$PKGDIR"/usr/lib
 # libnvidia-wayland-client.so is open-source
 
 install -Dvm644 "15_nvidia_gbm.json" \

--- a/runtime-display/nvidia+580/01-utils/build-optenv32
+++ b/runtime-display/nvidia+580/01-utils/build-optenv32
@@ -33,12 +33,12 @@ install -Dvm755 "libnvidia-opticalflow.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-opticalflow.so.$PKGVER
 install -Dvm755 "libnvidia-nvvm.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-nvvm.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.4" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.4
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.4" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.4
-install -Dvm755 "libnvidia-egl-gbm.so.1.1.2" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-gbm.so.1.1.2
+install -Dvm755 "libnvidia-egl-xlib.so.1.0.5" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.5
+install -Dvm755 "libnvidia-egl-xcb.so.1.0.5" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.5
+install -Dvm755 "libnvidia-egl-gbm.so.1.1.3" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-gbm.so.1.1.3
 
 install -Dvm755 "libnvidia-gpucomp.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-gpucomp.so.$PKGVER

--- a/runtime-display/nvidia+580/spec
+++ b/runtime-display/nvidia+580/spec
@@ -1,8 +1,8 @@
-VER=580.119.02
+VER=580.159.04
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::8020f5dfd3ee88aee7a38990d0c3d2afe54751e9a170ba9eadd7ea670138ecd7"
+CHKSUMS__AMD64="sha256::c1e66761b088d17b3adf6cb6979de9af38be2684d102b001a176dcfafabdca1e"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::798718543e5768d6e9e243ee7bc7daff3520aeddaf1dd8e7e8340c603974b90b"
+CHKSUMS__ARM64="sha256::8912f2623bc7c839765f36fcee3db4a3531834a2caff3aa5d49c1259b2372aeb"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=387790"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia+390: fix DKMS build with Linux 7.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- nvidia+390: 390.157-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia+390 nvidia+580
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
