### PR TITLE
php: security update to 8.5.6

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,6 +1,5 @@
-VER=8.5.4
-REL=2
+VER=8.5.6
 EPOCH=1
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::c1569f1f543f6b025c583cdc0e730e5c5833c603618613f1aa8e75d1524b8c91"
+CHKSUMS="sha256::826c600b7c6f956bd335558ca3bdbcab23b22126c1cc8d9348be2280a2204bb7"
 CHKUPDATE="anitya::id=3627"

--- a/topics/php-8.5.6.toml
+++ b/topics/php-8.5.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PHP 8.5.6"
+
+[caution]
+default = "Fixes 10 security vulnerabilities disclosed since PHP 8.5.6 (3 of High, 5 of Medium, and 2 of Low severity)"
+zh_CN = "修复自 PHP 8.5.6 起披露的 10 个安全漏洞（含 3 个高危、5 个中危及 2 个低危漏洞）"
+
+[packages-v2]
+"php" = "< 1:8.5.6"


### PR DESCRIPTION
Topic Description
-----------------

- php: security update to 8.5.6
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- php: 8.5.6

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
