### PR TITLE
cachecontrol: adjust dependency version range due to uv update to 0.11.x

### DIFF
--- a/lang-python/cachecontrol/autobuild/patches/0001-uv-version-range.patch
+++ b/lang-python/cachecontrol/autobuild/patches/0001-uv-version-range.patch
@@ -14,7 +14,7 @@ index d5f4923..da6d4b0 100644
 @@ -1,5 +1,5 @@
  [build-system]
 -requires = ["uv_build>=0.9.6,<0.10.0"]
-+requires = ["uv_build>=0.9.6,<0.11.0"]
++requires = ["uv_build>=0.9.6,<0.12.0"]
  build-backend = "uv_build"
  
  [tool.uv.build-backend]

--- a/lang-python/cachecontrol/spec
+++ b/lang-python/cachecontrol/spec
@@ -1,4 +1,5 @@
 VER=0.14.4
+REL=1
 SRCS="pypi::version=$VER::CacheControl"
 CHKSUMS="sha256::e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1"
 CHKUPDATE="anitya::id=59291"


### PR DESCRIPTION
Topic Description
-----------------

- cachecontrol: adjust dependency version range
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- cachecontrol: 0.14.4-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit cachecontrol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
