### PR TITLE
pyiso8601: fix build

### DIFF
--- a/lang-python/pyiso8601/autobuild/defines
+++ b/lang-python/pyiso8601/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=pyiso8601
 PKGSEC=python
 PKGDES="ISO 8601-formatted datetime parser for Python"
 PKGDEP="python-3"
-BUILDDEP="setuptools"
+BUILDDEP="poetry-core"
 
 ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/pyiso8601/spec
+++ b/lang-python/pyiso8601/spec
@@ -1,5 +1,5 @@
 VER=2.1.0
+REL=2
 SRCS="git::commit=tags/${VER}::https://github.com/micktwomey/pyiso8601"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17228"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pyiso8601: fix build
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- pyiso8601: 2.1.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pyiso8601
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
