### PR TITLE
trove-classifiers: update to 2026.6.1.19

### DIFF
--- a/lang-python/trove-classifiers/autobuild/defines
+++ b/lang-python/trove-classifiers/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=trove-classifiers
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="python-build python-installer wheel calver setuptools-python3"
+BUILDDEP="setuptools calver"
 PKGDES="Canonical source for classifiers on PyPI"
 
 ABTYPE=pep517

--- a/lang-python/trove-classifiers/spec
+++ b/lang-python/trove-classifiers/spec
@@ -1,4 +1,4 @@
-VER=2026.1.14.14
+VER=2026.6.1.19
 SRCS="git::commit=$VER::https://github.com/pypa/trove-classifiers.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=88298"


### PR DESCRIPTION
Topic Description
-----------------

- trove-classifiers: update to 2026.6.1.19

Package(s) Affected
-------------------

- trove-classifiers: 2026.6.1.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit trove-classifiers
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
