### PR TITLE
xonsh: update to 0.23.8

### DIFF
--- a/lang-python/xonsh/spec
+++ b/lang-python/xonsh/spec
@@ -1,4 +1,4 @@
-VER=0.23.6
+VER=0.23.8
 SRCS="git::commit=tags/$VER::https://github.com/xonsh/xonsh"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10820"


### PR DESCRIPTION
Topic Description
-----------------

- xonsh: update to 0.23.8
    Co-authored-by: Lumiere \(@atlarator\) <vzstless@qq.com>

Package(s) Affected
-------------------

- xonsh: 0.23.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit xonsh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
