### PR TITLE
Sway 1.12 & Wlroots 0.20 Survey

### DIFF
--- a/desktop-wm/labwc/autobuild/defines
+++ b/desktop-wm/labwc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=labwc
 PKGSEC=x11
 PKGDEP="cairo glib glibc libinput libpng librsvg libsfdo libxcb libxkbcommon \
-        libxml2 pango pixman seatd wayland wlroots xcb-util-wm xwayland"
+        libxml2 pango pixman seatd wayland wlroots xcb-util-wm xwayland systemd"
 BUILDDEP="gcc git meson ninja scdoc wayland-protocols"
 PKGDES="Window-stacking Wayland compositor"
 
@@ -9,4 +9,12 @@ ABTYPE=meson
 MESON_AFTER=(
     '-Dman-pages=enabled'
     '-Dxwayland=enabled'
+    '-Dsvg=enabled'
+    '-Dicon=enabled'
+    '-Dlabnag=enabled'
+    '-Dnls=enabled'
+    '-Dsystemd-session=enabled'
+    '-Dstatic_analyzer=disabled'
+    '-Dtest=disabled'
+    '-Dsections=disabled'
 )

--- a/desktop-wm/labwc/spec
+++ b/desktop-wm/labwc/spec
@@ -1,4 +1,4 @@
-VER=0.9.7
+VER=0.20.1
 SRCS="git::commit=tags/${VER}::https://github.com/labwc/labwc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=176073"

--- a/desktop-wm/sway/spec
+++ b/desktop-wm/sway/spec
@@ -1,4 +1,4 @@
-VER=1.11
+VER=1.12
 SRCS="git::commit=tags/${VER/\~/-}::https://github.com/swaywm/sway"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11497"

--- a/desktop-wm/swayfx/spec
+++ b/desktop-wm/swayfx/spec
@@ -1,4 +1,4 @@
-VER=0.5.3
+VER=0.6
 SRCS="git::commit=tags/$VER::https://github.com/WillPower3309/swayfx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371635"

--- a/runtime-display/scenefx/autobuild/defines
+++ b/runtime-display/scenefx/autobuild/defines
@@ -3,13 +3,15 @@ PKGSEC=libs
 PKGDEP="wayland wlroots libxkbcommon pixman libdrm libglvnd"
 BUILDDEP="meson ninja wayland-protocols"
 PKGRECOM="xwayland"
-PKGDES="A drop-in replacement for the wlroots scene API"
+PKGDES="Drop-in replacement for the wlroots scene API"
 
 ABTYPE=meson
 
 MESON_AFTER=(
-    -Dexamples=true
-    -Drenderers=gles2
+    '-Dexamples=true'
+    '-Drenderers=gles2'
+    '-Dcolor-management=enabled'
+    '-Dtracy_enable=false'
 )
 
-PKGBREAK="swayfx<=0.5.1"
+PKGBREAK="swayfx<=0.5.3"

--- a/runtime-display/scenefx/spec
+++ b/runtime-display/scenefx/spec
@@ -1,4 +1,4 @@
-VER=0.4.1
+VER=0.5
 SRCS="git::commit=tags/$VER::https://github.com/wlrfx/scenefx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373099"

--- a/runtime-display/wlroots/autobuild/defines
+++ b/runtime-display/wlroots/autobuild/defines
@@ -1,19 +1,24 @@
 PKGNAME=wlroots
 PKGSEC=libs
 PKGDEP="wayland libdrm libinput libxkbcommon pixman systemd \
-        libxcb freerdp seatd xcb-util-wm xcb-util libdisplay-info \
+        libxcb lcms2 seatd xcb-util-wm xcb-util libdisplay-info \
         hwdata libliftoff seatd xcb-util-renderutil vulkan-loader \
-        vulkan-headers glslang"
+        vulkan-headers glslang xcb-util-errors mesa"
 BUILDDEP="wayland-protocols meson ninja xcb-proto ctags xwayland"
 PKGRECOM="xwayland"
-PKGDES="Pluggable, composable, unopinionated modules for building a Wayland compositor"
+PKGDES="Pluggable and composable modules for building a Wayland compositor"
 
 ABTYPE=meson
 MESON_AFTER=(
+    "-Dxcb-errors=enabled"
     "-Dxwayland=enabled"
+    "-Dexamples=false"
     "-Drenderers=gles2,vulkan"
     "-Dbackends=drm,libinput,x11"
+    "-Dallocators=gbm,udmabuf"
     "-Dsession=enabled"
+    "-Dcolor-management=enabled"
+    "-Dlibliftoff=enabled"
 )
 
-PKGBREAK="sway<=1.10.1 scenefx<=0.3 swayfx<=0.5.1"
+PKGBREAK="sway<=1.11 scenefx<=0.4.1 swayfx<=0.5.3 labwc<=0.9.7"

--- a/runtime-display/wlroots/spec
+++ b/runtime-display/wlroots/spec
@@ -1,5 +1,4 @@
-VER=0.19.2
-REL=1
+VER=0.20.2
 SRCS="git::commit=tags/${VER/\~/-}::https://gitlab.freedesktop.org/wlroots/wlroots.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18357"


### PR DESCRIPTION
Topic Description
-----------------

- sway: update to 1.12
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- wlroots: update to 0.20.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- sway: 1.12
- wlroots: 0.20.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wlroots sway labwc scenefx swayfx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
