### PR TITLE
sudoku: new, 0.4.6


### DIFF
--- a/app-proxy/sudoku/autobuild/defines
+++ b/app-proxy/sudoku/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=sudoku
+PKGSEC=net
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="A Sudoku-based proxy software"
+
+# FIXME: Autobuild does not yet support splitting out debug symbols from
+# Golang executables.
+ABSPLITDBG=0
+
+ABTYPE=gomod
+GO_PACKAGES=('./cmd/sudoku-tunnel')

--- a/app-proxy/sudoku/autobuild/overrides/usr/lib/systemd/system/sudoku.service
+++ b/app-proxy/sudoku/autobuild/overrides/usr/lib/systemd/system/sudoku.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sudoku Proxy
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/sudoku-tunnel -c /etc/sudoku/config.json
+LimitNPROC=500
+LimitNOFILE=1048576
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_TIME
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_SYS_TIME
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/app-proxy/sudoku/spec
+++ b/app-proxy/sudoku/spec
@@ -1,0 +1,4 @@
+VER=0.4.6
+SRCS="git::commit=tags/v$VER::https://github.com/SUDOKU-ASCII/sudoku"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390428"


### PR DESCRIPTION
Topic Description
-----------------

- sudoku: new, 0.4.6

Package(s) Affected
-------------------

- sudoku: 0.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit sudoku
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
