### PR TITLE
fcitx5-mozc: revive, update to 3.33.6133+fcitx5+git20260609

### DIFF
--- a/app-i18n/fcitx5-mozc/autobuild/beyond
+++ b/app-i18n/fcitx5-mozc/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing Fcitx 5 Mozc Icons ..."
+cd "$SRCDIR"/../mozc/scripts
+PREFIX="$PKGDIR"/usr "$SRCDIR"/../mozc/scripts/install_fcitx5_icons

--- a/app-i18n/fcitx5-mozc/autobuild/defines
+++ b/app-i18n/fcitx5-mozc/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME="fcitx5-mozc"
+PKGDES="Mozc input method for fcitx5"
+PKGDEP="fcitx5 hicolor-icon-theme qt-6"
+PKGSEC="x11"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_MOZC_ADDON=on'
+)

--- a/app-i18n/fcitx5-mozc/autobuild/patches/0001-AOSCOS-Fix-missing-python-binary-use-python3.patch
+++ b/app-i18n/fcitx5-mozc/autobuild/patches/0001-AOSCOS-Fix-missing-python-binary-use-python3.patch
@@ -1,0 +1,68 @@
+From 2ce78a8d8e65873ab8d6d267434c5885a8f9d8a1 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <wukaiyang@loongfans.cn>
+Date: Tue, 9 Jun 2026 16:23:44 +0800
+Subject: [PATCH] AOSCOS: Fix missing python binary, use python3
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ cmake/base.cmake                | 2 +-
+ scripts/gen_pos_cost_map.sh     | 2 +-
+ scripts/gen_pos_map.sh          | 2 +-
+ scripts/gen_pos_matcher_code.sh | 2 +-
+ scripts/gen_version_def.sh      | 4 ++--
+ 5 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/cmake/base.cmake b/cmake/base.cmake
+index c824835..24aac84 100644
+--- a/cmake/base.cmake
++++ b/cmake/base.cmake
+@@ -40,7 +40,7 @@ list(TRANSFORM composition_table PREPEND "preedit/")
+ 
+ add_custom_command(
+     OUTPUT "${config_file_stream_data_inc}"
+-    COMMAND python "${MOZC_SRC_DIR}/base/gen_config_file_stream_data.py" --output "${config_file_stream_data_inc}" ${composition_table} ${keymap_files}
++    COMMAND python3 "${MOZC_SRC_DIR}/base/gen_config_file_stream_data.py" --output "${config_file_stream_data_inc}" ${composition_table} ${keymap_files}
+     WORKING_DIRECTORY "${MOZC_SRC_DIR}/data"
+     COMMENT "Generating config_file_stream_data.inc"
+ )
+diff --git a/scripts/gen_pos_cost_map.sh b/scripts/gen_pos_cost_map.sh
+index 60d9ae3..7ba9d2a 100755
+--- a/scripts/gen_pos_cost_map.sh
++++ b/scripts/gen_pos_cost_map.sh
+@@ -1,3 +1,3 @@
+ set -e
+ 
+-PYTHONPATH=. python dictionary/gen_pos_cost_map.py --user_pos_file data/rules/user_pos.def --output $1
++PYTHONPATH=. python3 dictionary/gen_pos_cost_map.py --user_pos_file data/rules/user_pos.def --output $1
+diff --git a/scripts/gen_pos_map.sh b/scripts/gen_pos_map.sh
+index e2d0610..9949bcd 100755
+--- a/scripts/gen_pos_map.sh
++++ b/scripts/gen_pos_map.sh
+@@ -1,3 +1,3 @@
+ set -e
+ 
+-PYTHONPATH=. python dictionary/gen_pos_map.py --user_pos_file data/rules/user_pos.def --third_party_pos_map_file data/rules/third_party_pos_map.def --output $1
++PYTHONPATH=. python3 dictionary/gen_pos_map.py --user_pos_file data/rules/user_pos.def --third_party_pos_map_file data/rules/third_party_pos_map.def --output $1
+diff --git a/scripts/gen_pos_matcher_code.sh b/scripts/gen_pos_matcher_code.sh
+index 92c8719..ca497bb 100755
+--- a/scripts/gen_pos_matcher_code.sh
++++ b/scripts/gen_pos_matcher_code.sh
+@@ -1,3 +1,3 @@
+ set -e
+ 
+-PYTHONPATH=. python dictionary/gen_pos_matcher_code.py --pos_matcher_rule_file=data/rules/pos_matcher_rule.def --output_pos_matcher_h=$1
++PYTHONPATH=. python3 dictionary/gen_pos_matcher_code.py --pos_matcher_rule_file=data/rules/pos_matcher_rule.def --output_pos_matcher_h=$1
+diff --git a/scripts/gen_version_def.sh b/scripts/gen_version_def.sh
+index 1320724..81e1566 100755
+--- a/scripts/gen_version_def.sh
++++ b/scripts/gen_version_def.sh
+@@ -1,4 +1,4 @@
+ set -e
+ 
+-python build_tools/mozc_version.py --template_path version.bzl --target_platform=Mac --output $1
+-PYTHONPATH=. python build_tools/replace_version.py --version_file $1 --branding Mozc --input base/version_def_template.h --output $2
++python3 build_tools/mozc_version.py --template_path version.bzl --target_platform=Mac --output $1
++PYTHONPATH=. python3 build_tools/replace_version.py --version_file $1 --branding Mozc --input base/version_def_template.h --output $2
+-- 
+2.52.0
+

--- a/app-i18n/fcitx5-mozc/autobuild/prepare
+++ b/app-i18n/fcitx5-mozc/autobuild/prepare
@@ -1,0 +1,7 @@
+abinfo "Applying patches to protobuf ..."
+cd "$SRCDIR"/protobuf
+ab_apply_patches "$SRCDIR"/patches/protobuf.patch
+
+abinfo "Preparing mozc_data.inc ..."
+install -Dvm644 "$SRCDIR"/../mozc_data.inc \
+    -t "$BLDDIR"/data_manager/oss/

--- a/app-i18n/fcitx5-mozc/spec
+++ b/app-i18n/fcitx5-mozc/spec
@@ -1,0 +1,20 @@
+VER=3.33.6133+fcitx5+git20260609
+
+# NOTE: For each update, use local bazelisk to build mozc_data.inc from
+# fcitx5-mozc/mozc/src using the following command:
+#
+#    cd fcitx5-mozc/mozc/src
+#    bazelisk build --config oss_linux //data_manager/oss:mozc_data.inc
+#
+# and upload fcitx5-mozc/mozc/src/bazel-bin/data_manager/oss/mozc_data.inc to
+# aosc-repacks.
+#
+# NOTE: We use fcitx/mozc for input method status icons
+SRCS="git::commit=b8f1cc197fa7a62f9837ef909b1978ae3a0f7b17::https://github.com/fcitx-contrib/fcitx5-mozc.git \
+      git::commit=379a0cd1383b30d5bd30649940ebb040dbf0ae90;rename=mozc;submodule=false::https://github.com/fcitx/mozc.git \
+      file::rename=mozc_data.inc::https://repo.aosc.io/aosc-repacks/mozc_data_3.33.6133%2Bfcitx5%2Bgit20260609.inc"
+CHKSUMS="SKIP \
+         SKIP \
+         sha256::8927843f00d006f8c5df818f57b6a8bbf07240ec9f3ce2418baeaa81fd37482a"
+SUBDIR="fcitx5-mozc"
+CHKUPDATE="anitya::id=2016"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-mozc: revive, update to 3.33.6133+fcitx5+git20260609
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fcitx5-mozc: 3.33.6133+fcitx5+git20260609

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-mozc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
