### PR TITLE
notmuch: update to 0.40

### DIFF
--- a/app-web/notmuch/autobuild/beyond
+++ b/app-web/notmuch/autobuild/beyond
@@ -11,7 +11,7 @@ make install \
     exec_prefix="$PKGDIR"/usr \
     prefix=/usr
 
-cd "$SRCDIR"/bindings/python
+cd "$SRCDIR"/bindings/python-cffi
 
 abinfo "Building Python 3 bindings ..."
 python3 setup.py build

--- a/app-web/notmuch/spec
+++ b/app-web/notmuch/spec
@@ -1,5 +1,4 @@
-VER=0.38.3
-REL=3
+VER=0.40
 SRCS="tbl::https://notmuchmail.org/releases/notmuch-$VER.tar.xz"
-CHKSUMS="sha256::9af46cc80da58b4301ca2baefcc25a40d112d0315507e632c0f3f0f08328d054"
+CHKSUMS="sha256::4b4314bbf1c2029fdf793637e6c7bb15c1b1730d22be9aa04803c98c5bbc446f"
 CHKUPDATE="anitya::id=2498"


### PR DESCRIPTION
Topic Description
-----------------

- notmuch: update to 0.40
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- notmuch: 0.40

Security Update?
----------------

No

Build Order
-----------

```
#buildit notmuch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
