### PR TITLE
flake8-docstrings: revive, 1.7.0-1

### DIFF
--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -889,6 +889,7 @@ flake8
 flake8-builtins
 flake8-comprehensions
 pydocstyle
+flake8-docstrings
 flake8-import-order
 flake8-quotes
 flask-login

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -888,6 +888,7 @@ pyflakes
 flake8
 flake8-builtins
 flake8-comprehensions
+pydocstyle
 flake8-import-order
 flake8-quotes
 flask-login

--- a/lang-python/flake8-docstrings/autobuild/defines
+++ b/lang-python/flake8-docstrings/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=flake8-docstrings
+PKGSEC=python
+PKGDEP="python-3 flake8 pydocstyle"
+BUILDDEP="setuptools"
+PKGDES="Integration of pydocstyle and flake8 for combined linting and reporting"
+
+ABTYPE=python
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/flake8-docstrings/spec
+++ b/lang-python/flake8-docstrings/spec
@@ -1,0 +1,5 @@
+VER=1.7.0
+REL=1
+SRCS="git::commit=tags/$VER::https://github.com/pycqa/flake8-docstrings"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=321410"

--- a/lang-python/pydocstyle/autobuild/defines
+++ b/lang-python/pydocstyle/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pydocstyle
+PKGSEC=python
+PKGDEP="python-3 poetry-core snowballstemmer"
+BUILDDEP="setuptools"
+PKGDES="Docstring style checker"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pydocstyle/spec
+++ b/lang-python/pydocstyle/spec
@@ -1,0 +1,5 @@
+VER=6.3.0
+REL=1
+SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/PyCQA/pydocstyle"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=15553"


### PR DESCRIPTION
Topic Description
-----------------

- flake8-docstrings: revive, 1.7.0-1
    This reverts commit 5fde23da852b37b99ce707080617b501ca86858f.
- pydocstyle: revive, 6.3.0-1
    This reverts commit 6905f0b0d4dabe0fdb70393052b5353e86691699.

Package(s) Affected
-------------------

- flake8-docstrings: 1.7.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit flake8-docstrings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
