### PR TITLE
Fix deadlock in egl-wayland

### DIFF
--- a/runtime-display/egl-wayland/autobuild/patches/0001-wayland-eglstream-release-external-API-lock-before-c.patch
+++ b/runtime-display/egl-wayland/autobuild/patches/0001-wayland-eglstream-release-external-API-lock-before-c.patch
@@ -1,0 +1,68 @@
+From 6994954b4394b2ea22b7f7b85ee897f07ad9bfd4 Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Sun, 31 May 2026 00:58:53 -0400
+Subject: [PATCH] wayland-eglstream: release external API lock before calling
+ device EGL
+
+The following code path can potentially produce a deadlock:
+- wlEglCreateStreamAttribHook()
+- External API lock acquired on line 82.
+- Calls internal device driver EGL `createStreamAttrib` on line 201.
+- This internal device driver can potentially invoke another external API
+  like `wlEglAcquireDisplay`, which acquires the lock again.
+
+As `wlMutex` is initialized with `PTHREAD_MUTEX_ERRORCHECK` the deadlock
+on the same thread will crash the application.
+
+There's no point holding the lock once `wlStreamDpy` and `wlStream` are
+validated. Any device EGL that invokes platform EGL again would be
+doing their own validation (taking the lock in the process).
+
+Reference:
+- https://github.com/telegramdesktop/tdesktop/issues/29965
+---
+ src/wayland-eglstream.c | 11 ++++++-----
+ 1 file changed, 6 insertions(+), 5 deletions(-)
+
+diff --git a/src/wayland-eglstream.c b/src/wayland-eglstream.c
+index 3c40a0d..611e773 100644
+--- a/src/wayland-eglstream.c
++++ b/src/wayland-eglstream.c
+@@ -89,15 +89,17 @@ EGLStreamKHR wlEglCreateStreamAttribHook(EGLDisplay dpy,
+     }
+ 
+     if (err != EGL_SUCCESS) {
+-        goto fail;
++        goto fail_unlock;
+     }
+ 
+     wlStream = wl_eglstream_display_get_stream(wlStreamDpy, resource);
+     if (wlStream == NULL) {
+         err = EGL_BAD_ACCESS;
+-        goto fail;
++        goto fail_unlock;
+     }
+ 
++    wlExternalApiUnlock();
++
+     if (wlStream->eglStream != EGL_NO_STREAM_KHR ||
+         wlStream->handle == -1) {
+         err = EGL_BAD_STREAM_KHR;
+@@ -237,12 +239,11 @@ EGLStreamKHR wlEglCreateStreamAttribHook(EGLDisplay dpy,
+     wlStream->eglStream = stream;
+     wlStream->handle = -1;
+ 
+-    wlExternalApiUnlock();
+-
+     return stream;
+ 
+-fail:
++fail_unlock:
+     wlExternalApiUnlock();
++fail:
+     wlEglSetError(data, err);
+     return EGL_NO_STREAM_KHR;
+ }
+-- 
+2.52.0
+

--- a/runtime-display/egl-wayland/spec
+++ b/runtime-display/egl-wayland/spec
@@ -1,4 +1,5 @@
 VER=1.1.21
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/egl-wayland"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17778"


### PR DESCRIPTION
Topic Description
-----------------

- egl-wayland: fix deadlock in wlEglCreateStreamAttribHook

Package(s) Affected
-------------------

- egl-wayland: 1.1.21-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit egl-wayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
