### PR TITLE
thin-provisioning-tools: update to 1.3.2

### DIFF
--- a/app-admin/thin-provisioning-tools/spec
+++ b/app-admin/thin-provisioning-tools/spec
@@ -1,5 +1,4 @@
-VER=1.0.10
-REL=1
+VER=1.3.2
 SRCS="git::commit=tags/v$VER::https://github.com/jthornber/thin-provisioning-tools"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5385"


### PR DESCRIPTION
Topic Description
-----------------

- thin-provisioning-tools: update to 1.3.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- thin-provisioning-tools: 1.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit thin-provisioning-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
