### PR TITLE
navidrome: update to 0.62.0

### DIFF
--- a/app-multimedia/navidrome/autobuild/prepare
+++ b/app-multimedia/navidrome/autobuild/prepare
@@ -7,12 +7,5 @@ GO_LDFLAGS=(
 abinfo "Building UI ..."
 pushd "$SRCDIR"/ui
 npm install
-
-# FIXME: Build error with nodejs-24 on loongarch64.
-# https://issues.chromium.org/issues/429974680
-if ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
-    node --no-liftoff "$SRCDIR"/ui/node_modules/.bin/vite build
-else
-    npm run build
-fi
+npm run build
 popd

--- a/app-multimedia/navidrome/spec
+++ b/app-multimedia/navidrome/spec
@@ -1,5 +1,4 @@
-VER=0.61.0
-REL=2
+VER=0.62.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/navidrome/navidrome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326646"


### PR DESCRIPTION
Topic Description
-----------------

- navidrome: update to 0.62.0

Package(s) Affected
-------------------

- navidrome: 0.62.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit navidrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
