### PR TITLE
telegram-desktop: update to 6.9.1

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,12 +1,11 @@
-VER=6.8.2
-REL=4
+VER=6.9.1
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=e0943d068ce90b5010f1aea946e6901e25b43bf6
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::cce1c196ef00703e9872d7072defd14860c970effc52d52d990745c8dca16cac \
+CHKSUMS="sha256::ff694e702ca1412b1c13fc8debd8cda981ff19284d7a61eb7c31e21444a4a716 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.9.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- telegram-desktop: 6.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
