### PR TITLE
fwupd: update to 2.1.4+2

### DIFF
--- a/app-admin/fwupd/autobuild/defines
+++ b/app-admin/fwupd/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=fwupd
 PKGSEC=admin
 PKGDES="Firmware update daemon and utilities"
-PKGDEP="bluez curl flashrom fwupd-efi gcc-runtime glib glibc gnutls \
-        libdrm libjcat libmbim libmnl libqmi libusb libxmlb \
-        modemmanager passim polkit readline sqlite systemd tpm2-tss \
-        udisks-2 util-linux-runtime xz zlib"
+PKGDEP="bluez curl fwupd-efi gcc-runtime glib glibc gnutls libdrm \
+        libmbim libmnl libqmi libusb libxmlb modemmanager passim \
+        polkit readline sqlite systemd tpm2-tss udisks-2 \
+        util-linux-runtime xz zlib"
 BUILDDEP="cairo gobject-introspection jinja2 vala"
 # FIXME: Fwupd-efi is not yet available for ppc64el & loongson3.
 PKGDEP__LOONGSON3="${PKGDEP/fwupd-efi/}"
@@ -20,6 +20,7 @@ MESON_AFTER=(
     '-Dfirmware-packager=true'
     '-Dfish_completion=true'
     '-Dgnutls=enabled'
+    '-Dopenssl=enabled'
     '-Dhsi=disabled'
     '-Dintrospection=enabled'
     '-Dlibdrm=enabled'
@@ -31,7 +32,6 @@ MESON_AFTER=(
     '-Dp2p_policy=metadata'
     '-Dudev_hotplug=true'
     '-Dpassim=enabled'
-    '-Dplugin_flashrom=enabled'
     '-Dplugin_modem_manager=enabled'
     '-Dplugin_uefi_capsule_splash=true'
     '-Dpolkit=enabled'

--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=2.1.3
-SRCS="git::commit=tags/$VER::https://github.com/fwupd/fwupd.git"
-CHKSUMS="SKIP"
+VER=2.1.4+2
+SRCS="tbl::https://github.com/fwupd/fwupd/releases/download/${VER//+/-}/fwupd-${VER%%+*}.tar.xz"
+CHKSUMS="sha256::fa7ee00ccf5672bc9b93027fa51172dc8eabd8b93d02972c75396f3af7ca743c"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 2.1.4+2
    - Adjust meson options.
    - Adjust PKGDEP.

Package(s) Affected
-------------------

- fwupd: 2.1.4+2

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
