### PR TITLE
pcp: update to 7.1.5

### DIFF
--- a/app-utils/pcp/autobuild/beyond
+++ b/app-utils/pcp/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing docs ..."
+rm -rv "$PKGDIR"/var/lib/pcp/testsuite

--- a/app-utils/pcp/autobuild/defines
+++ b/app-utils/pcp/autobuild/defines
@@ -27,7 +27,6 @@ AUTOTOOLS_AFTER=(
     '--with-infiniband'
     '--with-user=pcp'
     '--with-group=pcp'
-    '--with-discovery'
     '--with-systemd'
     '--without-selinux'
     '--without-qt'
@@ -37,7 +36,6 @@ AUTOTOOLS_AFTER=(
     '--with-dstat-symlink'
     '--with-perfevent'
     '--with-pmdastatsd'
-    '--with-pmdabcc'
     '--without-pmdabpf'
     '--without-pmdabpftrace'
     '--with-pmdajson'
@@ -53,13 +51,6 @@ AUTOTOOLS_AFTER=(
 
 # FIXME: Hard-coded "./VERSION.pcp" path.
 ABSHADOW=0
-
-# FIXME: HAVE_64 in config.h.in; move to configsz.h.in for multilib. This
-# requires manual intervention after running an 'autoreconf'. Nuke it with
-# fire... or just discard the change to config.h.in in git.
-#
-# Disabling RECONF.
-RECONF=0
 
 # FIXME: NNO_CHOWN=true, do not perform chown based on user/group names during
 # installation.

--- a/app-utils/pcp/spec
+++ b/app-utils/pcp/spec
@@ -1,5 +1,4 @@
-VER=7.0.5
-REL=1
+VER=7.1.5
 SRCS="git::commit=tags/$VER::https://github.com/performancecopilot/pcp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231628"


### PR DESCRIPTION
Topic Description
-----------------

- pcp: update to 7.1.5

Package(s) Affected
-------------------

- pcp: 7.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit pcp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
