### PR TITLE
curtail: update to 1.16.2

### DIFF
--- a/app-imaging/curtail/autobuild/defines
+++ b/app-imaging/curtail/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=curtail
 PKGSEC=graphics
-PKGDES="Image compressor that supports PNG, JPEG, WebP and SVG file"
-PKGDEP="dconf gdk-pixbuf glib gtk-4 hicolor-icon-theme jpegoptim libadwaita \
-        libwebp pngquant python-3 pygobject-3 scour oxipng \
+PKGDEP="dconf gdk-pixbuf glib gtk-4 hicolor-icon-theme jpegoptim \
+        libadwaita libwebp pngquant python-3 pygobject-3 scour oxipng \
         gtk-update-icon-cache"
-BUILDDEP="appstream"
+BUILDDEP="blueprint-compiler"
+PKGDES="Image compressor for various image formats"
 
 ABHOST=noarch
+ABTYPE=meson

--- a/app-imaging/curtail/spec
+++ b/app-imaging/curtail/spec
@@ -1,5 +1,4 @@
-VER=1.12.0
-REL="2"
+VER=1.16.2
 SRCS="git::commit=tags/$VER::https://github.com/Huluti/Curtail.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=312431"


### PR DESCRIPTION
Topic Description
-----------------

- curtail: update to 1.16.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- curtail: 1.16.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit curtail
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
