### PR TITLE
topics: add HTTP/2 Bomb for nginx-1.30.1

### DIFF
--- a/topics/nginx-1.30.1.toml
+++ b/topics/nginx-1.30.1.toml
@@ -4,8 +4,8 @@ security = true
 default = "nginx 1.30.1"
 
 [caution]
-default = "Fixes 6 security vulnerabilities disclosed in F5 Security Advisory on May 13, 2026 (2 of high severity)"
-zh_CN = "修复 F5 在 2026 年 5 月 13 日发布的安全公告中披露的 6 个安全漏洞（含 2 个高危漏洞）"
+default = "Fixes 6 security vulnerabilities disclosed in F5 Security Advisory on May 13, 2026 (2 of high severity) and a memory-amplification DoS vulnerability (\"HTTP/2 Bomb\")"
+zh_CN = "修复 F5 在 2026 年 5 月 13 日发布的安全公告中披露的 6 个安全漏洞（含 2 个高危漏洞） 和 1 个内存放大型拒绝服务 (DoS) 漏洞 (\"HTTP/2 Bomb\")"
 
 [packages-v2]
 "nginx" = "< 1.30.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add HTTP/2 Bomb for nginx-1.30.1
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
