### PR TITLE
ROS2 control Survey

### DIFF
--- a/lang-python/coverage/autobuild/defines
+++ b/lang-python/coverage/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=coverage
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Code coverage measurement for Python"
+
+ABTYPE=pep517

--- a/lang-python/coverage/spec
+++ b/lang-python/coverage/spec
@@ -1,0 +1,4 @@
+VER=7.14.1
+SRCS="pypi::version=$VER::coverage"
+CHKSUMS="sha256::30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be"
+CHKUPDATE="anitya::id=3811"

--- a/lang-python/typeguard/autobuild/defines
+++ b/lang-python/typeguard/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=typeguard
+PKGSEC=python
+PKGDEP="typing-extensions"
+BUILDDEP="setuptools-scm"
+PKGDES="Run-time type checker for Python"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/typeguard/spec
+++ b/lang-python/typeguard/spec
@@ -1,0 +1,4 @@
+VER=4.5.2
+SRCS="pypi::version=$VER::typeguard"
+CHKSUMS="sha256::5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423"
+CHKUPDATE="anitya::id=38819"

--- a/lang-python/xacro/autobuild/defines
+++ b/lang-python/xacro/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=xacro
+PKGSEC=python
+PKGDEP="python-3 pyyaml"
+BUILDDEP="setuptools-scm"
+PKGDES="Macro language for XML"
+
+ABTYPE=pep517
+ABHOST=noarch

--- a/lang-python/xacro/spec
+++ b/lang-python/xacro/spec
@@ -1,0 +1,4 @@
+VER=2.1.1
+SRCS="pypi::version=$VER::xacro"
+CHKSUMS="sha256::3e7adf33cdd90d9fbe8ca0d07d9118acf770a2ad8bf575977019a5c8a60d4d1b"
+CHKUPDATE="anitya::id=390542"

--- a/runtime-common/backward-cpp/autobuild/defines
+++ b/runtime-common/backward-cpp/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=backward-cpp
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="Stack trace pretty printer for C++"
+
+ABTYPE=cmakeninja
+ABHOST=noarch

--- a/runtime-common/backward-cpp/autobuild/patches/0001-BACKPORT-support-loongarch.patch
+++ b/runtime-common/backward-cpp/autobuild/patches/0001-BACKPORT-support-loongarch.patch
@@ -1,0 +1,23 @@
+From 22ef5b66e8476aaa8a70e684063aba26843a5ac8 Mon Sep 17 00:00:00 2001
+From: tsingkong <tsingkong@163.com>
+Date: Wed, 5 Mar 2025 19:52:17 +0800
+Subject: [PATCH] add support for loongarch
+
+---
+ backward.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/backward.hpp b/backward.hpp
+index 2342b18..859d604 100644
+--- a/backward.hpp
++++ b/backward.hpp
+@@ -4280,6 +4280,8 @@ class SignalHandling {
+     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__rip);
+ #elif defined(__APPLE__)
+     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__eip);
++#elif defined(__loongarch__)
++    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.__pc);
+ #else
+ #warning ":/ sorry, ain't know no nothing none not of your architecture!"
+ #endif
+

--- a/runtime-common/backward-cpp/spec
+++ b/runtime-common/backward-cpp/spec
@@ -1,0 +1,4 @@
+VER=1.6
+SRCS="git::commit=tags/v$VER::https://github.com/bombela/backward-cpp"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=377503"

--- a/runtime-ros/ros-jazzy-backward-ros/autobuild/defines
+++ b/runtime-ros/ros-jazzy-backward-ros/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-backward-ros
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace elfutils"
+BUILDDEP="cmake"
+PKGDES="ROS 2 wrapper for \`backward-cpp\`"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-backward-ros/autobuild/patches/0001-FROMLIST-support-loongarch.patch
+++ b/runtime-ros/ros-jazzy-backward-ros/autobuild/patches/0001-FROMLIST-support-loongarch.patch
@@ -1,0 +1,23 @@
+From 7d12314e86b7a38cfc45293734874a27301ea8c0 Mon Sep 17 00:00:00 2001
+From: zhaixiaojuan <zhaixiaojuan@loongson.cn>
+Date: Mon, 7 Jul 2025 07:40:19 +0000
+Subject: [PATCH] Add loongarch64 support
+
+---
+ include/backward_ros/backward.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/backward_ros/backward.hpp b/include/backward_ros/backward.hpp
+index 93037d5..3dab933 100644
+--- a/include/backward_ros/backward.hpp
++++ b/include/backward_ros/backward.hpp
+@@ -4220,6 +4220,8 @@ class SignalHandling {
+     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.__gregs[REG_PC]);
+ #elif defined(__s390x__)
+     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.psw.addr);
++#elif defined(__loongarch64)
++    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.__pc);
+ #elif defined(__APPLE__) && defined(__x86_64__)
+     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__rip);
+ #elif defined(__APPLE__)
+

--- a/runtime-ros/ros-jazzy-backward-ros/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-backward-ros/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-backward-ros/spec
+++ b/runtime-ros/ros-jazzy-backward-ros/spec
@@ -1,0 +1,4 @@
+VER=1.0.8+1
+SRCS="git::commit=tags/release/jazzy/backward_ros/${VER/+/-}::https://github.com/ros2-gbp/backward_ros-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/backward_ros-release;pattern=release/jazzy/backward_ros/.*"

--- a/runtime-ros/ros-jazzy-control-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-control-msgs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-control-msgs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-action-msgs ros-jazzy-builtin-interfaces ros-jazzy-geometry-msgs ros-jazzy-sensor-msgs ros-jazzy-std-msgs ros-jazzy-trajectory-msgs ros-jazzy-rosidl-default-runtime"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators"
+PKGDES="Messages and actions for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-control-msgs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-control-msgs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-control-msgs/spec
+++ b/runtime-ros/ros-jazzy-control-msgs/spec
@@ -1,0 +1,4 @@
+VER=5.9.0+1
+SRCS="git::commit=tags/release/jazzy/control_msgs/${VER/+/-}::https://github.com/ros2-gbp/control_msgs-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/control_msgs-release;pattern=release/jazzy/control_msgs/.*"

--- a/runtime-ros/ros-jazzy-controller-interface/autobuild/defines
+++ b/runtime-ros/ros-jazzy-controller-interface/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-controller-interface
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-realtime-tools ros-jazzy-hardware-interface ros-jazzy-rclcpp-lifecycle"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gen-version-h fmt ros-jazzy-pal-statistics ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-geometry-msgs ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
+PKGDES="Base controller classes and helpers for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-controller-interface/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-controller-interface/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-controller-interface/spec
+++ b/runtime-ros/ros-jazzy-controller-interface/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/controller_interface/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/controller_interface/.*"

--- a/runtime-ros/ros-jazzy-controller-manager-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-controller-manager-msgs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-controller-manager-msgs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-builtin-interfaces ros-jazzy-lifecycle-msgs ros-jazzy-std-msgs ros-jazzy-rosidl-default-runtime"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators"
+PKGDES="Messages and services of controller manager for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-controller-manager-msgs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-controller-manager-msgs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-controller-manager-msgs/spec
+++ b/runtime-ros/ros-jazzy-controller-manager-msgs/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/controller_manager_msgs/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/controller_manager_msgs/.*"

--- a/runtime-ros/ros-jazzy-controller-manager/autobuild/defines
+++ b/runtime-ros/ros-jazzy-controller-manager/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-controller-manager
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-controller-interface ros-jazzy-controller-manager-msgs ros-jazzy-diagnostic-updater fmt ros-jazzy-generate-parameter-library ros-jazzy-hardware-interface ros-jazzy-libstatistics-collector ros-jazzy-lifecycle-msgs ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-realtime-tools ros-jazzy-std-msgs ros-jazzy-launch-ros ros-jazzy-launch-testing-ros ros-jazzy-launch py-filelock yaml ros-jazzy-rcl-interfaces ros-jazzy-rclpy ros-jazzy-ros2param ros-jazzy-sensor-msgs pyyaml"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ament-cmake-python ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-ament-cmake-pytest ros-jazzy-example-interfaces ros-jazzy-hardware-interface-testing ros-jazzy-launch-testing coverage ros-jazzy-robot-state-publisher ros-jazzy-ros2-control-test-assets ros-jazzy-ros2pkg"
+PKGDES="Entrypoint and management node for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-controller-manager/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-controller-manager/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-controller-manager/spec
+++ b/runtime-ros/ros-jazzy-controller-manager/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/controller_manager/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/controller_manager/.*"

--- a/runtime-ros/ros-jazzy-diagnostic-updater/autobuild/defines
+++ b/runtime-ros/ros-jazzy-diagnostic-updater/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-diagnostic-updater
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-diagnostic-msgs ros-jazzy-rclcpp ros-jazzy-rclpy ros-jazzy-std-msgs"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-python ros-jazzy-ament-cmake-ros ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-pytest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common ros-jazzy-launch ros-jazzy-launch-testing ros-jazzy-launch-testing-ros pytest ros-jazzy-rclcpp-lifecycle"
+PKGDES="Diagnostic information updater and publisher for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-diagnostic-updater/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-diagnostic-updater/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-diagnostic-updater/spec
+++ b/runtime-ros/ros-jazzy-diagnostic-updater/spec
@@ -1,0 +1,4 @@
+VER=4.2.7+1
+SRCS="git::commit=tags/release/jazzy/diagnostic_updater/${VER/+/-}::https://github.com/ros2-gbp/diagnostics-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/diagnostics-release;pattern=release/jazzy/diagnostic_updater/.*"

--- a/runtime-ros/ros-jazzy-generate-parameter-library-py/autobuild/defines
+++ b/runtime-ros/ros-jazzy-generate-parameter-library-py/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-generate-parameter-library-py
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace python-3 jinja2 typeguard yaml"
+BUILDDEP="pytest"
+PKGDES="Python code generator for ROS 2 parameter management using YAML"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-generate-parameter-library-py/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-generate-parameter-library-py/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-generate-parameter-library-py/spec
+++ b/runtime-ros/ros-jazzy-generate-parameter-library-py/spec
@@ -1,0 +1,4 @@
+VER=0.7.3+1
+SRCS="git::commit=tags/release/jazzy/generate_parameter_library_py/${VER/+/-}::https://github.com/ros2-gbp/generate_parameter_library-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/generate_parameter_library-release;pattern=release/jazzy/generate_parameter_library_py/.*"

--- a/runtime-ros/ros-jazzy-generate-parameter-library/autobuild/defines
+++ b/runtime-ros/ros-jazzy-generate-parameter-library/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-generate-parameter-library
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace fmt ros-jazzy-parameter-traits ros-jazzy-rclcpp ros-jazzy-rclpy ros-jazzy-rclcpp-lifecycle ros-jazzy-rsl ros-jazzy-tcb-span tl-expected ros-jazzy-tl-expected ros-jazzy-generate-parameter-library-py"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-python"
+PKGDES="C++ code generator for ROS 2 parameter management using YAML"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-generate-parameter-library/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-generate-parameter-library/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-generate-parameter-library/spec
+++ b/runtime-ros/ros-jazzy-generate-parameter-library/spec
@@ -1,0 +1,4 @@
+VER=0.7.3+1
+SRCS="git::commit=tags/release/jazzy/generate_parameter_library/${VER/+/-}::https://github.com/ros2-gbp/generate_parameter_library-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/generate_parameter_library-release;pattern=release/jazzy/generate_parameter_library/.*"

--- a/runtime-ros/ros-jazzy-gz-math-vendor/autobuild/defines
+++ b/runtime-ros/ros-jazzy-gz-math-vendor/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=ros-jazzy-gz-math-vendor
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-gz-cmake-vendor ros-jazzy-gz-utils-vendor eigen-3"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-gz-cmake-vendor ros-jazzy-gz-utils-vendor eigen"
 BUILDDEP="ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-test ros-jazzy-ament-cmake-vendor-package cmake pybind11 pytest ros-jazzy-ament-cmake-copyright ros-jazzy-ament-cmake-lint-cmake ros-jazzy-ament-cmake-xmllint"
-PKGDES="ROS 2 wrapper for gz-math7"
+PKGDES="ROS 2 wrapper for \`gz-math7\`"
 
 ABTYPE=cmakeninja
 PREFIX="/opt/ros/jazzy"

--- a/runtime-ros/ros-jazzy-gz-math-vendor/spec
+++ b/runtime-ros/ros-jazzy-gz-math-vendor/spec
@@ -1,4 +1,5 @@
 VER=0.0.9+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/gz_math_vendor/${VER/+/-}::https://github.com/ros2-gbp/gz_math_vendor-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/gz_math_vendor-release;pattern=release/jazzy/gz_math_vendor/.*"

--- a/runtime-ros/ros-jazzy-gz-tools-vendor/autobuild/defines
+++ b/runtime-ros/ros-jazzy-gz-tools-vendor/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-gz-tools-vendor
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-gz-cmake-vendor ruby backward-cpp"
+BUILDDEP="ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-test ros-jazzy-ament-cmake-vendor-package cmake ros-jazzy-ament-cmake-copyright ros-jazzy-ament-cmake-lint-cmake ros-jazzy-ament-cmake-xmllint"
+PKGDES="ROS 2 wrapper for Gazebo tools (\`gz-tools2\`)"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-gz-tools-vendor/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-gz-tools-vendor/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-gz-tools-vendor/spec
+++ b/runtime-ros/ros-jazzy-gz-tools-vendor/spec
@@ -1,0 +1,4 @@
+VER=0.0.7+1
+SRCS="git::commit=tags/release/jazzy/gz_tools_vendor/${VER/+/-}::https://github.com/ros2-gbp/gz_tools_vendor-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/gz_tools_vendor-release;pattern=release/jazzy/gz_tools_vendor/.*"

--- a/runtime-ros/ros-jazzy-hardware-interface-testing/autobuild/defines
+++ b/runtime-ros/ros-jazzy-hardware-interface-testing/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-hardware-interface-testing
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-control-msgs ros-jazzy-hardware-interface ros-jazzy-lifecycle-msgs ros-jazzy-pluginlib ros-jazzy-rclcpp-lifecycle ros-jazzy-ros2-control-test-assets fmt"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock"
+PKGDES="Mock components and testing utilities for ROS 2 hardware interfaces"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-hardware-interface-testing/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-hardware-interface-testing/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-hardware-interface-testing/spec
+++ b/runtime-ros/ros-jazzy-hardware-interface-testing/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/hardware_interface_testing/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/hardware_interface_testing/.*"

--- a/runtime-ros/ros-jazzy-hardware-interface/autobuild/defines
+++ b/runtime-ros/ros-jazzy-hardware-interface/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-hardware-interface
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-control-msgs ros-jazzy-joint-limits ros-jazzy-lifecycle-msgs ros-jazzy-pal-statistics ros-jazzy-pluginlib ros-jazzy-rclcpp-lifecycle ros-jazzy-rcpputils ros-jazzy-realtime-tools ros-jazzy-sdformat-urdf ros-jazzy-tinyxml2-vendor ros-jazzy-urdf fmt ros-jazzy-rcutils"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-ros2-control-test-assets"
+PKGDES="Hardware abstraction API and component base classes for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-hardware-interface/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-hardware-interface/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-hardware-interface/spec
+++ b/runtime-ros/ros-jazzy-hardware-interface/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/hardware_interface/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/hardware_interface/.*"

--- a/runtime-ros/ros-jazzy-joint-limits/autobuild/defines
+++ b/runtime-ros/ros-jazzy-joint-limits/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-joint-limits
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-pluginlib ros-jazzy-realtime-tools ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-trajectory-msgs ros-jazzy-urdf fmt"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-generate-parameter-library ros-jazzy-launch-ros ros-jazzy-launch-testing-ament-cmake"
+PKGDES="Interfaces to handle joint limits in controllers or hardware"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-joint-limits/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-joint-limits/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-joint-limits/spec
+++ b/runtime-ros/ros-jazzy-joint-limits/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/joint_limits/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/joint_limits/.*"

--- a/runtime-ros/ros-jazzy-joint-state-publisher-gui/autobuild/defines
+++ b/runtime-ros/ros-jazzy-joint-state-publisher-gui/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-joint-state-publisher-gui
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-joint-state-publisher ros-jazzy-python-qt-binding ros-jazzy-rclpy"
+
+PKGDES="GUI to set and publish joint state values from URDF"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-joint-state-publisher-gui/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-joint-state-publisher-gui/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-joint-state-publisher-gui/spec
+++ b/runtime-ros/ros-jazzy-joint-state-publisher-gui/spec
@@ -1,0 +1,4 @@
+VER=2.4.1+1
+SRCS="git::commit=tags/release/jazzy/joint_state_publisher_gui/${VER/+/-}::https://github.com/ros2-gbp/joint_state_publisher-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/joint_state_publisher-release;pattern=release/jazzy/joint_state_publisher_gui/.*"

--- a/runtime-ros/ros-jazzy-joint-state-publisher/autobuild/defines
+++ b/runtime-ros/ros-jazzy-joint-state-publisher/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-joint-state-publisher
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace packaging ros-jazzy-rclpy ros-jazzy-sensor-msgs ros-jazzy-std-msgs"
+BUILDDEP="ros-jazzy-ament-copyright ros-jazzy-ament-flake8 ros-jazzy-ament-pep257 ros-jazzy-ament-xmllint pytest ros-jazzy-launch-testing ros-jazzy-launch-testing-ros ros-jazzy-ros2topic"
+PKGDES="Set and publish joint state values from URDF"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-joint-state-publisher/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-joint-state-publisher/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-joint-state-publisher/spec
+++ b/runtime-ros/ros-jazzy-joint-state-publisher/spec
@@ -1,0 +1,4 @@
+VER=2.4.1+1
+SRCS="git::commit=tags/release/jazzy/joint_state_publisher/${VER/+/-}::https://github.com/ros2-gbp/joint_state_publisher-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/joint_state_publisher-release;pattern=release/jazzy/joint_state_publisher/.*"

--- a/runtime-ros/ros-jazzy-laser-geometry/autobuild/defines
+++ b/runtime-ros/ros-jazzy-laser-geometry/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=ros-jazzy-laser-geometry
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace numpy ros-jazzy-rclcpp ros-jazzy-rclpy ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-py ros-jazzy-tf2 eigen-3 ros-jazzy-eigen3-cmake-module"
+PKGDEP="ros-jazzy-ros-workspace numpy ros-jazzy-rclcpp ros-jazzy-rclpy ros-jazzy-sensor-msgs ros-jazzy-sensor-msgs-py ros-jazzy-tf2 eigen ros-jazzy-eigen3-cmake-module"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-eigen3-cmake-module ros-jazzy-ament-cmake-cppcheck ros-jazzy-ament-cmake-cpplint ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-lint-cmake ros-jazzy-ament-cmake-pytest ros-jazzy-ament-cmake-uncrustify ros-jazzy-python-cmake-module"
-PKGDES="ROS 2 module to convert 2D laser scan into point cloud"
+PKGDES="ROS 2 module to convert 2D laser scans to point clouds"
 
 ABTYPE=cmakeninja
 PREFIX="/opt/ros/jazzy"

--- a/runtime-ros/ros-jazzy-laser-geometry/spec
+++ b/runtime-ros/ros-jazzy-laser-geometry/spec
@@ -1,4 +1,5 @@
 VER=2.7.2+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/laser_geometry/${VER/+/-}::https://github.com/ros2-gbp/laser_geometry-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/laser_geometry-release;pattern=release/jazzy/laser_geometry/.*"

--- a/runtime-ros/ros-jazzy-orocos-kdl-vendor/autobuild/defines
+++ b/runtime-ros/ros-jazzy-orocos-kdl-vendor/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=ros-jazzy-orocos-kdl-vendor
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace eigen-3 ros-jazzy-eigen3-cmake-module orocos-kdl"
+PKGDEP="ros-jazzy-ros-workspace eigen ros-jazzy-eigen3-cmake-module orocos-kdl"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-vendor-package ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
-PKGDES="ROS 2 wrapper for orocos_kdl"
+PKGDES="ROS 2 wrapper for Orocos kinematics and dynamics library"
 
 ABTYPE=cmakeninja
 PREFIX="/opt/ros/jazzy"

--- a/runtime-ros/ros-jazzy-orocos-kdl-vendor/spec
+++ b/runtime-ros/ros-jazzy-orocos-kdl-vendor/spec
@@ -1,4 +1,5 @@
 VER=0.5.1+2
+REL=1
 SRCS="git::commit=tags/release/jazzy/orocos_kdl_vendor/${VER/+/-}::https://github.com/ros2-gbp/orocos_kdl_vendor-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/orocos_kdl_vendor-release;pattern=release/jazzy/orocos_kdl_vendor/.*"

--- a/runtime-ros/ros-jazzy-pal-statistics-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-pal-statistics-msgs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-pal-statistics-msgs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-std-msgs ros-jazzy-rosidl-default-runtime"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
+PKGDES="Messages for PAL statistics"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-pal-statistics-msgs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-pal-statistics-msgs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-pal-statistics-msgs/spec
+++ b/runtime-ros/ros-jazzy-pal-statistics-msgs/spec
@@ -1,0 +1,4 @@
+VER=2.7.0+1
+SRCS="git::commit=tags/release/jazzy/pal_statistics_msgs/${VER/+/-}::https://github.com/ros2-gbp/pal_statistics-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/pal_statistics-release;pattern=release/jazzy/pal_statistics_msgs/.*"

--- a/runtime-ros/ros-jazzy-pal-statistics/autobuild/defines
+++ b/runtime-ros/ros-jazzy-pal-statistics/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-pal-statistics
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace boost ros-jazzy-pal-statistics-msgs ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-rclpy"
+BUILDDEP="ros-jazzy-ament-cmake-auto ros-jazzy-ament-cmake-python ros-jazzy-ament-cmake-gmock ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-pytest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
+PKGDES="Performance metrics and internal variable collection for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-pal-statistics/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-pal-statistics/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-pal-statistics/spec
+++ b/runtime-ros/ros-jazzy-pal-statistics/spec
@@ -1,0 +1,4 @@
+VER=2.7.0+1
+SRCS="git::commit=tags/release/jazzy/pal_statistics/${VER/+/-}::https://github.com/ros2-gbp/pal_statistics-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/pal_statistics-release;pattern=release/jazzy/pal_statistics/.*"

--- a/runtime-ros/ros-jazzy-parameter-traits/autobuild/defines
+++ b/runtime-ros/ros-jazzy-parameter-traits/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-parameter-traits
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace fmt ros-jazzy-rclcpp ros-jazzy-rsl ros-jazzy-tcb-span ros-jazzy-tl-expected"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest"
+PKGDES="C++ template utilities and syntactic sugar for easy node parameter management"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-parameter-traits/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-parameter-traits/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-parameter-traits/spec
+++ b/runtime-ros/ros-jazzy-parameter-traits/spec
@@ -1,0 +1,4 @@
+VER=0.7.3+1
+SRCS="git::commit=tags/release/jazzy/parameter_traits/${VER/+/-}::https://github.com/ros2-gbp/generate_parameter_library-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/generate_parameter_library-release;pattern=release/jazzy/parameter_traits/.*"

--- a/runtime-ros/ros-jazzy-realtime-tools/autobuild/defines
+++ b/runtime-ros/ros-jazzy-realtime-tools/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-realtime-tools
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace boost ros-jazzy-rclcpp ros-jazzy-rclcpp-action libcap ros-jazzy-ament-cmake"
+BUILDDEP="ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-lifecycle-msgs ros-jazzy-rclcpp-lifecycle ros-jazzy-test-msgs"
+PKGDES="Thread-safe data structures and tools for real-time ROS 2 applications"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-realtime-tools/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-realtime-tools/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-realtime-tools/spec
+++ b/runtime-ros/ros-jazzy-realtime-tools/spec
@@ -1,0 +1,4 @@
+VER=3.11.0+1
+SRCS="git::commit=tags/release/jazzy/realtime_tools/${VER/+/-}::https://github.com/ros2-gbp/realtime_tools-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/realtime_tools-release;pattern=release/jazzy/realtime_tools/.*"

--- a/runtime-ros/ros-jazzy-ros2-control-cmake/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros2-control-cmake/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-ros2-control-cmake
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
+PKGDES="CMake macros for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-ros2-control-cmake/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ros2-control-cmake/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ros2-control-cmake/spec
+++ b/runtime-ros/ros-jazzy-ros2-control-cmake/spec
@@ -1,0 +1,4 @@
+VER=0.4.0+1
+SRCS="git::commit=tags/release/jazzy/ros2_control_cmake/${VER/+/-}::https://github.com/ros2-gbp/ros2_control_cmake-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control_cmake-release;pattern=release/jazzy/ros2_control_cmake/.*"

--- a/runtime-ros/ros-jazzy-ros2-control-test-assets/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros2-control-test-assets/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-ros2-control-test-assets
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Shared test resources for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-ros2-control-test-assets/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ros2-control-test-assets/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ros2-control-test-assets/spec
+++ b/runtime-ros/ros-jazzy-ros2-control-test-assets/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/ros2_control_test_assets/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/ros2_control_test_assets/.*"

--- a/runtime-ros/ros-jazzy-ros2-control/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros2-control/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-ros2-control
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-controller-interface ros-jazzy-controller-manager ros-jazzy-controller-manager-msgs ros-jazzy-hardware-interface ros-jazzy-joint-limits ros-jazzy-ros2-control-test-assets ros-jazzy-ros2controlcli ros-jazzy-transmission-interface ros-jazzy-ros2-control-cmake"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Metapackage for ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-ros2-control/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ros2-control/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ros2-control/spec
+++ b/runtime-ros/ros-jazzy-ros2-control/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/ros2_control/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/ros2_control/.*"

--- a/runtime-ros/ros-jazzy-ros2controlcli/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros2controlcli/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-ros2controlcli
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-rcl-interfaces ros-jazzy-rclpy ros-jazzy-ros2cli ros-jazzy-ros2node ros-jazzy-ros2param ros-jazzy-controller-manager ros-jazzy-controller-manager-msgs ros-jazzy-rosidl-runtime-py pygraphviz"
+
+PKGDES="Command line tools for ROS 2 control"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-ros2controlcli/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ros2controlcli/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ros2controlcli/spec
+++ b/runtime-ros/ros-jazzy-ros2controlcli/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/ros2controlcli/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/ros2controlcli/.*"

--- a/runtime-ros/ros-jazzy-rsl/autobuild/defines
+++ b/runtime-ros/ros-jazzy-rsl/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-rsl
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace eigen fmt ros-jazzy-rclcpp ros-jazzy-tcb-span tl-expected"
+BUILDDEP="doxygen ros-jazzy-ament-cmake-ros llvm git range-v3"
+PKGDES="C++ 17 utilities and helpers for ROS 2 development"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-rsl/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-rsl/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-rsl/spec
+++ b/runtime-ros/ros-jazzy-rsl/spec
@@ -1,0 +1,4 @@
+VER=1.3.0+1
+SRCS="git::commit=tags/release/jazzy/rsl/${VER/+/-}::https://github.com/ros2-gbp/RSL-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/RSL-release;pattern=release/jazzy/rsl/.*"

--- a/runtime-ros/ros-jazzy-rviz-rendering/autobuild/defines
+++ b/runtime-ros/ros-jazzy-rviz-rendering/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=ros-jazzy-rviz-rendering
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp qt-5 qt-5 qt-5 qt-5 ros-jazzy-resource-retriever ros-jazzy-rviz-assimp-vendor ros-jazzy-rviz-ogre-vendor eigen-3 qt-5 ros-jazzy-rviz-ogre-vendor ros-jazzy-eigen3-cmake-module"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp qt-5 qt-5 qt-5 qt-5 ros-jazzy-resource-retriever ros-jazzy-rviz-assimp-vendor ros-jazzy-rviz-ogre-vendor eigen qt-5 ros-jazzy-rviz-ogre-vendor ros-jazzy-eigen3-cmake-module"
 BUILDDEP="ros-jazzy-ament-cmake-ros ros-jazzy-eigen3-cmake-module ros-jazzy-ament-cmake-cppcheck ros-jazzy-ament-cmake-cpplint ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gmock ros-jazzy-ament-cmake-lint-cmake ros-jazzy-ament-cmake-uncrustify ros-jazzy-ament-cmake-xmllint ros-jazzy-ament-lint-auto"
-PKGDES="3D rendering library for RViz"
+PKGDES="3D rendering library for RViz2"
 
 ABTYPE=cmakeninja
 PREFIX="/opt/ros/jazzy"

--- a/runtime-ros/ros-jazzy-rviz-rendering/spec
+++ b/runtime-ros/ros-jazzy-rviz-rendering/spec
@@ -1,4 +1,5 @@
 VER=14.1.20+2
+REL=1
 SRCS="git::commit=tags/release/jazzy/rviz_rendering/${VER/+/-}::https://github.com/ros2-gbp/rviz-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/rviz-release;pattern=release/jazzy/rviz_rendering/.*"

--- a/runtime-ros/ros-jazzy-sdformat-test-files/autobuild/defines
+++ b/runtime-ros/ros-jazzy-sdformat-test-files/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-sdformat-test-files
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace cmake"
+
+PKGDES="Example files to test SDFormat XML tools"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-sdformat-test-files/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-sdformat-test-files/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-sdformat-test-files/spec
+++ b/runtime-ros/ros-jazzy-sdformat-test-files/spec
@@ -1,0 +1,4 @@
+VER=1.0.2+1
+SRCS="git::commit=tags/release/jazzy/sdformat_test_files/${VER/+/-}::https://github.com/ros2-gbp/sdformat_urdf-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/sdformat_urdf-release;pattern=release/jazzy/sdformat_test_files/.*"

--- a/runtime-ros/ros-jazzy-sdformat-urdf/autobuild/defines
+++ b/runtime-ros/ros-jazzy-sdformat-urdf/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-sdformat-urdf
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-sdformat-vendor ros-jazzy-urdf ros-jazzy-tinyxml2-vendor ros-jazzy-urdf-parser-plugin ros-jazzy-urdfdom-headers ros-jazzy-pluginlib ros-jazzy-rcutils ros-jazzy-ament-cmake-ros"
+BUILDDEP="ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common ros-jazzy-sdformat-test-files"
+PKGDES="URDF plugin to parse SDFormat XML into URDF C++ DOM objects"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-sdformat-urdf/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-sdformat-urdf/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-sdformat-urdf/spec
+++ b/runtime-ros/ros-jazzy-sdformat-urdf/spec
@@ -1,0 +1,4 @@
+VER=1.0.2+1
+SRCS="git::commit=tags/release/jazzy/sdformat_urdf/${VER/+/-}::https://github.com/ros2-gbp/sdformat_urdf-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/sdformat_urdf-release;pattern=release/jazzy/sdformat_urdf/.*"

--- a/runtime-ros/ros-jazzy-sdformat-vendor/autobuild/defines
+++ b/runtime-ros/ros-jazzy-sdformat-vendor/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-sdformat-vendor
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-gz-cmake-vendor ros-jazzy-gz-math-vendor ros-jazzy-gz-utils-vendor ros-jazzy-gz-tools-vendor tinyxml2 ros-jazzy-urdfdom pybind11"
+BUILDDEP="ros-jazzy-ament-cmake-core ros-jazzy-ament-cmake-test ros-jazzy-ament-cmake-vendor-package cmake libxml2 pypsutil pytest ros-jazzy-ament-cmake-copyright ros-jazzy-ament-cmake-lint-cmake ros-jazzy-ament-cmake-xmllint"
+PKGDES="ROS 2 wrapper for \`sdformat\`"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-sdformat-vendor/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-sdformat-vendor/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-sdformat-vendor/spec
+++ b/runtime-ros/ros-jazzy-sdformat-vendor/spec
@@ -1,0 +1,4 @@
+VER=0.0.11+1
+SRCS="git::commit=tags/release/jazzy/sdformat_vendor/${VER/+/-}::https://github.com/ros2-gbp/sdformat_vendor-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/sdformat_vendor-release;pattern=release/jazzy/sdformat_vendor/.*"

--- a/runtime-ros/ros-jazzy-tcb-span/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tcb-span/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-tcb-span
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest"
+PKGDES="ROS 2 wrapper for \`tcb_span\`, C++11 implementation of \`std::span\`"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-tcb-span/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-tcb-span/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-tcb-span/spec
+++ b/runtime-ros/ros-jazzy-tcb-span/spec
@@ -1,0 +1,4 @@
+VER=1.3.1+1
+SRCS="git::commit=tags/release/jazzy/tcb_span/${VER/+/-}::https://github.com/ros2-gbp/cpp_polyfills-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/cpp_polyfills-release;pattern=release/jazzy/tcb_span/.*"

--- a/runtime-ros/ros-jazzy-tl-expected/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tl-expected/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-tl-expected
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="ROS 2 wrapper for \`tl_expected\`, C++11/14/17 implementation of \`std::expected\` with functional extensions"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-tl-expected/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-tl-expected/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-tl-expected/spec
+++ b/runtime-ros/ros-jazzy-tl-expected/spec
@@ -1,0 +1,4 @@
+VER=1.3.1+1
+SRCS="git::commit=tags/release/jazzy/tl_expected/${VER/+/-}::https://github.com/ros2-gbp/cpp_polyfills-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/cpp_polyfills-release;pattern=release/jazzy/tl_expected/.*"

--- a/runtime-ros/ros-jazzy-transmission-interface/autobuild/defines
+++ b/runtime-ros/ros-jazzy-transmission-interface/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-transmission-interface
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-hardware-interface ros-jazzy-pluginlib fmt"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gen-version-h ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-ros2-control-test-assets"
+PKGDES="API for robotic mechanical transmissions in ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-transmission-interface/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-transmission-interface/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-transmission-interface/spec
+++ b/runtime-ros/ros-jazzy-transmission-interface/spec
@@ -1,0 +1,4 @@
+VER=4.45.2+1
+SRCS="git::commit=tags/release/jazzy/transmission_interface/${VER/+/-}::https://github.com/ros2-gbp/ros2_control-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_control-release;pattern=release/jazzy/transmission_interface/.*"


### PR DESCRIPTION
Topic Description
-----------------

- ros-jazzy-ros2-control: new, 4.45.2+1
- ros-jazzy-transmission-interface: new, 4.45.2+1
- ros-jazzy-ros2controlcli: new, 4.45.2+1
- ros-jazzy-controller-manager: new, 4.45.2+1
- ros-jazzy-hardware-interface-testing: new, 4.45.2+1
- ros-jazzy-diagnostic-updater: new, 4.2.7+1
- ros-jazzy-controller-manager-msgs: new, 4.45.2+1
- ros-jazzy-controller-interface: new, 4.45.2+1
- ros-jazzy-hardware-interface: new, 4.45.2+1
- ros-jazzy-ros2-control-test-assets: new, 4.45.2+1

... and 22 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit ros-jazzy-gz-math-vendor ros-jazzy-orocos-kdl-vendor ros-jazzy-rviz-rendering ros-jazzy-laser-geometry ros-jazzy-ros2-control ros-jazzy-joint-state-publisher-gui xacro
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
