### PR TITLE
ps3netsrv-go: update to 0.4.0

### DIFF
--- a/app-network/ps3netsrv-go/autobuild/defines
+++ b/app-network/ps3netsrv-go/autobuild/defines
@@ -6,13 +6,3 @@ BUILDDEP="go zstd"
 GO_PACKAGES=("cmd/ps3netsrv-go")
 
 ABTYPE=gomod
-# FIXME: Missing architcture support for MIPS
-#
-# # github.com/ebitengine/purego
-# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:189:9: undefined: addStruct
-# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:300:64: undefined: shouldBundleStackArgs
-# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:302:32: undefined: collectStackArgs
-# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:307:5: undefined: bundleStackArgs
-# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:380:8: undefined: getStruct
-# ../abgopath/pkg/mod/github.com/ebitengine/purego@v0.10.0/func.go:433:15: undefined: addStruct
-FAIL_ARCH="(loongson3)"

--- a/app-network/ps3netsrv-go/spec
+++ b/app-network/ps3netsrv-go/spec
@@ -1,4 +1,4 @@
-VER=0.3.1
+VER=0.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/xakep666/ps3netsrv-go"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383793"


### PR DESCRIPTION
Topic Description
-----------------

- ps3netsrv-go: update to 0.4.0

Package(s) Affected
-------------------

- ps3netsrv-go: 0.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ps3netsrv-go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
