### PR TITLE
ps3netsrv-go: update to 0.3.1

### DIFF
--- a/app-network/ps3netsrv-go/autobuild/defines
+++ b/app-network/ps3netsrv-go/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=ps3netsrv-go
 PKGSEC=net
-BUILDDEP="go"
-GO_PACKAGES=("cmd/ps3netsrv-go")
 PKGDES="Utility to serve games and applications to PlayStation 3 consoles"
+PKGDEP="libchdr"
+BUILDDEP="go zstd"
+GO_PACKAGES=("cmd/ps3netsrv-go")
+
 ABTYPE=gomod
 # FIXME: Missing architcture support for MIPS
 #

--- a/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/systemd/system/ps3netsrv-go.service
+++ b/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/systemd/system/ps3netsrv-go.service
@@ -11,7 +11,7 @@ Group=ps3netsrv-go
 ExecStart=/usr/bin/ps3netsrv-go server --config=/etc/ps3netsrv-go.conf
 Restart=on-failure
 RestartSec=5s
-MemoryMax=128M
+MemoryMax=512M
 
 [Install]
 WantedBy=multi-user.target

--- a/app-network/ps3netsrv-go/spec
+++ b/app-network/ps3netsrv-go/spec
@@ -1,4 +1,4 @@
-VER=0.2.4
+VER=0.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/xakep666/ps3netsrv-go"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383793"

--- a/runtime-common/libchdr/autobuild/defines
+++ b/runtime-common/libchdr/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libchdr
+PKGSEC=lib
+PKGDES="Library for reading MAME's CHDv1-v5 formats"
+PKGDEP="glibc"
+BUILDDEP="cmake zlib zstd"
+
+ABTYPE=cmakeninja

--- a/runtime-common/libchdr/spec
+++ b/runtime-common/libchdr/spec
@@ -1,0 +1,4 @@
+VER=0.3.0
+SRCS="git::commit=tags/v$VER::https://github.com/rtissera/libchdr"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390337"


### PR DESCRIPTION
Topic Description
-----------------

- libchdr: new, 0.3.0
- ps3netsrv-go: update to 0.3.1
- ps3netsrv-go: enable CHDR compression

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libchdr ps3netsrv-go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
