### PR TITLE
flatseal: update to 2.4.1

### DIFF
--- a/app-utils/flatseal/spec
+++ b/app-utils/flatseal/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.4.1
 SRCS="git::commit=tags/v${VER}::https://github.com/tchx84/Flatseal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=320449"


### PR DESCRIPTION
Topic Description
-----------------

- flatseal: update to 2.4.1
    Co-authored-by: 铺盖崽 \(@pugaizai\) <i@pugai.life>

Package(s) Affected
-------------------

- flatseal: 2.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit flatseal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
