### PR TITLE
libeconf: add PKGBREAK for linux-pam

### DIFF
--- a/app-admin/linux-pam/autobuild/defines
+++ b/app-admin/linux-pam/autobuild/defines
@@ -1,7 +1,6 @@
 PKGNAME=linux-pam
-PKGDES="Pluggable Authentication Modules"
 PKGSEC=admin
-
 PKGDEP="glibc libtirpc libnsl2 db systemd libeconf"
-
 BUILDDEP="docbook-xsl libxslt libxml2"
+PKGPRDEP="libeconf"
+PKGDES="Pluggable Authentication Modules"

--- a/app-admin/linux-pam/autobuild/defines
+++ b/app-admin/linux-pam/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=admin
 PKGDEP="glibc libtirpc libnsl2 db systemd libeconf"
 BUILDDEP="docbook-xsl libxslt libxml2"
 PKGPRDEP="libeconf"
+BUILDDEP="docbook-xsl"
 PKGDES="Pluggable Authentication Modules"

--- a/app-admin/linux-pam/autobuild/defines.stage2
+++ b/app-admin/linux-pam/autobuild/defines.stage2
@@ -1,14 +1,10 @@
 PKGNAME=linux-pam
-PKGDES="Pluggable Authentication Modules"
 PKGSEC=admin
-
 PKGDEP="glibc libtirpc libnsl2 db libeconf libxcrypt"
-
-BUILDDEP="docbook-xsl"
-BUILDDEP__RETRO=""
+PKGPRDEP="libeconf"
+PKGDES="Pluggable Authentication Modules"
 
 ABTYPE=meson
-
 MESON_AFTER=(
 	"-Ddocs=disabled"
 	"-Dexamples=false"

--- a/runtime-common/libeconf/autobuild/defines
+++ b/runtime-common/libeconf/autobuild/defines
@@ -7,3 +7,5 @@ ABTYPE=cmakeninja
 CMAKE_AFTER=(
     "-DBUILD_DOCUMENTATION=OFF"
 )
+
+PKGBREAK="linux-pam<=1.7.2"

--- a/runtime-common/libeconf/spec
+++ b/runtime-common/libeconf/spec
@@ -1,4 +1,5 @@
 VER=0.8.3
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/openSUSE/libeconf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21922"


### PR DESCRIPTION
Topic Description
-----------------

- linux-pam: rebuild for libeconf 0.8.3
- libeconf: add PKGBREAK for linux-pam
    Users updating from pre-March 2026 sysroots may run into an issue where
    linux-pam stopped working, as it was not updated in conjunction with
    libeconf.
    Force a rebuild to the current linux-pam version, just to be safe.

Package(s) Affected
-------------------

- libeconf: 0.8.3-1
- linux-pam: 1.7.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libeconf:-pkgbreak linux-pam libeconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
