### PR TITLE
jsonpointer: update to 3.1.1

### DIFF
--- a/lang-python/jsonpointer/spec
+++ b/lang-python/jsonpointer/spec
@@ -1,5 +1,4 @@
-VER=2.3
-SRCS="tbl::https://pypi.io/packages/source/j/jsonpointer/jsonpointer-$VER.tar.gz"
-CHKSUMS="sha256::97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be093c0d69c99a"
+VER=3.1.1
+SRCS="pypi::version=$VER::jsonpointer"
+CHKSUMS="sha256::0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900"
 CHKUPDATE="anitya::id=3897"
-REL="3"


### PR DESCRIPTION
Topic Description
-----------------

- pcp: update to 7.1.5
- jsonpointer: update to 3.1.1

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit jsonpointer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
