### PR TITLE
gcc-14: update to 14.3.0-2

### DIFF
--- a/app-devel/gcc-14/01-runtime/beyond
+++ b/app-devel/gcc-14/01-runtime/beyond
@@ -113,4 +113,4 @@ fi
 
 abinfo "Installing libgo symlinks ..."
 LIBGO="$(find "$PKGDIR"/"$GCC_LIBDIR" -type l -name 'libgo.so.*' -printf '%f\n')"
-ln -svf "${GCC_LIBDIR##/usr/lib/}"/"$LIBGO".0.0 "$PKGDIR"/usr/lib/"$LIBGO"
+[[ -z "${LIBGO}" ]] || ln -svf "${GCC_LIBDIR##/usr/lib/}"/"$LIBGO".0.0 "$PKGDIR"/usr/lib/"$LIBGO"

--- a/app-devel/gcc-14/01-runtime/defines
+++ b/app-devel/gcc-14/01-runtime/defines
@@ -61,7 +61,6 @@ AUTOTOOLS_AFTER=(
 	"--disable-libssp"
 	"--enable-gnu-unique-object"
 	"--enable-linker-build-id"
-	"--with-isl=/usr"
 	"--enable-lto"
 	"--enable-plugin"
 	"--enable-install-libiberty"

--- a/app-devel/gcc-14/01-runtime/patches/0001-libiberty-also-generate-a-PIC-version-of-libiberty.a.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0001-libiberty-also-generate-a-PIC-version-of-libiberty.a.patch
@@ -1,7 +1,7 @@
 From 73263f21ae4527b0337bad7b2e5a0142ba456526 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 25 Nov 2024 15:09:30 +0800
-Subject: [PATCH 1/5] libiberty: also generate a PIC version of libiberty.a
+Subject: [PATCH 01/10] libiberty: also generate a PIC version of libiberty.a
 
 ---
  libiberty/configure | 4 ----
@@ -23,5 +23,5 @@ index 5c69fee56c1..bc335693b5c 100755
  NOASANFLAG=
  case " ${CFLAGS} " in
 -- 
-2.51.1
+2.54.0
 

--- a/app-devel/gcc-14/01-runtime/patches/0002-BACKPORT-LoongArch-Generate-the-final-immediate-for-.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0002-BACKPORT-LoongArch-Generate-the-final-immediate-for-.patch
@@ -1,7 +1,7 @@
 From f9317c51db8ffec9906367bb4e6af57226d825ce Mon Sep 17 00:00:00 2001
 From: mengqinggang <mengqinggang@loongson.cn>
 Date: Fri, 10 Jan 2025 10:27:09 +0800
-Subject: [PATCH 2/5] BACKPORT: LoongArch: Generate the final immediate for
+Subject: [PATCH 02/10] BACKPORT: LoongArch: Generate the final immediate for
  lu12i.w, lu32i.d and lu52i.d
 
 Generate 0x1010 instead of 0x1010000>>12 for lu12i.w. lu32i.d and lu52i.d use
@@ -42,7 +42,7 @@ diff --git a/gcc/config/loongarch/lasx.md b/gcc/config/loongarch/lasx.md
 index fe32194e811..c041629d696 100644
 --- a/gcc/config/loongarch/lasx.md
 +++ b/gcc/config/loongarch/lasx.md
-@@ -845,7 +845,7 @@
+@@ -845,7 +845,7 @@ (define_insn "mov<mode>_lasx"
    [(set (match_operand:LASX 0 "nonimmediate_operand" "=f,f,R,*r,*f")
  	(match_operand:LASX 1 "move_operand" "fYGYI,R,f,*f,*r"))]
    "ISA_HAS_LASX"
@@ -106,7 +106,7 @@ diff --git a/gcc/config/loongarch/loongarch.md b/gcc/config/loongarch/loongarch.
 index f467e310696..19ef3618d25 100644
 --- a/gcc/config/loongarch/loongarch.md
 +++ b/gcc/config/loongarch/loongarch.md
-@@ -2164,7 +2164,7 @@
+@@ -2164,7 +2164,7 @@ (define_insn_and_split "*movdi_32bit"
    "!TARGET_64BIT
     && (register_operand (operands[0], DImode)
         || reg_or_0_operand (operands[1], DImode))"
@@ -115,7 +115,7 @@ index f467e310696..19ef3618d25 100644
    "CONST_INT_P (operands[1]) && REG_P (operands[0]) && GP_REG_P (REGNO
    (operands[0]))"
    [(const_int 0)]
-@@ -2183,7 +2183,9 @@
+@@ -2183,7 +2183,9 @@ (define_insn_and_split "*movdi_64bit"
    "TARGET_64BIT
     && (register_operand (operands[0], DImode)
         || reg_or_0_operand (operands[1], DImode))"
@@ -126,7 +126,7 @@ index f467e310696..19ef3618d25 100644
    "CONST_INT_P (operands[1]) && REG_P (operands[0]) && GP_REG_P (REGNO
    (operands[0]))"
    [(const_int 0)]
-@@ -2270,7 +2272,7 @@
+@@ -2270,7 +2272,7 @@ (define_insn_and_split "*movsi_internal"
  	(match_operand:SI 1 "move_operand" "r,Yd,w,rJ,*r*J,m,*f,*f"))]
    "(register_operand (operands[0], SImode)
      || reg_or_0_operand (operands[1], SImode))"
@@ -135,7 +135,7 @@ index f467e310696..19ef3618d25 100644
    "CONST_INT_P (operands[1]) && REG_P (operands[0]) && GP_REG_P (REGNO
    (operands[0]))"
    [(const_int 0)]
-@@ -2304,7 +2306,7 @@
+@@ -2304,7 +2306,7 @@ (define_insn_and_split "*movhi_internal"
  	(match_operand:HI 1 "move_operand" "r,Yd,I,m,rJ,k,rJ"))]
    "(register_operand (operands[0], HImode)
         || reg_or_0_operand (operands[1], HImode))"
@@ -144,7 +144,7 @@ index f467e310696..19ef3618d25 100644
    "CONST_INT_P (operands[1]) && REG_P (operands[0]) && GP_REG_P (REGNO
    (operands[0]))"
    [(const_int 0)]
-@@ -2338,7 +2340,7 @@
+@@ -2338,7 +2340,7 @@ (define_insn "*movqi_internal"
  	(match_operand:QI 1 "move_operand" "r,I,m,rJ,k,rJ"))]
    "(register_operand (operands[0], QImode)
         || reg_or_0_operand (operands[1], QImode))"
@@ -153,7 +153,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "move_type" "move,const,load,store,load,store")
     (set_attr "mode" "QI")])
  
-@@ -2359,7 +2361,7 @@
+@@ -2359,7 +2361,7 @@ (define_insn "*movsf_hardfloat"
    "TARGET_HARD_FLOAT
     && (register_operand (operands[0], SFmode)
         || reg_or_0_operand (operands[1], SFmode))"
@@ -162,7 +162,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "move_type" "fmove,mgtf,fpload,fpstore,fpload,fpstore,store,store,mgtf,mftg,move,load,store")
     (set_attr "mode" "SF")])
  
-@@ -2369,7 +2371,7 @@
+@@ -2369,7 +2371,7 @@ (define_insn "*movsf_softfloat"
    "TARGET_SOFT_FLOAT
     && (register_operand (operands[0], SFmode)
         || reg_or_0_operand (operands[1], SFmode))"
@@ -171,7 +171,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "move_type" "move,load,store")
     (set_attr "mode" "SF")])
  
-@@ -2390,7 +2392,7 @@
+@@ -2390,7 +2392,7 @@ (define_insn "*movdf_hardfloat"
    "TARGET_DOUBLE_FLOAT
     && (register_operand (operands[0], DFmode)
         || reg_or_0_operand (operands[1], DFmode))"
@@ -180,7 +180,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "move_type" "fmove,mgtf,fpload,fpstore,fpload,fpstore,store,store,mgtf,mftg,move,load,store")
     (set_attr "mode" "DF")])
  
-@@ -2400,7 +2402,7 @@
+@@ -2400,7 +2402,7 @@ (define_insn "*movdf_softfloat"
    "(TARGET_SOFT_FLOAT || TARGET_SINGLE_FLOAT)
     && (register_operand (operands[0], DFmode)
         || reg_or_0_operand (operands[1], DFmode))"
@@ -189,7 +189,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "move_type" "move,load,store")
     (set_attr "mode" "DF")])
  
-@@ -2578,7 +2580,10 @@
+@@ -2578,7 +2580,10 @@ (define_insn "lu32i_d"
  	    (subreg:SI (match_operand:DI 1 "register_operand" "0") 0))
  	  (match_operand:DI 2 "const_lu32i_operand" "u")))]
    "TARGET_64BIT"
@@ -201,7 +201,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "type" "arith")
     (set_attr "mode" "DI")])
  
-@@ -2589,7 +2594,10 @@
+@@ -2589,7 +2594,10 @@ (define_insn "lu52i_d"
  		  (match_operand 2 "lu52i_mask_operand"))
  	  (match_operand 3 "const_lu52i_operand" "v")))]
    "TARGET_64BIT"
@@ -213,7 +213,7 @@ index f467e310696..19ef3618d25 100644
    [(set_attr "type" "arith")
     (set_attr "mode" "DI")])
  
-@@ -2733,7 +2741,7 @@
+@@ -2733,7 +2741,7 @@ (define_insn "load_low<mode>"
    "TARGET_HARD_FLOAT"
  {
    operands[0] = loongarch_subword (operands[0], 0);
@@ -222,7 +222,7 @@ index f467e310696..19ef3618d25 100644
  }
    [(set_attr "move_type" "mgtf,fpload")
     (set_attr "mode" "<HALFMODE>")])
-@@ -2748,7 +2756,7 @@
+@@ -2748,7 +2756,7 @@ (define_insn "load_high<mode>"
    "TARGET_HARD_FLOAT"
  {
    operands[0] = loongarch_subword (operands[0], 1);
@@ -231,7 +231,7 @@ index f467e310696..19ef3618d25 100644
  }
    [(set_attr "move_type" "mgtf,fpload")
     (set_attr "mode" "<HALFMODE>")])
-@@ -2763,7 +2771,7 @@
+@@ -2763,7 +2771,7 @@ (define_insn "store_word<mode>"
    "TARGET_HARD_FLOAT"
  {
    operands[1] = loongarch_subword (operands[1], INTVAL (operands[2]));
@@ -240,7 +240,7 @@ index f467e310696..19ef3618d25 100644
  }
    [(set_attr "move_type" "mftg,fpstore")
     (set_attr "mode" "<HALFMODE>")])
-@@ -4238,9 +4246,9 @@
+@@ -4238,9 +4246,9 @@ (define_insn "*join2_load_store<JOIN_MODE:mode>"
    {
      /* The load destination does not overlap the source.  */
      gcc_assert (!reg_overlap_mentioned_p (operands[0], operands[1]));
@@ -256,7 +256,7 @@ diff --git a/gcc/config/loongarch/lsx.md b/gcc/config/loongarch/lsx.md
 index 67ba8e8ad5d..8b58ecad842 100644
 --- a/gcc/config/loongarch/lsx.md
 +++ b/gcc/config/loongarch/lsx.md
-@@ -722,7 +722,7 @@
+@@ -722,7 +722,7 @@ (define_insn "mov<mode>_lsx"
    [(set (match_operand:LSX 0 "nonimmediate_operand" "=f,f,R,*r,*f,*r")
  	(match_operand:LSX 1 "move_operand" "fYGYI,R,f,*f,*r,*r"))]
    "ISA_HAS_LSX"
@@ -277,5 +277,5 @@ index c04ca33996f..33291fe89bd 100644
  long int
  test (void)
 -- 
-2.51.1
+2.54.0
 

--- a/app-devel/gcc-14/01-runtime/patches/0003-BACKPORT-libsanitizer-Fix-build-with-glibc-2.42.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0003-BACKPORT-libsanitizer-Fix-build-with-glibc-2.42.patch
@@ -1,7 +1,7 @@
-From 44b3389cae7cfa2368dae6b850f829faa0148ff3 Mon Sep 17 00:00:00 2001
+From 67f386321747b29e70f5a54da9a8f1681d74d347 Mon Sep 17 00:00:00 2001
 From: Florian Weimer <fweimer@redhat.com>
 Date: Fri, 2 May 2025 17:41:43 +0200
-Subject: [PATCH 3/5] libsanitizer: Fix build with glibc 2.42
+Subject: [PATCH 03/10] BACKPORT: libsanitizer: Fix build with glibc 2.42
 
 The termio structure will be removed from glibc 2.42.  It has
 been deprecated since the late 80s/early 90s.
@@ -18,6 +18,9 @@ libsanitizer/
 	picked from LLVM commit 59978b21ad9c65276ee8e14f26759691b8a65763.
 	* sanitizer_common/sanitizer_platform_limits_posix.cpp: Likewise.
 	* sanitizer_common/sanitizer_platform_limits_posix.h: Likewise.
+
+(cherry picked from commit 1789c57dc97ea2f9819ef89e28bf17208b6208e7)
+(cherry picked from commit f0feb51ff40553643c582ec9c3ca7f293721ddc8)
 ---
  .../sanitizer_common_interceptors_ioctl.inc               | 8 --------
  .../sanitizer_common/sanitizer_platform_limits_posix.cpp  | 3 ---
@@ -73,5 +76,5 @@ index 58244c9944a..28e5bbbc371 100644
  extern unsigned struct_vt_sizes_sz;
  extern unsigned struct_vt_stat_sz;
 -- 
-2.51.1
+2.54.0
 

--- a/app-devel/gcc-14/01-runtime/patches/0004-BACKPORT-sanitizer_common-Remove-reference-to-obsole.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0004-BACKPORT-sanitizer_common-Remove-reference-to-obsole.patch
@@ -1,8 +1,8 @@
-From 675a40019ebe686d42c644857eeeabe98e31272b Mon Sep 17 00:00:00 2001
+From 01e6b6a8ce76366e481a7cb8935d5f498f566404 Mon Sep 17 00:00:00 2001
 From: Sam James <sam@gentoo.org>
 Date: Fri, 25 Jul 2025 19:45:18 +0100
-Subject: [PATCH 4/5] [sanitizer_common] Remove reference to obsolete termio
- ioctls (#138822)
+Subject: [PATCH 04/10] BACKPORT: [sanitizer_common] Remove reference to
+ obsolete termio ioctls (#138822)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -25,6 +25,9 @@ The termio ioctls are no longer used after commit 59978b21ad9c
 ../../../../libsanitizer/sanitizer_common/sanitizer_platform_limits_posix.cpp:771:28: error: invalid application of ‘sizeof’ to incomplete type ‘__sanitizer::termio’
   771 |   unsigned IOCTL_TCSETAW = TCSETAW;
       |                            ^~~~~~~
+
+(cherry picked from commit dbe0ba6c90d53229613c7eb3f476580ae1b9aae1)
+(cherry picked from commit 8af0c7785bacec6676091d274e9f45a2d3d613f6)
 ---
  .../sanitizer_common/sanitizer_platform_limits_posix.cpp      | 4 ----
  .../sanitizer_common/sanitizer_platform_limits_posix.h        | 4 ----
@@ -67,5 +70,5 @@ index 28e5bbbc371..9e4ab50dbaa 100644
  extern unsigned IOCTL_TCSETSF;
  extern unsigned IOCTL_TCSETSW;
 -- 
-2.51.1
+2.54.0
 

--- a/app-devel/gcc-14/01-runtime/patches/0005-DEBIAN-set-version-suffix-for-text-domains.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0005-DEBIAN-set-version-suffix-for-text-domains.patch
@@ -1,14 +1,16 @@
-From db47b0fd353401d108d517bdffc47ce79256b512 Mon Sep 17 00:00:00 2001
+From 427b204302cf30439c4c229407777591aff4a139 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 4 Oct 2025 22:05:59 +0800
-Subject: [PATCH 5/5] DEBIAN: set version suffix for text domains
+Subject: [PATCH 05/10] DEBIAN: set version suffix for text domains
 
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
  gcc/Makefile.in    |  4 ++--
+ gcc/intl.cc        |  4 ++--
  libcpp/Makefile.in | 10 ++++++----
  libcpp/init.cc     |  2 +-
  libcpp/system.h    |  2 +-
- 4 files changed, 10 insertions(+), 8 deletions(-)
+ 5 files changed, 12 insertions(+), 10 deletions(-)
 
 diff --git a/gcc/Makefile.in b/gcc/Makefile.in
 index d475bf1c32e..e2936179af5 100644
@@ -25,6 +27,21 @@ index d475bf1c32e..e2936179af5 100644
  	done
  
  # Rule for regenerating the message template (gcc.pot).
+diff --git a/gcc/intl.cc b/gcc/intl.cc
+index 6f653bff9b8..800f2d8aead 100644
+--- a/gcc/intl.cc
++++ b/gcc/intl.cc
+@@ -55,8 +55,8 @@ gcc_init_libintl (void)
+   setlocale (LC_ALL, "");
+ #endif
+ 
+-  (void) bindtextdomain ("gcc", LOCALEDIR);
+-  (void) textdomain ("gcc");
++  (void) bindtextdomain ("gcc-14", LOCALEDIR);
++  (void) textdomain ("gcc-14");
+ 
+   /* Opening quotation mark.  */
+   open_quote = _("`");
 diff --git a/libcpp/Makefile.in b/libcpp/Makefile.in
 index ebbca37777f..3c7c5228d69 100644
 --- a/libcpp/Makefile.in
@@ -90,5 +107,5 @@ index ae6540a9572..3858f9b90b2 100644
  
  #ifndef N_
 -- 
-2.51.1
+2.54.0
 

--- a/app-devel/gcc-14/01-runtime/patches/0006-BACKPORT-LoongArch-Define-hook-TARGET_COMPUTE_PRESSU.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0006-BACKPORT-LoongArch-Define-hook-TARGET_COMPUTE_PRESSU.patch
@@ -1,0 +1,64 @@
+From c272802cdd4c22aff05b953689b268bf8af36b6c Mon Sep 17 00:00:00 2001
+From: Lulu Cheng <chenglulu@loongson.cn>
+Date: Wed, 13 Aug 2025 11:04:35 +0800
+Subject: [PATCH 06/10] BACKPORT: LoongArch: Define hook
+ TARGET_COMPUTE_PRESSURE_CLASSES[PR120476].
+
+The rtx cost value defined by the target backend affects the
+calculation of register pressure classes in the IRA, thus affecting
+scheduling.  This may cause program performance degradation.
+For example, OpenSSL 3.5.1 SHA512 and SPEC CPU 2017 exchange_r.
+
+This problem can be avoided by defining a set of register pressure
+classes in the target backend instead of using the default IRA to
+automatically calculate them.
+
+gcc/ChangeLog:
+
+	PR target/120476
+	* config/loongarch/loongarch.cc
+	(loongarch_compute_pressure_classes): New function.
+	(TARGET_COMPUTE_PRESSURE_CLASSES): Define.
+
+(cherry picked from commit d94178d9b3fb1cb869b90d6f061990eae75c770e)
+(cherry picked from commit 00c19ad6da2339add251579fef3d97b3f8a57c2f)
+---
+ gcc/config/loongarch/loongarch.cc | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/gcc/config/loongarch/loongarch.cc b/gcc/config/loongarch/loongarch.cc
+index a8b5be53180..2e32ce7a9d8 100644
+--- a/gcc/config/loongarch/loongarch.cc
++++ b/gcc/config/loongarch/loongarch.cc
+@@ -11022,6 +11022,18 @@ loongarch_c_mode_for_suffix (char suffix)
+   return VOIDmode;
+ }
+ 
++/* Implement TARGET_COMPUTE_PRESSURE_CLASSES.  */
++
++static int
++loongarch_compute_pressure_classes (reg_class *classes)
++{
++  int i = 0;
++  classes[i++] = GENERAL_REGS;
++  classes[i++] = FP_REGS;
++  classes[i++] = FCC_REGS;
++  return i;
++}
++
+ /* Initialize the GCC target structure.  */
+ #undef TARGET_ASM_ALIGNED_HI_OP
+ #define TARGET_ASM_ALIGNED_HI_OP "\t.half\t"
+@@ -11284,6 +11296,9 @@ loongarch_c_mode_for_suffix (char suffix)
+ #undef TARGET_C_MODE_FOR_SUFFIX
+ #define TARGET_C_MODE_FOR_SUFFIX loongarch_c_mode_for_suffix
+ 
++#undef TARGET_COMPUTE_PRESSURE_CLASSES
++#define TARGET_COMPUTE_PRESSURE_CLASSES loongarch_compute_pressure_classes
++
+ struct gcc_target targetm = TARGET_INITIALIZER;
+ 
+ #include "gt-loongarch.h"
+-- 
+2.54.0
+

--- a/app-devel/gcc-14/01-runtime/patches/0007-BACKPORT-gcc-check-if-target-install-name-equals-the.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0007-BACKPORT-gcc-check-if-target-install-name-equals-the.patch
@@ -1,0 +1,47 @@
+From 69ca67ce91dce0bdeea4e7934c34dab6410ddf5f Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Tue, 11 Nov 2025 10:19:35 +0800
+Subject: [PATCH 07/10] BACKPORT: gcc: check if target install name equals the
+ full driver name
+
+When a major version program suffix is specified, along with
+--with-gcc-major-version-only, GCC tries to install $TRIPLE-gcc-tmp into
+the destination BINDIR and link it to TRIPLE-gcc-SUFFIX. However this
+executable is installed in the previous step, thus leaving the gcc-tmp
+unmodified.
+
+This is because when --program-suffix=15 (any major version) and
+--with-gcc-major-version-only, $(version) will be the major version
+number, thus making FULL_DRIVER_NAME and GCC_TARGET_INSTALL_NAME
+identical to each other. We check if these two is identical and skip the
+latter step if they are.
+
+gcc/
+	PR bootstrap/105664
+	* Makefile.in (install-driver): detect name collision when
+	installing the driver program.
+
+Signed-off-by: Xinhui Yang <cyan@cyano.uk>
+(cherry picked from commit 722bd6847643ae5d3f66af2a68cc83374730bee6)
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ gcc/Makefile.in | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/gcc/Makefile.in b/gcc/Makefile.in
+index e2936179af5..6343eb3205a 100644
+--- a/gcc/Makefile.in
++++ b/gcc/Makefile.in
+@@ -3968,7 +3968,8 @@ install-driver: installdirs xgcc$(exeext)
+ 	      $(LN) $(GCC_INSTALL_NAME)$(exeext) $(FULL_DRIVER_NAME) ); \
+ 	  fi; \
+ 	  if [ ! -f gcc-cross$(exeext) ] \
+-	      && [ "$(GCC_INSTALL_NAME)" != "$(GCC_TARGET_INSTALL_NAME)" ]; then \
++	      && [ "$(GCC_INSTALL_NAME)" != "$(GCC_TARGET_INSTALL_NAME)" ] \
++	      && [ "$(GCC_TARGET_INSTALL_NAME)$(exeext)" != "$(FULL_DRIVER_NAME)" ] ; then \
+ 	    rm -f $(DESTDIR)$(bindir)/$(target_noncanonical)-gcc-tmp$(exeext); \
+ 	    ( cd $(DESTDIR)$(bindir) && \
+ 	      $(LN) $(GCC_INSTALL_NAME)$(exeext) $(target_noncanonical)-gcc-tmp$(exeext) && \
+-- 
+2.54.0
+

--- a/app-devel/gcc-14/01-runtime/patches/0008-BACKPORT-phiopt-Fix-up-DEBUG_EXPR_DECL-creation-in-s.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0008-BACKPORT-phiopt-Fix-up-DEBUG_EXPR_DECL-creation-in-s.patch
@@ -1,0 +1,87 @@
+From 54b22e3ae08af4db3bc799ef48ae2e952cbed8a6 Mon Sep 17 00:00:00 2001
+From: Jakub Jelinek <jakub@redhat.com>
+Date: Mon, 27 Oct 2025 17:43:17 +0100
+Subject: [PATCH 08/10] BACKPORT: phiopt: Fix up DEBUG_EXPR_DECL creation in
+ spaceship_replacement [PR122394]
+
+The following testcase ICEs in gcc 15 (and is at least latent in 12-14 too),
+because the DEBUG_EXPR_DECL has incorrect mode.  It has
+TREE_TYPE (orig_use_lhs) type, but TYPE_MODE (type) rather than
+TYPE_MODE (TREE_TYPE (orig_use_lhs)) where the two types are sometimes
+the same, but sometimes different (same if !has_cast_debug_uses, different
+otherwise).
+
+Though, there wouldn't be the this issue if it used the proper API to create
+the DEBUG_EXPR_DECL which takes care of everything.  This is the sole
+spot that doesn't use that API.
+
+Doesn't affect the trunk because the code has been removed and replaced with
+different stuff after the libstdc++ ABI change in r16-3474.
+Before r15-5557 the mode has been always wrong because this was done only
+for has_cast_debug_uses.  And the bug has been introduced with r12-5490.
+
+Enough archeology, while it could be fixed by changing the second
+SET_DECL_MODE argument, I think it is better to use build_debug_expr_decl.
+
+2025-10-27  Jakub Jelinek  <jakub@redhat.com>
+
+	PR tree-optimization/122394
+	* tree-ssa-phiopt.cc (spaceship_replacement): Use
+	build_debug_expr_decl instead of manually building DEBUG_EXPR_DECL
+	and getting SET_DECL_MODE wrong.
+
+	* g++.dg/opt/pr122394.C: New test.
+
+(cherry picked from commit 7efde2ae27fe616208f25804dcbf822eca5726ed)
+---
+ gcc/testsuite/g++.dg/opt/pr122394.C | 20 ++++++++++++++++++++
+ gcc/tree-ssa-phiopt.cc              |  6 ++----
+ 2 files changed, 22 insertions(+), 4 deletions(-)
+ create mode 100644 gcc/testsuite/g++.dg/opt/pr122394.C
+
+diff --git a/gcc/testsuite/g++.dg/opt/pr122394.C b/gcc/testsuite/g++.dg/opt/pr122394.C
+new file mode 100644
+index 00000000000..1f84bebd74c
+--- /dev/null
++++ b/gcc/testsuite/g++.dg/opt/pr122394.C
+@@ -0,0 +1,20 @@
++// PR tree-optimization/122394
++// { dg-do compile { target c++23 } }
++// { dg-options "-O1 -g" }
++
++#include <compare>
++
++struct A {
++  friend auto operator<=> (A, A) = default;
++  double a;
++};
++void foo ();
++A b, c;
++
++void
++bar ()
++{
++  bool d = c >= b;
++  if (d)
++    foo ();
++}
+diff --git a/gcc/tree-ssa-phiopt.cc b/gcc/tree-ssa-phiopt.cc
+index 89236637a59..cb258d4b11c 100644
+--- a/gcc/tree-ssa-phiopt.cc
++++ b/gcc/tree-ssa-phiopt.cc
+@@ -2824,10 +2824,8 @@ spaceship_replacement (basic_block cond_bb, basic_block middle_bb,
+ 	    {
+ 	      if (has_cast_debug_uses)
+ 		{
+-		  tree temp3 = make_node (DEBUG_EXPR_DECL);
+-		  DECL_ARTIFICIAL (temp3) = 1;
+-		  TREE_TYPE (temp3) = TREE_TYPE (orig_use_lhs);
+-		  SET_DECL_MODE (temp3, TYPE_MODE (type));
++		  tree temp3
++		    = build_debug_expr_decl (TREE_TYPE (orig_use_lhs));
+ 		  t = fold_convert (TREE_TYPE (temp3), temp2);
+ 		  g = gimple_build_debug_bind (temp3, t, phi);
+ 		  gsi_insert_before (&gsi, g, GSI_SAME_STMT);
+-- 
+2.54.0
+

--- a/app-devel/gcc-14/01-runtime/patches/0009-BACKPORT-LoongArch-harden-SSP-canary-set-and-test-ro.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0009-BACKPORT-LoongArch-harden-SSP-canary-set-and-test-ro.patch
@@ -1,0 +1,343 @@
+From 46f0186e5b384bcd750b020ee5829307f223e08b Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 28 Apr 2026 20:32:38 +0800
+Subject: [PATCH 09/10] BACKPORT: LoongArch: harden SSP canary set and test
+ routines [PR 125049]
+
+Add the stack_protect_combined_{set,test} expanders to expand the
+routines as unsplitable insns which does not leave any sensitive data
+(the canary value, the canary address, and all the intermediate values
+used materializing the address) in a register.  This prevents the
+attacker from defeating SSP by probing the canary value from the
+register context or overwriting the address spilled onto the stack.
+
+	PR target/125049
+
+gcc/
+
+	* config/loongarch/predicates.md (ssp_operand): New
+	define_predicate.
+	(ssp_normal_operand): New define_predicate.
+	* config/loongarch/constraints.md (ZE): New define_constraint.
+	(ZF): New define_constraint.
+	* config/loongarch/loongarch.md (UNSPEC_SSP): New unspec.
+	(cbranch4): Add "@" to create gen_cbranch4(machine_mode, ...).
+	(@stack_protect_combined_set_normal_<mode>): New define_insn.
+	(@stack_protect_combined_set_extreme_<mode>): New define_insn.
+	(@stack_protect_combined_test_internal_<mode>): New define_insn.
+	(stack_protect_combined_set): New define_expand.
+	(stack_protect_combined_test): New define_expand.
+	* config/loongarch/loongarch-protos.h
+	(loongarch_output_asm_load_canary): Declare.
+	* config/loongarch/loongarch.cc (loongarch_print_operand): Allow
+	'v' to print d/w for DImode/SImode.
+	(loongarch_output_asm_load_canary): Implement.
+
+gcc/testsuite/
+
+	* gcc.target/loongarch/pr125049.c: New test.
+
+(cherry picked from commit 62fdbd084f7ab04cb7a97d6186ffe70acfc70f1b)
+---
+ gcc/config/loongarch/constraints.md           |  9 ++
+ gcc/config/loongarch/loongarch-protos.h       |  1 +
+ gcc/config/loongarch/loongarch.cc             | 51 +++++++++++
+ gcc/config/loongarch/loongarch.md             | 88 ++++++++++++++++++-
+ gcc/config/loongarch/predicates.md            |  8 ++
+ gcc/testsuite/gcc.target/loongarch/pr125049.c | 50 +++++++++++
+ 6 files changed, 206 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/testsuite/gcc.target/loongarch/pr125049.c
+
+diff --git a/gcc/config/loongarch/constraints.md b/gcc/config/loongarch/constraints.md
+index f07d31650d2..0ef91373e58 100644
+--- a/gcc/config/loongarch/constraints.md
++++ b/gcc/config/loongarch/constraints.md
+@@ -365,3 +365,12 @@ (define_address_constraint "ZD"
+    and offset that is suitable for use in instructions with the same
+    addressing mode as @code{preld}."
+    (match_test "loongarch_12bit_offset_address_p (op, mode)"))
++
++(define_constraint "ZE"
++  "A symbolic suitable as stack canary in the normal/medium code model."
++  (match_operand 0 "ssp_normal_operand"))
++
++(define_constraint "ZF"
++  "A symbolic suitable as stack canary, but in the extreme code model."
++  (and (match_operand 0 "ssp_operand")
++       (not (match_operand 0 "ssp_normal_operand"))))
+diff --git a/gcc/config/loongarch/loongarch-protos.h b/gcc/config/loongarch/loongarch-protos.h
+index 060760a9e40..411269bcfe7 100644
+--- a/gcc/config/loongarch/loongarch-protos.h
++++ b/gcc/config/loongarch/loongarch-protos.h
+@@ -215,4 +215,5 @@ extern void loongarch_emit_swrsqrtsf (rtx, rtx, machine_mode, bool);
+ extern void loongarch_emit_swdivsf (rtx, rtx, rtx, machine_mode);
+ extern bool loongarch_explicit_relocs_p (enum loongarch_symbol_type);
+ extern bool loongarch_symbol_extreme_p (enum loongarch_symbol_type);
++extern void loongarch_output_asm_load_canary (rtx reg, rtx canary, rtx tmp);
+ #endif /* ! GCC_LOONGARCH_PROTOS_H */
+diff --git a/gcc/config/loongarch/loongarch.cc b/gcc/config/loongarch/loongarch.cc
+index 2e32ce7a9d8..3da0c55f7a0 100644
+--- a/gcc/config/loongarch/loongarch.cc
++++ b/gcc/config/loongarch/loongarch.cc
+@@ -6353,12 +6353,14 @@ loongarch_print_operand (FILE *file, rtx op, int letter)
+ 	case E_V4SFmode:
+ 	case E_V8SImode:
+ 	case E_V8SFmode:
++	case E_SImode:
+ 	  fprintf (file, "w");
+ 	  break;
+ 	case E_V2DImode:
+ 	case E_V2DFmode:
+ 	case E_V4DImode:
+ 	case E_V4DFmode:
++	case E_DImode:
+ 	  fprintf (file, "d");
+ 	  break;
+ 	default:
+@@ -11034,6 +11036,55 @@ loongarch_compute_pressure_classes (reg_class *classes)
+   return i;
+ }
+ 
++/* Output assembly to materialize the address of the stack canary value
++   into reg.  The third argument, tmp, should be and should only be
++   non-NULL if the extreme code model is effective for the canary.  If
++   the fourth arugment, load, is true, the canary value is loaded into
++   the register.
++
++   The assembly cannot be splitted due to security reason.  */
++void
++loongarch_output_asm_load_canary (rtx reg, rtx canary, rtx tmp)
++{
++  gcc_checking_assert (ssp_operand (canary, VOIDmode));
++  gcc_checking_assert ((!tmp) == ssp_normal_operand (canary, VOIDmode));
++  gcc_checking_assert (register_operand (reg, Pmode));
++
++  rtx op[] = {reg, canary, tmp};
++  bool got = (loongarch_classify_symbol (canary) == SYMBOL_GOT_DISP);
++  bool need_ld = false;
++
++  if (la_opt_explicit_relocs != EXPLICIT_RELOCS_ALWAYS)
++    {
++      if (got)
++	output_asm_insn (tmp ? "la.global\t%0,%2,%1" : "la.global\t%0,%1",
++			 op);
++      else
++	output_asm_insn (tmp ? "la.local\t%0,%2,%1" : "la.local\t%0,%1",
++			 op);
++
++      need_ld = true;
++    }
++  else
++    {
++      output_asm_insn ("pcalau12i\t%0,%r1", op);
++      if (!tmp)
++	output_asm_insn ("ld.%v0\t%0,%0,%L1", op);
++      else
++	{
++	  output_asm_insn ("addi.d\t%2,$r0,%L1", op);
++	  output_asm_insn ("lu32i.d\t%2,%R1", op);
++	  output_asm_insn ("lu52i.d\t%2,%2,%H1", op);
++	  output_asm_insn ("ldx.d\t%0,%0,%2", op);
++	}
++
++      need_ld = got;
++    }
++
++  if (need_ld)
++    output_asm_insn ("ld.%v0\t%0,%0,0", op);
++}
++
+ /* Initialize the GCC target structure.  */
+ #undef TARGET_ASM_ALIGNED_HI_OP
+ #define TARGET_ASM_ALIGNED_HI_OP "\t.half\t"
+diff --git a/gcc/config/loongarch/loongarch.md b/gcc/config/loongarch/loongarch.md
+index 19ef3618d25..682f4140a12 100644
+--- a/gcc/config/loongarch/loongarch.md
++++ b/gcc/config/loongarch/loongarch.md
+@@ -88,6 +88,8 @@ (define_c_enum "unspec" [
+   UNSPEC_LOAD_SYMBOL_OFFSET64
+   UNSPEC_LA_PCREL_64_PART1
+   UNSPEC_LA_PCREL_64_PART2
++
++  UNSPEC_SSP
+ ])
+ 
+ (define_c_enum "unspecv" [
+@@ -3348,7 +3350,7 @@ (define_insn "*branch_equality<mode>_inverted"
+ ;; QImode values so we can force zero-extension.
+ (define_mode_iterator BR [(QI "TARGET_64BIT") SI (DI "TARGET_64BIT")])
+ 
+-(define_expand "cbranch<mode>4"
++(define_expand "@cbranch<mode>4"
+   [(set (pc)
+ 	(if_then_else (match_operator 0 "comparison_operator"
+ 			[(match_operand:BR 1 "register_operand")
+@@ -4394,6 +4396,90 @@ (define_insn_and_rewrite "simple_store<mode>"
+     operands[0] = loongarch_rewrite_mem_for_simple_ldst (operands[0]);
+   })
+ 
++;; Set and check against stack canary without leaving it in a register.
++;; DO NOT ATTEMPT TO SPLIT THESE INSNS!  It's important for security reason
++;; that the canary value does not live beyond the life of this sequence.
++
++(define_insn "@stack_protect_combined_set_normal_<mode>"
++  [(set (match_operand:P 0 "memory_operand" "=m,ZC")
++        (unspec:P [(mem:P (match_operand:P 1 "ssp_normal_operand"))]
++		  UNSPEC_SSP))
++   (set (match_scratch:P 2 "=&r,&r") (const_int 0))]
++  ""
++{
++  loongarch_output_asm_load_canary (operands[2], operands[1], NULL_RTX);
++  output_asm_insn (which_alternative ? "stptr.d\t%2,%0" : "st.d\t%2,%0",
++		   operands);
++  return "ori\t%2,$r0,0";
++}
++  [(set_attr "type" "store")
++   (set_attr "length" "20")])
++
++(define_insn "@stack_protect_combined_set_extreme_<mode>"
++  [(set (match_operand:P 0 "memory_operand" "=m,ZC")
++        (unspec:P [(mem:P (match_operand:P 1 "ssp_operand"))] UNSPEC_SSP))
++   (set (match_scratch:P 2 "=&r,&r") (const_int 0))
++   (set (match_scratch:P 3 "=&r,&r") (const_int 0))]
++  ""
++{
++  loongarch_output_asm_load_canary (operands[2], operands[1], operands[3]);
++  output_asm_insn (which_alternative ? "stptr.d\t%2,%0" : "st.d\t%2,%0",
++		   operands);
++  return "ori\t%2,$r0,0\n\tori\t%3,$r0,0";
++}
++  [(set_attr "type" "store")
++   (set_attr "length" "36")])
++
++(define_insn "@stack_protect_combined_test_internal_<mode>"
++  [(set (match_operand:P 0 "register_operand" "=r,r,&r,&r")
++	(xor:P
++	  (match_operand:P 1 "memory_operand" "=m,ZC,m,ZC")
++	    (unspec:P
++	      [(mem:P (match_operand:P 2 "ssp_operand" "ZE,ZE,ZF,ZF"))]
++	      UNSPEC_SSP)))
++   (set (match_scratch:P 3 "=&r,&r,&r,&r") (const_int 0))]
++  ""
++{
++  rtx t = (which_alternative >= 2 ? operands[0] : NULL_RTX);
++  loongarch_output_asm_load_canary (operands[3], operands[2], t);
++  output_asm_insn ((which_alternative & 1) ? "ldptr.d\t%0,%1"
++					   : "ld.d\t%0,%1",
++		   operands);
++  return "xor\t%0,%0,%3\n\tori\t%3,$r0,0";
++}
++  [(set_attr "type" "load,load,load,load")
++   (set_attr "length" "24,24,36,36")])
++
++(define_expand "stack_protect_combined_set"
++  [(match_operand 0 "memory_operand")
++   (match_operand 1 "memory_operand")]
++  ""
++{
++  rtx canary = XEXP (operands[1], 0);
++  auto fn = (ssp_normal_operand (canary, VOIDmode)
++	     ? gen_stack_protect_combined_set_normal
++	     : gen_stack_protect_combined_set_extreme);
++
++  emit_insn (fn (Pmode, operands[0], canary));
++  DONE;
++})
++
++(define_expand "stack_protect_combined_test"
++  [(match_operand 0 "memory_operand")
++   (match_operand 1 "memory_operand")
++   (match_operand 2 "")]
++  ""
++{
++  rtx t = gen_reg_rtx (Pmode);
++  rtx canary = XEXP (operands[1], 0);
++  emit_insn (gen_stack_protect_combined_test_internal (Pmode, t,
++						       operands[0],
++						       canary));
++  rtx cond = gen_rtx_EQ (VOIDmode, t, const0_rtx);
++  emit_jump_insn (gen_cbranch4 (Pmode, cond, t, const0_rtx, operands[2]));
++  DONE;
++})
++
+ ;; Synchronization instructions.
+ 
+ (include "sync.md")
+diff --git a/gcc/config/loongarch/predicates.md b/gcc/config/loongarch/predicates.md
+index eba7f246c84..7c72d9e6acc 100644
+--- a/gcc/config/loongarch/predicates.md
++++ b/gcc/config/loongarch/predicates.md
+@@ -588,6 +588,14 @@ (define_predicate "symbolic_off64_or_reg_operand"
+  (ior (match_operand 0 "register_operand")
+       (match_operand 0 "symbolic_off64_operand")))
+ 
++;; Currently stack canary must be the global symbol __stack_chk_guard.
++(define_predicate "ssp_operand" (match_code "symbol_ref"))
++
++;; If the stack canary is within the normal/medium code model.
++(define_predicate "ssp_normal_operand"
++  (and (match_operand 0 "ssp_operand")
++       (not (match_operand 0 "symbolic_off64_operand"))))
++
+ (define_predicate "equality_operator"
+   (match_code "eq,ne"))
+ 
+diff --git a/gcc/testsuite/gcc.target/loongarch/pr125049.c b/gcc/testsuite/gcc.target/loongarch/pr125049.c
+new file mode 100644
+index 00000000000..cfe036e2061
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/loongarch/pr125049.c
+@@ -0,0 +1,50 @@
++/* PR 125049: ensure stack canary and its address are not leaked.  */
++/* { dg-options "-O2 -fstack-protector-strong -ffixed-r30 -ffixed-r31" } */
++/* { dg-do run } */
++/* { dg-require-effective-target fstack_protector } */
++
++extern long __stack_chk_guard;
++register long s7 asm ("s7"), *s8 asm ("s8");
++
++[[gnu::zero_call_used_regs ("all"), gnu::noipa]] void
++init_test (void)
++{
++  s7 = __stack_chk_guard;
++  s8 = &__stack_chk_guard;
++}
++
++[[gnu::always_inline]] static inline void
++check_reg (void)
++{
++#pragma GCC unroll 30
++  for (int i = 4; i < 30; i++)
++    asm goto (
++      "beq $r%0,$s7,%l[error]\n\t"
++      "beq $r%0,$s8,%l[error]\n\t"
++      :
++      : "i" (i)
++      :
++      : error
++    );
++  return;
++error:
++  __builtin_trap ();
++}
++
++[[gnu::noipa]] void
++test (void)
++{
++  char buf[256];
++  asm ("":"+m"(buf));
++
++  check_reg ();
++}
++
++int
++main (void)
++{
++  init_test ();
++  test ();
++
++  check_reg ();
++}
+-- 
+2.54.0
+

--- a/app-devel/gcc-14/01-runtime/patches/0010-BACKPORT-ifcvt-reject-use-of-ctrap-post-reload-PR-10.patch
+++ b/app-devel/gcc-14/01-runtime/patches/0010-BACKPORT-ifcvt-reject-use-of-ctrap-post-reload-PR-10.patch
@@ -1,0 +1,60 @@
+From eff96f44bcf49555b24b3b2e32e4d08f1fb4ee33 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 7 Apr 2026 04:03:09 +0800
+Subject: [PATCH 10/10] BACKPORT: ifcvt: reject use of ctrap post reload [PR
+ 105192]
+
+The ctrap expanders of several targets can end up creating pseudos.  And
+it would be really counter-intuitive to disallow a define_expand to
+generate pseudos.  So don't invoke the expander post reload.
+
+	PR target/105192
+
+gcc/
+
+	* ifcvt.cc (find_if_header): Don't attempt to use ctrap expander
+	after reload.
+
+gcc/testsuite/
+
+	* gcc.c-torture/compile/pr105192.c: New test.
+
+(cherry picked from commit 7f1e96ee025ab481cf0893b3a4ce82909b22d8f9)
+(cherry picked from commit a26a9a2665ba10b2ecc2413c69c29cf96e0d5908)
+---
+ gcc/ifcvt.cc                                   | 2 +-
+ gcc/testsuite/gcc.c-torture/compile/pr105192.c | 9 +++++++++
+ 2 files changed, 10 insertions(+), 1 deletion(-)
+ create mode 100644 gcc/testsuite/gcc.c-torture/compile/pr105192.c
+
+diff --git a/gcc/ifcvt.cc b/gcc/ifcvt.cc
+index 58ed42673e5..a1b59148d3c 100644
+--- a/gcc/ifcvt.cc
++++ b/gcc/ifcvt.cc
+@@ -4926,7 +4926,7 @@ find_if_header (basic_block test_bb, int pass)
+       && cond_exec_find_if_block (&ce_info))
+     goto success;
+ 
+-  if (targetm.have_trap ()
++  if (!reload_completed && targetm.have_trap ()
+       && optab_handler (ctrap_optab, word_mode) != CODE_FOR_nothing
+       && find_cond_trap (test_bb, then_edge, else_edge))
+     goto success;
+diff --git a/gcc/testsuite/gcc.c-torture/compile/pr105192.c b/gcc/testsuite/gcc.c-torture/compile/pr105192.c
+new file mode 100644
+index 00000000000..0cc61505218
+--- /dev/null
++++ b/gcc/testsuite/gcc.c-torture/compile/pr105192.c
+@@ -0,0 +1,9 @@
++/* { dg-additional-options "-fno-if-conversion -fharden-compares" } */
++
++int a, b;
++
++void
++foo (void)
++{
++  b = a % 0 > 0;
++}
+-- 
+2.54.0
+

--- a/app-devel/gcc-14/02-compiler/beyond
+++ b/app-devel/gcc-14/02-compiler/beyond
@@ -2,12 +2,6 @@ MAJOR="${PKGVER%%.*}"
 GCC_LIBDIR="$LIBDIR"/gcc/"${ARCH_TARGET[$ABHOST]}"/"$MAJOR"
 GCC_INCDIR="$GCC_LIBDIR"/include
 
-# FIXME: temporary copy of GCC is installed as TRIPLE-gcc-tmp.
-if [ -e "$PKGDIR"/usr/bin/"${ARCH_TARGET[$ABHOST]}"-gcc-tmp ] ; then
-	abinfo "Removing gcc-tmp ..."
-	rm -v "$PKGDIR"/usr/bin/"${ARCH_TARGET[$ABHOST]}"-gcc-tmp
-fi
-
 abinfo "Creating symlink - FHS expects "cpp" to be in /usr/lib..."
 ln -sv ../bin/cpp-"$MAJOR" \
     "$PKGDIR"/usr/lib/cpp-"$MAJOR"

--- a/app-devel/gcc-14/spec
+++ b/app-devel/gcc-14/spec
@@ -1,5 +1,5 @@
 VER=14.3.0
-REL=1
+REL=2
 # Note: Use with Git snapshots.
 # SRCS="tbl::https://repo.aosc.io/aosc-repacks/gcc-$VER.tar.xz"
 # Note: Use with upstream stable releases.


### PR DESCRIPTION
Topic Description
-----------------

gcc-14: update to 14.3.0-2

- Backport 5 patches from gcc-15 as they fix bugs affecting 14.3.0 as well.
  - This allows to get rid of the ad-hoc handling of $TRIPLE-gcc-tmp.
- Add a hunk missed in the text domain patch (persumably lefted when we renamed gcc to gcc-14 at the end of Core 12), so gcc-14 can find the translations.
- Remove --with-isl=/usr like gcc-16, to avoid issues like linking gcc-14 libstdc++.so against AOSC Core gcc-15 libgcc_s.so.
  - In the future (Core 14?) we should stop providing (unversioned) /usr/lib/libgcc_s.so and /usr/lib/libgcc*.a.  No other distros supporting multi GCC version (i.e. using --enable-version-specific-runtime-libs) do this, AFAIK.
- Tracking AOSC patches at AOSC-Tracking/gcc @ aosc/releases/gcc-14.3.0 (HEAD: eff96f44bcf49555b24b3b2e32e4d08f1fb4ee33).

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

- gcc-14: `14.3.0-2`
- gcc-runtime-14: `14.3.0-2`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit gcc-14
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
