### PR TITLE
daed: update to 1.27.0

### DIFF
--- a/app-proxy/daed/spec
+++ b/app-proxy/daed/spec
@@ -1,8 +1,7 @@
-VER=1.21.1
-REL=3
+VER=1.27.0
 SRCS="tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/daed-full-src.zip \
       tbl::https://github.com/daeuniverse/daed/releases/download/v$VER/web.zip"
-CHKSUMS="sha256::92cbdeadf30045e6a2e280d742f23125d686115093af1cde4f9def84c076dc24 \
-         sha256::ffba0f8b5e9411ad0da10349dfaab2336922d47cd5effd81163ce4415b4d84d7"
+CHKSUMS="sha256::64cebf2ace11ab9e081db31c13dc29b75954fea20eaa37a440bfaecfde46c96c \
+         sha256::da8755fb2cabfab392854e807e385b12d9e9842d6c8b5e347284d1ae0e582bfc"
 CHKUPDATE="anitya::id=375373"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- daed: update to 1.27.0
    Co-authored-by: \(@MutsukiC\)

Package(s) Affected
-------------------

- daed: 1.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit daed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
