### PR TITLE
coverage: new, 7.14.1

### DIFF
--- a/lang-python/coverage/autobuild/defines
+++ b/lang-python/coverage/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=coverage
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Code coverage measurement for Python"
+
+ABTYPE=pep517

--- a/lang-python/coverage/spec
+++ b/lang-python/coverage/spec
@@ -1,0 +1,4 @@
+VER=7.14.1
+SRCS="pypi::version=$VER::coverage"
+CHKSUMS="sha256::30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be"
+CHKUPDATE="anitya::id=3811"


### PR DESCRIPTION
Topic Description
-----------------

- coverage: new, 7.14.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- coverage: 7.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit coverage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
