### PR TITLE
rootlesskit: update to 3.0.1

### DIFF
--- a/app-admin/rootlesskit/spec
+++ b/app-admin/rootlesskit/spec
@@ -1,5 +1,4 @@
-VER=3.0.0
-REL=1
+VER=3.0.1
 SRCS="git::commit=tags/v$VER::https://github.com/rootless-containers/rootlesskit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369032"


### PR DESCRIPTION
Topic Description
-----------------

- rootlesskit: update to 3.0.1

Package(s) Affected
-------------------

- rootlesskit: 3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rootlesskit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
