### PR TITLE
mieru: new, 3.33.0


### DIFF
--- a/app-proxy/mieru/autobuild/beyond
+++ b/app-proxy/mieru/autobuild/beyond
@@ -1,0 +1,5 @@
+abinfo "Installing mieru & mita systemd services ..."
+install -Dvm644 "$SRCDIR"/configs/examples/mieru.service \
+    -t "$PKGDIR"/usr/lib/systemd/system
+install -Dvm644 "$SRCDIR"/configs/examples/mita.service \
+    -t "$PKGDIR"/usr/lib/systemd/system

--- a/app-proxy/mieru/autobuild/defines
+++ b/app-proxy/mieru/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=mieru
+PKGSEC=net
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="A socks5 / HTTP / HTTPS proxy software"
+
+# FIXME: Autobuild does not yet support splitting out debug symbols from
+# Golang executables.
+ABSPLITDBG=0
+
+ABTYPE=gomod
+GO_PACKAGES=('cmd/mieru' 'cmd/mita')
+
+PKGPROV=('mita')

--- a/app-proxy/mieru/autobuild/postinst
+++ b/app-proxy/mieru/autobuild/postinst
@@ -1,0 +1,5 @@
+getent group mita &>/dev/null || \
+    groupadd -r mita >/dev/null
+getent passwd mita &>/dev/null || \
+    useradd -r -g mita -d /var/lib/mita -c 'mita daemon' \
+        -s /bin/false mita >/dev/null

--- a/app-proxy/mieru/spec
+++ b/app-proxy/mieru/spec
@@ -1,0 +1,4 @@
+VER=3.33.0
+SRCS="git::commit=tags/v$VER::https://github.com/enfein/mieru"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390429"


### PR DESCRIPTION
Topic Description
-----------------

- mieru: new, 3.33.0

Package(s) Affected
-------------------

- mieru: 3.33.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mieru
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
