### PR TITLE
Zhaoxin GPU drivers survey (June 10, 2026)

### DIFF
--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
@@ -1,7 +1,7 @@
-From 30f60b2563c2214d9f45dbf33ed89fd3db66d6a1 Mon Sep 17 00:00:00 2001
+From 3a60dba763547ac1910a2268a34380c84a94a63e Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 7 Nov 2025 23:50:09 +0800
-Subject: [PATCH 1/3] AOSCOS: fix(dkms.conf): drop check_gcc_version()
+Subject: [PATCH 1/7] AOSCOS: fix(dkms.conf): drop check_gcc_version()
 
 Not even sure why it's here. Drop it.
 
@@ -11,7 +11,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 46 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 0a239dc..8b97cbc 100644
+index 1326747..71476e6 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -19,50 +19,5 @@ num_cpu_cores()

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
@@ -1,7 +1,7 @@
-From dd0046d224145aaf3a60e7b777a1981ef1533745 Mon Sep 17 00:00:00 2001
+From 2aa72971bba47acf152cea3e0098acb539fc2ff9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 7 Nov 2025 23:50:49 +0800
-Subject: [PATCH 2/3] AOSCOS: fix(dkms.conf): drop unused options
+Subject: [PATCH 2/7] AOSCOS: fix(dkms.conf): drop unused options
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
@@ -9,12 +9,12 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 8b97cbc..a1d8982 100644
+index 71476e6..3653f35 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,8 +1,6 @@
  PACKAGE_NAME="cx4"
- PACKAGE_VERSION=26.00.46
+ PACKAGE_VERSION=26.00.49
  AUTOINSTALL="yes"
 -#REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
@@ -1,7 +1,7 @@
-From 9faec9235268b84293639296bb13bb215f8d52af Mon Sep 17 00:00:00 2001
+From 4837de46af264dd095f069d73fc17c94b9c1127c Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 22:45:52 +0800
-Subject: [PATCH 3/3] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
+Subject: [PATCH 3/7] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
  6.17
 
 Follow commit 21aa65bf82a7 ("mm: remove callers of pfn_t functionality")

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0004-AOSCOS-fix-adapt-to-drm-atomic-changes-in-6.19.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0004-AOSCOS-fix-adapt-to-drm-atomic-changes-in-6.19.patch
@@ -1,0 +1,111 @@
+From 1b336deb88e1834d8c6f08b75841a4f3c3ec0e7c Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 10 Jun 2026 21:59:15 +0800
+Subject: [PATCH 4/7] AOSCOS: fix: adapt to drm/atomic changes in 6.19
+
+With commit 1226cd7 ("drm/atomic: Change state pointers to a more meaningful name"),
+the 'state' field in struct drm_plane_state, drm_crtc_state, and drm_connector_state
+was renamed to 'state_to_destroy'.
+
+Follow suit to fix build with kernels >= 6.19.
+---
+ linux/zx_crtc.c       |  4 ++++
+ linux/zx_drm_helper.h | 31 +++++++++++++++++++++++++++++++
+ 2 files changed, 35 insertions(+)
+
+diff --git a/linux/zx_crtc.c b/linux/zx_crtc.c
+index 95f5425..85cdedb 100644
+--- a/linux/zx_crtc.c
++++ b/linux/zx_crtc.c
+@@ -378,7 +378,11 @@ static bool zx_need_wait_vblank(struct drm_crtc *crtc, struct drm_crtc_state *ol
+         if(old_crtc_state->state->planes[i].ptr)
+         {
+             plane = old_crtc_state->state->planes[i].ptr;
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0))
++            old_plane_state = old_crtc_state->state->planes[i].state_to_destroy;
++#else
+             old_plane_state = old_crtc_state->state->planes[i].state;
++#endif
+             if(plane->state->crtc == crtc && (crtc->state->plane_mask & (1 << plane->index)))
+             {
+                 if(plane->state->fb != old_plane_state->fb)
+diff --git a/linux/zx_drm_helper.h b/linux/zx_drm_helper.h
+index b4ab3fe..dd7cd10 100644
+--- a/linux/zx_drm_helper.h
++++ b/linux/zx_drm_helper.h
+@@ -188,6 +188,16 @@ int zx_drm_crtc_in_use(struct drm_crtc *crtc)
+  * old_connector_state.
+  */
+ #if !defined(for_each_connector_in_state)
++#if (DRM_VERSION_CODE >= KERNEL_VERSION(6, 19, 0))
++#define zx_drm_for_each_connector_in_state(__state, connector,          \
++                                           connector_state, __i)        \
++    for ((__i) = 0;                                                     \
++         (__i) < (__state)->num_connector &&                            \
++         ((connector) = (__state)->connectors[__i].ptr,                 \
++         (connector_state) = (__state)->connectors[__i].state_to_destroy, 1);      \
++         (__i)++)                                                       \
++            for_each_if (connector_state)
++#else
+ #define zx_drm_for_each_connector_in_state(__state, connector,          \
+                                            connector_state, __i)        \
+     for ((__i) = 0;                                                     \
+@@ -196,6 +206,7 @@ int zx_drm_crtc_in_use(struct drm_crtc *crtc)
+          (connector_state) = (__state)->connectors[__i].state, 1);      \
+          (__i)++)                                                       \
+             for_each_if (connector_state)
++#endif
+ #else
+ #define zx_drm_for_each_connector_in_state(__state, connector,          \
+                                            connector_state, __i)        \
+@@ -209,6 +220,15 @@ int zx_drm_crtc_in_use(struct drm_crtc *crtc)
+  * old_crtc_state.
+  */
+ #if (!defined for_each_crtc_in_state)
++#if (DRM_VERSION_CODE >= KERNEL_VERSION(6, 19, 0))
++#define zx_drm_for_each_crtc_in_state(__state, crtc, crtc_state, __i) \
++    for ((__i) = 0;                                                   \
++         (__i) < (__state)->dev->mode_config.num_crtc &&              \
++         ((crtc) = (__state)->crtcs[__i].ptr,                         \
++         (crtc_state) = (__state)->crtcs[__i].state_to_destroy, 1);              \
++         (__i)++)                                                     \
++            for_each_if (crtc_state)
++#else
+ #define zx_drm_for_each_crtc_in_state(__state, crtc, crtc_state, __i) \
+     for ((__i) = 0;                                                   \
+          (__i) < (__state)->dev->mode_config.num_crtc &&              \
+@@ -216,6 +236,7 @@ int zx_drm_crtc_in_use(struct drm_crtc *crtc)
+          (crtc_state) = (__state)->crtcs[__i].state, 1);              \
+          (__i)++)                                                     \
+             for_each_if (crtc_state)
++#endif
+ #else
+ #define zx_drm_for_each_crtc_in_state(__state, crtc, crtc_state, __i) \
+     for_each_crtc_in_state(__state, crtc, crtc_state, __i)
+@@ -228,6 +249,15 @@ int zx_drm_crtc_in_use(struct drm_crtc *crtc)
+  * old_plane_state.
+  */
+ #if (!defined for_each_plane_in_state)
++#if (DRM_VERSION_CODE >= KERNEL_VERSION(6, 19, 0))
++#define zx_drm_for_each_plane_in_state(__state, plane, plane_state, __i)   \
++    for ((__i) = 0;                                                        \
++         (__i) < (__state)->dev->mode_config.num_total_plane &&            \
++         ((plane) = (__state)->planes[__i].ptr,                            \
++         (plane_state) = (__state)->planes[__i].state_to_destroy, 1);                 \
++         (__i)++)                                                          \
++            for_each_if (plane)
++#else
+ #define zx_drm_for_each_plane_in_state(__state, plane, plane_state, __i)   \
+     for ((__i) = 0;                                                        \
+          (__i) < (__state)->dev->mode_config.num_total_plane &&            \
+@@ -235,6 +265,7 @@ int zx_drm_crtc_in_use(struct drm_crtc *crtc)
+          (plane_state) = (__state)->planes[__i].state, 1);                 \
+          (__i)++)                                                          \
+             for_each_if (plane)
++#endif
+ #else
+ #define zx_drm_for_each_plane_in_state(__state, plane, plane_state, __i)   \
+     for_each_plane_in_state(__state, plane, plane_state, __i)
+-- 
+2.52.0
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0005-AOSCOS-fix-adapt-to-shmem_file_setup-changes-in-7.0.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0005-AOSCOS-fix-adapt-to-shmem_file_setup-changes-in-7.0.patch
@@ -1,0 +1,32 @@
+From 35cf0cda5687d370d7a8c8cf43c3b2ccf5f4a8ad Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 10 Jun 2026 22:01:25 +0800
+Subject: [PATCH 5/7] AOSCOS: fix: adapt to shmem_file_setup changes in 7.0
+
+With commit 590d356 ("mm: update shmem_[kernel]_file_*() functions to use vma_flags_t"),
+the flags parameter of shmem_file_setup() was changed from unsigned long to vma_flags_t.
+
+Follow suit to fix build with kernels >= 7.0.
+---
+ linux/os_interface.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/linux/os_interface.c b/linux/os_interface.c
+index 7b9dfa1..a813e52 100644
+--- a/linux/os_interface.c
++++ b/linux/os_interface.c
+@@ -2595,7 +2595,11 @@ int zx_query_platform_caps(void *pdev, platform_caps_t *caps)
+ 
+ void *zx_pages_memory_swapout(struct os_pages_memory *pages_memory)
+ {
++#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
++    struct file          *file_storage = shmem_file_setup("zx gmem", pages_memory->size, EMPTY_VMA_FLAGS);
++#else
+     struct file          *file_storage = shmem_file_setup("zx gmem", pages_memory->size, 0);
++#endif
+     struct address_space *file_addr_space;
+     struct page          **pages;
+     struct page          *src_page, *dst_page;
+-- 
+2.52.0
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0006-AOSCOS-fix-adapt-to-screen_info-changes-in-7.0.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0006-AOSCOS-fix-adapt-to-screen_info-changes-in-7.0.patch
@@ -1,0 +1,63 @@
+From a7bda6badbb58af9bd3f4c1d7f2bfbb9b6863d5e Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Wed, 10 Jun 2026 22:08:34 +0800
+Subject: [PATCH 6/7] AOSCOS: fix: adapt to screen_info changes in 7.0
+
+With commit a41e0ab ("sysfb: Replace screen_info with sysfb_primary_display"),
+the global screen_info variable was replaced by sysfb_primary_display.screen
+
+Follow suit to fix build with kernels >= 7.0.
+---
+ linux/zx_disp.c | 13 ++++++++++++-
+ linux/zx_kms.h  |  4 ++++
+ 2 files changed, 16 insertions(+), 1 deletion(-)
+
+diff --git a/linux/zx_disp.c b/linux/zx_disp.c
+index 199b3a4..1acf821 100644
+--- a/linux/zx_disp.c
++++ b/linux/zx_disp.c
+@@ -61,13 +61,24 @@ static void disp_info_pre_init(disp_info_t*  disp_info)
+     adapter_info_t*  adapter_info = disp_info->adp_info;
+     unsigned long long scrn_base = 0;
+ 
++#if (DRM_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
++    scrn_base = sysfb_primary_display.screen.lfb_base;
++#else
+     scrn_base = screen_info.lfb_base;
+-    
++#endif
++
+ #ifdef VIDEO_CAPABILITY_64BIT_BASE
++#if (DRM_VERSION_CODE >= KERNEL_VERSION(7, 0, 0))
++    if(sysfb_primary_display.screen.capabilities & VIDEO_CAPABILITY_64BIT_BASE)
++    {
++        scrn_base |= (unsigned long long)sysfb_primary_display.screen.ext_lfb_base << 32;
++    }
++#else
+     if(screen_info.capabilities & VIDEO_CAPABILITY_64BIT_BASE)
+     {
+         scrn_base |= (unsigned long long)screen_info.ext_lfb_base << 32;
+     }
++#endif
+ #endif
+ 
+     zx_info("Screen info base = 0x%lx.\n", scrn_base);
+diff --git a/linux/zx_kms.h b/linux/zx_kms.h
+index 5ece6ab..7e0a5b3 100644
+--- a/linux/zx_kms.h
++++ b/linux/zx_kms.h
+@@ -60,7 +60,11 @@
+ #endif
+ #endif
+ #include <drm/drm_fb_helper.h>
++#if DRM_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++#include <linux/sysfb.h>
++#else
+ #include <linux/screen_info.h>
++#endif
+ 
+ #ifndef  container_of
+ #define offsetof(TYPE, MEMBER) ((size_t) &((TYPE *)0)->MEMBER)
+-- 
+2.52.0
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0007-AOSCOS-fix-set-framebuffer-gem-objects.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0007-AOSCOS-fix-set-framebuffer-gem-objects.patch
@@ -1,0 +1,63 @@
+From d85884b84584b484dcf26974154229f446d723c7 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Thu, 11 Jun 2026 02:54:00 +0800
+Subject: [PATCH 7/7] AOSCOS: fix: set framebuffer gem objects
+
+Fix:
+
+RIP: 0010:drm_gem_lock+0x9/0x20
+Code: e9 ec d8 01 00 90 66 66 2e 0f 1f 84 00 00 00 00 00 90 90 90 90 90 90 90
+90 90 90 90 90 90 90 90 90 f3 0f 1e fa 0f 1f 44 00 00 <48> 8b bf f8 00 00 00
+31 f6 e9 19 fa 75 00 66 0f 1f 84 00 00 00 00
+RSP: 0018:ffffd063407efd80 EFLAGS: 00010296
+RAX: ffff8e6cfc1e7f00 RBX: ffff8e6cfc1ee700 RCX: 0000000000000000
+RDX: 0000000000000000 RSI: ffffd063407efde8 RDI: 0000000000000000
+RBP: ffffd063407efda8 R08: 0000000000000000 R09: 0000000000000000
+R10: 0000000000000000 R11: 0000000000000000 R12: 0000000000000000
+R13: ffffd063407efde8 R14: ffff8e6cc3e78000 R15: ffff8e6cfc1ee700
+FS:  0000000000000000(0000) GS:ffff8e6e4b2e0000(0000) knlGS:0000000000000000
+CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
+CR2: 00000000000000f8 CR3: 0000000102b0d003 CR4: 0000000000770ef0
+PKRU: 55555554
+Call Trace:
+ <TASK>
+ drm_client_buffer_vmap_local+0x2f/0x90
+ ? trace_hardirqs_on+0x30/0xb0
+ drm_fbdev_ttm_driver_fbdev_probe+0x25a/0xb60 [drm_ttm_helper]
+ ? _raw_spin_unlock_irqrestore+0x25/0x70
+ ? drm_vblank_get+0x75/0xf0
+ drm_fb_helper_damage_work+0xed/0x1a0
+ process_one_work+0x18b/0x390
+ worker_thread+0x19f/0x320
+ ? __pfx_worker_thread+0x10/0x10
+ kthread+0xf2/0x130
+ ? __pfx_kthread+0x10/0x10
+ ret_from_fork+0x1e9/0x2f0
+ ? __pfx_kthread+0x10/0x10
+ ret_from_fork_asm+0x1a/0x3
+
+Link: https://git.kernel.org/torvalds/c/9942d36a73c2
+Link: https://git.kernel.org/torvalds/c/ea39f2e66e61
+---
+ linux/zx_drmfb.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/linux/zx_drmfb.c b/linux/zx_drmfb.c
+index 8ea9617..d548b33 100644
+--- a/linux/zx_drmfb.c
++++ b/linux/zx_drmfb.c
+@@ -87,6 +87,11 @@ __zx_framebuffer_create(struct drm_device *dev,
+ 
+     zxfb->obj = obj;
+ 
++#if (DRM_VERSION_CODE >= KERNEL_VERSION(6, 19, 0))
++    if (zxfb->obj)
++        zxfb->base.obj[0] = &zxfb->obj->base;
++#endif
++
+     // map gpuva
+     map_va.allocation = obj->priv;
+     map_va.size = obj->info.size;
+-- 
+2.52.0
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
@@ -6,13 +6,10 @@ for i in postinst prerm; do
         "$SRCDIR/autobuild/$i"
 done
 
-abinfo "Unpacking upstream driver archive ..."
-7z x "$SRCDIR"/KX-6000G-Linux\ OS_x64-"$__UPSTREAM_VER".7z
-
 abinfo "Unpacking upstream deb package ..."
 dpkg-deb -X \
-"$SRCDIR"/KX-6000G-Linux\ OS_x64-"$__UPSTREAM_VER"/cx4-linux-graphics-driver-dri-glvnd_"$__UPSTREAM_VER"_amd64.deb \
-"$SRCDIR"
+    "$SRCDIR"/cx4-linux-graphics-driver-dri-glvnd_"$__UPSTREAM_VER"_amd64.deb \
+    "$SRCDIR"
 
 abinfo "Entering kernel module sources directory"
 cd "$SRCDIR"/usr/src/cx4-"$__UPSTREAM_VER"

--- a/runtime-display/cx4-linux-graphics-driver-dri/spec
+++ b/runtime-display/cx4-linux-graphics-driver-dri/spec
@@ -1,6 +1,6 @@
-UPSTREAM_VER=26.00.46
+UPSTREAM_VER=26.00.49
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
-SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3419&tag=0&ref=qdxz&pre=0&t=20ce3b68fe29466a"
-CHKSUMS="sha256::d4c4cc9ebfc81f9c4e5dd23ca9ca95e005517c9c13203a360ea982965f8701f2"
+SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3419&tag=0&ref=qdxz&pre=0&t=20ce3b68fe29466a&__for_acbs_hash_url=$UPSTREAM_VER"
+CHKSUMS="sha256::8f0884b4f9d16d416c060c135030e44930492e5a4662d60516b6f4b1f27e4740"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,7 +1,7 @@
 From 9c56049e285aac50ed92ca4ff0bd88501f4df3ca Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
-Subject: [PATCH 01/12] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
+Subject: [PATCH 01/18] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
 
 EXTRA_*FLAGS support was deprecated in 2007 and removed in 2025.
 
@@ -63,5 +63,5 @@ index a2b2900..277d1cf 100644
               -I${ZXGPU_FULL_PATH}/src/cbios/Device \
               -I${ZXGPU_FULL_PATH}/src/cbios/Device/Port \
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,7 +1,7 @@
-From 6065be81b4f240969e3f6850fd15ea96203db08c Mon Sep 17 00:00:00 2001
+From 9c56049e285aac50ed92ca4ff0bd88501f4df3ca Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
-Subject: [PATCH 1/9] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
+Subject: [PATCH 01/12] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
 
 EXTRA_*FLAGS support was deprecated in 2007 and removed in 2025.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,7 +1,7 @@
 From 68cd56c5bf707351debf761296feb2f48782c8cc Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
-Subject: [PATCH 02/12] chore: dkms: remove useless variables
+Subject: [PATCH 02/18] chore: dkms: remove useless variables
 
 REMAKE_INITRD was deprecated. SKIP_IMMD_MODPROBE is not standard.
 
@@ -37,5 +37,5 @@ index db9bd64..bbc3042 100644
  MAKE[0]="make -j$(num_cpu_cores) LINUXDIR=$kernel_source_dir -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
 -#POST_REMOVE="post-remove.sh $kernelver"
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,7 +1,7 @@
-From f3c87195ce735171e6f6a487beab243e48475156 Mon Sep 17 00:00:00 2001
+From 68cd56c5bf707351debf761296feb2f48782c8cc Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
-Subject: [PATCH 2/9] chore: dkms: remove useless variables
+Subject: [PATCH 02/12] chore: dkms: remove useless variables
 
 REMAKE_INITRD was deprecated. SKIP_IMMD_MODPROBE is not standard.
 
@@ -11,12 +11,12 @@ Link: https://github.com/dkms-project/dkms/commit/961f9ceac4cf6772cb4c52bf4836a0
  1 file changed, 5 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 10e3350..de2cefb 100644
+index db9bd64..bbc3042 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,16 +1,12 @@
  PACKAGE_NAME="zx"
- PACKAGE_VERSION=21.00.86
+ PACKAGE_VERSION=21.00.87
  AUTOINSTALL="yes"
 -#REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,7 +1,7 @@
 From 93cb462c8aa722eeb7d23f43d4ab7facd8ab354a Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 03/12] fix: kernel: 6.15
+Subject: [PATCH 03/18] fix: kernel: 6.15
 
 Make it compatible with Linux kernel 6.15.
 
@@ -43,5 +43,5 @@ index 89a7819..48706c2 100755
      .fb_dirty           = zxfb_dirty,
  #endif
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,7 +1,7 @@
-From ff9194d472e29eefd5b1a0c440f81947f5b1d7db Mon Sep 17 00:00:00 2001
+From 93cb462c8aa722eeb7d23f43d4ab7facd8ab354a Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 3/9] fix: kernel: 6.15
+Subject: [PATCH 03/12] fix: kernel: 6.15
 
 Make it compatible with Linux kernel 6.15.
 
@@ -13,7 +13,7 @@ Link: https://patchwork.freedesktop.org/patch/msgid/20241214-drm-connector-mode-
  2 files changed, 6 insertions(+)
 
 diff --git a/src/zx_connector.c b/src/zx_connector.c
-index eb6c48f..3127cbd 100644
+index c78307c..64b6e32 100644
 --- a/src/zx_connector.c
 +++ b/src/zx_connector.c
 @@ -303,7 +303,11 @@ END:
@@ -29,7 +29,7 @@ index eb6c48f..3127cbd 100644
      struct drm_device *dev = connector->dev;
      zx_card_t *zx_card = dev->dev_private;
 diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
-index 89a7819..48706c2 100644
+index 89a7819..48706c2 100755
 --- a/src/zx_fbdev.c
 +++ b/src/zx_fbdev.c
 @@ -264,7 +264,9 @@ static const struct drm_fb_helper_funcs zx_fb_helper_funcs = {

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,7 +1,7 @@
 From e225123a7332ce2c15e3b91cb883e6add1a46a0f Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 04/12] fix: kernel: 6.16
+Subject: [PATCH 04/18] fix: kernel: 6.16
 
 Make it compatible with Linux kernel 6.16.
 
@@ -39,5 +39,5 @@ index 84ff1da..4e91f71 100644
      struct pci_dev*    pdev    = to_pci_dev(kobj_to_dev(kobj));
      struct drm_device* drm_dev = pci_get_drvdata(pdev);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,7 +1,7 @@
-From 74abbff6fd42b951de65daaee59716f2f4f3422d Mon Sep 17 00:00:00 2001
+From e225123a7332ce2c15e3b91cb883e6add1a46a0f Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 4/9] fix: kernel: 6.16
+Subject: [PATCH 04/12] fix: kernel: 6.16
 
 Make it compatible with Linux kernel 6.16.
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,7 +1,7 @@
 From f86a538c09478d1d0957a75b3430c131c765ac1c Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
-Subject: [PATCH 05/12] fix: kernel: 6.17
+Subject: [PATCH 05/18] fix: kernel: 6.17
 
 Make it compatible with Linux kernel 6.17.
 
@@ -134,5 +134,5 @@ index e42435d..44f6ae7 100644
  #else
  typedef struct {
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,7 +1,7 @@
-From dd71d8af6ed71866597ea70073c4b5175a82737b Mon Sep 17 00:00:00 2001
+From f86a538c09478d1d0957a75b3430c131c765ac1c Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
-Subject: [PATCH 5/9] fix: kernel: 6.17
+Subject: [PATCH 05/12] fix: kernel: 6.17
 
 Make it compatible with Linux kernel 6.17.
 
@@ -88,7 +88,7 @@ index c7a5588..bc15be4 100644
                          struct drm_zx_gem_object *obj);
  #endif
 diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
-index 48706c2..6eecac4 100644
+index 48706c2..6eecac4 100755
 --- a/src/zx_fbdev.c
 +++ b/src/zx_fbdev.c
 @@ -164,7 +164,11 @@ static int zxfb_create(struct drm_fb_helper *helper, struct drm_fb_helper_surfac

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,7 +1,7 @@
 From 945dd75fd7d1964285745eec5765a61cb80ca135 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
-Subject: [PATCH 06/12] fix: kernel: 6.18
+Subject: [PATCH 06/18] fix: kernel: 6.18
 
 In the 6.18 cycle, Intel moved `struct_mutex' from the public `drm_device'
 struct to `drm_i915_private'. As this was really only used by Intel to
@@ -42,5 +42,5 @@ index 6eecac4..b55023e 100755
  }
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,7 +1,7 @@
-From 0f6cf34ca0dae84d1a4fb384a1589c789117fc1b Mon Sep 17 00:00:00 2001
+From 945dd75fd7d1964285745eec5765a61cb80ca135 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
-Subject: [PATCH 6/9] fix: kernel: 6.18
+Subject: [PATCH 06/12] fix: kernel: 6.18
 
 In the 6.18 cycle, Intel moved `struct_mutex' from the public `drm_device'
 struct to `drm_i915_private'. As this was really only used by Intel to
@@ -18,7 +18,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+)
 
 diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
-index 6eecac4..b55023e 100644
+index 6eecac4..b55023e 100755
 --- a/src/zx_fbdev.c
 +++ b/src/zx_fbdev.c
 @@ -129,7 +129,9 @@ static int zxfb_create(struct drm_fb_helper *helper, struct drm_fb_helper_surfac

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,7 +1,7 @@
 From 2bcfd1357b5d03aed5d39d5e36fea642e96ec02c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:34 +0800
-Subject: [PATCH 07/12] chore: import .gitignore from loonggpu-kernel-dkms
+Subject: [PATCH 07/18] chore: import .gitignore from loonggpu-kernel-dkms
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
@@ -24,5 +24,5 @@ index 0000000..223542a
 +*.order
 +conftest
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,7 +1,7 @@
-From 685add8c5611e324d78d731233c26c58e398f8b0 Mon Sep 17 00:00:00 2001
+From 2bcfd1357b5d03aed5d39d5e36fea642e96ec02c Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:34 +0800
-Subject: [PATCH 7/9] chore: import .gitignore from loonggpu-kernel-dkms
+Subject: [PATCH 07/12] chore: import .gitignore from loonggpu-kernel-dkms
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,7 +1,7 @@
 From 63d83087ffabafb00d749f2a05ea41aaeb83f376 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:48 +0800
-Subject: [PATCH 08/12] refactor (NFC): rename zxfb_create to zx_fbdev_probe
+Subject: [PATCH 08/18] refactor (NFC): rename zxfb_create to zx_fbdev_probe
 
 Make it more similar to reference implementations.
 
@@ -33,5 +33,5 @@ index b55023e..96a1456 100755
  #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
      .fb_dirty           = zxfb_dirty,
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,7 +1,7 @@
-From 4d190581c59c17c54450e383d0a0c541e3409b3e Mon Sep 17 00:00:00 2001
+From 63d83087ffabafb00d749f2a05ea41aaeb83f376 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:48 +0800
-Subject: [PATCH 8/9] refactor (NFC): rename zxfb_create to zx_fbdev_probe
+Subject: [PATCH 08/12] refactor (NFC): rename zxfb_create to zx_fbdev_probe
 
 Make it more similar to reference implementations.
 
@@ -11,7 +11,7 @@ Signed-off-by: Xi Ruoyao <xry111@xry111.site>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
-index b55023e..96a1456 100644
+index b55023e..96a1456 100755
 --- a/src/zx_fbdev.c
 +++ b/src/zx_fbdev.c
 @@ -114,7 +114,7 @@ static void zx_crtc_fb_gamma_get(struct drm_crtc *crtc, u16 *red, u16 *green, u1

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,7 +1,7 @@
 From 88dd99477a3303da1ac0cba28b48a659f224bb65 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 19:07:04 +0800
-Subject: [PATCH 09/12] fix: run DRM default client setup on Linux >= 6.15
+Subject: [PATCH 09/18] fix: run DRM default client setup on Linux >= 6.15
 
 Call drm_client_setup() to run the kernel's default client setup
 for DRM. Set fbdev_probe in struct drm_driver, so that the client
@@ -93,5 +93,5 @@ index a989f9a..8fe5d35 100755
  
  err_pci:
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,7 +1,7 @@
-From 1f2895b78cf6bc047e636f2191d1dae716e2bc4f Mon Sep 17 00:00:00 2001
+From 88dd99477a3303da1ac0cba28b48a659f224bb65 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 19:07:04 +0800
-Subject: [PATCH 9/9] fix: run DRM default client setup on Linux >= 6.15
+Subject: [PATCH 09/12] fix: run DRM default client setup on Linux >= 6.15
 
 Call drm_client_setup() to run the kernel's default client setup
 for DRM. Set fbdev_probe in struct drm_driver, so that the client
@@ -18,7 +18,7 @@ Signed-off-by: Xi Ruoyao <xry111@xry111.site>
  3 files changed, 22 insertions(+), 1 deletion(-)
 
 diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
-index 96a1456..58d5edf 100644
+index 96a1456..58d5edf 100755
 --- a/src/zx_fbdev.c
 +++ b/src/zx_fbdev.c
 @@ -114,7 +114,9 @@ static void zx_crtc_fb_gamma_get(struct drm_crtc *crtc, u16 *red, u16 *green, u1
@@ -53,7 +53,7 @@ index 704d624..6c56455 100644
 +int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_size *sizes);
  #endif
 diff --git a/src/zx_pcie.c b/src/zx_pcie.c
-index a989f9a..8fe5d35 100644
+index a989f9a..8fe5d35 100755
 --- a/src/zx_pcie.c
 +++ b/src/zx_pcie.c
 @@ -41,6 +41,14 @@

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0010-fix-adapt-for-shmem_file_setup-parameter-change-in-L.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0010-fix-adapt-for-shmem_file_setup-parameter-change-in-L.patch
@@ -1,7 +1,7 @@
 From b9ae4eb44179b8016ff7bbb469cb6b6ec1adf148 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 9 Jun 2026 21:47:37 +0800
-Subject: [PATCH 10/12] fix: adapt for shmem_file_setup() parameter change in
+Subject: [PATCH 10/18] fix: adapt for shmem_file_setup() parameter change in
  Linux 7.0
 
 Link: https://git.kernel.org/torvalds/c/590d356aa433
@@ -32,5 +32,5 @@ index da9851f..8e2bd7f 100644
      struct page          **pages;
      struct page          *src_page, *dst_page;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0010-fix-adapt-for-shmem_file_setup-parameter-change-in-L.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0010-fix-adapt-for-shmem_file_setup-parameter-change-in-L.patch
@@ -1,0 +1,36 @@
+From b9ae4eb44179b8016ff7bbb469cb6b6ec1adf148 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 9 Jun 2026 21:47:37 +0800
+Subject: [PATCH 10/12] fix: adapt for shmem_file_setup() parameter change in
+ Linux 7.0
+
+Link: https://git.kernel.org/torvalds/c/590d356aa433
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/os_interface.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/os_interface.c b/src/os_interface.c
+index da9851f..8e2bd7f 100644
+--- a/src/os_interface.c
++++ b/src/os_interface.c
+@@ -2165,9 +2165,15 @@ int zx_query_platform_caps(void *dev, platform_caps_t *caps)
+     return 0;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++#define SHMEM_FILE_SETUP_EMPTY_FLAG EMPTY_VMA_FLAGS
++#else
++#define SHMEM_FILE_SETUP_EMPTY_FLAG 0
++#endif
++
+ void *zx_pages_memory_swapout(struct os_pages_memory *pages_memory)
+ {
+-    struct file          *file_storage = shmem_file_setup("zx gmem", pages_memory->size, 0);
++    struct file          *file_storage = shmem_file_setup("zx gmem", pages_memory->size, SHMEM_FILE_SETUP_EMPTY_FLAG);
+     struct address_space *file_addr_space;
+     struct page          **pages;
+     struct page          *src_page, *dst_page;
+-- 
+2.52.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0011-fix-remove-zx_drm_last_close-on-Linux-6.12.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0011-fix-remove-zx_drm_last_close-on-Linux-6.12.patch
@@ -1,7 +1,7 @@
 From dcb4c88fc8a2ea0adea6894d7111ef587a98b649 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 9 Jun 2026 21:52:45 +0800
-Subject: [PATCH 11/12] fix: remove zx_drm_last_close on Linux >= 6.12
+Subject: [PATCH 11/18] fix: remove zx_drm_last_close on Linux >= 6.12
 
 This is not used on Linux >= 6.12, and it fails to build on Linux 6.19.
 
@@ -32,5 +32,5 @@ index 8fe5d35..ae27cc0 100755
  #if DRM_VERSION_CODE < KERNEL_VERSION(4,11,0)
  static int zx_drm_device_is_agp(struct drm_device * dev)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0011-fix-remove-zx_drm_last_close-on-Linux-6.12.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0011-fix-remove-zx_drm_last_close-on-Linux-6.12.patch
@@ -1,0 +1,36 @@
+From dcb4c88fc8a2ea0adea6894d7111ef587a98b649 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 9 Jun 2026 21:52:45 +0800
+Subject: [PATCH 11/12] fix: remove zx_drm_last_close on Linux >= 6.12
+
+This is not used on Linux >= 6.12, and it fails to build on Linux 6.19.
+
+Link: https://git.kernel.org/torvalds/c/943240d342f1
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_pcie.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/zx_pcie.c b/src/zx_pcie.c
+index 8fe5d35..ae27cc0 100755
+--- a/src/zx_pcie.c
++++ b/src/zx_pcie.c
+@@ -408,6 +408,7 @@ static void zx_drm_postclose(struct drm_device *dev, struct drm_file *file)
+     file->driver_priv = NULL;
+ }
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ void  zx_drm_last_close(struct drm_device* dev)
+ {
+     zx_card_t *zx = dev->dev_private;
+@@ -420,6 +421,7 @@ void  zx_drm_last_close(struct drm_device* dev)
+ 
+     drm_fb_helper_restore_fbdev_mode_unlocked(&fbdev->helper);
+ }
++#endif
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4,11,0)
+ static int zx_drm_device_is_agp(struct drm_device * dev)
+-- 
+2.52.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0012-fix-adapt-for-drm_fb_helper_alloc_info-removal-in-Li.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0012-fix-adapt-for-drm_fb_helper_alloc_info-removal-in-Li.patch
@@ -1,7 +1,7 @@
 From b11ab4841970a846002ec387a24b426f446081bb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 9 Jun 2026 21:58:17 +0800
-Subject: [PATCH 12/12] fix: adapt for drm_fb_helper_alloc_info removal in
+Subject: [PATCH 12/18] fix: adapt for drm_fb_helper_alloc_info removal in
  Linux 6.19
 
 On Linux >= 6.19 it's called by the DRM generic code and no longer
@@ -30,5 +30,5 @@ index 58d5edf..90eb614 100755
      info->par = helper;
  #if DRM_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0012-fix-adapt-for-drm_fb_helper_alloc_info-removal-in-Li.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0012-fix-adapt-for-drm_fb_helper_alloc_info-removal-in-Li.patch
@@ -1,0 +1,34 @@
+From b11ab4841970a846002ec387a24b426f446081bb Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 9 Jun 2026 21:58:17 +0800
+Subject: [PATCH 12/12] fix: adapt for drm_fb_helper_alloc_info removal in
+ Linux 6.19
+
+On Linux >= 6.19 it's called by the DRM generic code and no longer
+exported for the drivers.
+
+Link: https://git.kernel.org/torvalds/c/63c971af4036
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 58d5edf..90eb614 100755
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -205,8 +205,10 @@ int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_si
+ #else
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     info = drm_fb_helper_alloc_fbi(helper);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+     info = drm_fb_helper_alloc_info(helper);
++#else
++	info = helper->info;
+ #endif
+     info->par = helper;
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+-- 
+2.52.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0013-refactor-make-the-fbdev-ptr-in-zx_card_t-typed.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0013-refactor-make-the-fbdev-ptr-in-zx_card_t-typed.patch
@@ -1,0 +1,38 @@
+From 3f3a4dc0beab878e60969fc1a1d0ca5ae98e9302 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 17:20:35 +0800
+Subject: [PATCH 13/18] refactor: make the fbdev ptr in zx_card_t typed
+
+I don't know why they must have used void ptr here.  Maybe they simply
+didn't know foward declarations in C.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_driver.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/zx_driver.h b/src/zx_driver.h
+index d212a5b..ff399ed 100755
+--- a/src/zx_driver.h
++++ b/src/zx_driver.h
+@@ -34,6 +34,8 @@ typedef int (*zx_ioctl_t)(zx_file_t* priv, unsigned int cmd, unsigned long arg);
+ 
+ typedef int (*irq_func_t)(void*);
+ 
++struct zx_fbdev;
++
+ typedef struct
+ {
+     void              *adapter;
+@@ -67,7 +69,7 @@ typedef struct
+     int                 keyboard_rc_keynum;
+     void                *debugfs_dev;
+     struct device       *hwmon_dev;
+-    void                *fbdev;
++    struct zx_fbdev     *fbdev;
+     struct backlight_device *backlight_dev;
+ 
+     struct device      *pci_device;  //used when do dma page map.
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0014-refactor-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0014-refactor-Remove-load-callback-from-kms_driver.patch
@@ -1,0 +1,52 @@
+From 93724c7fc47234eb400ab7cf4f66a8acd71baf77 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 19:53:26 +0800
+Subject: [PATCH 14/18] refactor: Remove load callback from kms_driver
+
+The ".load" callback in "struct drm_driver" is deprecated. In order to
+remove the callback, we have to manually call "zx_drm_load" instead.
+
+Following up the reference implementation change.  Also remove the
+unused argument.
+
+Link: https://github.com/AOSC-Tracking/loonggpu-kernel-dkms/commit/5ec181b08ee1
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_pcie.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/zx_pcie.c b/src/zx_pcie.c
+index ae27cc0..281be89 100755
+--- a/src/zx_pcie.c
++++ b/src/zx_pcie.c
+@@ -256,7 +256,7 @@ static int zx_drm_resume(struct drm_device *dev)
+     return 0;
+ }
+ 
+-static int zx_drm_load(struct drm_device *dev, unsigned long flags)
++static int zx_drm_load(struct drm_device *dev)
+ {
+     struct pci_dev *pdev = to_pci_dev(dev->dev);
+     zx_card_t  *zx = NULL;
+@@ -571,7 +571,6 @@ static struct drm_zx_driver zx_drm_driver = {
+     #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+         .driver_features = ZX_DRM_FEATURE | DRIVER_ATOMIC,
+     #endif
+-        .load               = zx_drm_load,
+         .open               = zx_drm_open,
+ 
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(5,11,0)
+@@ -680,6 +679,10 @@ static int zx_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 
+     pci_set_drvdata(pdev, dev);
+ 
++    ret = zx_drm_load(dev);
++    if (ret)
++            goto err_pci;
++
+     ret = drm_dev_register(dev, ent->driver_data);
+     if (ret)
+             goto err_pci;
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0015-refactor-make-to_zx_fbdev-use-the-helper-ptr-stored-.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0015-refactor-make-to_zx_fbdev-use-the-helper-ptr-stored-.patch
@@ -1,0 +1,57 @@
+From 8c8fe67c3897cb4e204f733582c5b637ea4136c3 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 20:03:00 +0800
+Subject: [PATCH 15/18] refactor: make to_zx_fbdev use the helper ptr stored in
+ zx_card_t
+
+So we will be able to move the helper out of zx_fbdev later, as
+drm_client_setup wants to allocate its own helper and warns if we have
+to use our own helper.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 2 +-
+ src/zx_fbdev.h | 6 +++++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 90eb614..a78454a 100755
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -328,6 +328,7 @@ int zx_fbdev_init(zx_card_t *zx)
+ 
+     fbdev = zx_calloc(sizeof(*fbdev));
+     zx_assert(fbdev != NULL);
++    zx->fbdev = fbdev;
+ 
+     ret = zx_core_interface->create_device(zx->adapter, NULL, &fbdev->gpu_device);
+     zx_assert(ret == 0);
+@@ -359,7 +360,6 @@ int zx_fbdev_init(zx_card_t *zx)
+     drm_fb_helper_initial_config(&fbdev->helper);
+ #endif
+ 
+-    zx->fbdev = fbdev;
+ 
+     return 0;
+ }
+diff --git a/src/zx_fbdev.h b/src/zx_fbdev.h
+index 6c56455..997dc99 100644
+--- a/src/zx_fbdev.h
++++ b/src/zx_fbdev.h
+@@ -11,8 +11,12 @@ struct zx_fbdev
+     zx_device_debug_info_t *debug;
+ };
+ 
+-#define to_zx_fbdev(helper) container_of(helper, struct zx_fbdev, helper)
++static inline struct zx_fbdev *to_zx_fbdev(struct drm_fb_helper *helper)
++{
++    zx_card_t *zx = helper->client.dev->dev_private;
+ 
++    return zx->fbdev;
++}
+ 
+ void zx_fbdev_disable_vesa(zx_card_t *zx);
+ int zx_fbdev_init(zx_card_t *zx);
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0016-refactor-Suspend-resume-fbdev-emulation-via-client-i.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0016-refactor-Suspend-resume-fbdev-emulation-via-client-i.patch
@@ -1,0 +1,96 @@
+From 6621a9ee773139521b19ce08f6960f4ba4d4a3da Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 21:45:16 +0800
+Subject: [PATCH 16/18] refactor: Suspend/resume fbdev emulation via client
+ interfaces on Linux >= 6.15
+
+Remove yet another use of the helper embedded in zx_fbdev.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 10 ++++++++--
+ src/zx_pcie.c  | 17 +++++++++++++++--
+ 2 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index a78454a..f6d5229 100755
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -439,8 +439,11 @@ void zx_fbdev_set_suspend(zx_card_t *zx, int state)
+     {
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+         info = fbdev->helper.fbdev;
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
++        info = fbdev->helper.info;
+ #else
+-	info = fbdev->helper.info;
++        WARN_ONCE(true, "we really shouldn't reach here");
++        return;
+ #endif
+ 
+         console_lock();
+@@ -450,8 +453,11 @@ void zx_fbdev_set_suspend(zx_card_t *zx, int state)
+         {
+             fb_set_suspend(info, state);
+         }
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+         drm_fb_helper_set_suspend(&fbdev->helper, state);
++#else
++        WARN_ONCE(true, "we really shouldn't reach here");
++        return;
+ #endif
+ 
+         console_unlock();
+diff --git a/src/zx_pcie.c b/src/zx_pcie.c
+index 281be89..ad3077e 100755
+--- a/src/zx_pcie.c
++++ b/src/zx_pcie.c
+@@ -47,6 +47,8 @@
+ #else
+ #include <drm/drm_client_setup.h>
+ #endif
++
++#include <drm/drm_client_event.h>
+ #endif
+ 
+ #define DRIVER_NAME         "zx"
+@@ -157,6 +159,17 @@ static unsigned int zx_vga_set_decode(struct pci_dev *pdev, bool state)
+ 
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
++/* HACK! */
++#define drm_client_dev_suspend(dev) \
++	zx_fbdev_set_suspend((dev)->dev_private, 1)
++#define drm_client_dev_resume(dev) \
++	zx_fbdev_set_suspend((dev)->dev_private, 0)
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
++#define drm_client_dev_suspend(x) (drm_client_dev_suspend)((x), false)
++#define drm_client_dev_resume(x) (drm_client_dev_resume)((x), false)
++#endif
++
+ static int zx_drm_suspend(struct drm_device *dev, pm_message_t state)
+ {
+     zx_card_t* zx = dev->dev_private;
+@@ -169,7 +182,7 @@ static int zx_drm_suspend(struct drm_device *dev, pm_message_t state)
+ #ifndef __mips__
+     if(zx->zxfb_enable)
+     {
+-        zx_fbdev_set_suspend(zx, 1);
++        drm_client_dev_suspend(dev);
+         zx_info("drm suspend: save drmfb status finished.\n");
+     }
+ 
+@@ -240,7 +253,7 @@ static int zx_drm_resume(struct drm_device *dev)
+ 
+     if(zx->zxfb_enable)
+     {
+-        zx_fbdev_set_suspend(zx, 0);
++        drm_client_dev_resume(dev);
+         zx_info("drm resume: restore drmfb status finished.\n");
+     }
+ 
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0017-refactor-use-helper-instead-of-fbdev-helper-in-zx_fb.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0017-refactor-use-helper-instead-of-fbdev-helper-in-zx_fb.patch
@@ -1,0 +1,41 @@
+From 5283d06daa36e1d77ecbd76f0542008c219e6569 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Jun 2026 16:04:59 +0800
+Subject: [PATCH 17/18] refactor: use helper instead of &fbdev->helper in
+ zx_fbdev_probe
+
+It will be needed to move helper out of struct zx_fbdev.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index f6d5229..13f1796 100755
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -222,9 +222,9 @@ int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_si
+ #endif
+ 
+     info->skip_vt_switch = true;
+-    fbdev->helper.fb = &fb->base;
++    helper->fb = &fb->base;
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+-    fbdev->helper.funcs = &zx_fb_helper_funcs,
++    helper->funcs = &zx_fb_helper_funcs,
+ #endif
+     zx_vsprintf(info->fix.id, "%s", "zxfb");
+ 
+@@ -246,7 +246,7 @@ int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_si
+     drm_fb_helper_fill_fix(info, fb->base.pitches[0], fb->base.format->depth);
+     drm_fb_helper_fill_var(info, &fbdev->helper, sizes->fb_width, sizes->fb_height);
+ #else
+-    drm_fb_helper_fill_info(info, &fbdev->helper, sizes);
++    drm_fb_helper_fill_info(info, helper, sizes);
+ #endif
+ 
+     DRM_DEBUG_KMS("screen_base=0x%p,screen_size=0x%lx,smem_start=0x%lx,smem_len=0x%x,xres=%d,yres=%d\n",
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0018-fix-take-out-embedded-fb_helper-in-zx_fbdev-with-Lin.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0018-fix-take-out-embedded-fb_helper-in-zx_fbdev-with-Lin.patch
@@ -1,0 +1,143 @@
+From b42629f83b136787bcb11f3ddb9220f731c0e084 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Jun 2026 20:20:06 +0800
+Subject: [PATCH 18/18] fix: take out embedded fb_helper in zx_fbdev with Linux
+ >= 6.15
+
+With Linux 6.18, an "fb_helper is already set" warning had already
+indicated we were doing something unsupported.  And we've stopped
+"happening to work" with Linux 7.0.  So take out the embedded fb_helper
+and let DRM client framebuffer implementation to manage its own helper.
+Test shows this solved both the warning and the runtime crash on 7.0
+kernel.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site:
+---
+ src/zx_fbdev.c | 32 ++++++++++++++++++++++++++------
+ src/zx_fbdev.h |  2 ++
+ 2 files changed, 28 insertions(+), 6 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 13f1796..4a55206 100755
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -56,6 +56,18 @@ FB_GEN_DEFAULT_DEFERRED_IOMEM_OPS(zx, drm_fb_helper_damage_range, drm_fb_helper_
+ FB_GEN_DEFAULT_DEFERRED_IO_OPS(zx, drm_fb_helper_damage_range, drm_fb_helper_damage_area)
+ #endif
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++static void zx_fbdev_fb_destroy(struct fb_info *info)
++{
++    struct drm_fb_helper *fb_helper = info->par;
++    struct zx_fbdev *zxfb = to_zx_fbdev(fb_helper);
++
++    drm_fb_helper_fini(fb_helper);
++    drm_framebuffer_remove(fb_helper->fb);
++    drm_client_release(&fb_helper->client);
++}
++#endif
++
+ static struct fb_ops zxfb_ops = {
+     .owner = THIS_MODULE,
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+@@ -85,6 +97,9 @@ static struct fb_ops zxfb_ops = {
+     .fb_imageblit = cfb_imageblit,
+ #endif
+     .fb_mmap    = zxfb_mmap,
++#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 15, 0)
++    .fb_destroy = zx_fbdev_fb_destroy,
++#endif
+ };
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+@@ -335,6 +350,7 @@ int zx_fbdev_init(zx_card_t *zx)
+ 
+     fbdev->debug = zx_debugfs_add_device_node(zx->debugfs_dev, zx_get_current_pid(), fbdev->gpu_device);
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+     drm_fb_helper_prepare(zx->drm_dev, &fbdev->helper, &zx_fb_helper_funcs);
+ #else
+@@ -359,7 +375,7 @@ int zx_fbdev_init(zx_card_t *zx)
+ #else
+     drm_fb_helper_initial_config(&fbdev->helper);
+ #endif
+-
++#endif // 6.15.0
+ 
+     return 0;
+ }
+@@ -369,7 +385,6 @@ int zx_fbdev_deinit(zx_card_t *zx)
+ {
+     struct zx_fbdev *fbdev = zx->fbdev;
+     struct drm_zx_framebuffer *fb;
+-    struct fb_info *info;
+ 
+     if (!fbdev)
+     {
+@@ -378,16 +393,17 @@ int zx_fbdev_deinit(zx_card_t *zx)
+ 
+     fb = fbdev->fb;
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+-    info = fbdev->helper.fbdev;
+-#else
+-    info = fbdev->helper.info;
++    struct fb_info *info = fbdev->helper.fbdev;
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
++    struct fb_info *info = fbdev->helper.info;
+ #endif
++
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
+     unregister_framebuffer(info);
+ #else
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     drm_fb_helper_unregister_fbi(&fbdev->helper);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     drm_fb_helper_unregister_info(&fbdev->helper);
+ #endif
+ #endif
+@@ -415,11 +431,13 @@ int zx_fbdev_deinit(zx_card_t *zx)
+         fb->obj = NULL;
+     }
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     drm_fb_helper_fini(&fbdev->helper);
+     if(fbdev->fb)
+     {
+         drm_framebuffer_remove(&fbdev->fb->base);
+     }
++#endif
+ 
+     zx_debugfs_remove_device_node(zx->debugfs_dev, fbdev->debug);
+     zx_core_interface->destroy_device(zx->adapter, fbdev->gpu_device);
+@@ -464,6 +482,7 @@ void zx_fbdev_set_suspend(zx_card_t *zx, int state)
+     }
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ void zx_fbdev_poll_changed(struct drm_device *dev)
+ {
+     zx_card_t*  zx = dev->dev_private;
+@@ -478,3 +497,4 @@ void zx_fbdev_poll_changed(struct drm_device *dev)
+         drm_fb_helper_hotplug_event(&fbdev->helper);
+     }
+ }
++#endif
+diff --git a/src/zx_fbdev.h b/src/zx_fbdev.h
+index 997dc99..1915013 100644
+--- a/src/zx_fbdev.h
++++ b/src/zx_fbdev.h
+@@ -6,7 +6,9 @@
+ struct zx_fbdev
+ {
+     unsigned int gpu_device;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     struct drm_fb_helper helper;
++#endif
+     struct drm_zx_framebuffer *fb;
+     zx_device_debug_info_t *debug;
+ };
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,6 +1,6 @@
-UPSTREAM_VER=21.00.86
+UPSTREAM_VER=21.00.87
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=2509&tag=0&ref=qdxz&pre=0&t=eecb7eac5d344b6d&__for_acbs_hash_url=$UPSTREAM_VER"
-CHKSUMS="sha256::0c0ce66b412dd0f6be6c3a9ed6da168e4ab6fbf64ff127d6bec774f393379cb4"
+CHKSUMS="sha256::22c6c2a2537a7fb23d134aa108438e352262e227dd297d54ac3dd540a3609bbd"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- cx4-linux-graphics-driver-dri: update to 26.00.49
    Track patches at AOSC-Tracking/cx4-kernel-dkms @ aosc/v26.00.49
    \(HEAD: d85884b84584b484dcf26974154229f446d723c7\).
- zhaoxin-linux-graphics-driver-dri: update to 21.00.87
    Track patches at AOSC-Tracking/zx-kernel-dkms @ aosc/v21.00.87
    \(HEAD: b11ab4841970a846002ec387a24b426f446081bb\).

Package(s) Affected
-------------------

- cx4-linux-graphics-driver-dri: 26.00.49
- zhaoxin-linux-graphics-driver-dri: 21.00.87

Security Update?
----------------

No

Build Order
-----------

```
#buildit zhaoxin-linux-graphics-driver-dri cx4-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
