### PR TITLE
xsimd: update to 14.2.0

### DIFF
--- a/runtime-common/xsimd/autobuild/defines
+++ b/runtime-common/xsimd/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=libs
 PKGDEP=""
 PKGDES="C++ wrappers for SIMD intrinsics and parallelized, optimized mathematical functions"
 
+ABTYPE=cmakeninja
 ABHOST=noarch

--- a/runtime-common/xsimd/spec
+++ b/runtime-common/xsimd/spec
@@ -1,4 +1,4 @@
-VER=10.0.0
-SRCS="tbl::https://github.com/xtensor-stack/xsimd/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::73f818368b3a4dad92fab1b2933d93694241bd2365a6181747b2df1768f6afdd"
+VER=14.2.0
+SRCS="git::commit=tags/$VER::https://github.com/xtensor-stack/xsimd"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=138109"


### PR DESCRIPTION
Topic Description
-----------------

- xsimd: update to 14.2.0

Package(s) Affected
-------------------

- xsimd: 14.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xsimd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
