### PR TITLE
feh: update to 3.12.2

### DIFF
--- a/app-imaging/feh/spec
+++ b/app-imaging/feh/spec
@@ -1,4 +1,4 @@
-VER=3.12.1
+VER=3.12.2
 SRCS="tbl::https://feh.finalrewind.org/feh-$VER.tar.bz2"
-CHKSUMS="sha256::6772f48e7956a16736e4c165a8367f357efc413b895f5b04133366e01438f95d"
+CHKSUMS="sha256::7ce358b18a7f37bcc97a09b4efd89fdadd54cd8e7032db345f61e66dd04b1c3f"
 CHKUPDATE="anitya::id=790"


### PR DESCRIPTION
Topic Description
-----------------

- feh: update to 3.12.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- feh: 3.12.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit feh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
