### PR TITLE
ocserv: update to 1.4.2

### DIFF
--- a/app-network/ocserv/autobuild/defines
+++ b/app-network/ocserv/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=ocserv
 PKGSEC=net
-PKGDEP="autogen freeradius-client gnutls libev libnl libseccomp \
-        linux-pam oath-toolkit pcl protobuf-c systemd talloc less"
-BUILDDEP="gperf ipcalc"
+PKGDEP="autogen cjose freeradius-client gnutls less libev libnl \
+        libseccomp linux-pam oath-toolkit pcl protobuf-c systemd talloc"
+BUILDDEP="gperf ipcalc ronn-ng"
 PKGDES="OpenConnect VPN Server"
 
 ABTYPE=meson

--- a/app-network/ocserv/autobuild/defines
+++ b/app-network/ocserv/autobuild/defines
@@ -1,8 +1,38 @@
 PKGNAME=ocserv
 PKGSEC=net
 PKGDEP="autogen freeradius-client gnutls libev libnl libseccomp \
-        linux-pam oath-toolkit pcl protobuf-c systemd talloc"
+        linux-pam oath-toolkit pcl protobuf-c systemd talloc less"
 BUILDDEP="gperf ipcalc"
 PKGDES="OpenConnect VPN Server"
 
-ABTYPE=autotools
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dpam=enabled'
+    '-Dradius=enabled'
+    '-Dgssapi=enabled'
+    '-Dliboath=enabled'
+    '-Dlibnl=enabled'
+    '-Dmaxmind=enabled'
+    '-Dgeoip=enabled'
+    '-Dlz4=enabled'
+    '-Dcompression=enabled'
+    '-Dseccomp=enabled'
+    '-Dsystemd=enabled'
+    '-Doidc-auth=enabled'
+    '-Dlatency-stats=enabled'
+    '-Danyconnect-compat=enabled'
+    '-Dnamespaces=enabled'
+    '-Dutmp=enabled'
+    '-Dlibwrap=enabled'
+    '-Dlocal-talloc=false'
+    '-Dlocal-llhttp=false'
+    '-Dlocal-protobuf=false'
+    '-Dlocal-pcl=false'
+    '-Dseccomp-trap=false'
+    '-Droot-tests=false'
+    '-Dtun-tests=false'
+    '-Dkerberos-tests=false'
+    '-Dwith-werror=false'
+    '-Dpager=less'
+    '-Dfirewall-script=nftables'
+)

--- a/app-network/ocserv/spec
+++ b/app-network/ocserv/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=2
+VER=1.4.2
 SRCS="git::commit=tags/$VER::https://gitlab.com/openconnect/ocserv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2527"

--- a/lang-js/cjose/autobuild/defines
+++ b/lang-js/cjose/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=cjose
+PKGSEC=libs
+PKGDEP="jansson openssl"
+PKGDES="C/C++ implementation of Javascript Object Signing and Encryption (JOSE)"
+
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    # FIXME: Specifying either will cause the following error:
+    #
+    # ../libtool: line 7892: cd: yes/lib: No such file or directory
+    # libtool:   error: cannot determine absolute directory name of 'yes/lib'
+    #
+    #'--with-jansson'
+    #'--with-openssl'
+    '--without-rsapkcs1_5'
+)

--- a/lang-js/cjose/spec
+++ b/lang-js/cjose/spec
@@ -1,0 +1,4 @@
+VER=0.6.2.4
+SRCS="git::commit=tags/v$VER::https://github.com/OpenIDC/cjose"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=379690"


### PR DESCRIPTION
Topic Description
-----------------

- ocserv: update to 1.4.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
- cjose: new, 0.6.2.4

Package(s) Affected
-------------------

- cjose: 0.6.2.4
- ocserv: 1.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cjose ocserv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
