### PR TITLE
libdatachannel: update to 0.24.3

### DIFF
--- a/runtime-multimedia/libdatachannel/spec
+++ b/runtime-multimedia/libdatachannel/spec
@@ -1,4 +1,4 @@
-VER=0.24.2
+VER=0.24.3
 SRCS="git::commit=tags/v$VER::https://github.com/paullouisageneau/libdatachannel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369160"


### PR DESCRIPTION
Topic Description
-----------------

- libdatachannel: update to 0.24.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libdatachannel: 0.24.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdatachannel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
