### PR TITLE
iosevka-fonts: update to 34.6.1

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=34.4.0
+VER=34.6.1
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::24f7c8e6f874037aa51d6e9d2970755417cff5a845750e650251230d513b4b27 \
-         sha256::a2e8ebb91a8072a6f408f868062f4290096b56e07b495698df9f75656e5129a0 \
-         sha256::2a327d52965f432d9490bbf1ceb1c526caadcb330265b2b15004c1c43186c1b8 \
-         sha256::c3ce3b0eeae1a6a0ee8929a764d29b87830a8bab201dd2e47e9a68392bc8e3bb \
-         sha256::03f7a3e4794185d2452040bd29f007a427c331212d5690bda02d8506c13368ad \
-         sha256::48e6b36349034aef6eb1a365b7c47cd69cc0963baa4acffc34c97d3cd0c45b57 \
-         sha256::fe8d1b209c7860d8829e437ca8efe79f4e27ed4b82d64f183100776262ee0bd5 \
-         sha256::f9c41b85120e44037d6054749c3bde8bb668e129412da47a6654891300d399e5 \
-         sha256::342cb10ec0a119d9f963ba2e3fd35f736810f9d7011ac004c69e4a87aa51118b \
-         sha256::41748b88afb71741815c2c5cf46f540655225c7722842333ac8a4de70cd75370 \
-         sha256::f3b3583dd5402c482df84e9903df8dcb1550cb7341122971d7969a369d1aceaf \
-         sha256::546d25ef5f4a84d3179b02ed4279bdab8c4f313b1d21bb6870f322051db946ff \
-         sha256::ea8ab22db7da9721f4862830eedd9c40c6073b663e517d484c87a151d8cca6ee \
-         sha256::bda7f59de661509b68b18f7034e5cab38b6d349af72a7c755f673800c8c89fc7 \
-         sha256::4af303a6ff66af2e8716c0b858a947e99e8a897eb77ba4df44b17e1d01bd3c41 \
-         sha256::7482e6c3179a4bff1928ca5e4cc77ddd92f29fe256a906b34c84ec3a84729ad0 \
-         sha256::ddea34c8f0c9d9379afb4ba276620186e7143668f0f8f15c080bdf0aba83a979 \
-         sha256::fbb6e34e8e6636e54abfa77327b1685a3099d4a353589662a94fd104c7e96903 \
-         sha256::f97e64e9385f4b694a9b3c690856c753b1b2ee1084cf5746c78ed364a0359ec0 \
-         sha256::ca6fdf14ae0d375234fdc2922016fb6ac1e6cccbdd1d938e043da8e151f3101e \
-         sha256::6a6c23a1d3567e0ec2958f29bf15df8e01fc61b7d5e6f5e286589c7f79be89c2 \
-         sha256::2ecb83ed22cf7026788aad54e097dffab50c49fa2b34beacade6b9a8433a2ad5 \
-         sha256::3fcdcf84fb46acd4fe506116ace15106bbf1e5aeb254b989f8d77309767bccc2 \
-         sha256::77e35e36dac373bc24ffa532a73efcffae01124575876b2baeed659f6a705a0c \
+CHKSUMS="sha256::ff48478ec300081e8b17f66bcc6cf635a83ed26b8d35fbb8a2f203b7a92f54ab \
+         sha256::d85fac260053a90e3af660939ad3dcd5462418d6c8e853fddd25150fa587a5af \
+         sha256::b20a208102011169776029e621c5546f6c9946631923debf0a348dfa412a5319 \
+         sha256::3c61511fa7dd28da532aed8b2a57677517052bb4d88a284b59a2f8693850311c \
+         sha256::0b89e7ab48998d1c351d116250c2c7240c153c4746799484b83aa07b7c2dc708 \
+         sha256::bce5746934b51dcb27bdd790c81482559f827a36d0af36cce062a7e2cd04a730 \
+         sha256::be5402bec71a576aa831ab0e2ec89f6142c92ead525df12bd3fc161f4b92f986 \
+         sha256::e608aa8e117551445a48e5163bc186c9069bed106fb92a1b02205b61b895fb63 \
+         sha256::8173bdbe52fcc4a5935a733e39da857657d561d6a4c9f840029f91235f1d8643 \
+         sha256::746357a38e99421b8f6bcd44f98b4748af893e002702262989380306bc4f8f50 \
+         sha256::671a47b8adeea1d0d89595f211a081d500dfb0cce2b74e670a4da89cfc722b80 \
+         sha256::bdbc85b2dbf92d0fc94c9a38c8dfbf46f7aa16fe1f478457e7c9d54585bf7219 \
+         sha256::052da895f97861d4c0106e15f671e5382608c75c4ea8dd1a1b417f24d1e9283b \
+         sha256::5e5c127bae271872a38ac69a138b25cf7f5e9c4ae807b66eba3e8958146d55f6 \
+         sha256::408dd65d9889f0647f29a93c50cd772fef894f0877b5443e970aaae4cf986549 \
+         sha256::a5c9a319da80fc8acce80138594958f9f647eb4654b3fea5a1368b9414c8e1c7 \
+         sha256::e4b7904be7c13715057327125309fe02b3cf0d96658c2b66e5726d276a2877ae \
+         sha256::d48dca0e399c7bfa9a81d194770af8c0e2aa9e0bcac5813371971e3517080440 \
+         sha256::4cb269f069ad8b12187b3a0c49755ed9876728d8ff156aca4eef8a7d5152005f \
+         sha256::49c3b5fb76e2268b7951b0b6fc2bba8c1869dc0f0d1ad4a69365ceec194f169a \
+         sha256::e99934f8de75708ddadf4c85d257c243f1c67bab5e58844d62c2f472d42e6628 \
+         sha256::0ba75738d2fa2b57bfc558674f440dba8fd8ec68b5875c3d0ab0170826a3d620 \
+         sha256::b8556eaafe79020555542f7cb75b49b42278061ca660505d9a05d317c64e4fa0 \
+         sha256::b2f6b3572e1ab2a74ed727918f3b062b41de2166fa776b6a36cb8ef8b5c03c97 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.6.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
