### PR TITLE
redis: update to 8.8.0

### DIFF
--- a/app-database/redis/spec
+++ b/app-database/redis/spec
@@ -1,5 +1,4 @@
-VER=8.4.0
-REL=1
+VER=8.8.0
 SRCS="tbl::https://download.redis.io/releases/redis-$VER.tar.gz"
-CHKSUMS="sha256::ca909aa15252f2ecb3a048cd086469827d636bf8334f50bb94d03fba4bfc56e8"
+CHKSUMS="sha256::88422181efb0c9c0abba332e3e391d409e1e13714b838931669235e5796f704b"
 CHKUPDATE="anitya::id=4181"

--- a/topics/redis-8.8.0.toml
+++ b/topics/redis-8.8.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Redis 8.8.0"
+
+[caution]
+default = "Fixes 5 security vulnerabilities disclosed in Redis' security advisory on May 5, 2026 (including 4 of High and 1 of Medium severity)"
+zh_CN = "修复 Redis 在 2026 年 5 月 5 日发布的安全公告中披露的 5 个安全漏洞（含 4 个高危漏洞和 1 个中危漏洞）"
+
+[packages-v2]
+"redis" = "< 8.8.0"


### PR DESCRIPTION
Topic Description
-----------------

- redis: update to 8.8.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- redis: 8.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit redis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
