### PR TITLE
usbredir: security update to 0.15.0

### DIFF
--- a/runtime-devices/usbredir/spec
+++ b/runtime-devices/usbredir/spec
@@ -1,5 +1,4 @@
-VER=0.8.0
-REL=1
-SRCS="tbl::https://www.spice-space.org/download/usbredir/usbredir-$VER.tar.bz2"
-CHKSUMS="sha256::87bc9c5a81c982517a1bec70dc8d22e15ae197847643d58f20c0ced3c38c5e00"
+VER=0.15.0
+SRCS="git::commit=tags/usbredir-$VER::https://gitlab.freedesktop.org/spice/usbredir"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16012"

--- a/topics/usbredir-0.15.0.toml
+++ b/topics/usbredir-0.15.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "usbredir 0.15.0"
+
+[caution]
+default = "Fixes an Use After Free vulnerability (CVE-2021-3700, Severity: Medium)"
+zh_CN = "修复一个释放后使用漏洞（CVE-2021-3700，严重性：中）"
+
+[packages-v2]
+"usbredir" = "< 0.15.0"


### PR DESCRIPTION
Topic Description
-----------------

- usbredir: security update to 0.15.0

Package(s) Affected
-------------------

- usbredir: 0.15.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit usbredir
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
