### PR TITLE
NVIDIA EGL wayland 2

### DIFF
--- a/runtime-display/egl-wayland2/autobuild/defines
+++ b/runtime-display/egl-wayland2/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=egl-wayland2
+PKGSEC=libs
+PKGDEP="libdrm mesa wayland libglvnd"
+PKGRECOM="egl-wayland"
+BUILDDEP="eglexternalplatform wayland-protocols"
+PKGDES="Wayland EGL External Platform library (Version 2)"
+
+ABTYPE=meson
+# NVIDIA driver 560+ required for this one to work.
+# Not declaring PKGBREAK as EGL falls back to the old implementation
+# on older NVIDIA drivers.

--- a/runtime-display/egl-wayland2/spec
+++ b/runtime-display/egl-wayland2/spec
@@ -1,0 +1,4 @@
+VER=1.0.1
+SRCS="git::commit=tags/v$VER::https://github.com/NVIDIA/egl-wayland2"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=389353"

--- a/runtime-display/eglexternalplatform/autobuild/build
+++ b/runtime-display/eglexternalplatform/autobuild/build
@@ -1,4 +1,0 @@
-install -Dvm644 "$SRCDIR"/interface/* \
-    -t "$PKGDIR"/usr/include/EGL/
-install -Dvm644 "$SRCDIR"/*.pc \
-    -t "$PKGDIR"/usr/lib/pkgconfig/

--- a/runtime-display/eglexternalplatform/autobuild/defines
+++ b/runtime-display/eglexternalplatform/autobuild/defines
@@ -4,3 +4,4 @@ PKGDEP="libglvnd"
 PKGDES="The EGL External Platform interface"
 
 ABHOST=noarch
+ABTYPE=meson

--- a/runtime-display/eglexternalplatform/spec
+++ b/runtime-display/eglexternalplatform/spec
@@ -1,5 +1,4 @@
-VER=1.1
-REL=1
-SRCS="tbl::https://github.com/NVIDIA/eglexternalplatform/archive/$VER.tar.gz"
-CHKSUMS="sha256::72725c4c9dd06b4d44bceb8794e1e78f75ed8702be23201282f8f937252a6b32"
+VER=1.2
+SRCS="git::commit=tags/${VER}::https://github.com/NVIDIA/eglexternalplatform.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=12877"


### PR DESCRIPTION
Topic Description
-----------------

- egl-wayland2: new, 1.0.1
- eglexternalplatform: update to 1.2

Package(s) Affected
-------------------

- egl-wayland2: 1.0.1
- eglexternalplatform: 1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit eglexternalplatform egl-wayland2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
