### PR TITLE
samba: update to 4.24.3

### DIFF
--- a/app-network/samba/spec
+++ b/app-network/samba/spec
@@ -1,5 +1,4 @@
-VER=4.24.0
-REL=1
+VER=4.24.3
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
-CHKSUMS="sha256::1b1e457fd651a612cd08226cc6efd04e5d01e36d918c8b4c4e470e74e86881ea"
+CHKSUMS="sha256::4a5e0ed1ea192b798c873d9957c50a5767c10c2767cccb00d56ecc427e94f8e9"
 CHKUPDATE="anitya::id=4758"

--- a/topics/samba-4.24.3.toml
+++ b/topics/samba-4.24.3.toml
@@ -1,0 +1,13 @@
+security = true
+
+[name]
+default = "Samba 4.24.3"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (2 of critical severity, 3 of high severity, 1 of medium severity)"
+zh_CN = "修复 6 个安全漏洞（含 2 个严重、3 个高危、1 个中危）"
+zh_TW = "修復 6 個安全漏洞（含 2 個高危、3 個高危、1 個中危）"
+
+[packages-v2]
+"samba" = "< 4.24.3"
+"ldb" = "< 4.24.3"


### PR DESCRIPTION
Topic Description
-----------------

- samba: update to 4.24.3
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- ldb: 2:4.24.3
- samba: 4.24.3

Security Update?
----------------
Yes
[CVE-2026-4408](https://www.samba.org/samba/security/CVE-2026-4408.html), [CVE-2026-4480](https://www.samba.org/samba/security/CVE-2026-4480.html), [CVE-2026-2340](https://www.samba.org/samba/security/CVE-2026-2340.html), [CVE-2026-3012](https://www.samba.org/samba/security/CVE-2026-3012.html), [CVE-2026-3238](https://www.samba.org/samba/security/CVE-2026-3238.html), [CVE-2026-1933](https://www.samba.org/samba/security/CVE-2026-1933.html).


Build Order
-----------

```
#buildit samba
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
