### PR TITLE
sdl2-compat: update to 2.32.68

### DIFF
--- a/runtime-multimedia/sdl2-compat/spec
+++ b/runtime-multimedia/sdl2-compat/spec
@@ -1,4 +1,4 @@
-VER=2.32.60
+VER=2.32.68
 SRCS="git::commit=tags/release-$VER::https://github.com/libsdl-org/sdl2-compat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376380"


### PR DESCRIPTION
Topic Description
-----------------

- sdl2-compat: update to 2.32.68
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- sdl2-compat: 2.32.68

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdl2-compat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
