### PR TITLE
Xfce Survey, 2026 May

### DIFF
--- a/desktop-xfce/libxfce4ui/autobuild/defines
+++ b/desktop-xfce/libxfce4ui/autobuild/defines
@@ -6,9 +6,23 @@ BUILDDEP="intltool gtk-doc gobject-introspection vala"
 PKGDES="Common UI library for Xfce"
 
 ABTYPE=autotools
-
 # FIXME: Shadow build causes Vala bindings to fail to build.
 ABSHADOW=0
+# FIXME: Re-generation fails.
+#
+# docs/reference/Makefile.am:26: error: ENABLE_X11 does not appear in AM_CONDITIONAL
+# glade/Makefile.am:9: error: HAVE_GLADEUI2 does not appear in AM_CONDITIONAL
+# glade/Makefile.am: installing './depcomp'
+# glade/icons/16x16/Makefile.am:1: error: HAVE_GLADEUI2 does not appear in AM_CONDITIONAL
+# glade/icons/22x22/Makefile.am:1: error: HAVE_GLADEUI2 does not appear in AM_CONDITIONAL
+# libxfce4kbd-private/Makefile.am:58: error: ENABLE_X11 does not appear in AM_CONDITIONAL
+# libxfce4ui/Makefile.am:73: error: ENABLE_X11 does not appear in AM_CONDITIONAL
+# libxfce4ui/Makefile.am:156: error: ENABLE_X11 does not appear in AM_CONDITIONAL
+# libxfce4ui/Makefile.am:163: error: ENABLE_WAYLAND does not appear in AM_CONDITIONAL
+# xfce4-about/Makefile.am:20: error: HAVE_GLIBTOP does not appear in AM_CONDITIONAL
+# autoreconf: error: automake failed with exit status: 1
+RECONF=0
+
 AUTOTOOLS_AFTER=(
     '--enable-vala'
 )

--- a/desktop-xfce/libxfce4ui/autobuild/defines
+++ b/desktop-xfce/libxfce4ui/autobuild/defines
@@ -1,11 +1,14 @@
 PKGNAME=libxfce4ui
-PKGDES="Common UI library for Xfce"
+PKGSEC=xfce
 PKGDEP="libxfce4util gtk-3 xfconf startup-notification libgtop \
         libepoxy libgudev"
 BUILDDEP="intltool gtk-doc gobject-introspection vala"
-PKGSEC=xfce
+PKGDES="Common UI library for Xfce"
 
-AUTOTOOLS_AFTER="--enable-vala=yes"
-RECONF=0
-NOPARALLEL=1
+ABTYPE=autotools
+
+# FIXME: Shadow build causes Vala bindings to fail to build.
 ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--enable-vala'
+)

--- a/desktop-xfce/libxfce4ui/autobuild/defines
+++ b/desktop-xfce/libxfce4ui/autobuild/defines
@@ -5,6 +5,7 @@ PKGDEP="libxfce4util gtk-3 xfconf startup-notification libgtop \
 BUILDDEP="intltool gtk-doc gobject-introspection vala"
 PKGSEC=xfce
 
-AUTOTOOLS_AFTER="--enable-vala=no"
+AUTOTOOLS_AFTER="--enable-vala=yes"
 RECONF=0
 NOPARALLEL=1
+ABSHADOW=0

--- a/desktop-xfce/libxfce4ui/spec
+++ b/desktop-xfce/libxfce4ui/spec
@@ -1,4 +1,5 @@
 VER=4.20.2
+REL=1
 SRCS="https://archive.xfce.org/src/xfce/libxfce4ui/${VER%.*}/libxfce4ui-$VER.tar.bz2"
 CHKSUMS="sha256::5d3d67b1244a10cee0e89b045766c05fe1035f7938f0410ac6a3d8222b5df907"
 CHKUPDATE="anitya::id=232000"

--- a/desktop-xfce/libxfce4windowing/spec
+++ b/desktop-xfce/libxfce4windowing/spec
@@ -1,5 +1,4 @@
-VER=4.20.4
-REL=1
+VER=4.20.6
 SRCS="https://archive.xfce.org/src/xfce/libxfce4windowing/${VER%.*}/libxfce4windowing-$VER.tar.bz2"
-CHKSUMS="sha256::db467f9ac4bac8f1c4e82667902841fc0957af835c29603d6659a57440b6f8cb"
+CHKSUMS="sha256::2d06b6a567c965afbca1a51419fc728fd83bd0460e30ab62c34564d5e0aac9e3"
 CHKUPDATE="anitya::id=375258"

--- a/desktop-xfce/mousepad/spec
+++ b/desktop-xfce/mousepad/spec
@@ -1,5 +1,4 @@
-VER=0.6.5
-REL=1
+VER=0.7.0
 SRCS="https://archive.xfce.org/src/apps/mousepad/${VER%.*}/mousepad-$VER.tar.xz"
-CHKSUMS="sha256::21762bc8c3c4f120a4a509ce39f4a5a58dbc10e3f0da66cdc6d9a8c735fff2ac"
+CHKSUMS="sha256::e86c59feb08126d4cace368432c16b2dee8e519aaca8a9d2b409ae1cdd200802"
 CHKUPDATE="anitya::id=198617"

--- a/desktop-xfce/orage/spec
+++ b/desktop-xfce/orage/spec
@@ -1,4 +1,4 @@
-VER=4.20.2
+VER=4.20.3
 SRCS="https://archive.xfce.org/src/apps/orage/${VER%.*}/orage-$VER.tar.bz2"
-CHKSUMS="sha256::6bfd3da084c2977fb5cee26c8e94bf55e358da8e86dd2a83c6fa9174f24672a1"
+CHKSUMS="sha256::d9f6a3bcd1fdcd83d8277bc1996684a02d06ef60492b69c2404815f3314d640e"
 CHKUPDATE="anitya::id=231994"

--- a/desktop-xfce/ristretto/spec
+++ b/desktop-xfce/ristretto/spec
@@ -1,4 +1,4 @@
-VER=0.13.4
+VER=0.14.0
 SRCS="https://archive.xfce.org/src/apps/ristretto/${VER%.*}/ristretto-$VER.tar.xz"
-CHKSUMS="sha256::a84ef8cb80638681d9b9ef09cddff86a5d7a0e028603b4a601cf0ff6c2869ce8"
+CHKSUMS="sha256::502cf1577de14b38132dc89e56884c5e10f86f6a028d8dde379a8839110fda55"
 CHKUPDATE="anitya::id=8365"

--- a/desktop-xfce/thunar/spec
+++ b/desktop-xfce/thunar/spec
@@ -1,4 +1,4 @@
-VER=4.20.4
+VER=4.20.8
 SRCS="https://archive.xfce.org/src/xfce/thunar/${VER%.*}/thunar-$VER.tar.bz2"
-CHKSUMS="sha256::c4f2fc55d285deef134859847ef6f0e9096ed7987ef7aa066de5a9e347a15fd9"
+CHKSUMS="sha256::cc735954d948a88eba2e40016a94c598f876309b736686c9f4d0273a05870c69"
 CHKUPDATE="anitya::id=14669"

--- a/desktop-xfce/tumbler/spec
+++ b/desktop-xfce/tumbler/spec
@@ -1,5 +1,4 @@
-VER=4.20.0
-REL=2
+VER=4.20.1
 SRCS="https://archive.xfce.org/src/xfce/tumbler/${VER%.*}/tumbler-$VER.tar.bz2"
-CHKSUMS="sha256::74b1647d55926547e98bfac70838ff63c5a84299a5e10c81c38d1fab90e25880"
+CHKSUMS="sha256::87b90df8f30144a292d70889e710c8619d8b8803f0e1db3280a4293367a42eae"
 CHKUPDATE="anitya::id=5014"

--- a/desktop-xfce/xfce4-eyes-plugin/autobuild/defines
+++ b/desktop-xfce/xfce4-eyes-plugin/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=xfce4-eyes-plugin
 PKGSEC=xfce
-PKGDEP="xfce4-panel"
+PKGDEP="xfce4-panel libxfce4ui libxfce4util gtk-3"
 BUILDDEP="intltool perl-xml-parser"
 PKGDES="XEye plugin for the Xfce4 panel"
-RECONF=0
+
+ABTYPE=meson

--- a/desktop-xfce/xfce4-eyes-plugin/spec
+++ b/desktop-xfce/xfce4-eyes-plugin/spec
@@ -1,5 +1,4 @@
-VER=4.5.1
-SRCS="tbl::https://archive.xfce.org/src/panel-plugins/xfce4-eyes-plugin/${VER%.*}/xfce4-eyes-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::4db780178e529391d53da180e49386904e69a5a33b3bd5185835d0a7e6ff5ac5"
-REL=4
+VER=4.7.0
+SRCS="tbl::https://archive.xfce.org/src/panel-plugins/xfce4-eyes-plugin/${VER%.*}/xfce4-eyes-plugin-$VER.tar.xz"
+CHKSUMS="sha256::87f9b978ca75abb3aa5edb1315eb65ef98654a662c14621847ddffe8aa6574ad"
 CHKUPDATE="anitya::id=15885"

--- a/desktop-xfce/xfce4-mount-plugin/autobuild/defines
+++ b/desktop-xfce/xfce4-mount-plugin/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=xfce4-mount-plugin
 PKGSEC=xfce
-PKGDEP="xfce4-panel"
+PKGDEP="xfce4-panel libxfce4ui libxfce4util gtk-3"
 BUILDDEP="intltool"
 PKGDES="Mount/unmount plugin for the Xfce panel"
-RECONF=0
+
+ABTYPE=meson

--- a/desktop-xfce/xfce4-mount-plugin/spec
+++ b/desktop-xfce/xfce4-mount-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.1.5
-REL=3
-SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mount-plugin/${VER%.*}/xfce4-mount-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::584cd954929e542b3da0ff8d69e0325d8838dc39e7b32a509d1074ce3bb58ec2"
+VER=1.2.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-mount-plugin/${VER%.*}/xfce4-mount-plugin-$VER.tar.xz"
+CHKSUMS="sha256::adef71a83078e7dc45997e57411f8c43080a0204159a8b8db2ade0a9877e7b4c"
 CHKUPDATE="anitya::id=15881"

--- a/desktop-xfce/xfce4-panel/spec
+++ b/desktop-xfce/xfce4-panel/spec
@@ -1,4 +1,4 @@
-VER=4.20.5
+VER=4.20.7
 SRCS="https://archive.xfce.org/src/xfce/xfce4-panel/${VER%.*}/xfce4-panel-$VER.tar.bz2"
-CHKSUMS="sha256::3f91850c9c467680c8081d561f1a3fd83355c07db07be9a96da1764f8c842b2b"
+CHKSUMS="sha256::696e3eff0b1b5bfa8ba90fd7afdea58f5b06e5547840a7443d11388f2fd578ea"
 CHKUPDATE="anitya::id=232007"

--- a/desktop-xfce/xfce4-screensaver/spec
+++ b/desktop-xfce/xfce4-screensaver/spec
@@ -1,5 +1,4 @@
-VER=4.20.1
+VER=4.20.2
 SRCS="https://archive.xfce.org/src/apps/xfce4-screensaver/${VER%.*}/xfce4-screensaver-${VER}.tar.xz"
-CHKSUMS="sha256::a94ce9ca3f56db183f1cbc60ba4accd91575b02a6d20b1876ad19131982f2243"
+CHKSUMS="sha256::5032f60a31df5e50a80512e301b595be5ea6a6bd762cdd95cacc24cbd29a01d7"
 CHKUPDATE="anitya::id=232009"
-REL="1"

--- a/desktop-xfce/xfce4-screenshooter/spec
+++ b/desktop-xfce/xfce4-screenshooter/spec
@@ -1,4 +1,4 @@
-VER=1.11.2
+VER=1.11.3
 SRCS="https://archive.xfce.org/src/apps/xfce4-screenshooter/${VER%.*}/xfce4-screenshooter-$VER.tar.xz"
-CHKSUMS="sha256::6ae5bc4823d43e770b3a11700d048d56bdcaafdef37de7deacb8970b55fc1565"
+CHKSUMS="sha256::1f6a14f7d1b0c440f31e24a8cc4fe2996185357fa786f0c2cdfe564ef673a710"
 CHKUPDATE="anitya::id=15830"

--- a/desktop-xfce/xfce4-session/spec
+++ b/desktop-xfce/xfce4-session/spec
@@ -1,4 +1,4 @@
-VER=4.20.3
+VER=4.20.4
 SRCS="https://archive.xfce.org/src/xfce/xfce4-session/${VER%.*}/xfce4-session-$VER.tar.bz2"
-CHKSUMS="sha256::dbf00672c5316a30b7001fe852e6a5ba9f889afeab8a247545a160d4302f1fa2"
+CHKSUMS="sha256::805c373378d080754d69dd2f20db95cdc066c89a4f024a41435ca0d66571c402"
 CHKUPDATE="anitya::id=232010"

--- a/desktop-xfce/xfce4-settings/spec
+++ b/desktop-xfce/xfce4-settings/spec
@@ -1,5 +1,4 @@
-VER=4.20.2
-REL=1
+VER=4.20.4
 SRCS="https://archive.xfce.org/src/xfce/xfce4-settings/${VER%.*}/xfce4-settings-$VER.tar.bz2"
-CHKSUMS="sha256::6e11776e640798a1ac4168d53877f105bb3e8cf93b443c160841e3acdab63939"
+CHKSUMS="sha256::ad5c3c5bfb36f5eb091c05897d60f468d0d5cc4364c8d1d38ca53d8bb04387da"
 CHKUPDATE="anitya::id=232011"

--- a/desktop-xfce/xfce4-systemload-plugin/autobuild/defines
+++ b/desktop-xfce/xfce4-systemload-plugin/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=xfce4-systemload-plugin
 PKGSEC=xfce
-PKGDEP="xfce4-panel upower"
+PKGDEP="xfce4-panel libxfce4ui libxfce4util gtk-3 upower libgtop"
 BUILDDEP="intltool"
 PKGDES="System load plugin for the Xfce4 Panel"
-RECONF=0
+
+ABTYPE=meson

--- a/desktop-xfce/xfce4-systemload-plugin/spec
+++ b/desktop-xfce/xfce4-systemload-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.3.1
-SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-systemload-plugin/${VER%.*}/xfce4-systemload-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::56d1007801d52d7c2b5a13bb54745f6d7f06fda28b49ce936145633068817652"
+VER=1.4.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-systemload-plugin/${VER%.*}/xfce4-systemload-plugin-$VER.tar.xz"
+CHKSUMS="sha256::6e363bcf845bb88329b52858d65a1ec6e00db5121ae9246e46eb03135d9569c6"
 CHKUPDATE="anitya::id=15825"
-REL=2

--- a/desktop-xfce/xfce4-terminal/spec
+++ b/desktop-xfce/xfce4-terminal/spec
@@ -1,5 +1,4 @@
-VER=1.1.5
-REL=1
+VER=1.2.0
 SRCS="https://archive.xfce.org/src/apps/xfce4-terminal/${VER%.*}/xfce4-terminal-${VER}.tar.xz"
-CHKSUMS="sha256::3c5b1d3a01a9a113852ac0f77d1c85bf3a356b43de33ec805b21ceca7d6f0a63"
+CHKSUMS="sha256::6874c7b975cc3dc3bd636d57ffec723de7458202defe65377593d3a7e0734b94"
 CHKUPDATE="anitya::id=12981"

--- a/desktop-xfce/xfce4-time-out-plugin/autobuild/defines
+++ b/desktop-xfce/xfce4-time-out-plugin/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=xfce4-time-out-plugin
 PKGDES="Break timer plugin for the Xfce4 panel"
-PKGDEP="xfce4-panel"
+PKGDEP="xfce4-panel libxfce4ui libxfce4util gtk-3"
 BUILDDEP="intltool"
 PKGSEC=xfce
-RECONF=0
+
+ABTYPE=meson

--- a/desktop-xfce/xfce4-time-out-plugin/spec
+++ b/desktop-xfce/xfce4-time-out-plugin/spec
@@ -1,5 +1,4 @@
-VER=1.1.2
-SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-time-out-plugin/${VER%.*}/xfce4-time-out-plugin-$VER.tar.bz2"
-CHKSUMS="sha256::3dd8eba694ff3ba5c25bd7f5cd70dc22175fb2c0a759213f05ab8f0e629d82d4"
+VER=1.2.0
+SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-time-out-plugin/${VER%.*}/xfce4-time-out-plugin-$VER.tar.xz"
+CHKSUMS="sha256::e344d9f82a8acd23d44e7cf9b2efe9599ffff856d9ba1a9be0e67b022c0d2eb2"
 CHKUPDATE="anitya::id=15823"
-REL=2

--- a/desktop-xfce/xfce4-whiskermenu-plugin/autobuild/defines
+++ b/desktop-xfce/xfce4-whiskermenu-plugin/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=xfce4-whiskermenu-plugin
 PKGSEC=xfce
-PKGDEP="xfce4-panel mugshot gtk-layer-shell"
-BUILDDEP="intltool xfce4-dev-tools"
+PKGDEP="xfce4-panel libxfce4ui libxfce4util gtk-3 mugshot gtk-layer-shell accountsservice"
+BUILDDEP="intltool"
 PKGDES="Alternative application menu plugin for the Xfce4 panel"
+
+ABTYPE=meson

--- a/desktop-xfce/xfce4-whiskermenu-plugin/spec
+++ b/desktop-xfce/xfce4-whiskermenu-plugin/spec
@@ -1,4 +1,4 @@
-VER=2.10.0
+VER=2.10.1
 SRCS="https://archive.xfce.org/src/panel-plugins/xfce4-whiskermenu-plugin/${VER%.*}/xfce4-whiskermenu-plugin-$VER.tar.xz"
-CHKSUMS="sha256::c2efb3782816d44d421dcbee2900b9513bdb2469b695b776641f495601f33a10"
+CHKSUMS="sha256::8b5a777a5d9df1f1c39b109ba8b2d045cb2cc02c41a9a297aa00dcb2a4520530"
 CHKUPDATE="anitya::id=7201"

--- a/desktop-xfce/xfdashboard/autobuild/defines
+++ b/desktop-xfce/xfdashboard/autobuild/defines
@@ -3,4 +3,5 @@ PKGDES="GNOME Shell-like dashboard for Xfce"
 PKGSEC=xfce
 PKGDEP="clutter garcon libwnck-3"
 BUILDDEP="intltool xfce4-dev-tools"
-RECONF=0
+
+ABTYPE=meson

--- a/desktop-xfce/xfdashboard/spec
+++ b/desktop-xfce/xfdashboard/spec
@@ -1,5 +1,4 @@
-VER=1.0.0
-SRCS="https://archive.xfce.org/src/apps/xfdashboard/${VER:0:3}/xfdashboard-$VER.tar.bz2"
-CHKSUMS="sha256::a5284343e5ce09722f98d3b578588b36923e1ae5649754aa906980fdcdef48a5"
+VER=1.1.0
+SRCS="https://archive.xfce.org/src/apps/xfdashboard/${VER:0:3}/xfdashboard-$VER.tar.xz"
+CHKSUMS="sha256::bd577b36f389d5463040d7095926a487cb4ae7ab30173aa269a1bc29bb6ff8d1"
 CHKUPDATE="anitya::id=5186"
-REL=1

--- a/desktop-xfce/xfdesktop/spec
+++ b/desktop-xfce/xfdesktop/spec
@@ -1,4 +1,4 @@
-VER=4.20.1
+VER=4.20.2
 SRCS="https://archive.xfce.org/src/xfce/xfdesktop/${VER%.*}/xfdesktop-$VER.tar.bz2"
-CHKSUMS="sha256::acccde849265bbf4093925ba847977b7abf70bb2977e4f78216570e887c157b8"
+CHKSUMS="sha256::1d9bd76015fb6e9aca05e73cd998c7c66ed4fc8c10b626e08fc2eb7c39df3f7b"
 CHKUPDATE="anitya::id=14855"

--- a/desktop-xfce/xfmpc/autobuild/defines
+++ b/desktop-xfce/xfmpc/autobuild/defines
@@ -2,5 +2,6 @@ PKGNAME=xfmpc
 PKGDES="Graphical MPD client for Xfce"
 PKGSEC=xfce
 PKGDEP="libmpd libxfce4ui"
-BUILDDEP="intltool"
-RECONF=0
+BUILDDEP="intltool vala"
+
+ABTYPE=meson

--- a/desktop-xfce/xfmpc/autobuild/defines
+++ b/desktop-xfce/xfmpc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=xfmpc
-PKGDES="Graphical MPD client for Xfce"
 PKGSEC=xfce
 PKGDEP="libmpd libxfce4ui"
-BUILDDEP="intltool vala"
+BUILDDEP="gobject-introspection vala"
+PKGDES="Graphical MPD client for Xfce"
 
 ABTYPE=meson

--- a/desktop-xfce/xfmpc/autobuild/prepare
+++ b/desktop-xfce/xfmpc/autobuild/prepare
@@ -1,2 +1,0 @@
-abinfo "Adding -Wno-error=incompatible-pointer-types to fix compilation ..."
-export CFLAGS="${CFLAGS} -Wno-error=incompatible-pointer-types"

--- a/desktop-xfce/xfmpc/spec
+++ b/desktop-xfce/xfmpc/spec
@@ -1,4 +1,4 @@
-VER=0.3.0
-SRCS="https://archive.xfce.org/src/apps/xfmpc/${VER%.*}/xfmpc-$VER.tar.bz2"
-CHKSUMS="sha256::c76e2a88dc3e1d345da7a5c68fa39981494c2b40033748efcac54411c9e65689"
+VER=0.4.0
+SRCS="https://archive.xfce.org/src/apps/xfmpc/${VER%.*}/xfmpc-$VER.tar.xz"
+CHKSUMS="sha256::6b8efc8c1c0ada91a1ce02413000bc6e38c72364e16f2fa4db7edc71fda25935"
 CHKUPDATE="anitya::id=14466"


### PR DESCRIPTION
Topic Description
-----------------

- libxfce4ui: fix vala binding builds
- xfce4-whiskermenu-plugin: update to 2.10.1
- xfce4-time-out-plugin: update to 1.2.0
- xfce4-systemload-plugin: update to 1.4.0
- xfce4-mount-plugin: update to 1.2.0
- xfce4-eyes-plugin: update to 4.7.0
- xfce4-screensaver: update to 4.20.2
- xfce4-terminal: update to 1.2.0
- xfce4-screenshooter: update to 1.11.3
- xfmpc: update to 0.4.0

... and 11 more commits

Package(s) Affected
-------------------

- libxfce4ui: 4.20.2-1
- libxfce4windowing: 4.20.6
- mousepad: 0.7.0
- orage: 4.20.3
- ristretto: 0.14.0
- thunar: 4.20.8
- tumbler: 4.20.1
- xfce4-eyes-plugin: 4.7.0
- xfce4-mount-plugin: 1.2.0
- xfce4-panel: 1:4.20.7
- xfce4-screensaver: 4.20.2
- xfce4-screenshooter: 1.11.3
- xfce4-session: 1:4.20.4
- xfce4-settings: 4.20.4
- xfce4-systemload-plugin: 1.4.0
- xfce4-terminal: 1.2.0
- xfce4-time-out-plugin: 1.2.0
- xfce4-whiskermenu-plugin: 2.10.1
- xfdashboard: 1.1.0
- xfdesktop: 4.20.2
- xfmpc: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxfce4ui libxfce4windowing xfce4-panel thunar xfdesktop xfce4-settings xfce4-session mousepad orage tumbler ristretto xfdashboard xfmpc xfce4-screenshooter xfce4-terminal xfce4-screensaver xfce4-eyes-plugin xfce4-mount-plugin xfce4-systemload-plugin xfce4-time-out-plugin xfce4-whiskermenu-plugin
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
