### PR TITLE
ipython: update to 9.14.1

### DIFF
--- a/lang-python/ipython/spec
+++ b/lang-python/ipython/spec
@@ -1,4 +1,4 @@
-VER=9.14.0
+VER=9.14.1
 SRCS="tbl::https://pypi.io/packages/source/i/ipython/ipython-$VER.tar.gz"
-CHKSUMS="sha256::6f27ff0f1d9ea050e0551f71568bc4b34d8aba579e8f111c5b4175f44ac6b4aa"
+CHKSUMS="sha256::f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b"
 CHKUPDATE="anitya::id=1399"


### PR DESCRIPTION
Topic Description
-----------------

- ipython: update to 9.14.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ipython: 9.14.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
