### PR TITLE
codex: update to 0.138.0

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,31 +1,32 @@
-From 55240ec15d26fc0b6196e16c480cb0ca63dd9590 Mon Sep 17 00:00:00 2001
+From 6d5a5d409448ae1632e9b19fca5d88c24eee5a00 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Tue, 31 Mar 2026 15:36:13 +0800
+Date: Tue, 9 Jun 2026 14:36:42 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
 
+Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
 ---
  codex-rs/Cargo.lock | 2 --
  codex-rs/Cargo.toml | 2 ++
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 10b5cc2351..9a75aa6f9e 100644
+index d67e418..d86f8bb 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -13603,8 +13603,6 @@ dependencies = [
+@@ -14069,8 +14069,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "146.4.0"
+ version = "147.4.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "d97bcac5cdc5a195a4813f1855a6bc658f240452aac36caa12fd6c6f16026ab1"
+-checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
  dependencies = [
   "bindgen",
   "bitflags 2.10.0",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index c1258e83a1..133a6b4743 100644
+index 9522dcc..986b91c 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -516,5 +516,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -532,5 +532,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  
@@ -34,5 +35,5 @@ index c1258e83a1..133a6b4743 100644
  [patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
  tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
 -- 
-2.54.0
+2.52.0
 

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
@@ -1,15 +1,15 @@
-From 1bd4f0450b43560fb9ea15cec50a6a6ba4e75a6c Mon Sep 17 00:00:00 2001
+From d813a26e9b717bdcf7e3c8b4dd4374aaeaaa49c1 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Mon, 11 May 2026 14:42:19 +0800
+Date: Tue, 9 Jun 2026 14:39:06 +0800
 Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
 
-https://github.com/openai/codex/issues/14065
+Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
 ---
- codex-rs/Cargo.lock | 228 ++++++++++++++++++++++----------------------
- 1 file changed, 114 insertions(+), 114 deletions(-)
+ codex-rs/Cargo.lock | 244 ++++++++++++++++++++++----------------------
+ 1 file changed, 122 insertions(+), 122 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 9a75aa6f9e..7902126c3a 100644
+index d86f8bb..87e6991 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -402,7 +402,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
@@ -17,804 +17,867 @@ index 9a75aa6f9e..7902126c3a 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1778,7 +1778,7 @@ dependencies = [
+@@ -1800,7 +1800,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-graph-store"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "codex-protocol",
-@@ -1793,7 +1793,7 @@ dependencies = [
+@@ -1815,7 +1815,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-identity"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1812,7 +1812,7 @@ dependencies = [
+@@ -1834,7 +1834,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1832,7 +1832,7 @@ dependencies = [
+@@ -1854,7 +1854,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1841,7 +1841,7 @@ dependencies = [
+@@ -1863,7 +1863,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1875,7 +1875,7 @@ dependencies = [
+@@ -1898,7 +1898,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -1956,7 +1956,7 @@ dependencies = [
+@@ -1987,7 +1987,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -1981,7 +1981,7 @@ dependencies = [
+@@ -2014,7 +2014,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-app-server-daemon"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "anyhow",
+  "codex-app-server-protocol",
+@@ -2035,7 +2035,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2008,7 +2008,7 @@ dependencies = [
+@@ -2062,7 +2062,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2029,7 +2029,7 @@ dependencies = [
+@@ -2083,7 +2083,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-transport"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2068,7 +2068,7 @@ dependencies = [
+@@ -2122,7 +2122,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2087,7 +2087,7 @@ dependencies = [
+@@ -2141,7 +2141,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -2104,7 +2104,7 @@ dependencies = [
+@@ -2160,7 +2160,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "pretty_assertions",
-@@ -2114,7 +2114,7 @@ dependencies = [
+@@ -2170,7 +2170,7 @@ dependencies = [
  
  [[package]]
  name = "codex-aws-auth"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "aws-config",
   "aws-credential-types",
-@@ -2129,7 +2129,7 @@ dependencies = [
+@@ -2185,7 +2185,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -2146,7 +2146,7 @@ dependencies = [
+@@ -2202,7 +2202,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "serde",
   "serde_json",
-@@ -2155,7 +2155,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-builtin-mcps"
--version = "0.0.0"
-+version = "0.130.0"
- dependencies = [
-  "anyhow",
-  "codex-memories-mcp",
-@@ -2166,7 +2166,7 @@ dependencies = [
+@@ -2211,7 +2211,7 @@ dependencies = [
  
  [[package]]
  name = "codex-bwrap"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "cc",
   "libc",
-@@ -2175,7 +2175,7 @@ dependencies = [
+@@ -2220,7 +2220,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2198,7 +2198,7 @@ dependencies = [
+@@ -2243,7 +2243,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2255,7 +2255,7 @@ dependencies = [
+@@ -2317,7 +2317,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "bytes",
-@@ -2286,7 +2286,7 @@ dependencies = [
+@@ -2348,7 +2348,7 @@ dependencies = [
  
  [[package]]
- name = "codex-cloud-requirements"
+ name = "codex-cloud-config"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
-  "async-trait",
   "base64 0.22.1",
-@@ -2311,7 +2311,7 @@ dependencies = [
+  "chrono",
+@@ -2371,7 +2371,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2343,7 +2343,7 @@ dependencies = [
+@@ -2403,7 +2403,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2358,7 +2358,7 @@ dependencies = [
+@@ -2418,7 +2418,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "chrono",
-@@ -2368,7 +2368,7 @@ dependencies = [
+@@ -2428,7 +2428,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
-  "async-channel",
-  "async-trait",
-@@ -2385,11 +2385,11 @@ dependencies = [
+  "codex-protocol",
+  "deno_core_icudata",
+@@ -2443,11 +2443,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -2435,7 +2435,7 @@ dependencies = [
+@@ -2495,7 +2495,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2447,7 +2447,7 @@ dependencies = [
+@@ -2511,7 +2511,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-context-fragments"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "codex-protocol",
+  "codex-utils-string",
+@@ -2519,7 +2519,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2567,7 +2567,7 @@ dependencies = [
+@@ -2641,7 +2641,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-api"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-analytics",
   "codex-app-server-protocol",
-@@ -2585,7 +2585,7 @@ dependencies = [
+@@ -2660,7 +2660,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-plugins"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2623,7 +2623,7 @@ dependencies = [
+@@ -2700,7 +2700,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-skills"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-analytics",
-@@ -2654,7 +2654,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-debug-client"
--version = "0.0.0"
-+version = "0.130.0"
- dependencies = [
-  "anyhow",
-  "clap",
-@@ -2666,7 +2666,7 @@ dependencies = [
+@@ -2732,7 +2732,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2711,7 +2711,7 @@ dependencies = [
+@@ -2778,7 +2778,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2748,7 +2748,7 @@ dependencies = [
+@@ -2820,7 +2820,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2765,7 +2765,7 @@ dependencies = [
+@@ -2837,7 +2837,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy-legacy"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "allocative",
   "anyhow",
-@@ -2785,7 +2785,7 @@ dependencies = [
+@@ -2857,7 +2857,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2794,7 +2794,7 @@ dependencies = [
+@@ -2866,7 +2866,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-extension-api"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "async-trait",
+  "codex-context-fragments",
+@@ -2876,7 +2876,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-migration"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-hooks",
   "pretty_assertions",
-@@ -2806,7 +2806,7 @@ dependencies = [
+@@ -2888,7 +2888,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-sessions"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "chrono",
   "codex-app-server-protocol",
-@@ -2820,7 +2820,7 @@ dependencies = [
+@@ -2902,7 +2902,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -2833,7 +2833,7 @@ dependencies = [
+@@ -2915,7 +2915,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-login",
-@@ -2846,7 +2846,7 @@ dependencies = [
+@@ -2928,7 +2928,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2862,7 +2862,7 @@ dependencies = [
+@@ -2944,7 +2944,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-system"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "codex-protocol",
-@@ -2872,7 +2872,7 @@ dependencies = [
+@@ -2954,7 +2954,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-file-watcher"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "notify",
+  "pretty_assertions",
+@@ -2965,7 +2965,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2896,7 +2896,7 @@ dependencies = [
+@@ -2989,7 +2989,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-goal-extension"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "anyhow",
+  "async-trait",
+@@ -3011,7 +3011,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-guardian"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "async-trait",
+  "codex-core",
+@@ -3021,7 +3021,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2919,7 +2919,7 @@ dependencies = [
+@@ -3044,7 +3044,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-image-generation-extension"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "async-trait",
+  "codex-api",
+@@ -3065,7 +3065,7 @@ dependencies = [
  
  [[package]]
  name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
+  "codex-utils-absolute-path",
   "codex-utils-home-dir",
-  "pretty_assertions",
-@@ -2928,7 +2928,7 @@ dependencies = [
+@@ -3075,7 +3075,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "keyring",
   "tracing",
-@@ -2936,7 +2936,7 @@ dependencies = [
+@@ -3083,7 +3083,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "clap",
   "codex-core",
-@@ -2959,7 +2959,7 @@ dependencies = [
+@@ -3107,7 +3107,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -2973,7 +2973,7 @@ dependencies = [
+@@ -3121,7 +3121,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3015,7 +3015,7 @@ dependencies = [
+@@ -3163,7 +3163,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-channel",
-@@ -3048,7 +3048,7 @@ dependencies = [
+@@ -3195,7 +3195,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-arg0",
-@@ -3079,7 +3079,7 @@ dependencies = [
+@@ -3227,7 +3227,7 @@ dependencies = [
  
  [[package]]
- name = "codex-memories-mcp"
+ name = "codex-memories-extension"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
-  "anyhow",
-  "codex-utils-absolute-path",
-@@ -3096,7 +3096,7 @@ dependencies = [
+  "async-trait",
+  "codex-core",
+@@ -3249,7 +3249,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-read"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -3110,7 +3110,7 @@ dependencies = [
+@@ -3259,7 +3259,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-write"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3145,7 +3145,7 @@ dependencies = [
+@@ -3294,7 +3294,7 @@ dependencies = [
  
  [[package]]
  name = "codex-message-history"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-config",
-  "pretty_assertions",
-@@ -3158,7 +3158,7 @@ dependencies = [
+  "memchr",
+@@ -3308,7 +3308,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "codex-agent-identity",
-@@ -3182,7 +3182,7 @@ dependencies = [
+@@ -3332,7 +3332,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider-info"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-api",
   "codex-app-server-protocol",
-@@ -3199,7 +3199,7 @@ dependencies = [
+@@ -3349,7 +3349,7 @@ dependencies = [
  
  [[package]]
  name = "codex-models-manager"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "chrono",
-@@ -3220,7 +3220,7 @@ dependencies = [
+@@ -3370,7 +3370,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3251,7 +3251,7 @@ dependencies = [
+@@ -3404,7 +3404,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -3270,7 +3270,7 @@ dependencies = [
+@@ -3424,7 +3424,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -3302,7 +3302,7 @@ dependencies = [
+@@ -3456,7 +3456,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-config",
   "codex-utils-absolute-path",
-@@ -3312,7 +3312,7 @@ dependencies = [
+@@ -3466,7 +3466,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -3320,7 +3320,7 @@ dependencies = [
+@@ -3474,7 +3474,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-prompts"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "anyhow",
+  "codex-context-fragments",
+@@ -3488,7 +3488,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -3361,7 +3361,7 @@ dependencies = [
+@@ -3528,7 +3528,7 @@ dependencies = [
  
  [[package]]
  name = "codex-realtime-webrtc"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "libwebrtc",
   "thiserror 2.0.18",
-@@ -3370,7 +3370,7 @@ dependencies = [
+@@ -3537,7 +3537,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3381,7 +3381,7 @@ dependencies = [
+@@ -3548,7 +3548,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3398,7 +3398,7 @@ dependencies = [
+@@ -3565,7 +3565,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -3435,7 +3435,7 @@ dependencies = [
+@@ -3605,7 +3605,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3460,7 +3460,7 @@ dependencies = [
+@@ -3631,7 +3631,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout-trace"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-code-mode",
-@@ -3475,7 +3475,7 @@ dependencies = [
+@@ -3647,7 +3647,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3496,7 +3496,7 @@ dependencies = [
+@@ -3668,7 +3668,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "age",
   "anyhow",
-@@ -3517,7 +3517,7 @@ dependencies = [
+@@ -3689,7 +3689,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3537,7 +3537,7 @@ dependencies = [
+@@ -3710,7 +3710,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "async-trait",
-@@ -3558,7 +3558,7 @@ dependencies = [
+@@ -3731,7 +3731,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-utils-absolute-path",
   "include_dir",
-@@ -3567,7 +3567,7 @@ dependencies = [
+@@ -3740,7 +3740,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-skills-extension"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "async-trait",
+  "codex-core",
+@@ -3753,7 +3753,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3590,7 +3590,7 @@ dependencies = [
+@@ -3776,7 +3776,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-uds",
-@@ -3602,7 +3602,7 @@ dependencies = [
+@@ -3788,7 +3788,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -3610,7 +3610,7 @@ dependencies = [
+@@ -3796,7 +3796,7 @@ dependencies = [
  
  [[package]]
  name = "codex-test-binary-support"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-arg0",
   "tempfile",
-@@ -3618,7 +3618,7 @@ dependencies = [
+@@ -3804,7 +3804,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-manager-sample"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3629,7 +3629,7 @@ dependencies = [
+@@ -3815,7 +3815,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-store"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-trait",
   "chrono",
-@@ -3649,7 +3649,7 @@ dependencies = [
+@@ -3837,7 +3837,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
+  "async-trait",
   "codex-app-server-protocol",
-  "codex-code-mode",
-@@ -3666,7 +3666,7 @@ dependencies = [
+@@ -3861,7 +3861,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "arboard",
-@@ -3773,7 +3773,7 @@ dependencies = [
+@@ -3971,7 +3971,7 @@ dependencies = [
  
  [[package]]
  name = "codex-uds"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "async-io",
   "pretty_assertions",
-@@ -3785,7 +3785,7 @@ dependencies = [
+@@ -3983,7 +3983,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "dirs",
   "dunce",
-@@ -3799,14 +3799,14 @@ dependencies = [
+@@ -3997,14 +3997,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-protocol",
  ]
@@ -822,125 +885,125 @@ index 9a75aa6f9e..7902126c3a 100644
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "lru 0.16.3",
-  "sha1",
-@@ -3815,7 +3815,7 @@ dependencies = [
+  "sha1 0.10.6",
+@@ -4013,7 +4013,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -3824,7 +3824,7 @@ dependencies = [
+@@ -4022,7 +4022,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -3835,15 +3835,15 @@ dependencies = [
+@@ -4034,15 +4034,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dirs",
-@@ -3853,7 +3853,7 @@ dependencies = [
+@@ -4052,7 +4052,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -3865,7 +3865,7 @@ dependencies = [
+@@ -4065,7 +4065,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -3874,7 +3874,7 @@ dependencies = [
+@@ -4074,7 +4074,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -3884,7 +3884,7 @@ dependencies = [
+@@ -4084,7 +4084,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -3893,7 +3893,7 @@ dependencies = [
+@@ -4093,7 +4093,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -3903,7 +3903,7 @@ dependencies = [
+@@ -4103,7 +4103,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-exec-server",
   "codex-login",
-@@ -3916,7 +3916,7 @@ dependencies = [
+@@ -4116,7 +4116,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -3932,7 +3932,7 @@ dependencies = [
+@@ -4132,7 +4132,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "assert_matches",
   "async-trait",
-@@ -3943,14 +3943,14 @@ dependencies = [
+@@ -4143,14 +4143,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "rustls",
  ]
@@ -948,25 +1011,25 @@ index 9a75aa6f9e..7902126c3a 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -3961,7 +3961,7 @@ dependencies = [
+@@ -4161,7 +4161,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -3971,14 +3971,14 @@ dependencies = [
+@@ -4171,14 +4171,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -974,16 +1037,16 @@ index 9a75aa6f9e..7902126c3a 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -3988,14 +3988,14 @@ dependencies = [
+@@ -4188,14 +4188,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -991,37 +1054,46 @@ index 9a75aa6f9e..7902126c3a 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -4003,7 +4003,7 @@ dependencies = [
+@@ -4203,7 +4203,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-web-search-extension"
+-version = "0.0.0"
++version = "0.138.0"
+ dependencies = [
+  "async-trait",
+  "codex-api",
+@@ -4223,7 +4223,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4254,7 +4254,7 @@ dependencies = [
+@@ -4480,7 +4480,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -8436,7 +8436,7 @@ dependencies = [
+@@ -8834,7 +8834,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.130.0"
++version = "0.138.0"
  dependencies = [
   "anyhow",
   "codex-login",
 -- 
-2.54.0
+2.52.0
 

--- a/app-utils/codex/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,11 +1,7 @@
-<<<<<<< HEAD
-From 06f9e58ae5ab5dcda586aabbbdaf7bd00afd6357 Mon Sep 17 00:00:00 2001
-=======
-From 86774d3df6f250cdac3ac8e49bd42e19d9c48d36 Mon Sep 17 00:00:00 2001
->>>>>>> 4c0fc966722 (codex: new)
+From 19b099baf17f611b7681ebda212bfa7ca471f388 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Thu, 29 Jan 2026 23:09:43 +0800
-Subject: [PATCH 3/4] AOSCOS: Disable cross-compilation setup on arm64
+Date: Wed, 29 Apr 2026 19:29:06 +0800
+Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup on arm64
 
 Because we have native linux arm64 CI :)
 ---
@@ -13,12 +9,12 @@ Because we have native linux arm64 CI :)
  1 file changed, 16 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index a27baf1..d38c956 100644
+index b7a71b2698..3cf8f0231f 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -351,22 +351,6 @@ fn build_v8(is_asan: bool) {
-       gn_args.push(arg.to_string());
-     }
+@@ -379,22 +379,6 @@ fn build_v8(is_asan: bool) {
+   if needs_tls_define && !tls_define_injected {
+     gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
    }
 -  // cross-compilation setup
 -  if target_arch == "aarch64" {
@@ -36,9 +32,6 @@ index a27baf1..d38c956 100644
 -    maybe_install_sysroot("i386");
 -    maybe_install_sysroot("arm");
 -  }
- 
+
    let target_triple = env::var("TARGET").unwrap();
    // check if the target triple describes a non-native environment
--- 
-2.53.0
-

--- a/app-utils/codex/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,7 +1,7 @@
-From 765c931c0d5908b871e3f21635e3dbc5f211d070 Mon Sep 17 00:00:00 2001
+From cba75642b38a0dd58a73fba1f60c8b92770f48c2 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
-Subject: [PATCH 4/4] AOSCOS: build: correct Clang builtins path
+Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
 
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 
@@ -11,10 +11,10 @@ Correct the builtins path accordingly.
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index 5031ea2..b1c78e8 100644
+index e05032c0c6..67092527ad 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -182,22 +182,23 @@ template("clang_lib") {
+@@ -185,22 +185,23 @@ template("clang_lib") {
        } else if (is_apple) {
          _dir = "darwin"
        } else if (is_linux || is_chromeos) {
@@ -46,15 +46,12 @@ index 5031ea2..b1c78e8 100644
          } else {
            assert(false)  # Unhandled cpu type
          }
-@@ -228,7 +229,7 @@ template("clang_lib") {
+@@ -231,7 +232,7 @@ template("clang_lib") {
          assert(false)  # Unhandled target platform
        }
- 
+
 -      _clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"
 +      _clang_lib_dir = "$clang_base_path/lib/llvm-$clang_version/lib/clang/$clang_version/lib"
        _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
        libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
      }
--- 
-2.53.0
-

--- a/app-utils/codex/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,0 +1,46 @@
+From 307723a74fc208fe64c0cbfb3a0348f9885cfc50 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sun, 29 Mar 2026 18:50:37 +0800
+Subject: [PATCH 5/5] AOSCOS: drop unknown argument
+
+---
+ build/config/compiler/BUILD.gn | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
+index ff8022f047..9721cdd99b 100644
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -625,13 +625,6 @@ config("compiler") {
+       ]
+     }
+ 
+-    # The performance improvement does not seem worth the risk. See
+-    # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
+-    # for discussion.
+-    if (!is_wasm) {
+-      cflags += [ "-fno-lifetime-dse" ]
+-    }
+-
+     # TODO(hans): Remove this once Clang generates better optimized debug info
+     # by default. https://crbug.com/765793
+     cflags += [
+@@ -1892,18 +1885,6 @@ config("sanitize_c_array_bounds") {
+     cflags = [
+       "-fsanitize=array-bounds",
+       "-fsanitize-trap=array-bounds",
+-
+-      # Some code users feature detection to determine if UBSAN (or any
+-      # sanitizer) is enabled, they then do expensive debug like operations. We
+-      # want to suppress this behaviour since we want to keep performance costs
+-      # as low as possible while having these checks.
+-      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
+-
+-      # Because we've enabled array-bounds sanitizing we also want to suppress
+-      # the related warning about "unsafe-buffer-usage-in-static-sized-array",
+-      # since we know that the array bounds sanitizing will catch any out-of-
+-      # bounds accesses.
+-      "-Wno-unsafe-buffer-usage-in-static-sized-array",
+     ]
+   }
+ }

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,6 +1,6 @@
-VER=0.130.0
+VER=0.138.0
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
-RUSTY_V8_VER=146.4.0
+RUSTY_V8_VER=147.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.138.0

Package(s) Affected
-------------------

- codex: 0.138.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
