### PR TITLE
httpd: update to 2.4.67-2

### DIFF
--- a/app-web/httpd/autobuild/patches/0001-Fedora-Fix-envvars-install-location.patch
+++ b/app-web/httpd/autobuild/patches/0001-Fedora-Fix-envvars-install-location.patch
@@ -1,7 +1,7 @@
-From 37599303f63d20d2758c31c3550d26ff47516ddb Mon Sep 17 00:00:00 2001
+From 8153529d8ea5c1fc3c2f214a046775a91a6231a0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 4 Jul 2024 03:42:08 +0800
-Subject: [PATCH] [Fedora] Fix envvars install location
+Subject: [PATCH 1/2] [Fedora] Fix envvars install location
 
 ---
  support/Makefile.in  | 6 +++---

--- a/app-web/httpd/autobuild/patches/0002-UPSTREAM-Fix-cookie-header-accounting-against-LimitR.patch
+++ b/app-web/httpd/autobuild/patches/0002-UPSTREAM-Fix-cookie-header-accounting-against-LimitR.patch
@@ -1,0 +1,35 @@
+From 61c0bb8c40823e07344c4fbdea7dbd2208d3124f Mon Sep 17 00:00:00 2001
+From: MutsukiC <mutsuki@aosc.io>
+Date: Wed, 3 Jun 2026 11:25:42 +0800
+Subject: [PATCH 2/2] [UPSTREAM] Fix cookie header accounting against
+ LimitRequestFields.
+
+---
+ modules/http2/h2_util.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/modules/http2/h2_util.c b/modules/http2/h2_util.c
+index b377ff77f1..b3039451f3 100644
+--- a/modules/http2/h2_util.c
++++ b/modules/http2/h2_util.c
+@@ -1708,6 +1708,8 @@ static apr_status_t req_add_header(apr_table_t *headers, apr_pool_t *pool,
+              && !ap_cstr_casecmpn("cookie", (const char *)nv->name, nv->namelen)) {
+         existing = apr_table_get(headers, "cookie");
+         if (existing) {
++            if (!nv->valuelen)
++                return APR_SUCCESS;
+             /* Cookie header come separately in HTTP/2, but need
+              * to be merged by "; " (instead of default ", ")
+              */
+@@ -1719,6 +1721,8 @@ static apr_status_t req_add_header(apr_table_t *headers, apr_pool_t *pool,
+             apr_table_setn(headers, "Cookie",
+                            apr_psprintf(pool, "%s; %.*s", existing,
+                                         (int)nv->valuelen, nv->value));
++            /* Treat the merge as an "add" to not escape LimitRequestFields */
++            *pwas_added = 1;
+             return APR_SUCCESS;
+         }
+     }
+-- 
+2.52.0
+

--- a/app-web/httpd/spec
+++ b/app-web/httpd/spec
@@ -1,5 +1,5 @@
 VER=2.4.67
-REL=1
+REL=2
 SRCS="tbl::https://archive.apache.org/dist/httpd/httpd-$VER.tar.bz2"
 CHKSUMS="sha256::66cd206637b0d5c446fa7dabe75fe03525da8fb55855876c46288cd88b136aa4"
 CHKUPDATE="anitya::id=1335"

--- a/topics/httpd-2.4.67-2.toml
+++ b/topics/httpd-2.4.67-2.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Apache HTTP Server (httpd) 2.4.67-2"
+zh_CN = "Apache HTTP 服务器 (httpd) 2.4.67-2"
+
+[caution]
+default = "Fixes a memory-amplification DoS vulnerability (\"HTTP/2 Bomb\") - CVE-2026-49975"
+zh_CN = "修复 1 个内存放大型拒绝服务 (DoS) 漏洞 (\"HTTP/2 Bomb\")，漏洞编号 CVE-2026-49975"
+
+[packages-v2]
+"httpd" = "< 2.4.67-2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add httpd-2.4.67-2.toml
- httpd: update to 2.4.67-2
- Applied upstream patch to fix CVE-2026-49975

Package(s) Affected
-------------------

- httpd: 2.4.67-2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit httpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
