### PR TITLE
krita: update to 6.0.2.1

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -1,5 +1,4 @@
-VER=5.2.15
+VER=6.0.2.1
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
-CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
+CHKSUMS="sha256::f77daae0290c387063fafe1d2084517ddb0490d077dc0e6a2bd4f75e5dd5a100"
 CHKUPDATE="anitya::id=10918"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- krita: update to 6.0.2.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- krita: 6.0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit krita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
