### PR TITLE
go: update to 1.26.4+tools0.42.0

### DIFF
--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.26.3
+UPSTREAM_VER=1.26.4
 # Versions of Golang and Go tools
 GO_VER=${UPSTREAM_VER/\~/}
 TOOLS_VER=0.42.0
@@ -6,7 +6,7 @@ TOOLS_VER=0.42.0
 VER="${UPSTREAM_VER}+tools${TOOLS_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools"
-CHKSUMS="sha256::1c646875d0aa8799133184ed57cf79ff24bdefe8c8820470602a9d3d6d9192b8 \
+CHKSUMS="sha256::4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d \
          SKIP"
 CHKUPDATE="anitya::id=1227"
 SUBDIR="go"

--- a/topics/go-1.26.4+tools0.42.0.toml
+++ b/topics/go-1.26.4+tools0.42.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Go 1.26.4"
+
+[caution]
+default = "Fixes 3 security vulnerabilities (including 1 of high severity and 2 of medium severity)"
+zh_CN = "修复 3 个安全漏洞（含 1 个高危漏洞, 2 个中危漏洞）"
+
+[packages-v2]
+go = "< 1.26.4+tools0.42.0"


### PR DESCRIPTION
Topic Description
-----------------

- go: update to 1.26.4+tools0.42.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- go: 1.26.4+tools0.42.0
- go-runtime: 1.26.4+tools0.42.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
