### PR TITLE
btrfs-progs: update to 7.0

### DIFF
--- a/app-admin/btrfs-progs/spec
+++ b/app-admin/btrfs-progs/spec
@@ -1,4 +1,4 @@
-VER=6.19.1
+VER=7.0
 SRCS="https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/btrfs-progs-v$VER.tar.xz"
-CHKSUMS="sha256::bb27e1ec54e7c3c0b7b2e596f853a73c07a3d72f21bc94042073c24dbf045796"
+CHKSUMS="sha256::c286d6876cbcd72327a0b417e4cfd280353ec23e37b549fdbcd7800a832d9a99"
 CHKUPDATE="anitya::id=227"


### PR DESCRIPTION
Topic Description
-----------------

- btrfs-progs: update to 7.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- btrfs-progs: 7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit btrfs-progs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
