### PR TITLE
m64py: fix dependency sdl2 to py-sdl2

### DIFF
--- a/app-games/m64py/autobuild/defines
+++ b/app-games/m64py/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=m64py
 PKGSEC=games
-PKGDEP="python-3 mupen64plus numpy pyqt6 sdl2"
+PKGDEP="python-3 mupen64plus numpy pyqt6 py-sdl2"
 BUILDDEP="python-build python-installer wheel"
 PKGDES="Graphical frontend for Mupen64Plus"
 

--- a/app-games/m64py/spec
+++ b/app-games/m64py/spec
@@ -1,5 +1,5 @@
 VER=0.3.0
-REL="2"
+REL="3"
 SRCS="tbl::https://downloads.sourceforge.net/m64py/m64py-$VER.tar.gz"
 CHKSUMS="sha256::ac81a1b40e2812ac9e27405285e4e0c2b6bddfb32fde28c88300c10112a02f92"
 CHKUPDATE="anitya::id=12271"

--- a/lang-python/py-sdl2/autobuild/defines
+++ b/lang-python/py-sdl2/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=py-sdl2
+PKGSEC=python
+PKGDEP="python-3 sdl2 sdl2-image sdl2-mixer sdl2-ttf sdl2-gfx"
+PKGDES="Python ctypes wrapper around SDL2"
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/py-sdl2/spec
+++ b/lang-python/py-sdl2/spec
@@ -1,0 +1,4 @@
+VER=0.9.17
+SRCS="git::commit=tags/$VER::https://github.com/py-sdl/py-sdl2"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=12950"


### PR DESCRIPTION
Topic Description
-----------------

- m64py: fix wrong dependency sdl2 to py-sdl2
- py-sdl2: new, 0.9.17

Package(s) Affected
-------------------

- m64py: 0.3.0-3
- py-sdl2: 0.9.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit py-sdl2 m64py
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
