### PR TITLE
rocm: Libraries without MachineLearning update to 7.13[3/3]

### DIFF
--- a/runtime-rocm/rocm-hipblas/spec
+++ b/runtime-rocm/rocm-hipblas/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipcub/spec
+++ b/runtime-rocm/rocm-hipcub/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipcub"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hiprand/spec
+++ b/runtime-rocm/rocm-hiprand/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hiprand"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipsolver/autobuild/prepare
+++ b/runtime-rocm/rocm-hipsolver/autobuild/prepare
@@ -6,3 +6,6 @@ export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
 
 abinfo "Adding ROCm to PATH ..."
 export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Use LLD for Link ..."
+export LDFLAGS="${LDFLAGS} -fuse-ld=lld"

--- a/runtime-rocm/rocm-hipsolver/spec
+++ b/runtime-rocm/rocm-hipsolver/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipsolver"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipsparselt/autobuild/defines
+++ b/runtime-rocm/rocm-hipsparselt/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=rocm-hipsparselt
 PKGDES="ROCm SPARSE marshalling library"
 PKGSEC=devel
 PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipsparse rocm-hipblaslt"
-BUILDDEP="cmake msgpack-c++ pyyaml"
+BUILDDEP="cmake msgpack-c++ pyyaml python-msgpack"
 
 # FIXME: Segmentation Fault
 #  failed: null sections(STRTAB)

--- a/runtime-rocm/rocm-hipsparselt/spec
+++ b/runtime-rocm/rocm-hipsparselt/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipsparselt"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-rocthrust/spec
+++ b/runtime-rocm/rocm-rocthrust/spec
@@ -1,5 +1,5 @@
-VER=7.2.0
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+VER=7.13
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocthrust"
 CHKUPDATE="anitya::id=383650"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-hipsparselt: upgrade to 7.13
- rocm-hipsolver: upgrade to 7.13
- rocm-rocthrust: upgrade to 7.13
- rocm-hiprand: update to 7.13
- rocm-hipcub: update to 7.13
- rocm-hipblas: update to 7.13

Package(s) Affected
-------------------

- rocm-hipblas: 7.13
- rocm-hipcub: 7.13
- rocm-hiprand: 7.13
- rocm-hipsolver: 7.13
- rocm-hipsparselt: 7.13
- rocm-rocthrust: 7.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipblas rocm-hipcub rocm-hiprand rocm-rocthrust rocm-hipsolver rocm-hipsparselt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
