### PR TITLE
kstars: update to 3.8.3

### DIFF
--- a/desktop-kde/kstars/spec
+++ b/desktop-kde/kstars/spec
@@ -1,5 +1,4 @@
-VER=3.7.8
-REL=1
+VER=3.8.3
 SRCS="tbl::https://download.kde.org/stable/kstars/$VER/kstars-$VER.tar.xz"
-CHKSUMS="sha256::55b3aef29ec1aba50906bd393d565e8a7e0b5b3a5d2e8e3cdfc1b58d718d2c0c"
+CHKSUMS="sha256::c5ecfef89587710231e4c93e4d4781ae17276d0344e2da97df54fd6ed86a19d5"
 CHKUPDATE="anitya::id=229035"


### PR DESCRIPTION
Topic Description
-----------------

- kstars: update to 3.8.3
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- kstars: 1:3.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit kstars
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
