### PR TITLE
go: tools update to 0.45.0

### DIFF
--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,9 +1,8 @@
-UPSTREAM_VER=1.26.4
-# Versions of Golang and Go tools
-GO_VER=${UPSTREAM_VER/\~/}
-TOOLS_VER=0.42.0
+GO_VER=1.26.4
+# Go tools can be updated independently.
+TOOLS_VER=0.45.0
 
-VER="${UPSTREAM_VER}+tools${TOOLS_VER}"
+VER="${GO_VER}+tools${TOOLS_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools"
 CHKSUMS="sha256::4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d \


### PR DESCRIPTION
Topic Description
-----------------

- go: tools update to 0.45.0

Package(s) Affected
-------------------

- go: 1.26.4+tools0.45.0
- go-runtime: 1.26.4+tools0.45.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
