### PR TITLE
libreoffice: update to 26.2.4.2

### DIFF
--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,5 +1,5 @@
-VER=26.2.4.1
-SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://git.libreoffice.org/core"
+VER=26.2.4.2
+SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://github.com/LibreOffice/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"
 ENVREQ="total_mem=60 total_mem_per_core=2"

--- a/runtime-common/boost/autobuild/defines
+++ b/runtime-common/boost/autobuild/defines
@@ -33,7 +33,7 @@ PKGBREAK="0ad<=0.0.23 abyss<=2.0.3 aegisub<=3.2.2-8 aptitude<=0.8.10-1 \
           source-highlight<=3.1.8-4 swift-im<=3.0 synfig<=1.2.1 \
           tdepim<=14.0.4-2 vera++<=1.3.0-1 websocketpp<=0.7.0-3 \
           wesnoth<=1.12.6-1 yaml-cpp<=0.6.2 znc<=1.10.2 \
-          guitarix<=0.47.0-1"
+          guitarix<=0.47.0-1 libreoffice<=26.2.4.1"
 
 AB_FLAGS_O3=1
 

--- a/runtime-common/boost/spec
+++ b/runtime-common/boost/spec
@@ -1,5 +1,5 @@
 VER=1.91.0
-REL=2
+REL=3
 SRCS="tbl::https://archives.boost.io/release/$VER/source/boost_${VER//./_}.tar.bz2"
 CHKSUMS="sha256::de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5"
 CHKUPDATE="anitya::id=6845"


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: update to 26.2.4.2

Package(s) Affected
-------------------

- libreoffice: 26.2.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libreoffice boost
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
