### PR TITLE
python-3: fix CVE-2026-9669

### DIFF
--- a/lang-python/python-3/autobuild/patches/0002-CVE-2026-9669.patch
+++ b/lang-python/python-3/autobuild/patches/0002-CVE-2026-9669.patch
@@ -1,0 +1,103 @@
+From 157a5df8cb5d82b33f918a7489e72ce95ceb12b6 Mon Sep 17 00:00:00 2001
+From: Stan Ulbrych <stan@python.org>
+Date: Sun, 7 Jun 2026 19:37:10 +0100
+Subject: [PATCH] [3.14] gh-150599: Prevent bz2 decompressor reuse after errors
+ (#150600) (#151054)
+
+(cherry picked from commit 5755d0f083949ff3c5bf3a37e673e24e306b036e)
+---
+ Lib/test/test_bz2.py                           | 15 +++++++++++++++
+ ...6-05-30-09-36-20.gh-issue-150599.nlHqU-.rst |  3 +++
+ Modules/_bz2module.c                           | 18 +++++++++++++++---
+ 3 files changed, 33 insertions(+), 3 deletions(-)
+ create mode 100644 Misc/NEWS.d/next/Security/2026-05-30-09-36-20.gh-issue-150599.nlHqU-.rst
+
+diff --git a/Lib/test/test_bz2.py b/Lib/test/test_bz2.py
+index d8e3b671ec229f9..64293d757331d75 100644
+--- a/Lib/test/test_bz2.py
++++ b/Lib/test/test_bz2.py
+@@ -1032,6 +1032,21 @@ def test_failure(self):
+         # Previously, a second call could crash due to internal inconsistency
+         self.assertRaises(Exception, bzd.decompress, self.BAD_DATA * 30)
+ 
++    def test_decompress_after_data_error(self):
++        data = bytes.fromhex(
++            "425a6839314159265359000000000000007fffff000000000000000000000000"
++            "00000000000000000000000000000000000000e0370000000000000000000000"
++            "000000000000000000000000000000000000000000000000000083f3"
++        )
++        bzd = BZ2Decompressor()
++        with self.assertRaisesRegex(OSError, "Invalid data stream"):
++            bzd.decompress(data)
++        # Previously, a second call could crash due to internal inconsistency
++        self.assertFalse(bzd.needs_input)
++        self.assertFalse(bzd.eof)
++        with self.assertRaisesRegex(ValueError, "previous error"):
++            bzd.decompress(b'\x00' * 18)
++
+     @support.refcount_test
+     def test_refleaks_in___init__(self):
+         gettotalrefcount = support.get_attribute(sys, 'gettotalrefcount')
+diff --git a/Misc/NEWS.d/next/Security/2026-05-30-09-36-20.gh-issue-150599.nlHqU-.rst b/Misc/NEWS.d/next/Security/2026-05-30-09-36-20.gh-issue-150599.nlHqU-.rst
+new file mode 100644
+index 000000000000000..a37d86cf423f820
+--- /dev/null
++++ b/Misc/NEWS.d/next/Security/2026-05-30-09-36-20.gh-issue-150599.nlHqU-.rst
+@@ -0,0 +1,3 @@
++Fix a possible stack buffer overflow in :mod:`bz2` when a
++:class:`bz2.BZ2Decompressor` is reused after a decompression error.
++The decompressor now becomes unusable after libbz2 reports an error.
+diff --git a/Modules/_bz2module.c b/Modules/_bz2module.c
+index 6e76e537a77e8ae..e6b8198b909138d 100644
+--- a/Modules/_bz2module.c
++++ b/Modules/_bz2module.c
+@@ -116,6 +116,7 @@ typedef struct {
+ typedef struct {
+     PyObject_HEAD
+     bz_stream bzs;
++    int bzerror;
+     char eof;           /* Py_T_BOOL expects a char */
+     PyObject *unused_data;
+     char needs_input;
+@@ -459,8 +460,11 @@ decompress_buf(BZ2Decompressor *d, Py_ssize_t max_length)
+ 
+         d->bzs_avail_in_real += bzs->avail_in;
+ 
+-        if (catch_bz2_error(bzret))
++        if (catch_bz2_error(bzret)) {
++            d->bzerror = bzret;
++            _Py_atomic_store_char_relaxed(&d->needs_input, 0);
+             goto error;
++        }
+         if (bzret == BZ_STREAM_END) {
+             d->eof = 1;
+             break;
+@@ -629,10 +633,17 @@ _bz2_BZ2Decompressor_decompress_impl(BZ2Decompressor *self, Py_buffer *data,
+     PyObject *result = NULL;
+ 
+     ACQUIRE_LOCK(self);
+-    if (self->eof)
++    if (self->eof) {
+         PyErr_SetString(PyExc_EOFError, "End of stream already reached");
+-    else
++    }
++    else if (self->bzerror) {
++        // Re-entering BZ2_bzDecompress() after an error can write out of bounds.
++        PyErr_SetString(PyExc_ValueError,
++                        "Decompressor is unusable after a previous error");
++    }
++    else {
+         result = decompress(self, data->buf, data->len, max_length);
++    }
+     RELEASE_LOCK(self);
+     return result;
+ }
+@@ -666,6 +677,7 @@ _bz2_BZ2Decompressor_impl(PyTypeObject *type)
+         return NULL;
+     }
+ 
++    self->bzerror = 0;
+     self->needs_input = 1;
+     self->bzs_avail_in_real = 0;
+     self->input_buffer = NULL;
+

--- a/lang-python/python-3/spec
+++ b/lang-python/python-3/spec
@@ -1,4 +1,5 @@
 VER=3.14.5
+REL=1
 SRCS="tbl::https://www.python.org/ftp/python/${VER/~*/}/Python-${VER/\~/}.tar.xz"
 CHKSUMS="sha256::7e32597b99e5d9a39abed35de4693fa169df3e5850d4c334337ffd6a19a36db6"
 CHKUPDATE="anitya::id=13254"

--- a/topics/python-3-3.14.5-1.toml
+++ b/topics/python-3-3.14.5-1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Python 3.14.5，修订版本 1"
+
+[caution]
+default = "Fixes a Stack-based Buffer Overflow vulnerability (CVE-2026-9669, Severity: High)"
+zh_CN = "修复 1 个栈缓冲区溢出漏洞（漏洞编号 CVE-2026-9669，严重性：高）"
+
+[packages-v2]
+"python-3" = "< 3.14.5-1"


### PR DESCRIPTION
Topic Description
-----------------

- python-3: fix CVE-2026-9669
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- python-3: 3.14.5-1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit python-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
