### PR TITLE
audacious: update to 4.6.1

### DIFF
--- a/app-multimedia/audacious/autobuild/beyond
+++ b/app-multimedia/audacious/autobuild/beyond
@@ -1,7 +1,4 @@
-abinfo "Installing AppData XML ..."
-install -Dvm0644 "$SRCDIR"/contrib/audacious.appdata.xml \
-    "$PKGDIR"/usr/share/appdata/audacious.appdata.xml
-
+# Note: using subshell to avoid PWD pollution
 (
     cd "$SRCDIR"/../audacious-plugins-"$PKGVER"
     SRCDIR="$PWD"

--- a/app-multimedia/audacious/autobuild/beyond.stage2
+++ b/app-multimedia/audacious/autobuild/beyond.stage2
@@ -1,4 +1,1 @@
-abinfo "Installing AppData XML ..."
-cd "$SRCDIR"
-install -Dvm0644 "$SRCDIR"/contrib/audacious.appdata.xml \
-    "$PKGDIR"/usr/share/appdata/audacious.appdata.xml
+# dummy beyond script for stage 2

--- a/app-multimedia/audacious/autobuild/defines
+++ b/app-multimedia/audacious/autobuild/defines
@@ -3,7 +3,8 @@ PKGSEC=sound
 PKGDEP="gnome-icon-theme glib libguess hicolor-icon-theme desktop-file-utils \
         unzip alsa-lib pulseaudio jack lame libvorbis flac mpg123 faad2 \
         ffmpeg libmodplug fluidsynth libcdio-paranoia wavpack dbus-glib \
-        libnotify curl libmtp neon libmms libcue libsidplayfp qt-6 opusfile"
+        libnotify curl libmtp neon libmms libcue libresidfp libsidplayfp qt-6 \
+        opusfile"
 BUILDDEP="appstream-glib audacious"
 PKGDES="Audio player with support for plugins"
 

--- a/app-multimedia/audacious/autobuild/defines.stage2
+++ b/app-multimedia/audacious/autobuild/defines.stage2
@@ -3,7 +3,8 @@ PKGSEC=sound
 PKGDEP="gnome-icon-theme glib libguess hicolor-icon-theme desktop-file-utils \
         unzip alsa-lib pulseaudio jack lame libvorbis flac mpg123 faad2 \
         ffmpeg libmodplug fluidsynth libcdio-paranoia wavpack dbus-glib \
-        libnotify curl libmtp neon libmms libcue libsidplayfp qt-6 opusfile"
+        libnotify curl libmtp neon libmms libcue libresidfp libsidplayfp qt-6 \
+        opusfile"
 BUILDDEP="appstream-glib"
 PKGDES="Audio player with support for plugins"
 

--- a/app-multimedia/audacious/spec
+++ b/app-multimedia/audacious/spec
@@ -1,8 +1,7 @@
-VER=4.5.1
-REL=3
+VER=4.6.1
 SRCS="tbl::https://distfiles.audacious-media-player.org/audacious-$VER.tar.bz2 \
       git::rename=audacious-plugins-$VER;commit=tags/audacious-plugins-$VER::https://github.com/audacious-media-player/audacious-plugins"
-CHKSUMS="sha256::7194743a0a41b1d8f582c071488b77f7b917be47ca5e142dd76af5d81d36f9cd \
+CHKSUMS="sha256::62a5a609267eca7f6e3ce52ef6f42d5618d2961e3b4ddc227c6a5859026965d9 \
          SKIP"
 CHKUPDATE="anitya::id=138"
 SUBDIR="audacious-$VER"

--- a/runtime-multimedia/libresidfp/autobuild/defines
+++ b/runtime-multimedia/libresidfp/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libresidfp
+PKGSEC=sound
+PKGDEP="gcc-runtime glibc"
+PKGDES="Library to emulate the Commodore 64 SID chip"
+ABTYPE=autotools
+
+AUTOTOOLS_AFTER=('--disable-static')

--- a/runtime-multimedia/libresidfp/autobuild/defines
+++ b/runtime-multimedia/libresidfp/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=libresidfp
+PKGSEC=sound
+PKGDEP="gcc-runtime glibc"
+PKGDES="Library to emulate Commodore 64 SID chip"
+ABTYPE=autotools
+
+AUTOTOOLS_AFTER=('--disable-static')

--- a/runtime-multimedia/libresidfp/spec
+++ b/runtime-multimedia/libresidfp/spec
@@ -1,0 +1,4 @@
+VER=1.1.2
+SRCS="git::commit=tags/v$VER::https://github.com/libsidplayfp/libresidfp"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=389839"

--- a/runtime-multimedia/libsidplayfp/autobuild/defines
+++ b/runtime-multimedia/libsidplayfp/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libsidplayfp
 PKGSEC=sound
-PKGDEP="gcc-runtime"
+PKGDEP="libresidfp"
 BUILDDEP="xa"
 BUILDDEP__RETRO=""
 PKGDES="Library to play Commodore 64 music - derived from libsidplay2"

--- a/runtime-multimedia/libsidplayfp/spec
+++ b/runtime-multimedia/libsidplayfp/spec
@@ -1,4 +1,5 @@
 VER=3.0.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/libsidplayfp/libsidplayfp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1721"


### PR DESCRIPTION
Topic Description
-----------------

- audacious: update to 4.6.1
    - remove outdated appdata installation logic in favor of metainfo
    - add libresidfp for Commodore 64 SID music playback
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>
- libsidplayfp: rebuild for libresidfp
- libresidfp: new, 1.1.2

Package(s) Affected
-------------------

- audacious: 4.6.1
- libresidfp: 1.1.2
- libsidplayfp: 3.0.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libresidfp libsidplayfp audacious:+stage2 audacious
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
