### PR TITLE
qemu: add a patch fixing RISC-V virt ACPI tables running in KVM

### DIFF
--- a/app-virtualization/qemu/01-shared/patches/0001-UPSTREAM-hw-riscv-virt-acpi-build.c-Use-kvm-timer-fr.patch
+++ b/app-virtualization/qemu/01-shared/patches/0001-UPSTREAM-hw-riscv-virt-acpi-build.c-Use-kvm-timer-fr.patch
@@ -1,0 +1,53 @@
+From 7769abd5467200cc9b5dc998d5bd2bbcd7ca7f73 Mon Sep 17 00:00:00 2001
+From: Yicong Yang <yang.yicong@picoheart.com>
+Date: Wed, 25 Mar 2026 16:13:14 +0800
+Subject: [PATCH 1/2] UPSTREAM: hw/riscv/virt-acpi-build.c: Use kvm timer
+ frequency when kvm enabled
+
+The timer frequency is decided by the host(kvm) rather than a fixed
+RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ on kvm accelerated VM. So build
+RCHT with KVM provided timer frequency if KVM is enabled, just like
+how we build the timer node on DT based VM.
+
+Fixes: ebfd39289370 ("hw/riscv/virt: virt-acpi-build.c: Add RHCT Table")
+Signed-off-by: Yicong Yang <yang.yicong@picoheart.com>
+Reviewed-by: Andrew Jones <andrew.jones@oss.qualcomm.com>
+Message-ID: <20260325081314.57089-1-yang.yicong@picoheart.com>
+Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
+(cherry picked from commit 4cb2f91773e8ec9511002de851734820f7ba64fe)
+Signed-off-by: Icenowy Zheng <zhengxingda@iscas.ac.cn>
+---
+ hw/riscv/virt-acpi-build.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/hw/riscv/virt-acpi-build.c b/hw/riscv/virt-acpi-build.c
+index f1406cb683..fd6ca5dbc4 100644
+--- a/hw/riscv/virt-acpi-build.c
++++ b/hw/riscv/virt-acpi-build.c
+@@ -35,9 +35,11 @@
+ #include "hw/riscv/virt.h"
+ #include "hw/riscv/numa.h"
+ #include "hw/virtio/virtio-acpi.h"
++#include "kvm/kvm_riscv.h"
+ #include "migration/vmstate.h"
+ #include "qapi/error.h"
+ #include "qemu/error-report.h"
++#include "system/kvm.h"
+ #include "system/reset.h"
+ 
+ #define ACPI_BUILD_TABLE_SIZE             0x20000
+@@ -296,7 +298,10 @@ static void build_rhct(GArray *table_data,
+ 
+     /* Time Base Frequency */
+     build_append_int_noprefix(table_data,
+-                              RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ, 8);
++                              kvm_enabled() ?
++                              kvm_riscv_get_timebase_frequency(&s->soc->harts[0]) :
++                              RISCV_ACLINT_DEFAULT_TIMEBASE_FREQ,
++                              8);
+ 
+     /* ISA + N hart info */
+     num_rhct_nodes = 1 + ms->smp.cpus;
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0002-FROMLIST-hw-riscv-virt-acpi-build-Fix-RINTC-PLIC-con.patch
+++ b/app-virtualization/qemu/01-shared/patches/0002-FROMLIST-hw-riscv-virt-acpi-build-Fix-RINTC-PLIC-con.patch
@@ -1,0 +1,48 @@
+From fbfdf75587145c14948ca6bf1127e59bb5955d21 Mon Sep 17 00:00:00 2001
+From: Qingwei Hu <qingwei.hu@bytedance.com>
+Date: Thu, 4 Jun 2026 20:00:17 +0800
+Subject: [PATCH 2/2] FROMLIST: hw/riscv/virt-acpi-build: Fix RINTC PLIC
+ context ID for KVM
+
+Each RISC-V MADT RINTC entry contains an External Interrupt Controller
+ID field. On the virt machine without AIA, this field identifies the
+S-mode PLIC context associated with the hart.
+
+TCG virt has both M-mode and S-mode PLIC contexts, so the S-mode context
+ID is odd and 2 * local_cpu_id + 1 is correct. KVM virt exposes only
+S-mode PLIC contexts, and those contexts are numbered contiguously from
+0. Reporting the TCG context ID for KVM makes the guest enable a
+different PLIC context from the one used by QEMU.
+
+With ACPI enabled, this can leave PCI INTx interrupts pending in QEMU
+while the guest-programmed PLIC context remains disabled. A virtio-blk
+root disk can then stall during boot because its first interrupt is never
+delivered.
+
+Use local_cpu_id for KVM and keep the existing odd S-mode context ID for
+TCG.
+
+Fixes: d641da6ed43 ("hw/riscv/virt-acpi-build.c: Add PLIC in MADT")
+Signed-off-by: Qingwei Hu <qingwei.hu@bytedance.com>
+Link: https://lore.kernel.org/qemu-devel/20260604120017.398890-1-qingwei.hu@bytedance.com/
+Signed-off-by: Icenowy Zheng <zhengxingda@iscas.ac.cn>
+---
+ hw/riscv/virt-acpi-build.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/hw/riscv/virt-acpi-build.c b/hw/riscv/virt-acpi-build.c
+index fd6ca5dbc4..504a93025b 100644
+--- a/hw/riscv/virt-acpi-build.c
++++ b/hw/riscv/virt-acpi-build.c
+@@ -100,6 +100,8 @@ static void riscv_acpi_madt_add_rintc(uint32_t uid,
+         build_append_int_noprefix(entry,
+                                   ACPI_BUILD_INTC_ID(
+                                       arch_ids->cpus[uid].props.node_id,
++                                      kvm_enabled() ?
++                                      local_cpu_id :
+                                       2 * local_cpu_id + 1),
+                                   4);
+     } else {
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=11.0.0
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
 CHKSUMS="sha256::c04ca36012653f32d11c674d370cf52a710e7d3f18c2d8b63e4932052a4854d6"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: add a patch fixing RISC-V virt ACPI tables running in KVM
    M mode does not exist when running RISC-V KVM, but QEMU's ACPI table
    generator for RISC-V virt machine unconditionally assume M mode PLIC
    contexts exist.
    Add a patch fix this problem.
    This fixes booting KVM-accelerated RISC-V VMs with EDK2 firmware \(which
    will take the ACPI table from QEMU and pass it to the OS\).
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- qemu: 11.0.0-1
- qemu-aarch64-static: 11.0.0-1
- qemu-alpha-static: 11.0.0-1
- qemu-arm-static: 11.0.0-1
- qemu-armeb-static: 11.0.0-1
- qemu-guest-agent: 11.0.0-1
- qemu-i386-static: 11.0.0-1
- qemu-loongarch64-static: 11.0.0-1
- qemu-m68k-static: 11.0.0-1
- qemu-microblaze-static: 11.0.0-1
- qemu-microblazeel-static: 11.0.0-1
- qemu-mips-static: 11.0.0-1
- qemu-mips64-static: 11.0.0-1
- qemu-mips64el-static: 11.0.0-1
- qemu-mipsel-static: 11.0.0-1
- qemu-mipsn32-static: 11.0.0-1
- qemu-mipsn32el-static: 11.0.0-1
- qemu-or32-static: 11.0.0-1
- qemu-ppc-static: 11.0.0-1
- qemu-ppc64-static: 11.0.0-1
- qemu-ppc64le-static: 11.0.0-1
- qemu-riscv32-static: 11.0.0-1
- qemu-riscv64-static: 11.0.0-1
- qemu-s390x-static: 11.0.0-1
- qemu-sh4-static: 11.0.0-1
- qemu-sh4eb-static: 11.0.0-1
- qemu-sparc-static: 11.0.0-1
- qemu-sparc32plus-static: 11.0.0-1
- qemu-sparc64-static: 11.0.0-1
- qemu-user-static: 11.0.0-1
- qemu-x86-64-static: 11.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
