### PR TITLE
xorg-sever, xwayland: security updates on June 2, 2026

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,10 +1,9 @@
 UPSTREAM_VER=1.16.2
-REL=1
-XORG_VER=21.1.21
+XORG_VER=21.1.23
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::c0cbe5545b3f645bae6024b830d1d1154a956350683a4e52b2fff5b0fa1ab519"
+         sha256::e39832e5617dadaf072fdf9f0e19e5d2e1c2a13607ac280bac1aba9f8fe14634"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.21
+VER=21.1.23
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"

--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=24.1.9
-SRCS="tbl::https://xorg.freedesktop.org/archive/individual/xserver/xwayland-$VER.tar.xz"
-CHKSUMS="sha256::f297af27a84508db9b80d1cbbcc69c3801da38eb64c72f3b5b50f582459afdd0"
+VER=24.1.12
+SRCS="git::commit=tags/xwayland-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180949"

--- a/topics/xorg-server-21.1.23.toml
+++ b/topics/xorg-server-21.1.23.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "X.Org Server 21.1.23"
+
+[caution]
+default = "Fixes 9 security vulnerabilities disclosed in X.Org's Security Advisory on June 2, 2026"
+zh_CN = "修复 X.Org 在 2026 年 6 月 2 日的安全公告中披露的 9 个安全漏洞"
+
+[packages-v2]
+"tigervnc" = "< 1.16.2+xserver21.1.23"
+"xorg-server" = "< 21.1.23"

--- a/topics/xwayland-24.1.12.toml
+++ b/topics/xwayland-24.1.12.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Xwayland 24.1.12"
+
+[caution]
+default = "Fixes 9 security vulnerabilities disclosed in X.Org's Security Advisory on June 2, 2026"
+zh_CN = "修复 X.Org 在 2026 年 6 月 2 日的安全公告中披露的 9 个安全漏洞"
+
+[packages-v2]
+"xwayland" = "< 24.1.12"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add xorg-server, xwayland \(20260602\)
- tigervnc: udpate to 1.16.2+xserver21.1.23
- xwayland: update to 24.1.12
- xorg-server: update to 22.1.23

Package(s) Affected
-------------------

- tigervnc: 1.16.2+xserver21.1.23
- xorg-server: 21.1.23
- xwayland: 24.1.12

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit xorg-server xwayland tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
