### PR TITLE
cage: new, 0.2.1

### DIFF
--- a/desktop-wm/cage/autobuild/defines
+++ b/desktop-wm/cage/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=cage
+PKGSEC=x11
+PKGDEP="wayland wlroots libxkbcommon xwayland"
+BUILDDEP="meson scdoc"
+PKGDES="Wayland compositor to run a single, maximized application"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dman-pages=enabled'
+)

--- a/desktop-wm/cage/spec
+++ b/desktop-wm/cage/spec
@@ -1,0 +1,4 @@
+VER=0.2.1
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/cage-kiosk/cage"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya=21171"


### PR DESCRIPTION
Topic Description
-----------------

- cage: new, 0.2.1

Package(s) Affected
-------------------

- cage: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
