### PR TITLE
rocm: Libraries without MachineLearning update to 7.13[1/3]

### DIFF
--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas-common"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipblaslt/autobuild/defines
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=rocm-hipblaslt
 PKGDES="HIP library for GEMM operations with extended functionality"
 PKGSEC=devel
-PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipblas-common rocm-roctracer rocm-origami"
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipblas-common rocm-roctracer rocm-origami rocm-smi-lib"
 
 # FIXME: Undefined symbol: cblas_dgemm. Build-time dependency to lapack
 # was removed.
-BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib gtest pyyaml blis"
+BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib gtest pyyaml blis python-msgpack"
 
 USECLANG=1
 
@@ -29,22 +29,12 @@ CMAKE_AFTER=(
     '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
     '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
     '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
-    '-DCMAKE_Fortran_COMPILER=/usr/lib/rocm/lib/llvm/bin/flang'
     '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
     '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
     '-DROCM_PATH=/usr/lib/rocm'
-    '-DBUILD_CLIENTS_SAMPLES=OFF'
-    '-DTensile_ENABLE_MARKER=ON'
-    '-DTensile_EXPERIMENTAL=ON'
-    '-DBUILD_CLIENTS_TESTS=OFF'
-    '-DBUILD_CLIENTS_BENCHMARKS=OFF'
-    '-DHIPBLASLT_USE_ROCROLLER=OFF'
     '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
     '-DCMAKE_LINKER_TYPE=LLD'
-    '-DHIPBLASLT_ENABLE_BLIS=ON'
-    '-DBLIS_ROOT=/usr'
-    '-DBLIS_LIB=/usr/lib/libblis.so'
     # FIXME: ld.lld: error: undefined symbol: cblas_dgemm
     '-DHIPBLASLT_ENABLE_CLIENT=OFF'
     '-DORIGAMI_ENABLE_INSTALL=OFF'
@@ -53,7 +43,7 @@ CMAKE_AFTER=(
 # Note: Disable iGPU/CDNA on ARM64. Reduce build pressure.
 CMAKE_AFTER__ARM64=(
     "${CMAKE_AFTER[@]}"
-    '-DAMDGPU_TARGETS=gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
+    '-DGPU_TARGETS=gfx1100;gfx1101;gfx1102;gfx1200;gfx1201'
 )
 
 FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipblaslt/autobuild/patch
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/patch
@@ -1,1 +1,3 @@
-abinfo "There is currently no need to patch the main project."
+abinfo "Patch hipBLASLt in Root Project..."
+cd "$SRCDIR/../.."
+ab_apply_patches "$SRCDIR"/autobuild/patches/0001-Fix-LLVM-intrinsic-name-mangling-in-buffer-load-store-declaration.patch

--- a/runtime-rocm/rocm-hipblaslt/autobuild/patches/0001-Fix-LLVM-intrinsic-name-mangling-in-buffer-load-store-declaration.patch
+++ b/runtime-rocm/rocm-hipblaslt/autobuild/patches/0001-Fix-LLVM-intrinsic-name-mangling-in-buffer-load-store-declaration.patch
@@ -1,0 +1,100 @@
+From 8c27e1a909542a3aec284006ff084ea073ea013c Mon Sep 17 00:00:00 2001
+From: Harkirat Gill <harkirat.gill@amd.com>
+Date: Mon, 25 May 2026 13:36:25 -0400
+Subject: [PATCH] [hipBLASLt] Fix LLVM intrinsic name mangling in buffer
+ load/store declaration
+
+---
+ .../tensilelite/Tensile/Source/memory_gfx.h   | 20 +++++++++----------
+ 1 file changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/projects/hipblaslt/tensilelite/Tensile/Source/memory_gfx.h b/projects/hipblaslt/tensilelite/Tensile/Source/memory_gfx.h
+index d7d92ae9ce4..f0a8d12689f 100644
+--- a/projects/hipblaslt/tensilelite/Tensile/Source/memory_gfx.h
++++ b/projects/hipblaslt/tensilelite/Tensile/Source/memory_gfx.h
+@@ -161,35 +161,35 @@ __device__ char
+     llvm_amdgcn_raw_buffer_load_i8(int32x4_t buffer_resource,
+                                    uint32_t  voffset,
+                                    uint32_t  soffset,
+-                                   int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.load.i8.v4i32");
++                                   int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.load.i8");
+ 
+ // 2 bytes
+ __device__ float16_t
+     llvm_amdgcn_raw_buffer_load_f16(int32x4_t buffer_resource,
+                                     uint32_t  voffset,
+                                     uint32_t  soffset,
+-                                    int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.load.f16.v4i32");
++                                    int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.load.f16");
+ 
+ // 4 bytes
+ __device__ float32_t
+     llvm_amdgcn_raw_buffer_load_f32(int32x4_t buffer_resource,
+                                     uint32_t  voffset,
+                                     uint32_t  soffset,
+-                                    int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.load.f32.v4i32");
++                                    int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.load.f32");
+ 
+ // 8 bytes
+ __device__ float32x2_t
+     llvm_amdgcn_raw_buffer_load_f32x2(int32x4_t buffer_resource,
+                                       uint32_t  voffset,
+                                       uint32_t  soffset,
+-                                      int32_t cache_op) __asm("llvm.amdgcn.raw.buffer.load.v2f32.v4i32");
++                                      int32_t cache_op) __asm("llvm.amdgcn.raw.buffer.load.v2f32");
+ 
+ // 16 bytes
+ __device__ float32x4_t
+     llvm_amdgcn_raw_buffer_load_f32x4(int32x4_t buffer_resource,
+                                       uint32_t  voffset,
+                                       uint32_t  soffset,
+-                                      int32_t cache_op) __asm("llvm.amdgcn.raw.buffer.load.v4f32.v4i32");
++                                      int32_t cache_op) __asm("llvm.amdgcn.raw.buffer.load.v4f32");
+ 
+ // 4 bytes
+ __device__ int32_t
+@@ -219,7 +219,7 @@ __device__ void
+                                     int32x4_t buffer_resource,
+                                     uint32_t  voffset,
+                                     uint32_t  soffset,
+-                                    int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.store.i8.v4i32");
++                                    int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.store.i8");
+ 
+ // 2 bytes
+ __device__ void
+@@ -227,7 +227,7 @@ __device__ void
+                                      int32x4_t buffer_resource,
+                                      uint32_t  voffset,
+                                      uint32_t  soffset,
+-                                     int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.store.f16.v4i32");
++                                     int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.store.f16");
+ 
+ // 4 bytes
+ __device__ void
+@@ -235,7 +235,7 @@ __device__ void
+                                      int32x4_t buffer_resource,
+                                      uint32_t  voffset,
+                                      uint32_t  soffset,
+-                                     int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.store.f32.v4i32");
++                                     int32_t   cache_op) __asm("llvm.amdgcn.raw.buffer.store.f32");
+ 
+ // 8 bytes
+ __device__ void llvm_amdgcn_raw_buffer_store_f32x2(
+@@ -243,7 +243,7 @@ __device__ void llvm_amdgcn_raw_buffer_store_f32x2(
+     int32x4_t   buffer_resource,
+     uint32_t    voffset,
+     uint32_t    soffset,
+-    int32_t     cache_op) __asm("llvm.amdgcn.raw.buffer.store.v2f32.v4i32");
++    int32_t     cache_op) __asm("llvm.amdgcn.raw.buffer.store.v2f32");
+ 
+ // 16 bytes
+ __device__ void llvm_amdgcn_raw_buffer_store_f32x4(
+@@ -251,7 +251,7 @@ __device__ void llvm_amdgcn_raw_buffer_store_f32x4(
+     int32x4_t   buffer_resource,
+     uint32_t    voffset,
+     uint32_t    soffset,
+-    int32_t     cache_op) __asm("llvm.amdgcn.raw.buffer.store.v4f32.v4i32");
++    int32_t     cache_op) __asm("llvm.amdgcn.raw.buffer.store.v4f32");
+ 
+ ////////////////////////////////////////////////////////////////////////////////////////////////////
+ 

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblaslt"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-origami/spec
+++ b/runtime-rocm/rocm-origami/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/shared/origami"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-rocblas/autobuild/defines
+++ b/runtime-rocm/rocm-rocblas/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=rocm-rocblas
 PKGDES="rocBLAS is the AMD library for BLAS in ROCm. Implemented using the HIP language and optimized for AMD GPUs"
 PKGSEC=devel
 PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipblas-common rocm-roctracer rocm-hipblaslt rocm-origami"
-BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++"
+BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ pyyaml python-msgpack"
 
 USECLANG=1
 # Note: Control Flow Protection is not supported by GPU targets.

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocblas"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocfft"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocrand"
 CHKUPDATE="anitya::id=383650"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocrand: update to 7.13
- rocm-rocfft: update to 7.13
- rocm-rocblas: update to 7.13
- rocm-hipblaslt: update to 7.13
- rocm-origami: update to 7.13
- rocm-hipblas-common: update to 7.13

Package(s) Affected
-------------------

- rocm-hipblas-common: 7.13
- rocm-hipblaslt: 7.13
- rocm-origami: 7.13
- rocm-rocblas: 7.13
- rocm-rocfft: 7.13
- rocm-rocrand: 7.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipblas-common rocm-origami rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
