### PR TITLE
bcrypt: update to 5.0.0

### DIFF
--- a/lang-python/bcrypt/spec
+++ b/lang-python/bcrypt/spec
@@ -1,5 +1,4 @@
-VER=4.2.0
-REL="2"
+VER=5.0.0
 SRCS="pypi::version=$VER::bcrypt"
-CHKSUMS="sha256::cf69eaf5185fd58f268f805b505ce31f9b9fc2d64b376642164e9244540c1221"
+CHKSUMS="sha256::f748f7c2d6fd375cc93d3fba7ef4a9e3a092421b8dbf34d8d4dc06be9492dfdd"
 CHKUPDATE="anitya::id=9047"

--- a/lang-python/cryptography/spec
+++ b/lang-python/cryptography/spec
@@ -1,4 +1,4 @@
-VER=46.0.7
+VER=48.0.0
 SRCS="pypi::version=$VER::cryptography"
-CHKSUMS="sha256::e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"
+CHKSUMS="sha256::5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"
 CHKUPDATE="anitya::id=5532"

--- a/lang-python/paramiko/spec
+++ b/lang-python/paramiko/spec
@@ -1,4 +1,4 @@
-VER=4.0.0
+VER=5.0.0
 SRCS="pypi::version=$VER::paramiko"
-CHKSUMS="sha256::6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f"
+CHKSUMS="sha256::36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79"
 CHKUPDATE="anitya::id=52349"


### PR DESCRIPTION
Topic Description
-----------------

- cryptography: update to 48.0.0
- paramiko: update to 5.0.0
- bcrypt: update to 5.0.0

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit bcrypt paramiko cryptography
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
