### PR TITLE
openssl: security update to 3.6.3

### DIFF
--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.6.2
+VER=3.6.3
 SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
-CHKSUMS="sha256::aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.6.2
+VER=3.6.3
 SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
-CHKSUMS="sha256::aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2566"

--- a/topics/openssl-3.6.3.toml
+++ b/topics/openssl-3.6.3.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 3.6.3"
+
+[caution]
+default = "Fixes 18 security vulnerabilities disclosed in OpenSSL Security Advisory on June 9, 2026 (including 1 of High and 5 of Medium severity)"
+zh_CN = "修复 OpenSSL 在 2026 年 6 月 9 日发布的安全公告中披露的 18 个安全漏洞（含 1 个高危漏洞和 5 个中危漏洞）"
+
+[packages-v2]
+"openssl" = "< 3.6.3"
+"openssl+32" = "< 3.6.3"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add openssl-3.6.3.toml
- openssl+32: security update to 3.6.3
- openssl: security update to 3.6.3

Package(s) Affected
-------------------

- openssl: 3.6.3
- openssl-static: 3.6.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
