### PR TITLE
wine-emukit: update 11.10+gecko2.47.4+mono11.1.0

### DIFF
--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,10 +1,10 @@
 # Note: Sync with main `wine' package.
 EPOCH=3
 __GECKO_VER=2.47.4
-__MONO_VER=10.4.1
-UPSTREAM_VER=11.1
+__MONO_VER=11.1.0
+UPSTREAM_VER=11.10
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="file::rename=wine.deb::https://repo.aosc.io/anthon/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::87a88ae8768fc6da6aee9383f7f9c1dbd41d291070817ba1d39e8e9c7eddd410"
+CHKSUMS="sha256::fd2f1d38f4adbc4aaba9e8c9dcbe3b9900c28e605d55d0d5161bbf298caefaf7"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- wine-emukit: update 11.10+gecko2.47.4+mono11.1.0

Package(s) Affected
-------------------

- wine: 11.10+gecko2.47.4+mono11.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine-emukit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
