### PR TITLE
binutils: update to 2.46.1

### DIFF
--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,4 @@
-VER=2.46.0
-REL=1
+VER=2.46.1
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
-CHKSUMS="sha256::d75a94f4d73e7a4086f7513e67e439e8fcdcbb726ffe63f4661744e6256b2cf2"
+CHKSUMS="sha256::e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: update to 2.46.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- binutils: 2.46.1
- binutils+cross-amd64: 2.46.1
- binutils+cross-arm-none-eabi: 2.46.1
- binutils+cross-arm64: 2.46.1
- binutils+cross-loongarch64: 2.46.1
- binutils+cross-loongson3: 2.46.1
- binutils+cross-ppc64el: 2.46.1
- binutils+cross-riscv64: 2.46.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
