### PR TITLE
swaylock: update to 1.8.5

### DIFF
--- a/app-utils/swaylock/spec
+++ b/app-utils/swaylock/spec
@@ -1,4 +1,4 @@
-VER=1.8.4
+VER=1.8.5
 SRCS="git::commit=tags/v$VER::https://github.com/swaywm/swaylock"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19218"


### PR DESCRIPTION
Topic Description
-----------------

- swaylock: update to 1.8.5
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- swaylock: 1.8.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit swaylock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
