### PR TITLE
vim: update to 9.2.0586

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0502
+VER=9.2.0586
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.5086.toml
+++ b/topics/vim-9.2.5086.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0586"
+
+[caution]
+default = "Fixes 2 Out-of-bounds Read vulnerability (Severity: Moderate) and a Code Injection vulnerability (Severity: Moderate)"
+zh_CN = "修复 2 个越界读溢出漏洞（严重性：中）和 1 个代码注入漏洞（严重性：中）"
+
+[packages-v2]
+"vim" = "< 9.2.0586"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0586
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.0586
- vim: 9.2.0586

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
