### PR TITLE
flatpak-builder: security update to 1.4.8

### DIFF
--- a/app-devel/flatpak-builder/spec
+++ b/app-devel/flatpak-builder/spec
@@ -1,5 +1,4 @@
-VER=1.4.7
-REL=1
+VER=1.4.8
 SRCS="git::commit=tags/$VER::https://github.com/flatpak/flatpak-builder"
-CHKSUMS="sha256::fd5bc36fe3b974395f782e6c920d8955cee168f513370c32cc800b69acd980d0"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16046"

--- a/topics/flatpak-builder-1.4.8.toml
+++ b/topics/flatpak-builder-1.4.8.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "flatpak-builder 1.4.8"
+
+[caution]
+default = "Fixes a Path Traversal vulnerability (CVE-2026-39977, Severity: Medium)"
+zh_CN = "修复一个路径穿越漏洞（漏洞编号 CVE-2026-39977，严重性：中）"
+
+[packages-v2]
+"flatpak-builder" = "< 1.4.8"


### PR DESCRIPTION
Topic Description
-----------------

- flatpak-builder: security update to 1.4.8

Package(s) Affected
-------------------

- flatpak-builder: 1.4.8

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit flatpak-builder
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
