### PR TITLE
vscode: update to 1.123.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.122.1
+VER=1.123.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::44efd0aa505f4dc39e1cda51a52e36486ffb306af2835bc16de69aec6c1a23c6"
-CHKSUMS__ARM64="sha256::e7df36813bc42117b49ff6dbb4e1f0b81e1c9dd69aef973c5d8ec91bf7d47281"
+CHKSUMS__AMD64="sha256::c94076e6855f2e360ff5cf6824a8bb8890fb748f41476e5e4c33f4c54696b70d"
+CHKSUMS__ARM64="sha256::48d5d5c1da4898e534fc11694900423c4197a030a09093d8eb93bd3c231415c0"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.123.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.123.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
