### PR TITLE
rocm: Libraries MachineLearning update to 7.13

### DIFF
--- a/runtime-rocm/rocm-composable-kernel/autobuild/defines
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/defines
@@ -36,7 +36,6 @@ CMAKE_AFTER=(
     '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
     '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
-    '-DDL_KERNELS=ON'
     '-DDPP_KERNELS=ON'
     '-DCK_USE_FP8_ON_UNSUPPORTED_ARCH=OFF'
     '-DBUILD_DEV=OFF'

--- a/runtime-rocm/rocm-composable-kernel/spec
+++ b/runtime-rocm/rocm-composable-kernel/spec
@@ -1,6 +1,6 @@
-VER=7.2.0
+VER=7.13
 ENVREQ="total_mem=100"
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/composablekernel"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-miopen/spec
+++ b/runtime-rocm/rocm-miopen/spec
@@ -1,6 +1,6 @@
-VER=7.2.0
+VER=7.13
 ENVREQ="total_mem=100"
-SRCS="git::commit=tags/rocm-${VER};rename=rocm-libraries;copy-repo=true::https://github.com/ROCm/rocm-libraries.git"
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries;copy-repo=true::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/miopen"
 CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-rocmlir/spec
+++ b/runtime-rocm/rocm-rocmlir/spec
@@ -1,4 +1,4 @@
-VER=7.2.0
+VER=7.2.4
 SRCS="git::commit=tags/rocm-$VER::https://github.com/ROCm/rocMLIR"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378515"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-miopen: update to 7.13
- rocm-rocmlir: update to 7.2.4
- rocm-composable-kernel: update to 7.13

Package(s) Affected
-------------------

- rocm-composable-kernel: 7.13
- rocm-miopen: 7.13
- rocm-rocmlir: 7.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-composable-kernel rocm-rocmlir rocm-miopen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
