### PR TITLE
sccache: update to 0.15.0

### DIFF
--- a/app-devel/sccache/autobuild/defines
+++ b/app-devel/sccache/autobuild/defines
@@ -4,6 +4,7 @@ PKGDES="sccache is ccache with cloud storage"
 PKGDEP="openssl glibc gcc-runtime"
 BUILDDEP="cargo rustc llvm"
 
+ABTYPE=rust
 USECLANG=1
 ABSPLITDBG=0
 

--- a/app-devel/sccache/spec
+++ b/app-devel/sccache/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
-SRCS="tbl::https://github.com/mozilla/sccache/archive/v${VER}.tar.gz"
-CHKSUMS="sha256::309edaf43f44088e55e99ce14eb9cfdee8f85acad290171ebfd29eb9e368def3"
+VER=0.15.0
+SRCS="git::commit=tags/v$VER::https://github.com/mozilla/sccache"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227267"


### PR DESCRIPTION
Topic Description
-----------------

- sccache: update to 0.15.0

Package(s) Affected
-------------------

- sccache: 0.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sccache
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
