### PR TITLE
ps3netsrv-go: Add libchdr as an installation package dependency

### DIFF
--- a/app-network/ps3netsrv-go/autobuild/defines
+++ b/app-network/ps3netsrv-go/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=ps3netsrv-go
 PKGSEC=net
+PKGDES="Utility to serve games and applications to PlayStation 3 consoles"
+PKGDEP="libchdr"
 BUILDDEP="go"
 GO_PACKAGES=("cmd/ps3netsrv-go")
-PKGDES="Utility to serve games and applications to PlayStation 3 consoles"
+
 ABTYPE=gomod
 # FIXME: Missing architcture support for MIPS
 #

--- a/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/systemd/system/ps3netsrv-go.service
+++ b/app-network/ps3netsrv-go/autobuild/overrides/usr/lib/systemd/system/ps3netsrv-go.service
@@ -11,7 +11,7 @@ Group=ps3netsrv-go
 ExecStart=/usr/bin/ps3netsrv-go server --config=/etc/ps3netsrv-go.conf
 Restart=on-failure
 RestartSec=5s
-MemoryMax=128M
+MemoryMax=512M
 
 [Install]
 WantedBy=multi-user.target

--- a/app-network/ps3netsrv-go/spec
+++ b/app-network/ps3netsrv-go/spec
@@ -1,4 +1,5 @@
 VER=0.2.4
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/xakep666/ps3netsrv-go"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383793"


### PR DESCRIPTION
Topic Description
-----------------

- Add libchdr as an installation package dependency
- Increase MemoryMax from 128M to 512MB to accommodate CHD file reading
- Change REL version 0 => 1

Package(s) Affected
-------------------

- ps3netsrv-go: 0.2.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ps3netsrv-go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
