### PR TITLE
ffmpeg: rework again, update PKGBREAK

### DIFF
--- a/app-multimedia/ffmpeg/01-ffmpeg/defines
+++ b/app-multimedia/ffmpeg/01-ffmpeg/defines
@@ -32,7 +32,7 @@ PKGBREAK="akode<=14.1.5 alsa-plugins<=1.2.12-2 aubio<=0.4.9-7 \
           dragon<=23.08.5 fceux<=2.6.6+git20251111 ffmpegthumbnailer<=2.2.2-1 \
           ffmpegthumbs<=23.08.5-1 ffms2<=5.0 freerdp<=2:3.24.2 \
           gegl-0.4<=0.4.68-1 goldendict<=1:1.5.0-2 gpac<=2.2.1 \
-          gstreamer<=1.28.1-4 gtk-4<=4.14.2 guvcview<=2.1.0-1 \
+          gstreamer<=1.28.1-5 gtk-4<=4.14.2 guvcview<=2.1.0-1 \
           haruna<=0.12.3-3 harvid<=0.9.1-1 k3b<=23.08.5-5 \
           k3b-trinity<=14.1.5-1 k9copy-trinity<=14.1.5-1 kdenlive<=23.08.5 \
           kfilemetadata<=5.115.0-4 kid3<=3.9.5-2 kodi<=21.3-3 \
@@ -50,7 +50,7 @@ PKGBREAK="akode<=14.1.5 alsa-plugins<=1.2.12-2 aubio<=0.4.9-7 \
           qtav<=1.13.0-4 qtox<=1.17.6-1 replaysorcery<=0.6.0 \
           renpy<=8.5.2.26010301 scrcpy<=3.3.4 simplescreenrecorder<=0.4.4 \
           spek-x<=0.9.4-1 sunshine<=2025.924.154138 synfig<=1.5.3 \
-          stepmania<=1:5.0.12+git20221114 telegram-desktop<=6.8.2-2 \
+          stepmania<=1:5.0.12+git20221114 telegram-desktop<=6.8.2-3 \
           tigervnc<=1.16.2+xserver21.1.21 unpaper<=1:7.0.0 \
           vba-m<=2.2.3-1 vlc<=3.0.21-1 wine<=11.8+gecko2.47.4+mono11.1.0 \
           xine-lib<=1.2.13-10 xjadeo<=0.8.13-1 xpra<=5.0.8-1"

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=8.1.1
-REL=1
+REL=2
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"
 CHKUPDATE="anitya::id=5405"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,5 +1,5 @@
 VER=6.8.2
-REL=3
+REL=4
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=e0943d068ce90b5010f1aea946e6901e25b43bf6

--- a/runtime-multimedia/gstreamer/spec
+++ b/runtime-multimedia/gstreamer/spec
@@ -1,5 +1,5 @@
 VER=1.28.1
-REL=5
+REL=6
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.freedesktop.org/gstreamer/gstreamer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1263"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: update PKGBREAK
- telegram-desktop: rebuild for ffmpeg 8.1.1
- gstreamer: bump REL due to ffmpeg update to 8.1.1

Package(s) Affected
-------------------

- ffmpeg: 8.1.1-2
- ffmpeg-static-libs-for-sunshine: 8.1.1-2
- gstreamer: 1.28.1-6
- libde265: 1.0.18-2
- telegram-desktop: 6.8.2-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg:-pkgbreak libde265:+stage2 gstreamer:+stage2 libde265 gstreamer telegram-desktop ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
