### PR TITLE
aspell: update to 0.60.8.2

### DIFF
--- a/app-i18n/aspell/01-main/defines
+++ b/app-i18n/aspell/01-main/defines
@@ -1,6 +1,6 @@
 PKGNAME=aspell
 PKGSEC=localization
-PKGDES="An interactive spell checking program and the Aspell libraries"
+PKGDES="Interactive spell checking program and the Aspell libraries"
 PKGDEP="ncurses perl"
 PKGSUG="aspell-dicts"
 

--- a/app-i18n/aspell/spec
+++ b/app-i18n/aspell/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=0.60.8.1
+UPSTREAM_VER=0.60.8.2
 DICT_VER=20161024
 VER=${UPSTREAM_VER}+dict${DICT_VER}
 SRCS="tbl::https://ftp.gnu.org/gnu/aspell/aspell-${UPSTREAM_VER}.tar.gz \
       tbl::https://repo.aosc.io/aosc-repacks/aspell-dicts-${DICT_VER}.tar.xz"
-CHKSUMS="sha256::d6da12b34d42d457fa604e435ad484a74b2effcd120ff40acd6bb3fb2887d21b \
+CHKSUMS="sha256::57fe4863eae6048f72245a8575b44b718fb85ca14b9f8c0afc41b254dfd76919 \
          sha256::60e9e3ebbe818e04c9d2f51719cfac62c1c9e1280d31756ac237690e530510d8"
 CHKUPDATE="anitya::id=120"
 SUBDIR="aspell-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- aspell: fix build
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- aspell: 0.60.8.1+dict20161024-1
- aspell-dicts: 0.60.8.1+dict20161024-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aspell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
