### PR TITLE
flameshot: update to 14.0.0

### DIFF
--- a/app-utils/flameshot/spec
+++ b/app-utils/flameshot/spec
@@ -1,5 +1,4 @@
-VER=12.1.0
-REL=5
+VER=14.0.0
 SRCS="tbl::https://github.com/flameshot-org/flameshot/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c82c05d554e7a6d810aca8417ca12b21e4f74864455ab4ac94602668f85ac22a"
+CHKSUMS="sha256::31a9419089aee8570fa0a996515b97d165a23672b2da1e3a0b5ed2f7f68a3631"
 CHKUPDATE="anitya::id=16948"


### PR DESCRIPTION
Topic Description
-----------------

- flameshot: update to 14.0.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- flameshot: 14.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit flameshot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
