### PR TITLE
nuclei: update to 3.8.0

### DIFF
--- a/app-utils/nuclei/spec
+++ b/app-utils/nuclei/spec
@@ -1,5 +1,4 @@
-VER=3.7.1
-REL=2
+VER=3.8.0
 SRCS="git::commit=tags/v$VER::https://github.com/projectdiscovery/nuclei.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=106029"


### PR DESCRIPTION
Topic Description
-----------------

- nuclei: update to 3.8.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- nuclei: 3.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nuclei
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
