### PR TITLE
llvm-22: new, 22.1.6

### DIFF
--- a/app-devel/llvm-22/01-runtime/build
+++ b/app-devel/llvm-22/01-runtime/build
@@ -1,0 +1,71 @@
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+abinfo "Removing certain search path in PATH to avoid issues ..."
+# LLVM will not be able to find Python 3 otherwise
+PATH="${PATH/:\/bin/}"
+PATH="${PATH/:\/sbin/}"
+
+CPP_TRIPLE="$(gcc -dumpmachine)"
+if [[ "$USECLANG" = '1' ]]; then
+    abinfo "Selecting ${CPP_TRIPLE} for Clang ..."
+    clang -target "${CPP_TRIPLE}" -v
+    export CFLAGS="${CFLAGS} -target ${CPP_TRIPLE}"
+    export CXXFLAGS="${CXXFLAGS} -target ${CPP_TRIPLE}"
+    # only clang will have this idiotic issue
+    if ab_match_arch riscv64; then
+        abinfo 'Setting -D__LONG_WIDTH__=64 to workaround a Clang bug ...'
+        export CFLAGS="${CFLAGS} -D__LONG_WIDTH__=64"
+        export CXXFLAGS="${CXXFLAGS} -D__LONG_WIDTH__=64"
+    fi
+fi
+
+if ab_match_arch loongarch64; then
+    abinfo "Adding -mcmodel=medium for compiler-rt ..."
+    export CFLAGS="${CFLAGS} -mcmodel=medium"
+    export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
+fi
+
+# Remove this when uleb128 relocation support is landed
+if ab_match_arch riscv64; then
+    abinfo "Stripping debug symbols from libc_nonshared.a for ULEB128 relocation ..."
+    strip --strip-debug /usr/lib/libc_nonshared.a
+fi
+
+abinfo "Running CMake for LLVM ..."
+cmake "$SRCDIR" \
+    ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+    -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-${PKGVER%%.*} \
+    -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
+    -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
+    -DCMAKE_SKIP_RPATH=NO \
+    -DCMAKE_SKIP_INSTALL_RPATH=NO \
+    -GNinja
+
+abinfo "Building LLVM ..."
+ninja
+
+abinfo "Installing LLVM to a temporary installation directory ..."
+DESTDIR="$SRCDIR"/fakeroot \
+    ninja install
+
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib
+cp -Pv \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so* \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/
+# Note: not all targets have libunwind, libcxx and libcxxabi
+for i in "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/lib{unwind,c++}*.so*; do
+    if [ -e "$i" ]; then
+        cp -Pv "$i" \
+            "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/
+    fi
+done
+
+abinfo "Installing version-specific runtime libraries to the default location ..."
+cd "$PKGDIR"/usr/lib
+# The major sover must match the first segment of PKGVER to be considered
+# version-specific
+ln -sv llvm-"${PKGVER%%.*}"/lib/*.so."${PKGVER%%.*}"* .
+ln -sv llvm-"${PKGVER%%.*}"/lib/libLLVM-"${PKGVER%%.*}".so .

--- a/app-devel/llvm-22/01-runtime/build.stage2
+++ b/app-devel/llvm-22/01-runtime/build.stage2
@@ -1,0 +1,41 @@
+mkdir -pv "$SRCDIR"/build
+cd "$SRCDIR"/build
+
+abinfo "Removing certain search path in PATH to avoid issues ..."
+# LLVM will not be able to find Python 3 otherwise
+PATH="${PATH/:\/bin/}"
+PATH="${PATH/:\/sbin/}"
+
+CPP_TRIPLE="$(gcc -dumpmachine)"
+
+abinfo "Running CMake for LLVM ..."
+cmake "$SRCDIR" \
+    ${CMAKE_DEF[@]} ${CMAKE_AFTER[@]} \
+    -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-${PKGVER%%.*} \
+    -DLLVM_DEFAULT_TARGET_TRIPLE=${CPP_TRIPLE} \
+    -DLLVM_HOST_TRIPLE=${CPP_TRIPLE} \
+    -DCMAKE_SKIP_RPATH=NO \
+    -DCMAKE_SKIP_INSTALL_RPATH=NO \
+    -GNinja
+
+abinfo "Building LLVM ..."
+ninja
+
+abinfo "Installing LLVM to a temporary installation directory ..."
+DESTDIR="$SRCDIR"/fakeroot \
+    ninja install
+
+abinfo "Installing runtime libraries ..."
+install -vd "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib
+cp -Pv \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so* \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so \
+    "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/libc++*.so* \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/
+
+abinfo "Installing version-specific runtime libraries to the default location ..."
+cd "$PKGDIR"/usr/lib
+# The major sover must match the first segment of PKGVER to be considered
+# version-specific
+ln -sv llvm-"${PKGVER%%.*}"/lib/*.so."${PKGVER%%.*}"* .
+ln -sv llvm-"${PKGVER%%.*}"/lib/libLLVM-"${PKGVER%%.*}".so .

--- a/app-devel/llvm-22/01-runtime/defines
+++ b/app-devel/llvm-22/01-runtime/defines
@@ -1,0 +1,108 @@
+PKGNAME=llvm-runtime-22
+PKGSEC=libs
+PKGDEP="gcc-runtime libedit libffi ncurses zlib"
+BUILDDEP="swig doxygen ocaml findlib llvm-22"
+BUILDDEP__RETRO="llvm"
+BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
+BUILDDEP__I486="${BUILDDEP__RETRO}"
+BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
+BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
+BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGDES="Low Level Virtual Machine Infrastructure (runtime libraries, version 22)"
+
+AB_FLAGS_O3=1
+# Note: For size.
+AB_FLAGS_O3__RETRO=0
+
+# FIXME: Fails to link with LTO enabled.
+#
+# /usr/bin/ld.bfd: /tmp/ccT9v8pZ.ltrans62.ltrans.o: in function `llvm::AsmPrinter::getOrCreateGCPrinter(llvm::GCStrategy&)':
+# [...]/llvm-project-22.1.6.src/llvm/include/llvm/Support/Registry.h:111:(.text._ZN4llvm10AsmPrinter20getOrCreateGCPrinterERNS_10GCStrategyE+0x198): undefined reference to `llvm::Registry<llvm::GCMetadataPrinter>::Head'
+# /usr/bin/ld.bfd: /tmp/ccT9v8pZ.ltrans62.ltrans.o:[...]/llvm-project-22.1.6.src/llvm/include/llvm/Support/Registry.h:111:(.text._ZN4llvm10AsmPrinter20getOrCreateGCPrinterERNS_10GCStrategyE+0x19c): undefined reference to `llvm::Registry<llvm::GCMetadataPrinter>::Head'
+# collect2: error: ld returned 1 exit status
+NOLTO=1
+
+USECLANG=1
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+# Figure out which feature/module to enable
+_LLVM_MIN_SET="clang" # for Afterglow and other new ports
+_LLVM_BASE_SET="${_LLVM_MIN_SET};lld;lldb;clang-tools-extra;polly" # for main-T2 arch (e.g. loongson3, riscv64 ...)
+_LLVM_FULL_SET="${_LLVM_BASE_SET};mlir;bolt;flang" # for main-T1 arch (e.g. amd64, arm64 ...)
+
+_LLVM_MIN_RUNTIME_SET="libunwind" # for Afterglow and other new ports
+_LLVM_BASE_RUNTIME_SET="${_LLVM_MIN_RUNTIME_SET};libcxx;libcxxabi;compiler-rt;offload;openmp"
+_LLVM_FULL_RUNTIME_SET="${_LLVM_BASE_RUNTIME_SET}"
+
+CMAKE_AFTER=(
+    '-DLLVM_BUILD_LLVM_DYLIB=ON'
+    '-DLLVM_DYLIB_EXPORT_ALL=ON'
+    '-DLLVM_LINK_LLVM_DYLIB=ON'
+    '-DLLVM_ENABLE_RTTI=ON'
+    '-DLLVM_ENABLE_FFI=ON'
+    '-DLLVM_BUILD_DOCS=OFF'
+    '-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF'
+    "-DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi)"
+    '-DLLVM_BINUTILS_INCDIR=/usr/include'
+    '-DLLVM_INSTALL_UTILS=ON'
+    '-DLLVM_INCLUDE_TESTS=OFF'
+    '-DLLVM_USE_LINKER=lld'
+    '-DINSTALL_WITH_TOOLCHAIN=ON'
+    '-DCLANG_DEFAULT_PIE_ON_LINUX=ON'
+)
+CMAKE_AFTER__BASE=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+CMAKE_AFTER__FULL=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER__FULL[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER__LOONGARCH64[@]}"
+)
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER[@]}"
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+
+CMAKE_AFTER__RETRO=(
+    "${CMAKE_AFTER[@]}"
+    '-DLLVM_ENABLE_PROJECTS=${_LLVM_MIN_SET}'
+    '-DLLVM_USE_LINKER=bfd'
+)
+
+PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"
+PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"

--- a/app-devel/llvm-22/01-runtime/defines.stage2
+++ b/app-devel/llvm-22/01-runtime/defines.stage2
@@ -1,0 +1,111 @@
+PKGNAME=llvm-runtime-22
+PKGSEC=libs
+PKGDEP="gcc-runtime libedit libffi ncurses zlib"
+BUILDDEP=""
+BUILDDEP__RETRO=""
+BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
+BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
+BUILDDEP__I486="${BUILDDEP__RETRO}"
+BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
+BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
+BUILDDEP__PPC64="${BUILDDEP__RETRO}"
+PKGDES="Low Level Virtual Machine Infrastructure (runtime libraries, version 22)"
+
+AB_FLAGS_O3=1
+# Note: For size.
+AB_FLAGS_O3__RETRO=0
+
+# FIXME: Fails to link with LTO enabled.
+#
+# /usr/bin/ld.bfd: /tmp/ccT9v8pZ.ltrans62.ltrans.o: in function `llvm::AsmPrinter::getOrCreateGCPrinter(llvm::GCStrategy&)':
+# [...]/llvm-project-22.1.6.src/llvm/include/llvm/Support/Registry.h:111:(.text._ZN4llvm10AsmPrinter20getOrCreateGCPrinterERNS_10GCStrategyE+0x198): undefined reference to `llvm::Registry<llvm::GCMetadataPrinter>::Head'
+# /usr/bin/ld.bfd: /tmp/ccT9v8pZ.ltrans62.ltrans.o:[...]/llvm-project-22.1.6.src/llvm/include/llvm/Support/Registry.h:111:(.text._ZN4llvm10AsmPrinter20getOrCreateGCPrinterERNS_10GCStrategyE+0x19c): undefined reference to `llvm::Registry<llvm::GCMetadataPrinter>::Head'
+# collect2: error: ld returned 1 exit status
+NOLTO=1
+
+# Note: For bootstrapping.
+USECLANG=0
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+# Figure out which feature/module to enable
+_LLVM_MIN_SET="clang" # for Afterglow and other new ports
+_LLVM_BASE_SET="${_LLVM_MIN_SET};lld" # for main-T2 arch (e.g. loongson3, riscv64 ...)
+_LLVM_FULL_SET="${_LLVM_BASE_SET}" # for main-T1 arch (e.g. amd64, arm64 ...)
+
+_LLVM_BASE_RUNTIME_SET=""
+_LLVM_FULL_RUNTIME_SET=""
+_LLVM_BASE_RUNTIME_SET__LOONGARCH64=""
+# FIXME: Runtime libraries does not build without lld.
+_LLVM_BASE_RUNTIME_SET__LOONGSON3=""
+
+CMAKE_AFTER=(
+    '-DLLVM_BUILD_LLVM_DYLIB=ON'
+    '-DLLVM_DYLIB_EXPORT_ALL=ON'
+    '-DLLVM_LINK_LLVM_DYLIB=ON'
+    '-DLLVM_ENABLE_RTTI=ON'
+    '-DLLVM_ENABLE_FFI=ON'
+    '-DLLVM_BUILD_DOCS=OFF'
+    '-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF'
+    "-DFFI_INCLUDE_DIR=$(pkg-config --variable=includedir libffi)"
+    '-DLLVM_BINUTILS_INCDIR=/usr/include'
+    '-DLLVM_INSTALL_UTILS=ON'
+    '-DLLVM_INCLUDE_TESTS=OFF'
+    '-DLLVM_USE_LINKER=bfd'
+    '-DINSTALL_WITH_TOOLCHAIN=ON'
+    '-DCLANG_DEFAULT_PIE_ON_LINUX=ON'
+)
+CMAKE_AFTER__BASE=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+CMAKE_AFTER__FULL=(
+    "${CMAKE_AFTER[@]}"
+    '-DLIBOMPTARGET_ENABLE_DEBUG=ON'
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_FULL_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_FULL_RUNTIME_SET}"
+    '-DOPENMP_ENABLE_LIBOMP_PROFILING=ON'
+)
+
+CMAKE_AFTER__AMD64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__ARM64=(
+    "${CMAKE_AFTER__FULL[@]}"
+)
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER__FULL[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__LOONGARCH64_NOSIMD=(
+    "${CMAKE_AFTER__LOONGARCH64[@]}"
+)
+CMAKE_AFTER__LOONGSON3=(
+    "${CMAKE_AFTER[@]}"
+    "-DLLVM_ENABLE_PROJECTS=${_LLVM_BASE_SET}"
+    "-DLLVM_ENABLE_RUNTIMES=${_LLVM_BASE_RUNTIME_SET__LOONGSON3}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__RISCV64=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+CMAKE_AFTER__PPC64EL=(
+    "${CMAKE_AFTER__BASE[@]}"
+    '-DLLVM_PARALLEL_LINK_JOBS=2'
+)
+
+CMAKE_AFTER__RETRO=(
+    "${CMAKE_AFTER[@]}"
+    '-DLLVM_ENABLE_PROJECTS=${_LLVM_MIN_SET}'
+    '-DLLVM_USE_LINKER=bfd'
+)
+
+PKGBREAK="${PKGBREAK} llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"
+PKGREP="llvm<=17.0.6-6 llvm-runtime<=18.1.8-1 llvm-runtime-18<=18.1.8-10"

--- a/app-devel/llvm-22/01-runtime/patch
+++ b/app-devel/llvm-22/01-runtime/patch
@@ -1,0 +1,5 @@
+cd "$SRCDIR"/..
+abinfo "Applying patches for LLVM full workspace ..."
+ab_apply_patches "$SRCDIR/autobuild/patches/"*.patch
+ab_reverse_patches "$SRCDIR/autobuild/patches/"*.rpatch
+cd "$SRCDIR"

--- a/app-devel/llvm-22/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
+++ b/app-devel/llvm-22/01-runtime/patches/0001-Fix-fuzzer-objects-building-when-LTO-is-enabled.patch
@@ -1,0 +1,25 @@
+From 2083b15c0bdbe9b25fbfc80e68a050ddb42e25db Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:48:08 -0800
+Subject: [PATCH 1/6] Fix fuzzer objects building when LTO is enabled
+
+---
+ compiler-rt/lib/fuzzer/CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/lib/fuzzer/CMakeLists.txt b/compiler-rt/lib/fuzzer/CMakeLists.txt
+index a57e2fe46245..c278fd5888da 100644
+--- a/compiler-rt/lib/fuzzer/CMakeLists.txt
++++ b/compiler-rt/lib/fuzzer/CMakeLists.txt
+@@ -147,7 +147,7 @@ if(OS_NAME MATCHES "Android|Linux|Fuchsia" AND
+     set(cxx_${arch}_merge_dir "${CMAKE_CURRENT_BINARY_DIR}/cxx_${arch}_merge.dir")
+     file(MAKE_DIRECTORY ${cxx_${arch}_merge_dir})
+     add_custom_command(TARGET clang_rt.${name}-${arch} POST_BUILD
+-      COMMAND ${CMAKE_CXX_COMPILER} ${target_cflags} -Wl,--whole-archive "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" -Wl,--no-whole-archive ${dir}/lib/libc++.a -r -o ${name}.o
++      COMMAND ${CMAKE_CXX_COMPILER} ${target_cflags} -flto -Wl,--whole-archive "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" -Wl,--no-whole-archive ${dir}/lib/libc++.a -r -o ${name}.o
+       COMMAND ${CMAKE_OBJCOPY} --localize-hidden ${name}.o
+       COMMAND ${CMAKE_COMMAND} -E remove "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>"
+       COMMAND ${CMAKE_AR} qcs "$<TARGET_LINKER_FILE:clang_rt.${name}-${arch}>" ${name}.o
+-- 
+2.52.0
+

--- a/app-devel/llvm-22/01-runtime/patches/0002-Add-stub-for-mips64-LLDB-impl.patch
+++ b/app-devel/llvm-22/01-runtime/patches/0002-Add-stub-for-mips64-LLDB-impl.patch
@@ -1,0 +1,30 @@
+From cf36e6696e4ff94e6a5d0f3695a5b1a84d4a154b Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:49:26 -0800
+Subject: [PATCH 2/6] Add stub for mips64 LLDB impl
+
+---
+ .../Plugins/Process/Linux/NativeRegisterContextLinux.h     | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+index 08f19d374e28..a042dd3dd677 100644
+--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
++++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+@@ -32,7 +32,12 @@ public:
+   // given thread.
+   static std::unique_ptr<NativeRegisterContextLinux>
+   CreateHostNativeRegisterContextLinux(const ArchSpec &target_arch,
+-                                       NativeThreadLinux &native_thread);
++                                       NativeThreadLinux &native_thread)
++#ifdef __mips64
++  { llvm_unreachable("mips64 unsupported"); }
++#else
++  ;
++#endif
+ 
+   // Determine the architecture of the thread given by its ID.
+   static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
+-- 
+2.52.0
+

--- a/app-devel/llvm-22/01-runtime/patches/0003-Add-stub-for-lldb-arch-functions-on-loongson3.patch
+++ b/app-devel/llvm-22/01-runtime/patches/0003-Add-stub-for-lldb-arch-functions-on-loongson3.patch
@@ -1,0 +1,32 @@
+From 7252e3b49bc9cfe203abfd599f846991a6f01011 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:52:51 -0800
+Subject: [PATCH 3/6] Add stub for lldb arch functions on loongson3
+
+---
+ .../Plugins/Process/Linux/NativeRegisterContextLinux.h    | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+index a042dd3dd677..ee4901aa7cd3 100644
+--- a/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
++++ b/lldb/source/Plugins/Process/Linux/NativeRegisterContextLinux.h
+@@ -40,7 +40,15 @@ public:
+ #endif
+ 
+   // Determine the architecture of the thread given by its ID.
++#ifdef __mips64
++  static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid) {
++    return llvm::createStringError(
++        llvm::inconvertibleErrorCode(),
++        "Architecture does not support this function");
++  }
++#else
+   static llvm::Expected<ArchSpec> DetermineArchitecture(lldb::tid_t tid);
++#endif
+ 
+   // Invalidates cached values in register context data structures
+   virtual void InvalidateAllRegisters(){}
+-- 
+2.52.0
+

--- a/app-devel/llvm-22/01-runtime/patches/0004-HACK-force-enable-cacheflush-function.patch
+++ b/app-devel/llvm-22/01-runtime/patches/0004-HACK-force-enable-cacheflush-function.patch
@@ -1,0 +1,24 @@
+From a5628e0b34c357cdbcb4ccef7214cc92f1886691 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Sun, 28 Jan 2024 04:53:18 -0800
+Subject: [PATCH 4/6] HACK: force enable cacheflush function
+
+---
+ compiler-rt/lib/builtins/clear_cache.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/compiler-rt/lib/builtins/clear_cache.c b/compiler-rt/lib/builtins/clear_cache.c
+index eb58452d624e..fd6c6c1ae6bb 100644
+--- a/compiler-rt/lib/builtins/clear_cache.c
++++ b/compiler-rt/lib/builtins/clear_cache.c
+@@ -43,6 +43,7 @@ uintptr_t GetCurrentProcess(void);
+ #endif
+ 
+ #if defined(__linux__) && defined(__mips__)
++#define __USE_MISC
+ #include <sys/cachectl.h>
+ #include <sys/syscall.h>
+ #include <unistd.h>
+-- 
+2.52.0
+

--- a/app-devel/llvm-22/01-runtime/patches/0005-Disable-installing-of-custom-libcxx.patch
+++ b/app-devel/llvm-22/01-runtime/patches/0005-Disable-installing-of-custom-libcxx.patch
@@ -1,0 +1,41 @@
+From 6cc61bc8663976799a2339c85881198346d6997d Mon Sep 17 00:00:00 2001
+From: xtex <xtexchooser@duck.com>
+Date: Sat, 12 Apr 2025 15:25:26 +0800
+Subject: [PATCH 5/6] Disable installing of custom libcxx
+
+e7bad34475e2 ([compiler-rt] Use installed libc++(abi) for tests
+instead of build tree, 2024-11-06) removed 'INSTALL_COMMAND ""' line.
+After that, CMake will install files to locations like
+$DESTDIR/var/cache/acbs/build/acbs.p8hoyk2z/llvm-project-20.1.2.src/llvm/
+build/runtimes/runtimes-bins/compiler-rt/lib/fuzzer/libcxx_fuzzer_x86_64.
+
+Link: https://github.com/llvm/llvm-project/issues/135476
+Fixes: e7bad34475e2 ("[compiler-rt] Use installed libc++(abi) for tests instead of build tree")
+Signed-off-by: xtex <xtex@aosc.io>
+---
+ compiler-rt/cmake/Modules/AddCompilerRT.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/compiler-rt/cmake/Modules/AddCompilerRT.cmake b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+index d658b7009e85..29b0a68d2c99 100644
+--- a/compiler-rt/cmake/Modules/AddCompilerRT.cmake
++++ b/compiler-rt/cmake/Modules/AddCompilerRT.cmake
+@@ -658,7 +658,6 @@ macro(add_custom_libcxx name prefix)
+     CMAKE_SHARED_LINKER_FLAGS
+     CMAKE_MODULE_LINKER_FLAGS
+     CMAKE_EXE_LINKER_FLAGS
+-    CMAKE_INSTALL_PREFIX
+     CMAKE_MAKE_PROGRAM
+     CMAKE_LINKER
+     CMAKE_AR
+@@ -728,6 +727,7 @@ macro(add_custom_libcxx name prefix)
+                -DLLVM_INCLUDE_TESTS=OFF
+                -DLLVM_INCLUDE_DOCS=OFF
+                ${LIBCXX_CMAKE_ARGS}
++    INSTALL_COMMAND ""
+     STEP_TARGETS configure build
+     BUILD_ALWAYS 1
+     USES_TERMINAL_CONFIGURE 1
+-- 
+2.52.0
+

--- a/app-devel/llvm-22/01-runtime/patches/0006-Fix-musttail-161860.patch
+++ b/app-devel/llvm-22/01-runtime/patches/0006-Fix-musttail-161860.patch
@@ -1,0 +1,500 @@
+From 56b4d71cab900cf7402acd526b9c10ed81c2c4b2 Mon Sep 17 00:00:00 2001
+From: Djordje Todorovic <djordje.todorovic@htecgroup.com>
+Date: Tue, 27 Jan 2026 19:55:22 +0100
+Subject: [PATCH 6/6] Fix musttail (#161860)
+
+Properly handle clang::musttail attribute on MIPS backend.
+
+It fixes: https://github.com/llvm/llvm-project/issues/161193
+---
+ .../clang/Basic/DiagnosticCommonKinds.td      |   5 +
+ clang/lib/CodeGen/CGCall.cpp                  |  18 ++-
+ clang/lib/CodeGen/CodeGenModule.cpp           |  41 ++++--
+ .../Mips/musttail-forward-declaration.c       |  15 +++
+ clang/test/CodeGen/Mips/musttail-pic.c        |  21 +++
+ clang/test/CodeGen/Mips/musttail-visibility.c |  17 +++
+ clang/test/CodeGen/Mips/musttail-weak.c       |  13 ++
+ clang/test/CodeGen/Mips/musttail.c            |  19 +++
+ llvm/lib/Target/Mips/MipsISelLowering.cpp     |  50 +++++---
+ llvm/lib/Target/Mips/MipsSEISelLowering.cpp   |  10 +-
+ llvm/test/CodeGen/Mips/musttail.ll            | 120 ++++++++++++++++++
+ 11 files changed, 295 insertions(+), 34 deletions(-)
+ create mode 100644 clang/test/CodeGen/Mips/musttail-forward-declaration.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-pic.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-visibility.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail-weak.c
+ create mode 100644 clang/test/CodeGen/Mips/musttail.c
+ create mode 100644 llvm/test/CodeGen/Mips/musttail.ll
+
+diff --git a/clang/include/clang/Basic/DiagnosticCommonKinds.td b/clang/include/clang/Basic/DiagnosticCommonKinds.td
+index 6e50e225a8cc..9d20499e5045 100644
+--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
++++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
+@@ -372,6 +372,11 @@ def err_ppc_impossible_musttail: Error<
+   "indirect calls cannot be tail called on PPC|"
+   "external calls cannot be tail called on PPC}0"
+   >;
++def err_mips_impossible_musttail: Error<
++  "'musttail' attribute for this call is impossible because %select{"
++  "the MIPS16 ABI does not support tail calls|"
++  "calls outside the current linkage unit cannot be tail called on MIPS}0"
++  >;
+ def err_aix_musttail_unsupported: Error<
+   "'musttail' attribute is not supported on AIX">;
+ 
+diff --git a/clang/lib/CodeGen/CGCall.cpp b/clang/lib/CodeGen/CGCall.cpp
+index 06203733a126..fd1c339bc230 100644
+--- a/clang/lib/CodeGen/CGCall.cpp
++++ b/clang/lib/CodeGen/CGCall.cpp
+@@ -31,6 +31,7 @@
+ #include "clang/Basic/TargetInfo.h"
+ #include "clang/CodeGen/CGFunctionInfo.h"
+ #include "clang/CodeGen/SwiftCallingConv.h"
++#include "llvm/ADT/STLExtras.h"
+ #include "llvm/ADT/StringExtras.h"
+ #include "llvm/Analysis/ValueTracking.h"
+ #include "llvm/IR/Assumptions.h"
+@@ -6022,11 +6023,20 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
+     AddObjCARCExceptionMetadata(CI);
+ 
+   // Set tail call kind if necessary.
++  bool IsPPC = getTarget().getTriple().isPPC();
++  bool IsMIPS = getTarget().getTriple().isMIPS();
++  bool HasMips16 = false;
++  if (IsMIPS) {
++    const TargetOptions &TargetOpts = getTarget().getTargetOpts();
++    HasMips16 = TargetOpts.FeatureMap.lookup("mips16");
++    if (!HasMips16)
++      HasMips16 = llvm::is_contained(TargetOpts.Features, "+mips16");
++  }
+   if (llvm::CallInst *Call = dyn_cast<llvm::CallInst>(CI)) {
+     if (TargetDecl && TargetDecl->hasAttr<NotTailCalledAttr>())
+       Call->setTailCallKind(llvm::CallInst::TCK_NoTail);
+     else if (IsMustTail) {
+-      if (getTarget().getTriple().isPPC()) {
++      if (IsPPC) {
+         if (getTarget().getTriple().isOSAIX())
+           CGM.getDiags().Report(Loc, diag::err_aix_musttail_unsupported);
+         else if (!getTarget().hasFeature("pcrelative-memops")) {
+@@ -6052,6 +6062,12 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
+           }
+         }
+       }
++      if (IsMIPS) {
++        if (HasMips16)
++          CGM.getDiags().Report(Loc, diag::err_mips_impossible_musttail) << 0;
++        else if (const auto *FD = dyn_cast_or_null<FunctionDecl>(TargetDecl))
++          CGM.addUndefinedGlobalForTailCall({FD, Loc});
++      }
+       Call->setTailCallKind(llvm::CallInst::TCK_MustTail);
+     }
+   }
+diff --git a/clang/lib/CodeGen/CodeGenModule.cpp b/clang/lib/CodeGen/CodeGenModule.cpp
+index 85ed38f14462..89a094cabc59 100644
+--- a/clang/lib/CodeGen/CodeGenModule.cpp
++++ b/clang/lib/CodeGen/CodeGenModule.cpp
+@@ -1578,16 +1578,39 @@ void CodeGenModule::Release() {
+   setVisibilityFromDLLStorageClass(LangOpts, getModule());
+ 
+   // Check the tail call symbols are truly undefined.
+-  if (getTriple().isPPC() && !MustTailCallUndefinedGlobals.empty()) {
+-    for (auto &I : MustTailCallUndefinedGlobals) {
+-      if (!I.first->isDefined())
+-        getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
+-      else {
+-        StringRef MangledName = getMangledName(GlobalDecl(I.first));
+-        llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
+-        if (!Entry || Entry->isWeakForLinker() ||
+-            Entry->isDeclarationForLinker())
++  if (!MustTailCallUndefinedGlobals.empty()) {
++    if (getTriple().isPPC()) {
++      for (auto &I : MustTailCallUndefinedGlobals) {
++        if (!I.first->isDefined())
+           getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
++        else {
++          StringRef MangledName = getMangledName(GlobalDecl(I.first));
++          llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
++          if (!Entry || Entry->isWeakForLinker() ||
++              Entry->isDeclarationForLinker())
++            getDiags().Report(I.second, diag::err_ppc_impossible_musttail) << 2;
++        }
++      }
++    } else if (getTriple().isMIPS()) {
++      for (auto &I : MustTailCallUndefinedGlobals) {
++        const FunctionDecl *FD = I.first;
++        StringRef MangledName = getMangledName(GlobalDecl(FD));
++        llvm::GlobalValue *Entry = GetGlobalValue(MangledName);
++
++        if (!Entry)
++          continue;
++
++        bool CalleeIsLocal;
++        if (Entry->isDeclarationForLinker()) {
++          // For declarations, only visibility can indicate locality.
++          CalleeIsLocal =
++              Entry->hasHiddenVisibility() || Entry->hasProtectedVisibility();
++        } else {
++          CalleeIsLocal = Entry->isDSOLocal();
++        }
++
++        if (!CalleeIsLocal)
++          getDiags().Report(I.second, diag::err_mips_impossible_musttail) << 1;
+       }
+     }
+   }
+diff --git a/clang/test/CodeGen/Mips/musttail-forward-declaration.c b/clang/test/CodeGen/Mips/musttail-forward-declaration.c
+new file mode 100644
+index 000000000000..b25baa76f451
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-forward-declaration.c
+@@ -0,0 +1,15 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test that a forward declaration that is later defined in the same TU
++// is allowed for musttail calls.
++
++int func(int i);
++
++int caller(int i) {
++  // expected-no-diagnostics
++  [[clang::musttail]] return func(i);
++}
++
++int func(int i) {
++  return i + 1;
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-pic.c b/clang/test/CodeGen/Mips/musttail-pic.c
+new file mode 100644
+index 000000000000..bcad84d63f19
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-pic.c
+@@ -0,0 +1,21 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -pic-level 2 \
++// RUN:   -fhalf-no-semantic-interposition -o /dev/null -emit-llvm -verify
++
++// Test musttail behavior in PIC mode with semantic interposition.
++
++int external_defined(int i) { return i; }
++static int static_func(int i) { return i; }
++__attribute__((visibility("hidden"))) int hidden_defined(int i) { return i; }
++
++int call_external(int i) {
++  // expected-error@+1 {{'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS}}
++  [[clang::musttail]] return external_defined(i);
++}
++
++int call_static(int i) {
++  [[clang::musttail]] return static_func(i);
++}
++
++int call_hidden(int i) {
++  [[clang::musttail]] return hidden_defined(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-visibility.c b/clang/test/CodeGen/Mips/musttail-visibility.c
+new file mode 100644
+index 000000000000..351563e99112
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-visibility.c
+@@ -0,0 +1,17 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test that hidden and protected visibility functions can be tail called
++// because they are guaranteed to be DSO-local.
++
++extern int hidden_func(int i) __attribute__((visibility("hidden")));
++extern int protected_func(int i) __attribute__((visibility("protected")));
++extern int default_func(int i);
++
++int call_hidden(int i) {
++  // expected-no-diagnostics
++  [[clang::musttail]] return hidden_func(i);
++}
++
++int call_protected(int i) {
++  [[clang::musttail]] return protected_func(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail-weak.c b/clang/test/CodeGen/Mips/musttail-weak.c
+new file mode 100644
+index 000000000000..06c0726d3d1e
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail-weak.c
+@@ -0,0 +1,13 @@
++// RUN: %clang_cc1 %s -triple mipsel-unknown-linux-gnu -o /dev/null -emit-llvm -verify
++
++// Test musttail with weak functions.
++// Weak functions can be interposed, so they are not considered DSO-local.
++
++__attribute__((weak)) int weak_func(int i) {
++  return i;
++}
++
++int caller(int i) {
++  // expected-error@+1 {{'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS}}
++  [[clang::musttail]] return weak_func(i);
++}
+diff --git a/clang/test/CodeGen/Mips/musttail.c b/clang/test/CodeGen/Mips/musttail.c
+new file mode 100644
+index 000000000000..c0c0132e7f82
+--- /dev/null
++++ b/clang/test/CodeGen/Mips/musttail.c
+@@ -0,0 +1,19 @@
++// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -emit-llvm 2>&1 \
++// RUN:   | FileCheck %s
++// RUN: not %clang_cc1 %s -triple mipsel-unknown-linux-gnu -target-feature +mips16 \
++// RUN:   -emit-llvm 2>&1 | FileCheck %s --check-prefix=CHECK-MIPS16
++
++// CHECK: error: 'musttail' attribute for this call is impossible because calls outside the current linkage unit cannot be tail called on MIPS
++// CHECK-MIPS16: error: 'musttail' attribute for this call is impossible because the MIPS16 ABI does not support tail calls
++
++static int local(int x) { return x; }
++
++int call_local(int x) {
++  [[clang::musttail]] return local(x);
++}
++
++extern int external(int x);
++
++int call_external(int x) {
++  [[clang::musttail]] return external(x);
++}
+diff --git a/llvm/lib/Target/Mips/MipsISelLowering.cpp b/llvm/lib/Target/Mips/MipsISelLowering.cpp
+index dbbeb75e673c..4260716e01f6 100644
+--- a/llvm/lib/Target/Mips/MipsISelLowering.cpp
++++ b/llvm/lib/Target/Mips/MipsISelLowering.cpp
+@@ -86,6 +86,10 @@ STATISTIC(NumTailCalls, "Number of tail calls");
+ extern cl::opt<bool> EmitJalrReloc;
+ extern cl::opt<bool> NoZeroDivCheck;
+ 
++static cl::opt<bool> UseMipsTailCalls("mips-tail-calls", cl::Hidden,
++                                      cl::desc("MIPS: permit tail calls."),
++                                      cl::init(false));
++
+ static const MCPhysReg Mips64DPRegs[8] = {
+   Mips::D12_64, Mips::D13_64, Mips::D14_64, Mips::D15_64,
+   Mips::D16_64, Mips::D17_64, Mips::D18_64, Mips::D19_64
+@@ -3334,23 +3338,38 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+   if (MF.getTarget().Options.EmitCallGraphSection && CB && CB->isIndirectCall())
+     CSInfo = MachineFunction::CallSiteInfo(*CB);
+ 
+-  // Check if it's really possible to do a tail call. Restrict it to functions
+-  // that are part of this compilation unit.
+-  bool InternalLinkage = false;
++  // Check if it's really possible to do a tail call.
++  // For non-musttail calls, restrict to functions that won't require $gp
++  // restoration. In PIC mode, calling external functions via tail call can
++  // cause issues with $gp register handling (see D24763).
++  bool IsMustTail = CLI.CB && CLI.CB->isMustTailCall();
++  bool CalleeIsLocal = true;
++  if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
++    const GlobalValue *GV = G->getGlobal();
++    bool HasLocalLinkage = GV->hasLocalLinkage() || GV->hasPrivateLinkage();
++    bool HasHiddenVisibility =
++        GV->hasHiddenVisibility() || GV->hasProtectedVisibility();
++    if (GV->isDeclarationForLinker())
++      CalleeIsLocal = HasLocalLinkage || HasHiddenVisibility;
++    else
++      CalleeIsLocal = GV->isDSOLocal();
++  }
++
+   if (IsTailCall) {
+-    IsTailCall = isEligibleForTailCallOptimization(
+-        CCInfo, StackSize, *MF.getInfo<MipsFunctionInfo>());
+-    if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+-      InternalLinkage = G->getGlobal()->hasInternalLinkage();
+-      IsTailCall &= (InternalLinkage || G->getGlobal()->hasLocalLinkage() ||
+-                     G->getGlobal()->hasPrivateLinkage() ||
+-                     G->getGlobal()->hasHiddenVisibility() ||
+-                     G->getGlobal()->hasProtectedVisibility());
+-     }
++    if (!UseMipsTailCalls) {
++      IsTailCall = false;
++    } else {
++      bool Eligible = isEligibleForTailCallOptimization(
++          CCInfo, StackSize, *MF.getInfo<MipsFunctionInfo>());
++      if (!Eligible || !CalleeIsLocal) {
++        IsTailCall = false;
++        if (IsMustTail)
++          report_fatal_error(
++              "failed to perform tail call elimination on a call "
++              "site marked musttail");
++      }
++    }
+   }
+-  if (!IsTailCall && CLI.CB && CLI.CB->isMustTailCall())
+-    report_fatal_error("failed to perform tail call elimination on a call "
+-                       "site marked musttail");
+ 
+   if (IsTailCall)
+     ++NumTailCalls;
+@@ -3525,6 +3544,7 @@ MipsTargetLowering::LowerCall(TargetLowering::CallLoweringInfo &CLI,
+     }
+   }
+ 
++  bool InternalLinkage = false;
+   if (GlobalAddressSDNode *G = dyn_cast<GlobalAddressSDNode>(Callee)) {
+     if (Subtarget.isTargetCOFF() &&
+         G->getGlobal()->hasDLLImportStorageClass()) {
+diff --git a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+index 0906ab56e167..3ff595678670 100644
+--- a/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
++++ b/llvm/lib/Target/Mips/MipsSEISelLowering.cpp
+@@ -52,10 +52,6 @@ using namespace llvm;
+ 
+ #define DEBUG_TYPE "mips-isel"
+ 
+-static cl::opt<bool>
+-UseMipsTailCalls("mips-tail-calls", cl::Hidden,
+-                    cl::desc("MIPS: permit tail calls."), cl::init(false));
+-
+ static cl::opt<bool> NoDPLoadStore("mno-ldc1-sdc1", cl::init(false),
+                                    cl::desc("Expand double precision loads and "
+                                             "stores to their single precision "
+@@ -1206,9 +1202,6 @@ MipsSETargetLowering::EmitInstrWithCustomInserter(MachineInstr &MI,
+ bool MipsSETargetLowering::isEligibleForTailCallOptimization(
+     const CCState &CCInfo, unsigned NextStackOffset,
+     const MipsFunctionInfo &FI) const {
+-  if (!UseMipsTailCalls)
+-    return false;
+-
+   // Exception has to be cleared with eret.
+   if (FI.isISR())
+     return false;
+@@ -1217,8 +1210,7 @@ bool MipsSETargetLowering::isEligibleForTailCallOptimization(
+   if (CCInfo.getInRegsParamsCount() > 0 || FI.hasByvalArg())
+     return false;
+ 
+-  // Return true if the callee's argument area is no larger than the
+-  // caller's.
++  // Return true if the callee's argument area is no larger than the caller's.
+   return NextStackOffset <= FI.getIncomingArgSize();
+ }
+ 
+diff --git a/llvm/test/CodeGen/Mips/musttail.ll b/llvm/test/CodeGen/Mips/musttail.ll
+new file mode 100644
+index 000000000000..b96cb2b92398
+--- /dev/null
++++ b/llvm/test/CodeGen/Mips/musttail.ll
+@@ -0,0 +1,120 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py
++; RUN: llc -mtriple=mips-unknown-linux-gnu -mips-tail-calls=1 < %s | FileCheck %s --check-prefix=MIPS32
++; RUN: llc -mtriple=mips64-unknown-linux-gnu -mips-tail-calls=1 < %s | FileCheck %s --check-prefix=MIPS64
++
++; Test musttail support for MIPS
++
++define dso_local i32 @callee_args(i32 %a, i32 %b, i32 %c) {
++  ret i32 %a;
++}
++
++define i32 @test_musttail_args(i32 %x, i32 %y, i32 %z) {
++; MIPS32-LABEL: test_musttail_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    j callee_args
++; MIPS32-NEXT:    nop
++;
++; MIPS64-LABEL: test_musttail_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j callee_args
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 @callee_args(i32 %x, i32 %y, i32 %z)
++  ret i32 %ret
++}
++
++; Test musttail with many arguments that spill to stack (involves memory)
++; MIPS O32 ABI: first 4 args in $a0-$a3, rest on stack
++define hidden i32 @many_args_callee(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
++  ret i32 %a
++}
++
++define i32 @test_musttail_many_args(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h) {
++; MIPS32-LABEL: test_musttail_many_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 24($sp)
++; MIPS32-NEXT:    lw $2, 20($sp)
++; MIPS32-NEXT:    lw $3, 16($sp)
++; MIPS32-NEXT:    sw $3, 16($sp)
++; MIPS32-NEXT:    sw $2, 20($sp)
++; MIPS32-NEXT:    sw $1, 24($sp)
++; MIPS32-NEXT:    lw $1, 28($sp)
++; MIPS32-NEXT:    j many_args_callee
++; MIPS32-NEXT:    sw $1, 28($sp)
++;
++; MIPS64-LABEL: test_musttail_many_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j many_args_callee
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 @many_args_callee(i32 %a, i32 %b, i32 %c, i32 %d, i32 %e, i32 %f, i32 %g, i32 %h)
++  ret i32 %ret
++}
++
++; Test musttail with large struct passed by value (involves memory)
++%struct.large = type { i32, i32, i32, i32, i32, i32, i32, i32 }
++
++define hidden i32 @callee_with_struct(%struct.large %s, i32 %x) {
++  ret i32 %x
++}
++
++define i32 @test_musttail_struct(%struct.large %s, i32 %x) {
++; MIPS32-LABEL: test_musttail_struct:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 28($sp)
++; MIPS32-NEXT:    lw $2, 24($sp)
++; MIPS32-NEXT:    lw $3, 20($sp)
++; MIPS32-NEXT:    lw $8, 16($sp)
++; MIPS32-NEXT:    sw $8, 16($sp)
++; MIPS32-NEXT:    sw $3, 20($sp)
++; MIPS32-NEXT:    sw $2, 24($sp)
++; MIPS32-NEXT:    sw $1, 28($sp)
++; MIPS32-NEXT:    lw $1, 32($sp)
++; MIPS32-NEXT:    j callee_with_struct
++; MIPS32-NEXT:    sw $1, 32($sp)
++;
++; MIPS64-LABEL: test_musttail_struct:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    ld $1, 0($sp)
++; MIPS64-NEXT:    j callee_with_struct
++; MIPS64-NEXT:    sd $1, 0($sp)
++  %ret = musttail call i32 @callee_with_struct(%struct.large %s, i32 %x)
++  ret i32 %ret
++}
++
++; Test musttail with mixed int and float arguments that use stack
++define hidden float @mixed_args_callee(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f) {
++  ret float %b
++}
++
++define float @test_musttail_mixed_args(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f) {
++; MIPS32-LABEL: test_musttail_mixed_args:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    lw $1, 16($sp)
++; MIPS32-NEXT:    sw $1, 16($sp)
++; MIPS32-NEXT:    lwc1 $f0, 20($sp)
++; MIPS32-NEXT:    j mixed_args_callee
++; MIPS32-NEXT:    swc1 $f0, 20($sp)
++;
++; MIPS64-LABEL: test_musttail_mixed_args:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    j mixed_args_callee
++; MIPS64-NEXT:    nop
++  %ret = musttail call float @mixed_args_callee(i32 %a, float %b, i32 %c, float %d, i32 %e, float %f)
++  ret float %ret
++}
++
++; Test musttail with indirect call
++define i32 @test_musttail_fptr(ptr %fptr, i32 %x) {
++; MIPS32-LABEL: test_musttail_fptr:
++; MIPS32:       # %bb.0:
++; MIPS32-NEXT:    move $25, $4
++; MIPS32-NEXT:    jr $25
++; MIPS32-NEXT:    nop
++;
++; MIPS64-LABEL: test_musttail_fptr:
++; MIPS64:       # %bb.0:
++; MIPS64-NEXT:    move $25, $4
++; MIPS64-NEXT:    jr $25
++; MIPS64-NEXT:    nop
++  %ret = musttail call i32 %fptr(ptr %fptr, i32 %x)
++  ret i32 %ret
++}
+-- 
+2.52.0
+

--- a/app-devel/llvm-22/02-compiler/beyond
+++ b/app-devel/llvm-22/02-compiler/beyond
@@ -1,0 +1,47 @@
+##### Control part variables
+LLVM_SUFFIX="-${PKGVER%%.*}"
+
+abinfo "Generating postinst scripts ..."
+printf 'update-alternatives --install /usr/bin/llvm-config llvm /usr/lib/llvm%s/bin/llvm-config 80' \
+    "$LLVM_SUFFIX" \
+    >> "$SRCDIR/autobuild/postinst"
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/bin/*; do
+    BIN="$(basename $i)"
+    [[ "$BIN" == 'llvm-config' || "$BIN" == "clang$LLVM_SUFFIX" ]] || \
+        printf " --slave /usr/bin/$BIN $BIN /usr/lib/llvm%s/bin/$BIN" \
+            "$LLVM_SUFFIX" \
+            >> "$SRCDIR/autobuild/postinst"
+done
+
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/cmake/*; do
+    BIN="$(basename $i)"
+    printf " --slave /usr/lib/cmake/$BIN ${BIN}-cmake /usr/lib/llvm%s/lib/cmake/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/include/*; do
+    ! [[ "$i" =~ .*unwind.* ]] || continue
+    ! [[ "$i" =~ .*clc ]] || continue
+    ! [[ "$i" =~ .*c\+\+ ]] || continue
+    BIN="$(basename $i)"
+    printf " --slave /usr/include/$BIN ${BIN}-include /usr/lib/llvm%s/include/$BIN" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
+for i in "$PKGDIR"/usr/lib/llvm${LLVM_SUFFIX}/lib/libomp*; do
+    OMP_LIB="$(basename $i)"
+    printf " --slave /usr/lib/$OMP_LIB $OMP_LIB /usr/lib/llvm%s/lib/$OMP_LIB" \
+        "$LLVM_SUFFIX" \
+        >> "$SRCDIR/autobuild/postinst"
+done
+
+cat << EOF > "$SRCDIR/autobuild/postrm"
+if [ "\$1" != "upgrade" ]; then
+    update-alternatives --remove llvm /usr/lib/llvm${LLVM_SUFFIX}/bin/llvm-config || true
+fi
+EOF
+
+abinfo "Final postinst script:"
+cat "$SRCDIR/autobuild/postinst"

--- a/app-devel/llvm-22/02-compiler/build
+++ b/app-devel/llvm-22/02-compiler/build
@@ -1,0 +1,94 @@
+llvm_ir_strip () {
+    mkdir -pv "$SRCDIR"/strip-tmp
+    cat << 'EOF' > "$SRCDIR"/strip-tmp/build.ninja
+rule ir-strip
+  command = TMPDIR="$$(mktemp -d)" && cd "$$TMPDIR" && llvm-ar x "$in" && for i in *.o; do if llvm-bcanalyzer "$$i" > /dev/null; then echo "-- Removing debug markers in $$i"; opt --strip-debug "$$i" -o "$$i"; fi done && llvm-ar rcs "$out" *.o && rm -rf "$$TMPDIR"
+  description = Stripping $in ...
+
+EOF
+    abinfo "Removing installed LTO archives ..."
+    rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+    abinfo "Generating stripping scripts ..."
+    for i in "$SRCDIR"/fakeroot/usr/lib/llvm-${PKGVER%%.*}/lib/*.a; do
+        local outfile="$(basename "$i")"
+        printf "build $PKGDIR/usr/lib/llvm-${PKGVER%%.*}/lib/$outfile: ir-strip $i\n\n" >> "$SRCDIR"/strip-tmp/build.ninja
+    done
+    abinfo "Executing LLVM IR stripping scripts ..."
+    ninja -C "$SRCDIR"/strip-tmp/
+}
+
+abinfo "Installing all files from LLVM ..."
+mkdir -pv "$PKGDIR"
+cp -arv "$SRCDIR"/fakeroot/* \
+    "$PKGDIR"/
+
+if [[ "$NOLTO" = 0 ]]; then
+    abinfo "Preparing for LLVM IR strip in LTO archives ..."
+    llvm_ir_strip
+else
+    abinfo "Dropping executable bit from static libraries ..."
+    chmod -v 644 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+fi
+
+abinfo "Installing clang-analyzer ..."
+install -dvm755 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer
+for prog in scan-build scan-view; do
+    cp -rfv "$SRCDIR"/../clang/tools/$prog \
+        "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/
+    ln -sfv ../lib/clang-analyzer/$prog/bin/$prog \
+        "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/bin/
+done
+ln -sfv ../../../bin/clang \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/scan-build/
+
+abinfo "Dropping runtime libraries ..."
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so*
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so
+# FIXME: Broken ld.lld => no extra runtime library may be built.
+if ! ab_match_arch loongson3; then
+    rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{unwind,c++}*.so*
+fi
+
+abinfo "Stripping static libraries ..."
+strip \
+    --verbose \
+    --strip-debug \
+    --enable-deterministic-archives \
+    --remove-section=.comment \
+    --remove-section=.note \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+abinfo "Making compatible version symlinks ..."
+ln -sv "${PKGVER%%.*}" \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"
+
+# FIXME: Chromium would fail to detect Clang prefix unless a full absolute
+# path to the compilers were set. Debian creates a symlink:
+#
+#   /usr/lib/clang/${PKGVER%%.*}
+#       => /usr/lib/llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*}
+#
+# to counteract this - not sure if needed anywhere else but create this
+# symlink just to be safe.
+abinfo "Making Clang prefix symlinks ..."
+mkdir -pv "$PKGDIR"/usr/lib/clang
+ln -sv ../llvm-${PKGVER%%.*}/lib/clang/${PKGVER%%.*} \
+    "$PKGDIR"/usr/lib/clang/${PKGVER%%.*}
+
+abinfo "Creating versioned executable symlinks ..."
+mkdir -pv "$PKGDIR"/usr/bin
+cd "$PKGDIR"/usr/bin
+for i in ../lib/llvm-${PKGVER%%.*}/bin/*; do 
+    ln -sv $i $(basename $i)-${PKGVER%%.*}
+done
+# Note: Remove double-suffixed executables.
+rm -v "$PKGDIR"/usr/bin/*-${PKGVER%%.*}-${PKGVER%%.*}
+
+# FIXME: https://github.com/llvm/llvm-project/issues/135476
+abinfo "Workaround mis-installed fuzzer libcxx ..."
+if [[ -e "$PKGDIR"/var/cache/acbs/build ]]; then
+    rm -vrf "$PKGDIR"/var/cache/acbs/build
+fi
+rm -vdf "$PKGDIR"/var/cache/acbs
+rm -vdf "$PKGDIR"/var/cache
+rm -vdf "$PKGDIR"/var

--- a/app-devel/llvm-22/02-compiler/build.stage2
+++ b/app-devel/llvm-22/02-compiler/build.stage2
@@ -1,0 +1,48 @@
+abinfo "Installing all files from LLVM ..."
+mkdir -pv "$PKGDIR"
+cp -arv "$SRCDIR"/fakeroot/* \
+    "$PKGDIR"/
+
+abinfo "Dropping executable bit from static libraries ..."
+chmod -v 644 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+abinfo "Installing clang-analyzer ..."
+install -dvm755 "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer
+for prog in scan-build scan-view; do
+    cp -rfv "$SRCDIR"/../clang/tools/$prog \
+        "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/
+done
+ln -sfv ../../../bin/clang \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang-analyzer/scan-build/
+
+abinfo "Dropping runtime libraries ..."
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{clang,LLVM,LTO}*.so*
+# Note: not all targets have libunwind, libcxx and libcxxabi.
+for i in "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{unwind,c++}*.so*; do
+    if [ -e "$i" ]; then
+        rm -v $i
+    fi
+done
+rm -v "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/LLVMgold.so
+
+abinfo "Making compatible version symlinks ..."
+ln -sv "${PKGVER%%.*}" \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"
+
+abinfo "Stripping static libraries ..."
+strip \
+    --verbose \
+    --strip-debug \
+    --enable-deterministic-archives \
+    --remove-section=.comment \
+    --remove-section=.note \
+    "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
+
+# FIXME: https://github.com/llvm/llvm-project/issues/135476
+abinfo "Workaround mis-installed fuzzer libcxx ..."
+if [[ -e "$PKGDIR"/var/cache/acbs/build ]]; then
+    rm -vrf "$PKGDIR"/var/cache/acbs/build
+fi
+rm -vdf "$PKGDIR"/var/cache/acbs
+rm -vdf "$PKGDIR"/var/cache
+rm -vdf "$PKGDIR"/var

--- a/app-devel/llvm-22/02-compiler/defines
+++ b/app-devel/llvm-22/02-compiler/defines
@@ -1,0 +1,16 @@
+PKGNAME=llvm-22
+PKGSEC=devel
+PKGDEP="gcc llvm-runtime-22 perl python-3"
+BUILDDEP="pypsutil setuptools"
+PKGDES="Low Level Virtual Machine Infrastructure (version 22)"
+
+NOSTATIC=0
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+PKGPROV="clang"
+
+PKGBREAK="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"
+PKGREP="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"

--- a/app-devel/llvm-22/02-compiler/defines.stage2
+++ b/app-devel/llvm-22/02-compiler/defines.stage2
@@ -1,0 +1,15 @@
+PKGNAME=llvm-22
+PKGSEC=devel
+PKGDEP="gcc llvm-runtime-22"
+PKGDES="Low Level Virtual Machine Infrastructure (version 22)"
+
+NOSTATIC=0
+
+# FIXME: With debuginfo, the binaries are too large to link on many
+# 32-bit architectures.
+ABSPLITDBG__RETRO=0
+
+PKGPROV="clang"
+
+PKGBREAK="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"
+PKGREP="llvm-runtime<=3.7.0-2 llvm<=18.1.8-1"

--- a/app-devel/llvm-22/spec
+++ b/app-devel/llvm-22/spec
@@ -1,0 +1,16 @@
+VER=22.1.6
+# Use tarball-based source when possible
+SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
+SUBDIR="llvm-project-$VER.src/llvm"
+# Use git-based source when the upstream hasn't uploaded their own tarball yet
+#SRCS="git::commit=tags/llvmorg-${VER}::https://github.com/llvm/llvm-project.git"
+#SUBDIR="llvm-22/llvm"
+
+CHKSUMS="sha256::6e0b376a1f6d9873e7dfb09ae6e04b9c7024400f01733fa4c29be69d5c138bc2"
+CHKUPDATE="anitya::id=1830"
+
+ENVREQ="total_mem=60"
+# Note: cmakeninja + lots of cores = higher mem:core ratio.
+ENVREQ__LOONGARCH64="total_mem_per_core=5"
+ENVREQ__LOONGARCH64_NOSIMD="total_mem_per_core=5"
+ENVREQ__PPC64EL="total_mem_per_core=5"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-21: new, 22.1.6
    - Remove libclc from project set as it is a standalone package.
    - Track patches at AOSC-Tracking/llvm-project @ aosc/llvmorg-22.1.6
    \(HEAD: 56b4d71cab900cf7402acd526b9c10ed81c2c4b2\).

Package(s) Affected
-------------------

- llvm-22: 22.1.6
- llvm-runtime-22: 22.1.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-22:+stage2 llvm-22
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
