### PR TITLE
vscode: update to 1.122.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.121.0
+VER=1.122.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::a9ee29ba18142b99c10bbcbaf7c9447f5dd59bc1ffcc3be1ccb64587e2230d73"
-CHKSUMS__ARM64="sha256::1ce853ad6b839b9a0568261f93ce2a02e9de362a62a4d133d8b329bc332057ca"
+CHKSUMS__AMD64="sha256::44efd0aa505f4dc39e1cda51a52e36486ffb306af2835bc16de69aec6c1a23c6"
+CHKSUMS__ARM64="sha256::e7df36813bc42117b49ff6dbb4e1f0b81e1c9dd69aef973c5d8ec91bf7d47281"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.122.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.122.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
