### PR TITLE
isodate: update to 0.7.2

### DIFF
--- a/app-multimedia/streamlink/autobuild/defines
+++ b/app-multimedia/streamlink/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=streamlink
 PKGSEC=video
-PKGDES="A tool for extracting video streams from various websites to a video player"
-PKGDEP="python-3 rtmpdump ffmpeg certifi isodate lxml pycountry pycryptodome pysocks requests typing-extensions urllib3 websocket-client trio trio-websocket"
-BUILDDEP="versioningit setuptools wheel"
+PKGDES="Command-line utility that extracts streams from various services and pipes them into a video player of choice"
+PKGDEP="python-3 rtmpdump ffmpeg certifi isodate lxml pycountry pycryptodome pysocks requests trio trio-websocket urllib3 websocket-client"
+BUILDDEP="versioningit setuptools"
 
 ABTYPE=python
 ABHOST=noarch

--- a/app-multimedia/streamlink/spec
+++ b/app-multimedia/streamlink/spec
@@ -1,5 +1,4 @@
-VER=6.7.4
-SRCS="tbl::https://pypi.io/packages/source/s/streamlink/streamlink-$VER.tar.gz"
-CHKSUMS="sha256::9337537ab119fe77524a5d665aaecebbfb06e2cb8df28d1260d92876425751ce"
+VER=8.4.0
+SRCS="pypi::version=$VER::streamlink"
+CHKSUMS="sha256::f477e9493336bcb7c3a2b10eea72a60ae9a7f49e968ada0d4d01bff78eac44bb"
 CHKUPDATE="anitya::id=47101"
-REL="1"

--- a/lang-python/isodate/autobuild/defines
+++ b/lang-python/isodate/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=isodate
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
+BUILDDEP="setuptools-scm"
 PKGDES="Date/time/duration parser and formatter"
 
 ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/isodate/spec
+++ b/lang-python/isodate/spec
@@ -1,5 +1,4 @@
-VER=0.6.1
-SRCS="tbl::https://pypi.io/packages/source/i/isodate/isodate-$VER.tar.gz"
-CHKSUMS="sha256::48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
+VER=0.7.2
+SRCS="pypi::version=$VER::isodate"
+CHKSUMS="sha256::4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6"
 CHKUPDATE="anitya::id=5686"
-REL="3"

--- a/lang-python/rdflib/autobuild/defines
+++ b/lang-python/rdflib/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=rdflib
 PKGSEC=python
-PKGDEP="isodate pyparsing"
-BUILDDEP="python-build python-installer poetry-core setuptools wheel"
-PKGDES="A python library for working with RDF"
+PKGDEP="pyparsing"
+BUILDDEP="poetry-core"
+PKGDES="Python library for working with RDF"
 
 ABTYPE=pep517
 

--- a/lang-python/rdflib/spec
+++ b/lang-python/rdflib/spec
@@ -1,5 +1,4 @@
-VER=6.2.0
-REL="2"
-SRCS="tbl::https://pypi.io/packages/source/r/rdflib/rdflib-$VER.tar.gz"
-CHKSUMS="sha256::62dc3c86d1712db0f55785baf8047f63731fa59b2682be03219cb89262065942"
+VER=7.6.0
+SRCS="pypi::version=$VER::rdflib"
+CHKSUMS="sha256::6c831288d5e4a5a7ece85d0ccde9877d512a3d0f02d7c06455d00d6d0ea379df"
 CHKUPDATE="anitya::id=20022"


### PR DESCRIPTION
Topic Description
-----------------

- streamlink: update to 8.4.0
- rdflib: update to 7.6.0
- isodate: update to 0.7.2

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit isodate rdflib streamlink
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
