### PR TITLE
mangohud: update to 0.8.4

### DIFF
--- a/app-utils/mangohud/spec
+++ b/app-utils/mangohud/spec
@@ -1,5 +1,4 @@
-VER=0.8.2
-REL=1
+VER=0.8.4
 SRCS="tbl::https://github.com/flightlessmango/MangoHud/releases/download/v${VER/\+/-}/MangoHud-v${VER/\+/-}-Source.tar.xz"
-CHKSUMS="sha256::9fe98da24f790f4489efc1e0c8e3ad0291c80efd882a406797d54dab82f8765b"
+CHKSUMS="sha256::bbe5a2b976313c53f21dc24b98bbed03226589460a0cce20d923cb2c36c9d8b0"
 CHKUPDATE="anitya::id=138139"

--- a/runtime-optenv32/mangohud+32/spec
+++ b/runtime-optenv32/mangohud+32/spec
@@ -1,4 +1,4 @@
-VER=0.8.2
+VER=0.8.4
 SRCS="tbl::https://github.com/flightlessmango/MangoHud/releases/download/v${VER/\+/-}/MangoHud-v${VER/\+/-}-Source.tar.xz"
-CHKSUMS="sha256::9fe98da24f790f4489efc1e0c8e3ad0291c80efd882a406797d54dab82f8765b"
+CHKSUMS="sha256::bbe5a2b976313c53f21dc24b98bbed03226589460a0cce20d923cb2c36c9d8b0"
 CHKUPDATE="anitya::id=138139"


### PR DESCRIPTION
Topic Description
-----------------

- mangohud: update to 0.8.4
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- mangohud: 0.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mangohud
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
