### PR TITLE
gitea: update to 1.26.2

### DIFF
--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,5 +1,4 @@
-VER=1.25.4
-REL=4
+VER=1.26.2
 SRCS="tbl::https://dl.gitea.com/gitea/$VER/gitea-src-$VER.tar.gz"
-CHKSUMS="sha256::2c067547343c5c0763d3370d82c81ef4c6e511fe342b300e5a687f664f3b405e"
+CHKSUMS="sha256::ce1462ad93dcbf3221a452457008b8159cbab3d0c93958179b88649df1e401cf"
 CHKUPDATE="anitya::id=13537"


### PR DESCRIPTION
Topic Description
-----------------

- gitea: update to 1.26.2
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gitea: 1.26.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
