### PR TITLE
libmpd: fix C99 compile error and add missing strndup function including

### DIFF
--- a/runtime-multimedia/libmpd/autobuild/patches/0001-FEDORA-libmpd-c99.patch
+++ b/runtime-multimedia/libmpd/autobuild/patches/0001-FEDORA-libmpd-c99.patch
@@ -1,0 +1,16 @@
+Return an error code instead of NULL.  Fixes an int-conversion build
+failure.
+
+diff --git a/src/libmpd-playlist.c b/src/libmpd-playlist.c
+index c3c30ec019bb6bc9..64c64ea4412a7830 100644
+--- a/src/libmpd-playlist.c
++++ b/src/libmpd-playlist.c
+@@ -780,7 +780,7 @@ int mpd_playlist_load(MpdObj *mi, const char *path)
+ 	if(mpd_lock_conn(mi))
+ 	{
+ 		debug_printf(DEBUG_ERROR,"lock failed\n");
+-		return NULL;
++		return MPD_LOCK_FAILED;
+ 	}
+     mpd_sendLoadCommand(mi->connection,path);
+ 	mpd_finishCommand(mi->connection);

--- a/runtime-multimedia/libmpd/autobuild/patches/0002-FEDORA-libmpd-11.8.17-strndup.patch
+++ b/runtime-multimedia/libmpd/autobuild/patches/0002-FEDORA-libmpd-11.8.17-strndup.patch
@@ -1,0 +1,15 @@
+In file included from /usr/include/string.h:630:0,
+		 from libmpd-strfsong.c:29:
+libmpd-internal.h:210:10: error: expected identifier or '(' before '__extension__'
+	char *   strndup     (const char *s, size_t n);
+
+--- a/src/libmpd-strfsong.c
++++ b/src/libmpd-strfsong.c
+@@ -28,6 +28,7 @@
+ #include <unistd.h>
+ #include <string.h>
+ #include <glib.h>
++#include "config.h"
+ #include "libmpd.h"
+ #include "libmpd-internal.h"
+ 

--- a/runtime-multimedia/libmpd/spec
+++ b/runtime-multimedia/libmpd/spec
@@ -1,5 +1,5 @@
 VER=11.8.17
-REL=2
+REL=3
 SRCS="tbl::https://download.sarine.nl/Programs/gmpc/${VER:0:4}/libmpd-$VER.tar.gz"
 CHKSUMS="sha256::fe20326b0d10641f71c4673fae637bf9222a96e1712f71f170fca2fc34bf7a83"
 CHKUPDATE="anitya::id=21661"


### PR DESCRIPTION
Topic Description
-----------------

- libmpd: fix C99 compile error and add missing strndup function including

Package(s) Affected
-------------------

- libmpd: 11.8.17-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
