### PR TITLE
xdg-desktop-portal-termfilechooser: update to 1.4.2

### DIFF
--- a/app-admin/xdg-desktop-portal-termfilechooser/spec
+++ b/app-admin/xdg-desktop-portal-termfilechooser/spec
@@ -1,4 +1,4 @@
-VER=1.4.1
+VER=1.4.2
 SRCS="git::commit=tags/v$VER::https://github.com/hunkyburrito/xdg-desktop-portal-termfilechooser.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377242"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal-termfilechooser: update to 1.4.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- xdg-desktop-portal-termfilechooser: 1.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal-termfilechooser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
