### PR TITLE
putty: update to 0.84

### DIFF
--- a/app-network/putty/spec
+++ b/app-network/putty/spec
@@ -1,4 +1,4 @@
-VER=0.83
+VER=0.84
 SRCS="tbl::https://the.earth.li/~sgtatham/putty/$VER/putty-$VER.tar.gz"
-CHKSUMS="sha256::718777c13d63d0dff91fe03162bc2a05b4dfc8b0827634cd60b51cefdff631c6"
+CHKSUMS="sha256::06057862ae198f1dbd219d0c7493080d59f606194bb5056c549e342aa01b69fe"
 CHKUPDATE="anitya::id=5749"

--- a/topics/putty-0.84.toml
+++ b/topics/putty-0.84.toml
@@ -1,0 +1,12 @@
+security = true
+must_match_all = false
+
+[name]
+default = "PuTTY 0.84"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (1 of Medium severity)"
+zh_CN = "修复 4 个安全漏洞（含 1 个中危漏洞）"
+
+[packages-v2]
+"putty" = "< 0.84"


### PR DESCRIPTION
Topic Description
-----------------

- putty: update to 0.84
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- putty: 0.84

Security Update?
----------------

No

Build Order
-----------

```
#buildit putty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
