### PR TITLE
rsync: update to 3.4.4

### DIFF
--- a/app-network/rsync/spec
+++ b/app-network/rsync/spec
@@ -1,4 +1,4 @@
-VER=3.4.3
+VER=3.4.4
 SRCS="tbl::https://download.samba.org/pub/rsync/rsync-$VER.tar.gz"
-CHKSUMS="sha256::c72e63ca3021cbc80ba86ec30102773f4c5631fbc492b52e773b3958f82a53d3"
+CHKSUMS="sha256::bd88cf82fa653da32314fb229136407c5c90f80d1758d8f4b091767877d8fa96"
 CHKUPDATE="anitya::id=4217"


### PR DESCRIPTION
Topic Description
-----------------

- rsync: update to 3.4.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- rsync: 3.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit rsync
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
