### PR TITLE
vala: update to 0.56.19

### DIFF
--- a/app-devel/vala/autobuild/defines
+++ b/app-devel/vala/autobuild/defines
@@ -1,10 +1,10 @@
 PKGNAME=vala
-PKGDES="Compiler for the Gobject type system"
+PKGSEC=devel
 PKGDEP="gcc glib graphviz gtk-doc libgee pkg-config noto-fonts"
 BUILDDEP="help2man libxslt gobject-introspection"
-PKGSEC=devel
+PKGDES="Compiler for the GObject type system"
 
-AB_FLAGS_O3=1
-RECONF=0
-
-AUTOTOOLS_AFTER="--enable-valadoc"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--enable-valadoc'
+)

--- a/app-devel/vala/autobuild/defines.stage2
+++ b/app-devel/vala/autobuild/defines.stage2
@@ -1,10 +1,10 @@
 PKGNAME=vala
-PKGDES="Compiler for the Gobject type system"
+PKGSEC=devel
 PKGDEP="gcc glib libgee pkg-config"
 BUILDDEP="help2man libxslt gobject-introspection"
-PKGSEC=devel
+PKGDES="Compiler for the GObject type system"
 
-AB_FLAGS_O3=1
-RECONF=0
-
-AUTOTOOLS_AFTER="--disable-valadoc"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--disable-valadoc'
+)

--- a/app-devel/vala/spec
+++ b/app-devel/vala/spec
@@ -1,5 +1,4 @@
-VER=0.56.18
-REL=1
+VER=0.56.19
 SRCS="https://download.gnome.org/sources/vala/${VER:0:4}/vala-$VER.tar.xz"
-CHKSUMS="sha256::f2affe7d40ab63db8e7b9ecc3f6bdc9c2fc7e3134c84ff2d795f482fe926a382"
+CHKSUMS="sha256::5ad7cbbfcc0de61b403d6797c9ef60455bfbebd8e162aec33b5b0b097adfb9d5"
 CHKUPDATE="anitya::id=5065"


### PR DESCRIPTION
Topic Description
-----------------

- vala: update to 0.56.19
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- vala: 0.56.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit vala
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
