### PR TITLE
kconfig-frontends: new, 4.11.0.1

### DIFF
--- a/app-devel/kconfig-frontends/autobuild/defines
+++ b/app-devel/kconfig-frontends/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=kconfig-frontends
+PKGSEC=devel
+PKGDEP="python-3 ncurses qt-5"
+BUILDDEP="gperf"
+PKGDES="Standalone implementation of the Linux Kconfig parser and frontend"

--- a/app-devel/kconfig-frontends/spec
+++ b/app-devel/kconfig-frontends/spec
@@ -1,0 +1,4 @@
+VER=4.11.0.1
+SRCS="git::commit=tags/v$VER::https://github.com/TizenTeam/kconfig-frontends.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391406"


### PR DESCRIPTION
Topic Description
-----------------

- kconfig-frontends: new, 4.11.0.1
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- kconfig-frontends: 4.11.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit kconfig-frontends
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
