### PR TITLE
nginx: security update to 1.30.2

### DIFF
--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,11 +1,11 @@
-NGINX_VER=1.30.1
+NGINX_VER=1.30.2
 BROTLI_VER=1.0.0~rc1+git20231009
 VER="${NGINX_VER}+brotli${BROTLI_VER}"
 # Note: After v1.0.0rc, there are still some necessary updates (including upstream submodules), 
 # so the following commit refers to the latest one in master branch.
 SRCS="tbl::https://nginx.org/download/nginx-$NGINX_VER.tar.gz \
       git::commit=a71f9312c2deb28875acc7bacfdd5695a111aa53;rename=ngx_brotli::https://github.com/google/ngx_brotli.git"
-CHKSUMS="sha256::99765000d974896b31ca5882d8c279ce3fe7ef6f5c6f9f0a967ed7fd3407f9cc \
+CHKSUMS="sha256::7df3090907fca3cc0e456d6dc00ceb230da74ea88026ceff0affc29dbbd9ac4c \
          SKIP"
 CHKUPDATE="anitya::id=5413"
 SUBDIR="nginx-$NGINX_VER"

--- a/topics/nginx-1.30.2.toml
+++ b/topics/nginx-1.30.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "nginx 1.30.2"
+
+[caution]
+default = "Fixes a buffer overflow vulnerability (CVE-2026-9256, Severity: Critical)"
+zh_CN = "修复一个缓冲区溢出漏洞（CVE-2026-9256，严重性：严重）"
+
+[packages-v2]
+"nginx" = "< 1.30.2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add nginx-1.30.2.toml
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- nginx: security update to 1.30.2
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- nginx: 1.30.2+brotli1.0.0~rc1+git20231009

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
