### PR TITLE
racket: update to 9.2

### DIFF
--- a/lang-lisp/racket/autobuild/patches/0001-add-sys-time-include.patch.loongson3
+++ b/lang-lisp/racket/autobuild/patches/0001-add-sys-time-include.patch.loongson3
@@ -1,0 +1,12 @@
+diff --git a/rktio/rktio_poll_set.c b/rktio/rktio_poll_set.c
+index efb7148..1616a80 100644
+--- a/rktio/rktio_poll_set.c
++++ b/rktio/rktio_poll_set.c
+@@ -6,6 +6,7 @@
+ # include <fcntl.h>
+ # include <errno.h>
+ # include <math.h>
++# include <time.h>
+ # ifdef USE_ULIMIT
+ #  include <ulimit.h>
+ # endif

--- a/lang-lisp/racket/spec
+++ b/lang-lisp/racket/spec
@@ -1,5 +1,5 @@
-VER=9.1
+VER=9.2
 SRCS="tbl::https://download.racket-lang.org/installers/$VER/racket-$VER-src.tgz"
 SUBDIR="racket-$VER/src"
-CHKSUMS="sha256::1062dce1826884a2a758b565318570440dfd06699f1b1c47cd27d805e4f6833e"
+CHKSUMS="sha256::ccf98fd81444dfb3e3d0fde86e8db0753a7e8568725d45c0189ce5c8b7c4bb19"
 CHKUPDATE="anitya::id=13609"


### PR DESCRIPTION
Topic Description
-----------------

- racket: update to 9.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- racket: 9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit racket
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
