### PR TITLE
woff2:  fix build

### DIFF
--- a/desktop-fonts/woff2/autobuild/beyond
+++ b/desktop-fonts/woff2/autobuild/beyond
@@ -1,2 +1,0 @@
-# FIXME: error when /usr/lib/gcc/specs is a directory.
-mv -v /specs /usr/lib/gcc/

--- a/desktop-fonts/woff2/autobuild/patches/0001-fix-build.patch
+++ b/desktop-fonts/woff2/autobuild/patches/0001-fix-build.patch
@@ -1,0 +1,38 @@
+From 1f184d05566b3e25827a1f8e68eb82b9ccf54f3b Mon Sep 17 00:00:00 2001
+From: Sergei Trofimovich <slyich@gmail.com>
+Date: Fri, 2 Aug 2024 22:12:03 +0100
+Subject: [PATCH] include/woff2/output.h: add missing <stdint.h> include
+
+Without the change `woff2` build fails on upcoming `gcc-15` as:
+
+    In file included from src/woff2_out.cc:9:
+    include/woff2/output.h:73:25: error: expected ')' before '*' token
+       73 |   WOFF2MemoryOut(uint8_t* buf, size_t buf_size);
+          |                 ~       ^
+          |                         )
+    include/woff2/output.h:79:3: error: 'uint8_t' does not name a type
+       79 |   uint8_t* buf_;
+          |   ^~~~~~~
+    include/woff2/output.h:16:1: note: 'uint8_t' is defined in header '<cstdint>';
+      this is probably fixable by adding '#include <cstdint>'
+       15 | #include <string>
+      +++ |+#include <cstdint>
+       16 |
+---
+ include/woff2/output.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/woff2/output.h b/include/woff2/output.h
+index 377e66c..7889e29 100644
+--- a/include/woff2/output.h
++++ b/include/woff2/output.h
+@@ -9,6 +9,8 @@
+ #ifndef WOFF2_WOFF2_OUT_H_
+ #define WOFF2_WOFF2_OUT_H_
+ 
++#include <stdint.h>
++
+ #include <algorithm>
+ #include <cstring>
+ #include <memory>
+

--- a/desktop-fonts/woff2/autobuild/prepare
+++ b/desktop-fonts/woff2/autobuild/prepare
@@ -1,4 +1,0 @@
-# FIXME: error when /usr/lib/gcc/specs is a directory.
-mv -v /usr/lib/gcc/specs /
-
-sed -i 's/NOT BUILD_SHARED_LIBS/TRUE/' CMakeLists.txt

--- a/desktop-fonts/woff2/spec
+++ b/desktop-fonts/woff2/spec
@@ -1,5 +1,5 @@
 VER=1.0.2
-REL=2
+REL=3
 SRCS="tbl::https://github.com/google/woff2/archive/v$VER.tar.gz"
 CHKSUMS="sha256::add272bb09e6384a4833ffca4896350fdb16e0ca22df68c0384773c67a175594"
 CHKUPDATE="anitya::id=17587"


### PR DESCRIPTION
Topic Description
-----------------

- woff2:  fix build
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- woff2: 1.0.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit woff2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
