### PR TITLE
rustc: update to 1.96.0

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 65001cf312cd9145c5a95d10b5a932a36d9dcf35 Mon Sep 17 00:00:00 2001
+From d9168ba488d19900d2f70668bc4841927ba63707 Mon Sep 17 00:00:00 2001
 From: Jiajie Chen <c@jia.je>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 1/3] Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 1/3] Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index 57effe3a86..752d35ace8 100644
+index 0601f9d7c2..6706760a9e 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1436,6 +1436,7 @@ supported_targets! {
+@@ -1447,6 +1447,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),

--- a/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,4 +1,4 @@
-From 29950909cac95e82214bfbaa9889667c6afd22a0 Mon Sep 17 00:00:00 2001
+From 093c85749c5645d584d1510dff12b7ef7cb375a0 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 20:12:53 +0200
 Subject: [PATCH 2/3] ARCHLINUX: compiler: Swap primary and secondary lib dirs
@@ -9,10 +9,10 @@ Arch Linux (editor's note: also AOSC OS) prefers "lib" over "lib64".
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/compiler/rustc_target/src/lib.rs b/compiler/rustc_target/src/lib.rs
-index dfa1b23207..fe7d266dea 100644
+index d46802bf45..9a8a3e2dc2 100644
 --- a/compiler/rustc_target/src/lib.rs
 +++ b/compiler/rustc_target/src/lib.rs
-@@ -50,20 +50,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
+@@ -48,20 +48,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
      // If --libdir is set during configuration to the value other than
      // "lib" (i.e., non-default), this value is used (see issue #16552).
  

--- a/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,4 +1,4 @@
-From 27b5d77a054b2174357bd9d98ea1e3238b213da0 Mon Sep 17 00:00:00 2001
+From 0d67414a67f644bb99b2be4e60cae87d3813227e Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 19:01:26 +0200
 Subject: [PATCH 3/3] ARCHLINUX: bootstrap: Workaround for system stage0
@@ -9,10 +9,10 @@ See: http://github.com/rust-lang/rust/issues/143735
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
-index 11f2a28bb9..94b3bfb24b 100644
+index 46d05b9d5d..0c8ab4e0eb 100644
 --- a/src/bootstrap/src/core/build_steps/compile.rs
 +++ b/src/bootstrap/src/core/build_steps/compile.rs
-@@ -827,7 +827,10 @@ impl Step for StdLink {
+@@ -812,7 +812,10 @@ impl Step for StdLink {
                  let _ = fs::remove_dir_all(sysroot.join("lib/rustlib/src/rust"));
              }
  

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,7 +1,7 @@
-VER=1.95.0
+VER=1.96.0
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::62b67230754da642a264ca0cb9fc08820c54e2ed7b3baba0289876d4cdb48c08"
+CHKSUMS="sha256::b99ce16cdf0ecfc761b585ac84d131b46733465a02f8ecd0ff2de9713c62ee09"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.96.0
    Track patches at AOSC-Tracking/rustc @ aosc/v1.96.0
    \(HEAD: 0d67414a67f644bb99b2be4e60cae87d3813227e\).

Package(s) Affected
-------------------

- rustc: 1:1.96.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
