### PR TITLE
ROS Update Survey 20260601

### DIFF
--- a/runtime-ros/ros-jazzy-action-msgs/spec
+++ b/runtime-ros/ros-jazzy-action-msgs/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/action_msgs/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/action_msgs/.*"

--- a/runtime-ros/ros-jazzy-action-tutorials-cpp/spec
+++ b/runtime-ros/ros-jazzy-action-tutorials-cpp/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/action_tutorials_cpp/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/action_tutorials_cpp/.*"

--- a/runtime-ros/ros-jazzy-action-tutorials-interfaces/spec
+++ b/runtime-ros/ros-jazzy-action-tutorials-interfaces/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/action_tutorials_interfaces/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/action_tutorials_interfaces/.*"

--- a/runtime-ros/ros-jazzy-action-tutorials-py/spec
+++ b/runtime-ros/ros-jazzy-action-tutorials-py/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/action_tutorials_py/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/action_tutorials_py/.*"

--- a/runtime-ros/ros-jazzy-ament-clang-format/spec
+++ b/runtime-ros/ros-jazzy-ament-clang-format/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_clang_format/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_clang_format/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-clang-format/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-clang-format/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_clang_format/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_clang_format/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-copyright/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-copyright/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_copyright/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_copyright/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-cppcheck/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-cppcheck/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_cppcheck/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_cppcheck/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-cpplint/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-cpplint/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_cpplint/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_cpplint/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-flake8/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-flake8/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_flake8/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_flake8/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-lint-cmake/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-lint-cmake/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_lint_cmake/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_lint_cmake/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-pep257/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-pep257/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_pep257/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_pep257/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-uncrustify/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-uncrustify/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_uncrustify/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_uncrustify/.*"

--- a/runtime-ros/ros-jazzy-ament-cmake-xmllint/spec
+++ b/runtime-ros/ros-jazzy-ament-cmake-xmllint/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cmake_xmllint/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cmake_xmllint/.*"

--- a/runtime-ros/ros-jazzy-ament-copyright/spec
+++ b/runtime-ros/ros-jazzy-ament-copyright/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_copyright/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_copyright/.*"

--- a/runtime-ros/ros-jazzy-ament-cppcheck/spec
+++ b/runtime-ros/ros-jazzy-ament-cppcheck/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cppcheck/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cppcheck/.*"

--- a/runtime-ros/ros-jazzy-ament-cpplint/spec
+++ b/runtime-ros/ros-jazzy-ament-cpplint/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_cpplint/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_cpplint/.*"

--- a/runtime-ros/ros-jazzy-ament-flake8/spec
+++ b/runtime-ros/ros-jazzy-ament-flake8/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_flake8/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_flake8/.*"

--- a/runtime-ros/ros-jazzy-ament-index-cpp/spec
+++ b/runtime-ros/ros-jazzy-ament-index-cpp/spec
@@ -1,4 +1,4 @@
-VER=1.8.3+1
+VER=1.8.4+1
 SRCS="git::commit=tags/release/jazzy/ament_index_cpp/${VER/+/-}::https://github.com/ros2-gbp/ament_index-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_index-release;pattern=release/jazzy/ament_index_cpp/.*"

--- a/runtime-ros/ros-jazzy-ament-index-python/spec
+++ b/runtime-ros/ros-jazzy-ament-index-python/spec
@@ -1,4 +1,4 @@
-VER=1.8.3+1
+VER=1.8.4+1
 SRCS="git::commit=tags/release/jazzy/ament_index_python/${VER/+/-}::https://github.com/ros2-gbp/ament_index-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_index-release;pattern=release/jazzy/ament_index_python/.*"

--- a/runtime-ros/ros-jazzy-ament-lint-auto/spec
+++ b/runtime-ros/ros-jazzy-ament-lint-auto/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_lint_auto/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_lint_auto/.*"

--- a/runtime-ros/ros-jazzy-ament-lint-cmake/spec
+++ b/runtime-ros/ros-jazzy-ament-lint-cmake/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_lint_cmake/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_lint_cmake/.*"

--- a/runtime-ros/ros-jazzy-ament-lint-common/spec
+++ b/runtime-ros/ros-jazzy-ament-lint-common/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_lint_common/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_lint_common/.*"

--- a/runtime-ros/ros-jazzy-ament-lint/spec
+++ b/runtime-ros/ros-jazzy-ament-lint/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_lint/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_lint/.*"

--- a/runtime-ros/ros-jazzy-ament-mypy/spec
+++ b/runtime-ros/ros-jazzy-ament-mypy/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_mypy/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_mypy/.*"

--- a/runtime-ros/ros-jazzy-ament-pep257/spec
+++ b/runtime-ros/ros-jazzy-ament-pep257/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_pep257/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_pep257/.*"

--- a/runtime-ros/ros-jazzy-ament-pycodestyle/spec
+++ b/runtime-ros/ros-jazzy-ament-pycodestyle/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_pycodestyle/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_pycodestyle/.*"

--- a/runtime-ros/ros-jazzy-ament-uncrustify/spec
+++ b/runtime-ros/ros-jazzy-ament-uncrustify/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_uncrustify/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_uncrustify/.*"

--- a/runtime-ros/ros-jazzy-ament-xmllint/spec
+++ b/runtime-ros/ros-jazzy-ament-xmllint/spec
@@ -1,4 +1,4 @@
-VER=0.17.4+1
+VER=0.17.5+1
 SRCS="git::commit=tags/release/jazzy/ament_xmllint/${VER/+/-}::https://github.com/ros2-gbp/ament_lint-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ament_lint-release;pattern=release/jazzy/ament_xmllint/.*"

--- a/runtime-ros/ros-jazzy-builtin-interfaces/spec
+++ b/runtime-ros/ros-jazzy-builtin-interfaces/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/builtin_interfaces/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/builtin_interfaces/.*"

--- a/runtime-ros/ros-jazzy-composition-interfaces/spec
+++ b/runtime-ros/ros-jazzy-composition-interfaces/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/composition_interfaces/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/composition_interfaces/.*"

--- a/runtime-ros/ros-jazzy-composition/spec
+++ b/runtime-ros/ros-jazzy-composition/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/composition/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/composition/.*"

--- a/runtime-ros/ros-jazzy-demo-nodes-cpp-native/spec
+++ b/runtime-ros/ros-jazzy-demo-nodes-cpp-native/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/demo_nodes_cpp_native/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/demo_nodes_cpp_native/.*"

--- a/runtime-ros/ros-jazzy-demo-nodes-cpp/spec
+++ b/runtime-ros/ros-jazzy-demo-nodes-cpp/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/demo_nodes_cpp/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/demo_nodes_cpp/.*"

--- a/runtime-ros/ros-jazzy-demo-nodes-py/spec
+++ b/runtime-ros/ros-jazzy-demo-nodes-py/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/demo_nodes_py/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/demo_nodes_py/.*"

--- a/runtime-ros/ros-jazzy-dummy-map-server/spec
+++ b/runtime-ros/ros-jazzy-dummy-map-server/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/dummy_map_server/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/dummy_map_server/.*"

--- a/runtime-ros/ros-jazzy-dummy-robot-bringup/spec
+++ b/runtime-ros/ros-jazzy-dummy-robot-bringup/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/dummy_robot_bringup/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/dummy_robot_bringup/.*"

--- a/runtime-ros/ros-jazzy-dummy-sensors/spec
+++ b/runtime-ros/ros-jazzy-dummy-sensors/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/dummy_sensors/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/dummy_sensors/.*"

--- a/runtime-ros/ros-jazzy-geometry2/spec
+++ b/runtime-ros/ros-jazzy-geometry2/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/geometry2/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/geometry2/.*"

--- a/runtime-ros/ros-jazzy-gz-math-vendor/spec
+++ b/runtime-ros/ros-jazzy-gz-math-vendor/spec
@@ -1,4 +1,4 @@
-VER=0.0.8+1
+VER=0.0.9+1
 SRCS="git::commit=tags/release/jazzy/gz_math_vendor/${VER/+/-}::https://github.com/ros2-gbp/gz_math_vendor-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/gz_math_vendor-release;pattern=release/jazzy/gz_math_vendor/.*"

--- a/runtime-ros/ros-jazzy-image-tools/spec
+++ b/runtime-ros/ros-jazzy-image-tools/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/image_tools/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/image_tools/.*"

--- a/runtime-ros/ros-jazzy-image-transport/spec
+++ b/runtime-ros/ros-jazzy-image-transport/spec
@@ -1,4 +1,4 @@
-VER=5.1.7+1
+VER=5.1.8+1
 SRCS="git::commit=tags/release/jazzy/image_transport/${VER/+/-}::https://github.com/ros2-gbp/image_common-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/image_common-release;pattern=release/jazzy/image_transport/.*"

--- a/runtime-ros/ros-jazzy-intra-process-demo/spec
+++ b/runtime-ros/ros-jazzy-intra-process-demo/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/intra_process_demo/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/intra_process_demo/.*"

--- a/runtime-ros/ros-jazzy-liblz4-vendor/spec
+++ b/runtime-ros/ros-jazzy-liblz4-vendor/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/liblz4_vendor/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/liblz4_vendor/.*"

--- a/runtime-ros/ros-jazzy-lifecycle-msgs/spec
+++ b/runtime-ros/ros-jazzy-lifecycle-msgs/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/lifecycle_msgs/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/lifecycle_msgs/.*"

--- a/runtime-ros/ros-jazzy-lifecycle/spec
+++ b/runtime-ros/ros-jazzy-lifecycle/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/lifecycle/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/lifecycle/.*"

--- a/runtime-ros/ros-jazzy-logging-demo/spec
+++ b/runtime-ros/ros-jazzy-logging-demo/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/logging_demo/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/logging_demo/.*"

--- a/runtime-ros/ros-jazzy-mcap-vendor/spec
+++ b/runtime-ros/ros-jazzy-mcap-vendor/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/mcap_vendor/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/mcap_vendor/.*"

--- a/runtime-ros/ros-jazzy-message-filters/spec
+++ b/runtime-ros/ros-jazzy-message-filters/spec
@@ -1,4 +1,4 @@
-VER=4.11.11+1
+VER=4.11.15+1
 SRCS="git::commit=tags/release/jazzy/message_filters/${VER/+/-}::https://github.com/ros2-gbp/ros2_message_filters-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ros2_message_filters-release;pattern=release/jazzy/message_filters/.*"

--- a/runtime-ros/ros-jazzy-pendulum-control/spec
+++ b/runtime-ros/ros-jazzy-pendulum-control/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/pendulum_control/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/pendulum_control/.*"

--- a/runtime-ros/ros-jazzy-pendulum-msgs/spec
+++ b/runtime-ros/ros-jazzy-pendulum-msgs/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/pendulum_msgs/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/pendulum_msgs/.*"

--- a/runtime-ros/ros-jazzy-pluginlib/spec
+++ b/runtime-ros/ros-jazzy-pluginlib/spec
@@ -1,4 +1,4 @@
-VER=5.4.4+1
+VER=5.4.5+1
 SRCS="git::commit=tags/release/jazzy/pluginlib/${VER/+/-}::https://github.com/ros2-gbp/pluginlib-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/pluginlib-release;pattern=release/jazzy/pluginlib/.*"

--- a/runtime-ros/ros-jazzy-point-cloud-transport/spec
+++ b/runtime-ros/ros-jazzy-point-cloud-transport/spec
@@ -1,4 +1,4 @@
-VER=4.0.7+1
+VER=4.0.8+1
 SRCS="git::commit=tags/release/jazzy/point_cloud_transport/${VER/+/-}::https://github.com/ros2-gbp/point_cloud_transport-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/point_cloud_transport-release;pattern=release/jazzy/point_cloud_transport/.*"

--- a/runtime-ros/ros-jazzy-qt-dotgraph/spec
+++ b/runtime-ros/ros-jazzy-qt-dotgraph/spec
@@ -1,4 +1,4 @@
-VER=2.7.5+1
+VER=2.7.6+1
 SRCS="git::commit=tags/release/jazzy/qt_dotgraph/${VER/+/-}::https://github.com/ros2-gbp/qt_gui_core-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/qt_gui_core-release;pattern=release/jazzy/qt_dotgraph/.*"

--- a/runtime-ros/ros-jazzy-qt-gui-cpp/spec
+++ b/runtime-ros/ros-jazzy-qt-gui-cpp/spec
@@ -1,4 +1,4 @@
-VER=2.7.5+1
+VER=2.7.6+1
 SRCS="git::commit=tags/release/jazzy/qt_gui_cpp/${VER/+/-}::https://github.com/ros2-gbp/qt_gui_core-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/qt_gui_core-release;pattern=release/jazzy/qt_gui_cpp/.*"

--- a/runtime-ros/ros-jazzy-qt-gui-py-common/spec
+++ b/runtime-ros/ros-jazzy-qt-gui-py-common/spec
@@ -1,4 +1,4 @@
-VER=2.7.5+1
+VER=2.7.6+1
 SRCS="git::commit=tags/release/jazzy/qt_gui_py_common/${VER/+/-}::https://github.com/ros2-gbp/qt_gui_core-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/qt_gui_core-release;pattern=release/jazzy/qt_gui_py_common/.*"

--- a/runtime-ros/ros-jazzy-qt-gui/spec
+++ b/runtime-ros/ros-jazzy-qt-gui/spec
@@ -1,4 +1,4 @@
-VER=2.7.5+1
+VER=2.7.6+1
 SRCS="git::commit=tags/release/jazzy/qt_gui/${VER/+/-}::https://github.com/ros2-gbp/qt_gui_core-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/qt_gui_core-release;pattern=release/jazzy/qt_gui/.*"

--- a/runtime-ros/ros-jazzy-quality-of-service-demo-cpp/spec
+++ b/runtime-ros/ros-jazzy-quality-of-service-demo-cpp/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/quality_of_service_demo_cpp/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/quality_of_service_demo_cpp/.*"

--- a/runtime-ros/ros-jazzy-quality-of-service-demo-py/spec
+++ b/runtime-ros/ros-jazzy-quality-of-service-demo-py/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/quality_of_service_demo_py/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/quality_of_service_demo_py/.*"

--- a/runtime-ros/ros-jazzy-rcl-interfaces/spec
+++ b/runtime-ros/ros-jazzy-rcl-interfaces/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/rcl_interfaces/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/rcl_interfaces/.*"

--- a/runtime-ros/ros-jazzy-rclcpp-action/spec
+++ b/runtime-ros/ros-jazzy-rclcpp-action/spec
@@ -1,4 +1,4 @@
-VER=28.1.17+3
+VER=28.1.18+1
 SRCS="git::commit=tags/release/jazzy/rclcpp_action/${VER/+/-}::https://github.com/ros2-gbp/rclcpp-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rclcpp-release;pattern=release/jazzy/rclcpp_action/.*"

--- a/runtime-ros/ros-jazzy-rclcpp-components/spec
+++ b/runtime-ros/ros-jazzy-rclcpp-components/spec
@@ -1,4 +1,4 @@
-VER=28.1.17+3
+VER=28.1.18+1
 SRCS="git::commit=tags/release/jazzy/rclcpp_components/${VER/+/-}::https://github.com/ros2-gbp/rclcpp-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rclcpp-release;pattern=release/jazzy/rclcpp_components/.*"

--- a/runtime-ros/ros-jazzy-rclcpp-lifecycle/spec
+++ b/runtime-ros/ros-jazzy-rclcpp-lifecycle/spec
@@ -1,4 +1,4 @@
-VER=28.1.17+3
+VER=28.1.18+1
 SRCS="git::commit=tags/release/jazzy/rclcpp_lifecycle/${VER/+/-}::https://github.com/ros2-gbp/rclcpp-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rclcpp-release;pattern=release/jazzy/rclcpp_lifecycle/.*"

--- a/runtime-ros/ros-jazzy-rclcpp/spec
+++ b/runtime-ros/ros-jazzy-rclcpp/spec
@@ -1,4 +1,4 @@
-VER=28.1.17+3
+VER=28.1.18+1
 SRCS="git::commit=tags/release/jazzy/rclcpp/${VER/+/-}::https://github.com/ros2-gbp/rclcpp-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rclcpp-release;pattern=release/jazzy/rclcpp/.*"

--- a/runtime-ros/ros-jazzy-rclpy/spec
+++ b/runtime-ros/ros-jazzy-rclpy/spec
@@ -1,4 +1,4 @@
-VER=7.1.10+1
+VER=7.1.11+1
 SRCS="git::commit=tags/release/jazzy/rclpy/${VER/+/-}::https://github.com/ros2-gbp/rclpy-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rclpy-release;pattern=release/jazzy/rclpy/.*"

--- a/runtime-ros/ros-jazzy-ros2bag/spec
+++ b/runtime-ros/ros-jazzy-ros2bag/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/ros2bag/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/ros2bag/.*"

--- a/runtime-ros/ros-jazzy-ros2cli-common-extensions/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros2cli-common-extensions/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-ros2cli-common-extensions
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-launch-xml ros-jazzy-launch-yaml ros-jazzy-ros2action ros-jazzy-ros2cli ros-jazzy-ros2component ros-jazzy-ros2doctor ros-jazzy-ros2interface ros-jazzy-ros2launch ros-jazzy-ros2lifecycle ros-jazzy-ros2multicast ros-jazzy-ros2node ros-jazzy-ros2param ros-jazzy-ros2pkg ros-jazzy-ros2run ros-jazzy-ros2service ros-jazzy-ros2topic ros-jazzy-sros2"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-launch-xml ros-jazzy-launch-yaml ros-jazzy-ros2action ros-jazzy-ros2cli ros-jazzy-ros2component ros-jazzy-ros2doctor ros-jazzy-ros2interface ros-jazzy-ros2launch ros-jazzy-ros2lifecycle ros-jazzy-ros2multicast ros-jazzy-ros2node ros-jazzy-ros2param ros-jazzy-ros2pkg ros-jazzy-ros2run ros-jazzy-ros2service ros-jazzy-ros2topic ros-jazzy-sros2 ros-jazzy-ros2plugin"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
 PKGDES="Meta package for common ros2cli extensions"
 

--- a/runtime-ros/ros-jazzy-ros2cli-common-extensions/spec
+++ b/runtime-ros/ros-jazzy-ros2cli-common-extensions/spec
@@ -1,4 +1,5 @@
 VER=0.3.1+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/ros2cli_common_extensions/${VER/+/-}::https://github.com/ros2-gbp/ros2cli_common_extensions-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/ros2cli_common_extensions-release;pattern=release/jazzy/ros2cli_common_extensions/.*"

--- a/runtime-ros/ros-jazzy-ros2plugin/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros2plugin/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-ros2plugin
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-ros2cli ros-jazzy-ros2pkg"
+BUILDDEP="ros-jazzy-ament-copyright ros-jazzy-ament-flake8 ros-jazzy-ament-pep257 ros-jazzy-ament-xmllint pytest"
+PKGDES="The plugin command for ROS 2 command line tools"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-ros2plugin/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ros2plugin/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ros2plugin/spec
+++ b/runtime-ros/ros-jazzy-ros2plugin/spec
@@ -1,0 +1,4 @@
+VER=5.4.5+1
+SRCS="git::commit=tags/release/jazzy/ros2plugin/${VER/+/-}::https://github.com/ros2-gbp/pluginlib-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/pluginlib-release;pattern=release/jazzy/ros2plugin/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-compression-zstd/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-compression-zstd/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_compression_zstd/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_compression_zstd/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-compression/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-compression/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_compression/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_compression/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-cpp/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-cpp/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_cpp/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_cpp/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-interfaces/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-interfaces/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_interfaces/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_interfaces/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-py/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-py/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_py/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_py/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-storage-default-plugins/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-storage-default-plugins/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_storage_default_plugins/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_storage_default_plugins/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-storage-mcap/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-storage-mcap/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_storage_mcap/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_storage_mcap/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-storage-sqlite3/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-storage-sqlite3/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_storage_sqlite3/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_storage_sqlite3/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-storage/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-storage/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_storage/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_storage/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-test-common/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-test-common/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_test_common/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_test_common/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-test-msgdefs/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-test-msgdefs/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_test_msgdefs/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_test_msgdefs/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-tests/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-tests/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_tests/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_tests/.*"

--- a/runtime-ros/ros-jazzy-rosbag2-transport/spec
+++ b/runtime-ros/ros-jazzy-rosbag2-transport/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2_transport/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2_transport/.*"

--- a/runtime-ros/ros-jazzy-rosbag2/spec
+++ b/runtime-ros/ros-jazzy-rosbag2/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/rosbag2/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/rosbag2/.*"

--- a/runtime-ros/ros-jazzy-rosgraph-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-rosgraph-msgs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-rosgraph-msgs
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-builtin-interfaces ros-jazzy-rosidl-default-runtime"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-builtin-interfaces ros-jazzy-rcl-interfaces ros-jazzy-rosidl-default-runtime"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators ros-jazzy-ament-lint-common"
 PKGDES="Messages of ROS 2 Computation Graph"
 

--- a/runtime-ros/ros-jazzy-rosgraph-msgs/spec
+++ b/runtime-ros/ros-jazzy-rosgraph-msgs/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/rosgraph_msgs/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/rosgraph_msgs/.*"

--- a/runtime-ros/ros-jazzy-rosidl-core-generators/autobuild/defines
+++ b/runtime-ros/ros-jazzy-rosidl-core-generators/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-rosidl-core-generators
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-cmake-core ros-jazzy-rosidl-cmake ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-cpp ros-jazzy-rosidl-generator-py ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-introspection-cpp"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-cmake-core ros-jazzy-rosidl-cmake ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-generator-cpp ros-jazzy-rosidl-generator-py ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-fastrtps-c ros-jazzy-rosidl-typesupport-introspection-c ros-jazzy-rosidl-typesupport-cpp ros-jazzy-rosidl-typesupport-fastrtps-cpp ros-jazzy-rosidl-typesupport-introspection-cpp ros-jazzy-rosidl-generator-rs"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
 PKGDES="Define core ROS 2 interface generators"
 

--- a/runtime-ros/ros-jazzy-rosidl-core-generators/spec
+++ b/runtime-ros/ros-jazzy-rosidl-core-generators/spec
@@ -1,4 +1,5 @@
 VER=0.2.1+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/rosidl_core_generators/${VER/+/-}::https://github.com/ros2-gbp/rosidl_core-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosidl_core-release;pattern=release/jazzy/rosidl_core_generators/.*"

--- a/runtime-ros/ros-jazzy-rosidl-generator-rs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-rosidl-generator-rs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-rosidl-generator-rs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-rosidl-generator-c ros-jazzy-rosidl-parser ros-jazzy-ament-cmake ros-jazzy-ros-environment ros-jazzy-rosidl-cmake ros-jazzy-rosidl-pycommon ros-jazzy-rosidl-typesupport-c ros-jazzy-rosidl-typesupport-interface"
+BUILDDEP="ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
+PKGDES="Generator for ROS interfaces in Rust"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-rosidl-generator-rs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-rosidl-generator-rs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-rosidl-generator-rs/spec
+++ b/runtime-ros/ros-jazzy-rosidl-generator-rs/spec
@@ -1,0 +1,4 @@
+VER=0.4.12+1
+SRCS="git::commit=tags/release/jazzy/rosidl_generator_rs/${VER/+/-}::https://github.com/ros2-gbp/rosidl_rust-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/rosidl_rust-release;pattern=release/jazzy/rosidl_generator_rs/.*"

--- a/runtime-ros/ros-jazzy-rqt-reconfigure/spec
+++ b/runtime-ros/ros-jazzy-rqt-reconfigure/spec
@@ -1,4 +1,4 @@
-VER=1.6.3+1
+VER=1.6.4+1
 SRCS="git::commit=tags/release/jazzy/rqt_reconfigure/${VER/+/-}::https://github.com/ros2-gbp/rqt_reconfigure-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rqt_reconfigure-release;pattern=release/jazzy/rqt_reconfigure/.*"

--- a/runtime-ros/ros-jazzy-service-msgs/spec
+++ b/runtime-ros/ros-jazzy-service-msgs/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/service_msgs/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/service_msgs/.*"

--- a/runtime-ros/ros-jazzy-sqlite3-vendor/spec
+++ b/runtime-ros/ros-jazzy-sqlite3-vendor/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/sqlite3_vendor/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/sqlite3_vendor/.*"

--- a/runtime-ros/ros-jazzy-statistics-msgs/spec
+++ b/runtime-ros/ros-jazzy-statistics-msgs/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/statistics_msgs/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/statistics_msgs/.*"

--- a/runtime-ros/ros-jazzy-test-msgs/spec
+++ b/runtime-ros/ros-jazzy-test-msgs/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/test_msgs/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/test_msgs/.*"

--- a/runtime-ros/ros-jazzy-tf2-bullet/spec
+++ b/runtime-ros/ros-jazzy-tf2-bullet/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_bullet/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_bullet/.*"

--- a/runtime-ros/ros-jazzy-tf2-eigen-kdl/spec
+++ b/runtime-ros/ros-jazzy-tf2-eigen-kdl/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_eigen_kdl/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_eigen_kdl/.*"

--- a/runtime-ros/ros-jazzy-tf2-eigen/spec
+++ b/runtime-ros/ros-jazzy-tf2-eigen/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_eigen/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_eigen/.*"

--- a/runtime-ros/ros-jazzy-tf2-geometry-msgs/spec
+++ b/runtime-ros/ros-jazzy-tf2-geometry-msgs/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_geometry_msgs/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_geometry_msgs/.*"

--- a/runtime-ros/ros-jazzy-tf2-kdl/spec
+++ b/runtime-ros/ros-jazzy-tf2-kdl/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_kdl/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_kdl/.*"

--- a/runtime-ros/ros-jazzy-tf2-msgs/spec
+++ b/runtime-ros/ros-jazzy-tf2-msgs/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_msgs/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_msgs/.*"

--- a/runtime-ros/ros-jazzy-tf2-py/spec
+++ b/runtime-ros/ros-jazzy-tf2-py/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_py/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_py/.*"

--- a/runtime-ros/ros-jazzy-tf2-ros-py/spec
+++ b/runtime-ros/ros-jazzy-tf2-ros-py/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_ros_py/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_ros_py/.*"

--- a/runtime-ros/ros-jazzy-tf2-ros/spec
+++ b/runtime-ros/ros-jazzy-tf2-ros/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_ros/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_ros/.*"

--- a/runtime-ros/ros-jazzy-tf2-sensor-msgs/spec
+++ b/runtime-ros/ros-jazzy-tf2-sensor-msgs/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_sensor_msgs/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_sensor_msgs/.*"

--- a/runtime-ros/ros-jazzy-tf2-tools/spec
+++ b/runtime-ros/ros-jazzy-tf2-tools/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2_tools/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_tools/.*"

--- a/runtime-ros/ros-jazzy-tf2/spec
+++ b/runtime-ros/ros-jazzy-tf2/spec
@@ -1,4 +1,4 @@
-VER=0.36.19+1
+VER=0.36.20+1
 SRCS="git::commit=tags/release/jazzy/tf2/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2/.*"

--- a/runtime-ros/ros-jazzy-topic-monitor/spec
+++ b/runtime-ros/ros-jazzy-topic-monitor/spec
@@ -1,4 +1,4 @@
-VER=0.33.9+1
+VER=0.33.10+1
 SRCS="git::commit=tags/release/jazzy/topic_monitor/${VER/+/-}::https://github.com/ros2-gbp/demos-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/demos-release;pattern=release/jazzy/topic_monitor/.*"

--- a/runtime-ros/ros-jazzy-type-description-interfaces/spec
+++ b/runtime-ros/ros-jazzy-type-description-interfaces/spec
@@ -1,4 +1,4 @@
-VER=2.0.3+1
+VER=2.0.4+1
 SRCS="git::commit=tags/release/jazzy/type_description_interfaces/${VER/+/-}::https://github.com/ros2-gbp/rcl_interfaces-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rcl_interfaces-release;pattern=release/jazzy/type_description_interfaces/.*"

--- a/runtime-ros/ros-jazzy-zstd-vendor/spec
+++ b/runtime-ros/ros-jazzy-zstd-vendor/spec
@@ -1,4 +1,4 @@
-VER=0.26.9+1
+VER=0.26.10+2
 SRCS="git::commit=tags/release/jazzy/zstd_vendor/${VER/+/-}::https://github.com/ros2-gbp/rosbag2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rosbag2-release;pattern=release/jazzy/zstd_vendor/.*"


### PR DESCRIPTION
Topic Description
-----------------

- ros-jazzy-rqt-reconfigure: update to 1.6.4+1
- ros-jazzy-rosidl-core-generators: add new dependency
- ros-jazzy-zstd-vendor: update to 0.26.10+2
- ros-jazzy-sqlite3-vendor: update to 0.26.10+2
- ros-jazzy-rosbag2-transport: update to 0.26.10+2
- ros-jazzy-rosbag2-tests: update to 0.26.10+2
- ros-jazzy-rosbag2-test-msgdefs: update to 0.26.10+2
- ros-jazzy-rosbag2-test-common: update to 0.26.10+2
- ros-jazzy-rosbag2-storage-sqlite3: update to 0.26.10+2
- ros-jazzy-rosbag2-storage-mcap: update to 0.26.10+2

... and 95 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit ros-jazzy-ament-lint-auto ros-jazzy-ament-lint ros-jazzy-ament-flake8 ros-jazzy-ament-pep257 ros-jazzy-ament-copyright ros-jazzy-ament-lint-cmake ros-jazzy-ament-cmake-lint-cmake ros-jazzy-ament-cmake-copyright ros-jazzy-ament-pycodestyle ros-jazzy-ament-cppcheck ros-jazzy-ament-cmake-cppcheck ros-jazzy-ament-cpplint ros-jazzy-ament-cmake-cpplint ros-jazzy-ament-cmake-flake8 ros-jazzy-ament-cmake-pep257 ros-jazzy-ament-uncrustify ros-jazzy-ament-cmake-uncrustify ros-jazzy-ament-xmllint ros-jazzy-ament-cmake-xmllint ros-jazzy-ament-lint-common ros-jazzy-rosidl-generator-rs ros-jazzy-rosidl-core-generators ros-jazzy-builtin-interfaces ros-jazzy-service-msgs ros-jazzy-action-msgs ros-jazzy-action-tutorials-interfaces ros-jazzy-statistics-msgs ros-jazzy-ament-index-cpp ros-jazzy-rcl-interfaces ros-jazzy-rosgraph-msgs ros-jazzy-test-msgs ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-composition-interfaces ros-jazzy-rclcpp-components ros-jazzy-action-tutorials-cpp ros-jazzy-lifecycle-msgs ros-jazzy-ament-index-python ros-jazzy-rclpy ros-jazzy-action-tutorials-py ros-jazzy-ament-clang-format ros-jazzy-ament-cmake-clang-format ros-jazzy-ament-mypy ros-jazzy-composition ros-jazzy-demo-nodes-cpp ros-jazzy-demo-nodes-cpp-native ros-jazzy-demo-nodes-py ros-jazzy-dummy-map-server ros-jazzy-dummy-sensors ros-jazzy-dummy-robot-bringup ros-jazzy-tf2 ros-jazzy-rclcpp-lifecycle ros-jazzy-message-filters ros-jazzy-tf2-msgs ros-jazzy-tf2-ros ros-jazzy-tf2-bullet ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-kdl ros-jazzy-tf2-py ros-jazzy-tf2-ros-py ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-kdl ros-jazzy-tf2-sensor-msgs ros-jazzy-tf2-tools ros-jazzy-geometry2 ros-jazzy-gz-math-vendor ros-jazzy-image-tools ros-jazzy-pluginlib ros-jazzy-image-transport ros-jazzy-intra-process-demo ros-jazzy-liblz4-vendor ros-jazzy-lifecycle ros-jazzy-logging-demo ros-jazzy-zstd-vendor ros-jazzy-mcap-vendor ros-jazzy-pendulum-msgs ros-jazzy-pendulum-control ros-jazzy-point-cloud-transport ros-jazzy-qt-dotgraph ros-jazzy-qt-gui ros-jazzy-qt-gui-cpp ros-jazzy-qt-gui-py-common ros-jazzy-quality-of-service-demo-cpp ros-jazzy-quality-of-service-demo-py ros-jazzy-rosbag2-test-common ros-jazzy-rosbag2-storage ros-jazzy-rosbag2-storage-mcap ros-jazzy-sqlite3-vendor ros-jazzy-rosbag2-storage-sqlite3 ros-jazzy-rosbag2-storage-default-plugins ros-jazzy-rosbag2-test-msgdefs ros-jazzy-rosbag2-cpp ros-jazzy-rosbag2-compression ros-jazzy-rosbag2-interfaces ros-jazzy-rosbag2-compression-zstd ros-jazzy-rosbag2-transport ros-jazzy-rosbag2-py ros-jazzy-ros2bag ros-jazzy-ros2plugin ros-jazzy-ros2cli-common-extensions ros-jazzy-rosbag2-tests ros-jazzy-rosbag2 ros-jazzy-rqt-reconfigure ros-jazzy-topic-monitor ros-jazzy-type-description-interfaces
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
