### PR TITLE
Zathura Document Viewer Survey 20260609

### DIFF
--- a/app-doc/zathura-cb/autobuild/defines
+++ b/app-doc/zathura-cb/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=zathura-cb
+PKGSEC=doc
+PKGDEP="libarchive zathura girara glib cairo"
+BUILDDEP="meson"
+PKGDES="Comic book support for Zathura"
+
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dtests=disabled'
+)

--- a/app-doc/zathura-cb/spec
+++ b/app-doc/zathura-cb/spec
@@ -1,0 +1,4 @@
+VER=2026.05.10
+SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-cb"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=14845"

--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,4 +1,4 @@
-VER=2026.02.03
+VER=2026.05.10
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,4 +1,4 @@
-VER=2026.02.03
+VER=2026.05.10
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -1,13 +1,14 @@
 PKGNAME=zathura
 PKGSEC=doc
 PKGDEP="gtk-3 glib json-glib girara sqlite file libseccomp texlive"
-BUILDDEP="sphinx bash-completion fish librsvg"
+BUILDDEP="sphinx bash-completion fish librsvg gettext"
 PKGDES="Document viewer"
 
 ABTYPE=meson
 MESON_AFTER=(
     '-Dsynctex=enabled'
     '-Dseccomp=enabled'
+    '-Dlandlock=enabled'
     '-Dmanpages=enabled'
     '-Dtests=disabled'
     '-Dconvert-icon=enabled'

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=2026.02.22
+VER=2026.05.20
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-cb: new, 2026.05.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-pdf-poppler: update to 2026.05.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-djvu: update to 2026.05.10
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura: update to 2026.05.20
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- zathura: 2026.05.20
- zathura-cb: 2026.05.10
- zathura-djvu: 2026.05.10
- zathura-pdf-poppler: 2026.05.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit zathura zathura-djvu zathura-pdf-poppler zathura-cb
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
