### PR TITLE
scummvm: update to 2026.2.0

### DIFF
--- a/app-games/scummvm/spec
+++ b/app-games/scummvm/spec
@@ -1,5 +1,4 @@
-VER=2.9.0
-REL=1
+VER=2026.2.0
 SRCS="tbl::https://www.scummvm.org/frs/scummvm/$VER/scummvm-$VER.tar.xz"
-CHKSUMS="sha256::d5b33532bd70d247f09127719c670b4b935810f53ebb6b7b6eafacaa5da99452"
+CHKSUMS="sha256::4e10ed977daa36780c97a9b3bd7c124842f5ed9b0bfea4e8e35eda4658fa60f3"
 CHKUPDATE="anitya::id=4775"


### PR DESCRIPTION
Topic Description
-----------------

- scummvm: update to 2026.2.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- scummvm: 2026.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit scummvm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
