### PR TITLE
libdrm: update to 2.4.134

### DIFF
--- a/runtime-display/libdrm/spec
+++ b/runtime-display/libdrm/spec
@@ -1,4 +1,4 @@
-VER=2.4.131
+VER=2.4.134
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::45ba9983b51c896406a3d654de81d313b953b76e6391e2797073d543c5f617d5"
+CHKSUMS="sha256::ac5e74d157830eb8bee44c6a6bf3ad49774ef0dd2a72bdad74a8f20308b52a95"
 CHKUPDATE="anitya::id=1596"

--- a/runtime-optenv32/libdrm+32/spec
+++ b/runtime-optenv32/libdrm+32/spec
@@ -1,4 +1,4 @@
-VER=2.4.131
+VER=2.4.134
 SRCS="tbl::https://dri.freedesktop.org/libdrm/libdrm-$VER.tar.xz"
-CHKSUMS="sha256::45ba9983b51c896406a3d654de81d313b953b76e6391e2797073d543c5f617d5"
+CHKSUMS="sha256::ac5e74d157830eb8bee44c6a6bf3ad49774ef0dd2a72bdad74a8f20308b52a95"
 CHKUPDATE="anitya::id=1596"


### PR DESCRIPTION
Topic Description
-----------------

- libdrm+32: update to 2.4.134
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- libdrm: update to 2.4.134
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- libdrm: 2.4.134

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdrm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
