### PR TITLE
sbcl: update to 2.6.5

### DIFF
--- a/lang-lisp/sbcl/spec
+++ b/lang-lisp/sbcl/spec
@@ -1,4 +1,4 @@
-VER=2.5.10
+VER=2.6.5
 SRCS="tbl::https://downloads.sourceforge.net/project/sbcl/sbcl/$VER/sbcl-$VER-source.tar.bz2"
-CHKSUMS="sha256::bf5fb49f2a42f36b3e003d2e4d234386addf07d9dd8ca8634656927cc96ce125"
+CHKSUMS="sha256::91ec75f647252ed6e6aeae9b1a13f47c7c6cfd9b68488dc69f1a6fea5accb440"
 CHKUPDATE="anitya::id=16339"


### PR DESCRIPTION
Topic Description
-----------------

- sbcl: update to 2.6.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sbcl: 2.6.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit sbcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
