### PR TITLE
poppler: update to 26.06.0

### DIFF
--- a/app-creativity/inkscape/autobuild/patches/0001-UPSTREAM-fix-support-for-popler-26.05-font-encoding-.patch
+++ b/app-creativity/inkscape/autobuild/patches/0001-UPSTREAM-fix-support-for-popler-26.05-font-encoding-.patch
@@ -1,0 +1,70 @@
+From 6ad5f8aaadbb8302fcb3a81fd9e63f2f8e848f91 Mon Sep 17 00:00:00 2001
+From: Varasina Farmadani <sina@sinanonym.my.id>
+Date: Mon, 11 May 2026 02:29:05 +0700
+Subject: [PATCH 1/2] UPSTREAM: fix: support for popler >= 26.05 font encoding
+ change
+
+Poppler version 26.05.0 changed the return type of
+gfx8bit->getEncoding() from char** to const std::array<const char*,256>&.
+this caused a compilation error due to type incompatibility:
+    error: assigning to 'char **' from incompatible type 'const std::array<const char *, 256>
+    error: no viable conversion from 'const std::array<const char *, 256>' to 'char **'
+
+(cherry picked from commit 98828255aa0c1212329236b3ff4ac7f41efb4a67)
+Signed-off-by: Kaiyang Wu <wukaiyang@loongfans.cn>
+---
+ .../pdfinput/poppler-cairo-font-engine.cpp         | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+index b6ed11c8c0..9d908a33e3 100644
+--- a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
++++ b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+@@ -313,7 +313,11 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+ #else
+     GfxFontLoc *fontLoc;
+ #endif
++#if POPPLER_CHECK_VERSION(26, 5, 0)
++    const char * const *enc;
++#else
+     char **enc;
++#endif
+     const char *name;
+ #if POPPLER_CHECK_VERSION(25, 7, 0)
+     std::unique_ptr<FoFiType1C> ff1c;
+@@ -385,7 +389,11 @@ CairoFreeTypeFont *CairoFreeTypeFont::create(GfxFont *gfxFont, XRef *xref, FT_Li
+                 goto err2;
+             }
+ 
++#if POPPLER_CHECK_VERSION(26, 5, 0)
++            enc = gfx8bit->getEncoding().data();
++#else
+             enc = gfx8bit->getEncoding();
++#endif
+ 
+             codeToGID.resize(256);
+             for (i = 0; i < 256; ++i) {
+@@ -677,7 +685,7 @@ CairoType3Font *CairoType3Font::create(GfxFont *gfxFont, PDFDoc *doc, CairoFontE
+ #endif
+ 
+     std::vector<int> codeToGID;
+-    char *name;
++    const char *name;
+ 
+     Dict *charProcs = gfx8bit->getCharProcs();
+     Ref ref = *gfxFont->getID();
+@@ -694,7 +702,11 @@ CairoType3Font *CairoType3Font::create(GfxFont *gfxFont, PDFDoc *doc, CairoFontE
+ 
+     cairo_font_face_set_user_data(font_face, &type3_font_key, (void *)info, _free_type3_font_info);
+ 
++#if POPPLER_CHECK_VERSION(26, 5, 0)
++    const char * const *enc = gfx8bit->getEncoding().data();
++#else
+     char **enc = gfx8bit->getEncoding();
++#endif
+     codeToGID.resize(256);
+     for (int i = 0; i < 256; ++i) {
+         codeToGID[i] = 0;
+-- 
+2.52.0
+

--- a/app-creativity/inkscape/autobuild/patches/0002-UPSTREAM-Fix-Building-with-Poppler-26.06.0.patch
+++ b/app-creativity/inkscape/autobuild/patches/0002-UPSTREAM-Fix-Building-with-Poppler-26.06.0.patch
@@ -1,0 +1,517 @@
+From f903ea68b5068e2364c0cb06c29623d67bd6fda4 Mon Sep 17 00:00:00 2001
+From: KrIr17 <elendil.krir17@gmail.com>
+Date: Mon, 8 Jun 2026 20:16:32 +0200
+Subject: [PATCH 2/2] UPSTREAM: Fix Building with Poppler 26.06.0
+
+- pdfparser: Some `const PDFRectangle *` to `const PDFRectangle &` [1]
+- pdfparser: Some `const GfxColor *` to `const GfxColor &` [2]
+- pdf-utils: Add a `getRect(const PDFRectangle &)` alongside `getRect(const
+  PDFRectangle *)`
+- poppler-cairo-font-engine: `getKey()` now returns std::string and not
+  char[], so change `strcmp` to `std::string(...).compare(...)` [3]
+- poppler-utils: `obj->dictGetKey()` etc. were removed; use
+  `obj->dict()->getKey()` instead (these have also existed in poppler
+  since the beginning, so shouldn't break any old poppler) [4,5]
+- svg-builder: `convertGfxColor` now takes `const GfxColor &` as input.
+  A convenience function taking `const GfxColor *` (for older poppler)
+  now calls the new one after confirming `color` is a valid pointer
+- svg-builder: `_addStopToGradient` now  takes `const GfxColor &` as
+  input. This was used only in `convertGfxColor` and therefore doesn't
+  need a helper function for compatibility
+- testfiles pdf-utils-test: `<poppler/*.h>` to `<*.h>` (see e3eb1210)
+- testfiles pdf-utils-test: Some `const PDFRectangle *`
+  to `const PDFRectangle &` [1]
+
+Fixes https://gitlab.com/inkscape/inkscape/-/work_items/6210
+
+Upstream Commits:
+
+[1] https://gitlab.freedesktop.org/poppler/poppler/-/commit/d50a4510
+[2] https://gitlab.freedesktop.org/poppler/poppler/-/commit/0f94f530
+[3] https://gitlab.freedesktop.org/poppler/poppler/-/commit/a3de7f8a
+[4] https://gitlab.freedesktop.org/poppler/poppler/-/commit/bb13b0f5
+[5] https://gitlab.freedesktop.org/poppler/poppler/-/commit/8ae0f8e7
+
+Link: https://gitlab.com/inkscape/inkscape/-/work_items/6210#note_3438034571
+Signed-off-by: Kaiyang Wu <wukaiyang@loongfans.cn>
+---
+ src/extension/internal/pdfinput/pdf-input.cpp | 14 +++++-
+ .../internal/pdfinput/pdf-parser.cpp          | 43 ++++++++++---------
+ src/extension/internal/pdfinput/pdf-parser.h  |  4 +-
+ src/extension/internal/pdfinput/pdf-utils.cpp |  5 +++
+ src/extension/internal/pdfinput/pdf-utils.h   |  3 ++
+ .../pdfinput/poppler-cairo-font-engine.cpp    |  2 +-
+ .../pdfinput/poppler-transition-api.h         | 16 +++++++
+ .../internal/pdfinput/poppler-utils.cpp       | 20 +++++----
+ .../internal/pdfinput/svg-builder.cpp         | 29 ++++++++-----
+ src/extension/internal/pdfinput/svg-builder.h |  3 +-
+ 10 files changed, 94 insertions(+), 45 deletions(-)
+
+diff --git a/src/extension/internal/pdfinput/pdf-input.cpp b/src/extension/internal/pdfinput/pdf-input.cpp
+index 45df931f00..441871bb10 100644
+--- a/src/extension/internal/pdfinput/pdf-input.cpp
++++ b/src/extension/internal/pdfinput/pdf-input.cpp
+@@ -808,7 +808,11 @@ PdfInput::add_builder_page(std::shared_ptr<PDFDoc>pdf_doc, SvgBuilder *builder,
+     }
+ 
+     // Apply crop settings
++#if POPPLER_CHECK_VERSION(26, 2, 0)
++    std::optional<PDFRectangle> clipToBox;
++#else
+     _POPPLER_CONST PDFRectangle *clipToBox = nullptr;
++#endif
+ 
+     if (crop_to == "media-box") {
+         clipToBox = page->getMediaBox();
+@@ -822,8 +826,16 @@ PdfInput::add_builder_page(std::shared_ptr<PDFDoc>pdf_doc, SvgBuilder *builder,
+         clipToBox = page->getArtBox();
+     }
+ 
++    std::optional<PDFRectangle> cropBox;
++#if POPPLER_CHECK_VERSION(26, 2, 0)
++    cropBox = clipToBox;
++#else
++    if (clipToBox) {
++        cropBox = *clipToBox;
++    }
++#endif
+     // Create parser  (extension/internal/pdfinput/pdf-parser.h)
+-    auto pdf_parser = PdfParser(pdf_doc, builder, page, clipToBox);
++    auto pdf_parser = PdfParser(pdf_doc, builder, page, cropBox);
+ 
+     // Set up approximation precision for parser. Used for converting Mesh Gradients into tiles.
+     if ( color_delta <= 0.0 ) {
+diff --git a/src/extension/internal/pdfinput/pdf-parser.cpp b/src/extension/internal/pdfinput/pdf-parser.cpp
+index d24dc05dab..e32fa24b32 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.cpp
++++ b/src/extension/internal/pdfinput/pdf-parser.cpp
+@@ -43,6 +43,7 @@
+ #include <poppler/GlobalParams.h>
+ #include <poppler/Lexer.h>
+ #include <poppler/Object.h>
++#include <poppler/OptionalContent.h>
+ #include <poppler/OutputDev.h>
+ #include <poppler/PDFDoc.h>
+ #include <poppler/Page.h>
+@@ -266,7 +267,7 @@ GfxPatch blankPatch()
+ //------------------------------------------------------------------------
+ 
+ PdfParser::PdfParser(std::shared_ptr<PDFDoc> pdf_doc, Inkscape::Extension::Internal::SvgBuilder *builderA, Page *page,
+-                     _POPPLER_CONST PDFRectangle *cropBox)
++                     const std::optional<PDFRectangle> &cropBox)
+     : _pdf_doc(pdf_doc)
+     , xref(pdf_doc->getXRef())
+     , builder(builderA)
+@@ -307,8 +308,8 @@ PdfParser::PdfParser(std::shared_ptr<PDFDoc> pdf_doc, Inkscape::Extension::Inter
+     builder->setMargins(getRect(page->getTrimBox()) * scale,
+                         getRect(page->getArtBox()) * scale,
+                         getRect(page->getBleedBox()) * scale);
+-    if (cropBox && getRect(cropBox) != page_box) {
+-        builder->cropPage(getRect(cropBox) * scale);
++    if (cropBox && getRect(*cropBox) != page_box) {
++        builder->cropPage(getRect(*cropBox) * scale);
+     }
+ 
+     saveState();
+@@ -325,7 +326,7 @@ PdfParser::PdfParser(XRef *xrefA, Inkscape::Extension::Internal::SvgBuilder *bui
+     , printCommands(false)
+     , res(new GfxResources(xref, resDict, nullptr))
+     , // start the resource stack
+-    state(new GfxState(72, 72, box, 0, false))
++    state(new _POPPLER_GFX_STATE(72, 72, *box, 0, false))
+     , fontChanged(gFalse)
+     , clip(clipNone)
+     , ignoreUndef(0)
+@@ -992,7 +993,7 @@ void PdfParser::opSetFillGray(Object args[], int /*numArgs*/)
+   state->setFillPattern(nullptr);
+   state->setFillColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceGrayColorSpace>()));
+   color.c[0] = dblToCol(args[0].getNum());
+-  state->setFillColor(&color);
++  state->_POPPLER_SET_FILL_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1004,7 +1005,7 @@ void PdfParser::opSetStrokeGray(Object args[], int /*numArgs*/)
+   state->setStrokePattern(nullptr);
+   state->setStrokeColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(std::make_unique<GfxDeviceGrayColorSpace>()));
+   color.c[0] = dblToCol(args[0].getNum());
+-  state->setStrokeColor(&color);
++  state->_POPPLER_SET_STROKE_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1019,7 +1020,7 @@ void PdfParser::opSetFillCMYKColor(Object args[], int /*numArgs*/)
+   for (i = 0; i < 4; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+-  state->setFillColor(&color);
++  state->_POPPLER_SET_FILL_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1033,7 +1034,7 @@ void PdfParser::opSetStrokeCMYKColor(Object args[], int /*numArgs*/)
+   for (int i = 0; i < 4; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+-  state->setStrokeColor(&color);
++  state->_POPPLER_SET_STROKE_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1047,7 +1048,7 @@ void PdfParser::opSetFillRGBColor(Object args[], int /*numArgs*/)
+   for (int i = 0; i < 3; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+-  state->setFillColor(&color);
++  state->_POPPLER_SET_FILL_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1060,7 +1061,7 @@ void PdfParser::opSetStrokeRGBColor(Object args[], int /*numArgs*/) {
+   for (int i = 0; i < 3; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+-  state->setStrokeColor(&color);
++  state->_POPPLER_SET_STROKE_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1076,7 +1077,7 @@ void PdfParser::opSetFillColorSpace(Object args[], int numArgs)
+     GfxColor color;
+     colorSpace->getDefaultColor(&color);
+     state->setFillColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(colorSpace));
+-    state->setFillColor(&color);
++    state->_POPPLER_SET_FILL_COLOR(color);
+     builder->updateStyle(state);
+   } else {
+     error(errSyntaxError, getPos(), "Bad color space (fill)");
+@@ -1097,7 +1098,7 @@ void PdfParser::opSetStrokeColorSpace(Object args[], int numArgs)
+     GfxColor color;
+     colorSpace->getDefaultColor(&color);
+     state->setStrokeColorSpace(_POPPLER_CONSUME_UNIQPTR_ARG(colorSpace));
+-    state->setStrokeColor(&color);
++    state->_POPPLER_SET_STROKE_COLOR(color);
+     builder->updateStyle(state);
+   } else {
+     error(errSyntaxError, getPos(), "Bad color space (stroke)");
+@@ -1117,7 +1118,7 @@ void PdfParser::opSetFillColor(Object args[], int numArgs) {
+   for (i = 0; i < numArgs; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+-  state->setFillColor(&color);
++  state->_POPPLER_SET_FILL_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1134,7 +1135,7 @@ void PdfParser::opSetStrokeColor(Object args[], int numArgs) {
+   for (i = 0; i < numArgs; ++i) {
+     color.c[i] = dblToCol(args[i].getNum());
+   }
+-  state->setStrokeColor(&color);
++  state->_POPPLER_SET_STROKE_COLOR(color);
+   builder->updateStyle(state);
+ }
+ 
+@@ -1155,7 +1156,7 @@ void PdfParser::opSetFillColorN(Object args[], int numArgs) {
+ 	  color.c[i] = dblToCol(args[i].getNum());
+ 	}
+       }
+-      state->setFillColor(&color);
++      state->_POPPLER_SET_FILL_COLOR(color);
+       builder->updateStyle(state);
+     }
+     if (auto pattern = lookupPattern(&(args[numArgs - 1]), state)) {
+@@ -1174,7 +1175,7 @@ void PdfParser::opSetFillColorN(Object args[], int numArgs) {
+ 	color.c[i] = dblToCol(args[i].getNum());
+       }
+     }
+-    state->setFillColor(&color);
++    state->_POPPLER_SET_FILL_COLOR(color);
+     builder->updateStyle(state);
+   }
+ }
+@@ -1198,7 +1199,7 @@ void PdfParser::opSetStrokeColorN(Object args[], int numArgs) {
+ 	  color.c[i] = dblToCol(args[i].getNum());
+ 	}
+       }
+-      state->setStrokeColor(&color);
++      state->_POPPLER_SET_STROKE_COLOR(color);
+       builder->updateStyle(state);
+     }
+     if (auto pattern = lookupPattern(&(args[numArgs - 1]), state)) {
+@@ -1217,7 +1218,7 @@ void PdfParser::opSetStrokeColorN(Object args[], int numArgs) {
+ 	color.c[i] = dblToCol(args[i].getNum());
+       }
+     }
+-    state->setStrokeColor(&color);
++    state->_POPPLER_SET_STROKE_COLOR(color);
+     builder->updateStyle(state);
+   }
+ }
+@@ -1700,7 +1701,7 @@ void PdfParser::doFunctionShFill1(GfxFunctionShading *shading,
+ 
+     // use the center color
+     shading->getColor(xM, yM, &fillColor);
+-    state->setFillColor(&fillColor);
++    state->_POPPLER_SET_FILL_COLOR(fillColor);
+ 
+     // fill the rectangle
+     state->moveTo(x0 * matrix[0] + y0 * matrix[2] + matrix[4],
+@@ -1799,7 +1800,7 @@ void PdfParser::gouraudFillTriangle(double x0, double y0, GfxColor *color0,
+     }
+   }
+   if (i == nComps || depth == maxDepths[pdfGouraudTriangleShading-1]) {
+-    state->setFillColor(color0);
++    state->_POPPLER_SET_FILL_COLOR(*color0);
+     state->moveTo(x0, y0);
+     state->lineTo(x1, y1);
+     state->lineTo(x2, y2);
+@@ -1877,7 +1878,7 @@ void PdfParser::fillPatch(_POPPLER_CONST GfxPatch *patch, int nComps, int depth)
+     color.c[i] = GfxColorComp(patch->color[0][0].c[i]);
+   }
+   if (i == nComps || depth == maxDepths[pdfPatchMeshShading-1]) {
+-    state->setFillColor(&color);
++    state->_POPPLER_SET_FILL_COLOR(color);
+     state->moveTo(patch->x[0][0], patch->y[0][0]);
+     state->curveTo(patch->x[0][1], patch->y[0][1],
+ 		   patch->x[0][2], patch->y[0][2],
+diff --git a/src/extension/internal/pdfinput/pdf-parser.h b/src/extension/internal/pdfinput/pdf-parser.h
+index c136ebf1ef..58044fb518 100644
+--- a/src/extension/internal/pdfinput/pdf-parser.h
++++ b/src/extension/internal/pdfinput/pdf-parser.h
+@@ -112,8 +112,8 @@ struct OpHistoryEntry {
+ class PdfParser {
+ public:
+ 
+-  // Constructor for regular output.
+-    PdfParser(std::shared_ptr<PDFDoc> pdf_doc, SvgBuilder *builderA, Page *page, _POPPLER_CONST PDFRectangle *cropBox);
++    // Constructor for regular output.
++    PdfParser(std::shared_ptr<PDFDoc> pdf_doc, SvgBuilder *builderA, Page *page, const std::optional<PDFRectangle> &cropBox);
+     // Constructor for a sub-page object.
+     PdfParser(XRef *xrefA, SvgBuilder *builderA, Dict *resDict, _POPPLER_CONST PDFRectangle *box);
+ 
+diff --git a/src/extension/internal/pdfinput/pdf-utils.cpp b/src/extension/internal/pdfinput/pdf-utils.cpp
+index d126426b62..28c1678f2d 100644
+--- a/src/extension/internal/pdfinput/pdf-utils.cpp
++++ b/src/extension/internal/pdfinput/pdf-utils.cpp
+@@ -133,6 +133,11 @@ Geom::Rect getRect(_POPPLER_CONST PDFRectangle *box)
+     return Geom::Rect(box->x1, box->y1, box->x2, box->y2);
+ }
+ 
++Geom::Rect getRect(const PDFRectangle &box)
++{
++    return Geom::Rect(box.x1, box.y1, box.x2, box.y2);
++}
++
+ Geom::PathVector getPathV(GfxPath *path) 
+ {
+     if (!path) {
+diff --git a/src/extension/internal/pdfinput/pdf-utils.h b/src/extension/internal/pdfinput/pdf-utils.h
+index 59efdeae27..d5b3020d61 100644
+--- a/src/extension/internal/pdfinput/pdf-utils.h
++++ b/src/extension/internal/pdfinput/pdf-utils.h
+@@ -59,6 +59,9 @@ private:
+ };
+ 
+ Geom::Rect getRect(_POPPLER_CONST PDFRectangle *box);
++Geom::Rect getRect(_POPPLER_CONST PDFRectangle &box);
+ Geom::PathVector getPathV(GfxPath *gPath);
++Geom::PathVector maybeIntersect(Geom::PathVector const &v1, Geom::PathVector const &v2,
++                                FillRule fill1 = FillRule::fill_nonZero, FillRule fill2 = FillRule::fill_nonZero);
+ 
+ #endif /* PDF_UTILS_H */
+diff --git a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+index 9d908a33e3..af132ad735 100644
+--- a/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
++++ b/src/extension/internal/pdfinput/poppler-cairo-font-engine.cpp
+@@ -712,7 +712,7 @@ CairoType3Font *CairoType3Font::create(GfxFont *gfxFont, PDFDoc *doc, CairoFontE
+         codeToGID[i] = 0;
+         if (charProcs && (name = enc[i])) {
+             for (int j = 0; j < charProcs->getLength(); j++) {
+-                if (strcmp(name, charProcs->getKey(j)) == 0) {
++                if (std::string(charProcs->getKey(j)).compare(name) == 0) {
+                     codeToGID[i] = j;
+                 }
+             }
+diff --git a/src/extension/internal/pdfinput/poppler-transition-api.h b/src/extension/internal/pdfinput/poppler-transition-api.h
+index 7f299bd05a..bf42f54142 100644
+--- a/src/extension/internal/pdfinput/poppler-transition-api.h
++++ b/src/extension/internal/pdfinput/poppler-transition-api.h
+@@ -15,6 +15,22 @@
+ #include <glib/poppler-features.h>
+ #include <poppler/UTF.h>
+ 
++#if POPPLER_CHECK_VERSION(26, 6, 0)
++#define _POPPLER_GET_GRAY(color, gray) getGray(color, gray)
++#define _POPPLER_GET_RGB(color, rgb) getRGB(color, rgb)
++#define _POPPLER_GET_CMYK(color, cmyk) getCMYK(color, cmyk)
++#define _POPPLER_SET_FILL_COLOR(color) setFillColor(color)
++#define _POPPLER_SET_STROKE_COLOR(color) setStrokeColor(color)
++#define _POPPLER_GFX_STATE(h, v, Rect, rotateA, upsideDown) GfxState(h, v, Rect, rotateA, upsideDown)
++#else
++#define _POPPLER_GET_GRAY(color, gray) getGray(&color, gray)
++#define _POPPLER_GET_RGB(color, rgb) getRGB(&color, rgb)
++#define _POPPLER_GET_CMYK(color, cmyk) getCMYK(&color, cmyk)
++#define _POPPLER_SET_FILL_COLOR(color) setFillColor(&color)
++#define _POPPLER_SET_STROKE_COLOR(color) setStrokeColor(&color)
++#define _POPPLER_GFX_STATE(h, v, Rect, rotateA, upsideDown) GfxState(h, v, &Rect, rotateA, upsideDown)
++#endif
++
+ #if POPPLER_CHECK_VERSION(26, 2, 0)
+ #define _POPPLER_WMODE GfxFont::WritingMode
+ #define _POPPLER_WMODE_HORIZONTAL GfxFont::WritingMode::Horizontal
+diff --git a/src/extension/internal/pdfinput/poppler-utils.cpp b/src/extension/internal/pdfinput/poppler-utils.cpp
+index a65a5780ee..902736281a 100644
+--- a/src/extension/internal/pdfinput/poppler-utils.cpp
++++ b/src/extension/internal/pdfinput/poppler-utils.cpp
+@@ -195,15 +195,17 @@ void InkFontDict::hashFontObject1(const Object *obj, FNVHash *h)
+                 hashFontObject1(&obj2, h);
+             }
+             break;
+-        case objDict:
+-            h->hash('d');
+-            n = obj->dictGetLength();
+-            h->hash((char *)&n, sizeof(int));
+-            for (i = 0; i < n; ++i) {
+-                p = obj->dictGetKey(i);
+-                h->hash(p, (int)strlen(p));
+-                const Object &obj2 = obj->dictGetValNF(i);
+-                hashFontObject1(&obj2, h);
++        case objDict: {
++                h->hash('d');
++                auto objdict = obj->getDict();
++                n = objdict->getLength();
++                h->hash((char *)&n, sizeof(int));
++                for (i = 0; i < n; ++i) {
++                    auto p = std::string(objdict->getKey(i));
++                    h->hash(p.c_str(), p.length());
++                    const Object &obj2 = objdict->getValNF(i);
++                    hashFontObject1(&obj2, h);
++                }
+             }
+             break;
+         case objStream:
+diff --git a/src/extension/internal/pdfinput/svg-builder.cpp b/src/extension/internal/pdfinput/svg-builder.cpp
+index d854ed8a2e..c308561319 100644
+--- a/src/extension/internal/pdfinput/svg-builder.cpp
++++ b/src/extension/internal/pdfinput/svg-builder.cpp
+@@ -384,6 +384,7 @@ static gchar *svgConvertRGBToText(double r, double g, double b) {
+     return (gchar *)&tmp;
+ }
+ 
++// for poppler < 26.06.0
+ static std::string svgConvertGfxRGB(GfxRGB *color)
+ {
+     double r = (double)color->r / 65535.0;
+@@ -393,6 +394,14 @@ static std::string svgConvertGfxRGB(GfxRGB *color)
+ }
+ 
+ std::string SvgBuilder::convertGfxColor(const GfxColor *color, GfxColorSpace *space)
++{
++    if (!color) {
++        return "";
++    }
++    return convertGfxColor(*color, space);
++}
++
++std::string SvgBuilder::convertGfxColor(const GfxColor &color, GfxColorSpace *space)
+ {
+     std::string icc = "";
+     switch (space->getMode()) {
+@@ -412,14 +421,14 @@ std::string SvgBuilder::convertGfxColor(const GfxColor *color, GfxColorSpace *sp
+     }
+ 
+     GfxRGB rgb;
+-    space->getRGB(color, &rgb);
++    space->_POPPLER_GET_RGB(color, &rgb);
+     auto rgb_color = svgConvertGfxRGB(&rgb);
+ 
+     if (!icc.empty()) {
+         Inkscape::CSSOStringStream icc_color;
+         icc_color << rgb_color << " icc-color(" << icc;
+         for (int i = 0; i < space->getNComps(); ++i) {
+-            icc_color << ", " << colToDbl((*color).c[i]);
++            icc_color << ", " << colToDbl((color).c[i]);
+         }
+         icc_color << ");";
+         return icc_color.str();
+@@ -1204,7 +1213,7 @@ gchar *SvgBuilder::_createGradient(GfxShading *shading, const Geom::Affine pat_m
+ /**
+  * \brief Adds a stop with the given properties to the gradient's representation
+  */
+-void SvgBuilder::_addStopToGradient(Inkscape::XML::Node *gradient, double offset, GfxColor *color, GfxColorSpace *space,
++void SvgBuilder::_addStopToGradient(Inkscape::XML::Node *gradient, double offset, GfxColor &color, GfxColorSpace *space,
+                                     double opacity)
+ {
+     Inkscape::XML::Node *stop = _xml_doc->createElement("svg:stop");
+@@ -1214,7 +1223,7 @@ void SvgBuilder::_addStopToGradient(Inkscape::XML::Node *gradient, double offset
+     if (space->getMode() == csDeviceGray) {
+         // This is a transparency mask.
+         GfxRGB rgb;
+-        space->getRGB(color, &rgb);
++        space->_POPPLER_GET_RGB(color, &rgb);
+         double gray = (double)rgb.r / 65535.0;
+         gray = CLAMP(gray, 0.0, 1.0);
+         os_opacity << gray;
+@@ -1255,8 +1264,8 @@ bool SvgBuilder::_addGradientStops(Inkscape::XML::Node *gradient, GfxShading *sh
+         if (!svgGetShadingColor(shading, 0.0, &stop1) || !svgGetShadingColor(shading, 1.0, &stop2)) {
+             return false;
+         } else {
+-            _addStopToGradient(gradient, 0.0, &stop1, space, 1.0);
+-            _addStopToGradient(gradient, 1.0, &stop2, space, 1.0);
++            _addStopToGradient(gradient, 0.0, stop1, space, 1.0);
++            _addStopToGradient(gradient, 1.0, stop2, space, 1.0);
+         }
+     } else if (type == _POPPLER_FUNCTION_TYPE_STITCHING) {
+         auto stitchingFunc = static_cast<_POPPLER_CONST StitchingFunction*>(func);
+@@ -1269,7 +1278,7 @@ bool SvgBuilder::_addGradientStops(Inkscape::XML::Node *gradient, GfxShading *sh
+         // Add stops from all the stitched functions
+         GfxColor prev_color, color;
+         svgGetShadingColor(shading, bounds[0], &prev_color);
+-        _addStopToGradient(gradient, bounds[0], &prev_color, space, 1.0);
++        _addStopToGradient(gradient, bounds[0], prev_color, space, 1.0);
+         for ( int i = 0 ; i < num_funcs ; i++ ) {
+             svgGetShadingColor(shading, bounds[i + 1], &color);
+             // Add stops
+@@ -1279,14 +1288,14 @@ bool SvgBuilder::_addGradientStops(Inkscape::XML::Node *gradient, GfxShading *sh
+                     expE = (bounds[i + 1] - bounds[i])/expE;    // approximate exponential as a single straight line at x=1
+                     if (encode[2*i] == 0) {    // normal sequence
+                         auto offset = (bounds[i + 1] - expE) / max_bound;
+-                        _addStopToGradient(gradient, offset, &prev_color, space, 1.0);
++                        _addStopToGradient(gradient, offset, prev_color, space, 1.0);
+                     } else {                   // reflected sequence
+                         auto offset = (bounds[i] + expE) / max_bound;
+-                        _addStopToGradient(gradient, offset, &color, space, 1.0);
++                        _addStopToGradient(gradient, offset, color, space, 1.0);
+                     }
+                 }
+             }
+-            _addStopToGradient(gradient, bounds[i + 1] / max_bound, &color, space, 1.0);
++            _addStopToGradient(gradient, bounds[i + 1] / max_bound, color, space, 1.0);
+             prev_color = color;
+         }
+     } else { // Unsupported function type
+diff --git a/src/extension/internal/pdfinput/svg-builder.h b/src/extension/internal/pdfinput/svg-builder.h
+index b814a67807..4041c95a9f 100644
+--- a/src/extension/internal/pdfinput/svg-builder.h
++++ b/src/extension/internal/pdfinput/svg-builder.h
+@@ -186,7 +186,7 @@ private:
+     // Pattern creation
+     gchar *_createPattern(GfxPattern *pattern, GfxState *state, bool is_stroke=false);
+     gchar *_createGradient(GfxShading *shading, const Geom::Affine pat_matrix, bool for_shading = false);
+-    void _addStopToGradient(Inkscape::XML::Node *gradient, double offset, GfxColor *color, GfxColorSpace *space,
++    void _addStopToGradient(Inkscape::XML::Node *gradient, double offset, GfxColor &color, GfxColorSpace *space,
+                             double opacity);
+     bool _addGradientStops(Inkscape::XML::Node *gradient, GfxShading *shading,
+                            _POPPLER_CONST Function *func);
+@@ -239,6 +239,7 @@ private:
+     static bool _attrEqual(Inkscape::XML::Node *a, Inkscape::XML::Node *b, char const *attr);
+ 
+     // Colors
++    std::string convertGfxColor(const GfxColor &color, GfxColorSpace *space);
+     std::string convertGfxColor(const GfxColor *color, GfxColorSpace *space);
+     std::string _getColorProfile(cmsHPROFILE hp);
+ 
+-- 
+2.52.0
+

--- a/app-creativity/inkscape/spec
+++ b/app-creativity/inkscape/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=1_4_3
+UPSTREAM_VER=1_4_4
 VER=${UPSTREAM_VER//_/.}
-REL=6
 SRCS="git::commit=tags/INKSCAPE_${UPSTREAM_VER}::https://gitlab.com/inkscape/inkscape"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1381"

--- a/app-creativity/openboard/autobuild/defines
+++ b/app-creativity/openboard/autobuild/defines
@@ -1,10 +1,15 @@
 PKGNAME=openboard
 PKGSEC=graphics
-PKGDEP="ffmpeg glibc qt-6 openssl zlib x11-lib"
-BUILDDEP="libglvnd openssl poppler ffmpeg libpaper libva libxcb alsa-lib x264 libvpx libvorbis libtheora lame sdl12-compat opus fdkaac libass xz bzip2 quazip"
+PKGDEP="ffmpeg glibc qt-6 openssl zlib x11-lib libglvnd poppler quazip libva \
+        libxcb alsa-lib x264 libvpx libvorbis libtheora lame sdl12-compat opus \
+        fdkaac libass xz bzip2 libpaper"
 PKGDES="Interactive whiteboard application"
 
 ABTYPE=cmakeninja
+
+# FIXME: Use C++20 since poppler header files require newer C++ standards
+#
+# NOTE: Use Qt 6 here to support QtWebEngine on loongarch64
 CMAKE_AFTER=(
     "-DCMAKE_CXX_STANDARD=20"
     "-DQT_VERSION=6"

--- a/app-creativity/openboard/autobuild/patches/0002-FROMLIST-refactor-Remove-unused-pdf-title-code.patch
+++ b/app-creativity/openboard/autobuild/patches/0002-FROMLIST-refactor-Remove-unused-pdf-title-code.patch
@@ -1,0 +1,88 @@
+From 0f77142d768426147a133b031da3e94a51a2947d Mon Sep 17 00:00:00 2001
+From: Vekhir <Vekhir@yahoo.com>
+Date: Wed, 15 Apr 2026 01:18:37 +0200
+Subject: [PATCH] FROMLIST: refactor: Remove unused pdf title code
+
+The code breaks with poppler 26.04. There are no known uses of this
+function in the code base, and limited testing showed no regressions.
+
+Link: https://github.com/OpenBoard-org/OpenBoard/pull/1474
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/pdf/PDFRenderer.h    |  2 --
+ src/pdf/XPDFRenderer.cpp | 33 ---------------------------------
+ src/pdf/XPDFRenderer.h   |  1 -
+ 3 files changed, 36 deletions(-)
+
+diff --git a/src/pdf/PDFRenderer.h b/src/pdf/PDFRenderer.h
+index 8f0cb93e..a5e87261 100644
+--- a/src/pdf/PDFRenderer.h
++++ b/src/pdf/PDFRenderer.h
+@@ -58,8 +58,6 @@ class PDFRenderer : public QObject
+ 
+         virtual QSizeF pointSizeF(int pageNumber) const = 0;
+ 
+-        virtual QString title() const = 0;
+-
+         void attach();
+         void detach();
+ 
+diff --git a/src/pdf/XPDFRenderer.cpp b/src/pdf/XPDFRenderer.cpp
+index 8e361430..bb4bca36 100644
+--- a/src/pdf/XPDFRenderer.cpp
++++ b/src/pdf/XPDFRenderer.cpp
+@@ -157,39 +157,6 @@ int XPDFRenderer::pageCount() const
+         return 0;
+ }
+ 
+-QString XPDFRenderer::title() const
+-{
+-    if (isValid())
+-    {
+-#if POPPLER_VERSION_MAJOR > 0 || POPPLER_VERSION_MINOR >= 55
+-        Object pdfInfo = mDocument->getDocInfo();
+-#else
+-        Object pdfInfo;
+-        mDocument->getDocInfo(&pdfInfo);
+-#endif
+-        if (pdfInfo.isDict())
+-        {
+-            Dict *infoDict = pdfInfo.getDict();
+-#if POPPLER_VERSION_MAJOR > 0 || POPPLER_VERSION_MINOR >= 55
+-            Object title = infoDict->lookup((char*)"Title");
+-#else
+-            Object title;
+-            infoDict->lookup((char*)"Title", &title);
+-#endif
+-            if (title.isString())
+-            {
+-#if POPPLER_VERSION_MAJOR > 0 || POPPLER_VERSION_MINOR >= 72
+-                return QString(title.getString()->c_str());
+-#else
+-                return QString(title.getString()->getCString());
+-#endif
+-            }
+-        }
+-    }
+-
+-    return QString();
+-}
+-
+ 
+ QSizeF XPDFRenderer::pageSizeF(int pageNumber) const
+ {
+diff --git a/src/pdf/XPDFRenderer.h b/src/pdf/XPDFRenderer.h
+index 6264ae1b..7a9bdf77 100644
+--- a/src/pdf/XPDFRenderer.h
++++ b/src/pdf/XPDFRenderer.h
+@@ -73,7 +73,6 @@ class XPDFRenderer : public PDFRenderer
+         virtual QSizeF pageSizeF(int pageNumber) const override;
+         virtual int pageRotation(int pageNumber) const override;
+         virtual QSizeF pointSizeF(int pageNumber) const override;
+-        virtual QString title() const override;
+         virtual void render(QPainter *p, int pageNumber, const bool cacheAllowed, const QRectF &bounds = QRectF()) override;
+ 
+     signals:
+-- 
+2.52.0
+

--- a/app-creativity/openboard/spec
+++ b/app-creativity/openboard/spec
@@ -1,5 +1,5 @@
 VER=1.7.7
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/OpenBoard-org/OpenBoard.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=65331"

--- a/app-doc/pdfgrep/spec
+++ b/app-doc/pdfgrep/spec
@@ -1,5 +1,5 @@
 VER=2.1.2
-REL=5
+REL=6
 SRCS="tbl::https://pdfgrep.org/download/pdfgrep-$VER.tar.gz"
 CHKSUMS="sha256::0ef3dca1d749323f08112ffe68e6f4eb7bc25f56f90a2e933db477261b082aba"
 CHKUPDATE="anitya::id=9917"

--- a/app-productivity/libreoffice/autobuild/patches/0001-AOSCOS-Make-pyuno-work-with-system-wide-module-insta.patch
+++ b/app-productivity/libreoffice/autobuild/patches/0001-AOSCOS-Make-pyuno-work-with-system-wide-module-insta.patch
@@ -1,7 +1,7 @@
-From 9ee025ede08394d1ba72815f05d5bbfda9c91f9f Mon Sep 17 00:00:00 2001
+From 599d4e30edc9b1633d5669508bb52426caf5c6de Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sat, 12 Oct 2024 13:15:01 +0000
-Subject: [PATCH 1/4] AOSCOS: Make pyuno work with system-wide module install
+Subject: [PATCH 1/3] AOSCOS: Make pyuno work with system-wide module install
 
 Signed-off-by: Bingwu Zhang <xtex@aosc.io>
 ---
@@ -28,8 +28,6 @@ index b2a75bd03982..dde88af9ac41 100644
  import traceback
  import warnings
  
-
-base-commit: e1cf4a87eb02d755bce1a01209907ea5ddc8f069
 -- 
-2.48.1
+2.52.0
 

--- a/app-productivity/libreoffice/autobuild/patches/0002-AOSCOS-Allow-building-bundled-Firebird-with-LTO.patch
+++ b/app-productivity/libreoffice/autobuild/patches/0002-AOSCOS-Allow-building-bundled-Firebird-with-LTO.patch
@@ -1,7 +1,7 @@
-From 505c4450f1654682d839ee8995c4a4f7d4ca5454 Mon Sep 17 00:00:00 2001
+From b36a044fc89f00ce6581f5310d52d892ef2bd3cf Mon Sep 17 00:00:00 2001
 From: xtex <xtexchooser@duck.com>
 Date: Sat, 12 Oct 2024 13:16:42 +0000
-Subject: [PATCH 2/4] AOSCOS: Allow building bundled Firebird with LTO
+Subject: [PATCH 2/3] AOSCOS: Allow building bundled Firebird with LTO
 
 Signed-off-by: Bingwu Zhang <xtex@aosc.io>
 ---
@@ -37,5 +37,5 @@ index 16fe160a3af6..3a972f2bea5f 100644
  		" \
  		&& export LIBREOFFICE_ICU_LIB="$(gb_UnpackedTarball_workdir)/icu/source/lib" \
 -- 
-2.48.1
+2.52.0
 

--- a/app-productivity/libreoffice/autobuild/patches/0003-UPSTREAM-poppler-upgrade-to-26.06.patch
+++ b/app-productivity/libreoffice/autobuild/patches/0003-UPSTREAM-poppler-upgrade-to-26.06.patch
@@ -1,0 +1,173 @@
+From 503253e3c79553d8889fee685e79245d20e07930 Mon Sep 17 00:00:00 2001
+From: Xisco Fauli <xiscofauli@libreoffice.org>
+Date: Wed, 3 Jun 2026 17:37:11 +0200
+Subject: [PATCH 3/3] UPSTREAM: poppler: upgrade to 26.06
+
+Downloaded from https://poppler.freedesktop.org/poppler-26.06.0.tar.xz
+
+Change-Id: Idbcf3baf344f7400dad28d06e4a2b18118e647f4
+Reviewed-on: https://gerrit.libreoffice.org/c/core/+/205964
+Reviewed-by: Xisco Fauli <xiscofauli@libreoffice.org>
+Tested-by: Jenkins
+
+(cherry picked from commit b08afae7e41fd5ca3a4101de07366783b17b3887)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ download.lst                                  |  4 ++--
+ external/poppler/disable-freetype.patch.1     |  4 ++--
+ external/poppler/poppler-config.patch.1       | 12 +++++------
+ .../pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx  | 20 +++++++++++++++++--
+ 4 files changed, 28 insertions(+), 12 deletions(-)
+
+diff --git a/download.lst b/download.lst
+index e217b679efbc..eb4a9961321d 100644
+--- a/download.lst
++++ b/download.lst
+@@ -599,8 +599,8 @@ LIBTIFF_TARBALL := tiff-4.7.1.tar.xz
+ # three static lines
+ # so that git cherry-pick
+ # will not run into conflicts
+-POPPLER_SHA256SUM := 6fef27ff04f37db43054c86bcdff6128c9fb1f6af4ef3c8b369a7e9abd68d0bb
+-POPPLER_TARBALL := poppler-26.05.0.tar.xz
++POPPLER_SHA256SUM := 4cb4e5a3dc8cb5eec751c8a23c8ba19f61f96dedc0cd07d2aee6b0c8e2cf6ba4
++POPPLER_TARBALL := poppler-26.06.0.tar.xz
+ POPPLER_DATA_SHA256SUM := c835b640a40ce357e1b83666aabd95edffa24ddddd49b8daff63adb851cdab74
+ POPPLER_DATA_TARBALL := poppler-data-0.4.12.tar.gz
+ # three static lines
+diff --git a/external/poppler/disable-freetype.patch.1 b/external/poppler/disable-freetype.patch.1
+index ea0d37ea24de..26c9ca84c355 100644
+--- a/external/poppler/disable-freetype.patch.1
++++ b/external/poppler/disable-freetype.patch.1
+@@ -23,14 +23,14 @@ disable freetype dependent code
+  #include <unordered_set>
+  
+  // helper for using std::visit to get a dependent false for static_asserts
+-@@ -2723,6 +2723,8 @@
++@@ -2738,6 +2738,8 @@
+  
+  Form::AddFontResult Form::addFontToDefaultResources(const std::string &filepath, int faceIndex, const std::string &fontFamily, const std::string &fontStyle, bool fontSubstitutedIn, bool forceName)
+  {
+ +    return {};
+ +#if 0
+      if (!filepath.ends_with(".ttf") && !filepath.ends_with(".ttc") && !filepath.ends_with(".otf")) {
+-         error(errIO, -1, "We only support embedding ttf/ttc/otf fonts for now. The font file for {0:s} {1:s} was {2:s}", fontFamily.c_str(), fontStyle.c_str(), filepath.c_str());
++         error(errIO, -1, "We only support embedding ttf/ttc/otf fonts for now. The font file for {0:r} {1:r} was {2:r}", &fontFamily, &fontStyle, &filepath);
+          return {};
+ @@ -2974,6 +2974,7 @@
+      }
+diff --git a/external/poppler/poppler-config.patch.1 b/external/poppler/poppler-config.patch.1
+index 3a1f2c1eb6ba..b6ace1d64f08 100644
+--- a/external/poppler/poppler-config.patch.1
++++ b/external/poppler/poppler-config.patch.1
+@@ -120,7 +120,7 @@ index 0fbd336a..451213f8 100644
+ +#define PACKAGE_NAME "poppler"
+ +
+ +/* Define to the full name and version of this package. */
+-+#define PACKAGE_STRING "poppler 26.04.0"
+++#define PACKAGE_STRING "poppler 26.06.0"
+ +
+ +/* Define to the one symbol short name of this package. */
+ +#define PACKAGE_TARNAME "poppler"
+@@ -129,7 +129,7 @@ index 0fbd336a..451213f8 100644
+ +#define PACKAGE_URL ""
+ +
+ +/* Define to the version of this package. */
+-+#define PACKAGE_VERSION "26.04.0"
+++#define PACKAGE_VERSION "26.06.0"
+ +
+ +/* Poppler data dir */
+ +#define POPPLER_DATADIR "/usr/local/share/poppler"
+@@ -144,7 +144,7 @@ index 0fbd336a..451213f8 100644
+ +#define USE_FLOAT 0
+ +
+ +/* Version number of package */
+-+#define VERSION "26.04.0"
+++#define VERSION "26.06.0"
+ +
+ +#if defined(__APPLE__)
+ +#elif defined (_WIN32)
+@@ -222,7 +222,7 @@ index 0fbd336a..451213f8 100644
+ +#define POPPLER_CONFIG_H
+ +
+ +/* Defines the poppler version. */
+-+#define POPPLER_VERSION "26.04.0"
+++#define POPPLER_VERSION "26.06.0"
+ +
+ +/* Use single precision arithmetic in the Splash backend */
+ +#define USE_FLOAT 0
+@@ -310,9 +310,9 @@ index 0fbd336a..451213f8 100644
+ +
+ +#include "poppler-global.h"
+ +
+-+#define POPPLER_VERSION "26.04.0"
+++#define POPPLER_VERSION "26.06.0"
+ +#define POPPLER_VERSION_MAJOR 26
+-+#define POPPLER_VERSION_MINOR 04
+++#define POPPLER_VERSION_MINOR 06
+ +#define POPPLER_VERSION_MICRO 0
+ +
+ +namespace poppler
+diff --git a/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx b/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx
+index 18c855908f02..ed91b5553334 100644
+--- a/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx
++++ b/sdext/source/pdfimport/xpdfwrapper/pdfioutdev_gpl.cxx
+@@ -60,6 +60,10 @@
+ #include "UTF8.h"
+ #endif
+ 
++#if POPPLER_CHECK_VERSION(26, 6, 0)
++#include <Annot.h>
++#endif
++
+ #ifdef _WIN32
+ # define snprintf _snprintf
+ 
+@@ -1223,7 +1227,9 @@ void PDFOutDev::drawImage(GfxState*, Object*, Stream* str,
+         {
+             GfxRGB aMinRGB;
+             colorMap->getColorSpace()->getRGB(
+-#if POPPLER_CHECK_VERSION(0, 82, 0)
++#if POPPLER_CHECK_VERSION(26, 6, 0)
++                *reinterpret_cast<const GfxColor*>(maskColors),
++#elif POPPLER_CHECK_VERSION(0, 82, 0)
+                 reinterpret_cast<const GfxColor*>(maskColors),
+ #else
+                 reinterpret_cast<GfxColor*>(maskColors),
+@@ -1232,7 +1238,9 @@ void PDFOutDev::drawImage(GfxState*, Object*, Stream* str,
+ 
+             GfxRGB aMaxRGB;
+             colorMap->getColorSpace()->getRGB(
+-#if POPPLER_CHECK_VERSION(0, 82, 0)
++#if POPPLER_CHECK_VERSION(26, 6, 0)
++                *(reinterpret_cast<const GfxColor*>(maskColors)+gfxColorMaxComps),
++#elif POPPLER_CHECK_VERSION(0, 82, 0)
+                 reinterpret_cast<const GfxColor*>(maskColors)+gfxColorMaxComps,
+ #else
+                 reinterpret_cast<GfxColor*>(maskColors)+gfxColorMaxComps,
+@@ -1365,7 +1373,11 @@ poppler_bool PDFOutDev::tilingPatternFill(GfxState *state, Gfx *, Catalog *,
+     aBox.y2 = pBbox[3];
+ 
+     const int nDPI = 72; // GfxState seems to have 72.0 as magic for some reason
++#if POPPLER_CHECK_VERSION(26, 6, 0)
++    auto pSplashGfxState = new GfxState(nDPI, nDPI, aBox, 0, false);
++#else
+     auto pSplashGfxState = new GfxState(nDPI, nDPI, &aBox, 0, false);
++#endif
+ #if POPPLER_CHECK_VERSION(26, 2, 0)
+     auto pSplashOut = new SplashOutputDev(splashModeRGB8, 1, nullptr);
+ #else
+@@ -1375,7 +1387,11 @@ poppler_bool PDFOutDev::tilingPatternFill(GfxState *state, Gfx *, Catalog *,
+     pSplashOut->startDoc(m_pDoc);
+     pSplashOut->startPage(0 /* pageNum */, pSplashGfxState, nullptr /* xref */);
+ 
++#if POPPLER_CHECK_VERSION(26, 6, 0)
++    auto pSplashGfx = new Gfx(m_pDoc, pSplashOut, pResDict, aBox, nullptr);
++#else
+     auto pSplashGfx = new Gfx(m_pDoc, pSplashOut, pResDict, &aBox, nullptr);
++#endif
+     pSplashGfx->display(aStr);
+     std::unique_ptr<SplashBitmap> pSplashBitmap(pSplashOut->takeBitmap());
+     // Poppler tells us to free the splash device immediately after taking the
+-- 
+2.52.0
+

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,4 +1,5 @@
 VER=26.2.4.2
+REL=1
 SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://github.com/LibreOffice/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"

--- a/app-productivity/scribus/autobuild/patches/0001-BACKPORT-17808-Fix-failure-to-build-with-poppler-26..patch
+++ b/app-productivity/scribus/autobuild/patches/0001-BACKPORT-17808-Fix-failure-to-build-with-poppler-26..patch
@@ -1,0 +1,78 @@
+From 5224822ffe8f24bc8c4ee48e7ef005df606c8346 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Fri, 12 Jun 2026 18:40:49 +0800
+Subject: [PATCH 1/2] BACKPORT: #17808: Fix failure to build with poppler
+ 26.05.0
+
+Link: https://bugs.scribus.net/view.php?id=17808
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ scribus/plugins/import/pdf/importpdfconfig.h |  4 ++++
+ scribus/plugins/import/pdf/slaoutput.cpp     | 24 +++++++++++++++++---
+ 2 files changed, 25 insertions(+), 3 deletions(-)
+
+diff --git a/scribus/plugins/import/pdf/importpdfconfig.h b/scribus/plugins/import/pdf/importpdfconfig.h
+index bd4d30f..cbd5a7e 100644
+--- a/scribus/plugins/import/pdf/importpdfconfig.h
++++ b/scribus/plugins/import/pdf/importpdfconfig.h
+@@ -21,4 +21,8 @@ for which a new license (GPL+exception) is in place.
+ #define POPPLER_CONST_25_02
+ #endif
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 5, 0)
++using SplashCoord = double;
++#endif
++
+ #endif
+diff --git a/scribus/plugins/import/pdf/slaoutput.cpp b/scribus/plugins/import/pdf/slaoutput.cpp
+index c88f8af..f78ea63 100644
+--- a/scribus/plugins/import/pdf/slaoutput.cpp
++++ b/scribus/plugins/import/pdf/slaoutput.cpp
+@@ -3177,7 +3177,13 @@ void SlaOutputDev::updateFont(GfxState *state)
+ 		// load the font file
+ 		switch (fontType) {
+ 		case fontType1:
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 2, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 5, 0)
++			if (!(fontFile = m_fontEngine->loadType1Font(std::move(id), std::move(fontsrc), static_cast<Gfx8BitFont*>(gfxFont)->getEncoding(), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 2, 0)
+ 			if (!(fontFile = m_fontEngine->loadType1Font(std::move(id), std::move(fontsrc), (const char**) ((Gfx8BitFont*) gfxFont)->getEncoding(), fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
+@@ -3198,7 +3204,13 @@ void SlaOutputDev::updateFont(GfxState *state)
+ #endif
+ 			break;
+ 		case fontType1C:
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 2, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 5, 0)
++			if (!(fontFile = m_fontEngine->loadType1CFont(std::move(id), std::move(fontsrc), static_cast<Gfx8BitFont*>(gfxFont)->getEncoding(), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 2, 0)
+ 			if (!(fontFile = m_fontEngine->loadType1CFont(std::move(id), std::move(fontsrc), (const char**) ((Gfx8BitFont*) gfxFont)->getEncoding(), fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
+@@ -3219,7 +3231,13 @@ void SlaOutputDev::updateFont(GfxState *state)
+ #endif
+ 			break;
+ 		case fontType1COT:
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 2, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 5, 0)
++			if (!(fontFile = m_fontEngine->loadOpenTypeT1CFont(std::move(id), std::move(fontsrc), static_cast<Gfx8BitFont*>(gfxFont)->getEncoding(), fontLoc->fontNum)))
++			{
++				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
++				goto err2;
++			}
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 2, 0)
+ 			if (!(fontFile = m_fontEngine->loadOpenTypeT1CFont(std::move(id), std::move(fontsrc), (const char**) ((Gfx8BitFont*) gfxFont)->getEncoding(), fontLoc->fontNum)))
+ 			{
+ 				error(errSyntaxError, -1, "Couldn't create a font for '{0:s}'", gfxFont->getName() ? gfxFont->getName()->c_str() : "(unnamed)");
+-- 
+2.52.0
+

--- a/app-productivity/scribus/autobuild/patches/0002-BACKPORT-17832-Fix-failure-to-build-with-poppler-26..patch
+++ b/app-productivity/scribus/autobuild/patches/0002-BACKPORT-17832-Fix-failure-to-build-with-poppler-26..patch
@@ -1,0 +1,423 @@
+From e85e32a19f43f20281de6d1e00865e3dde3a4ad1 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Fri, 12 Jun 2026 23:54:11 +0800
+Subject: [PATCH 2/2] BACKPORT: #17832: Fix failure to build with poppler
+ 26.06.0
+
+Link: https://bugs.scribus.net/view.php?id=17832
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ scribus/plugins/import/pdf/importpdf.cpp     | 21 +++++
+ scribus/plugins/import/pdf/importpdfconfig.h |  6 ++
+ scribus/plugins/import/pdf/slaoutput.cpp     | 96 ++++++++++++++++++--
+ scribus/plugins/import/pdf/slaoutput.h       | 24 ++++-
+ 4 files changed, 138 insertions(+), 9 deletions(-)
+
+diff --git a/scribus/plugins/import/pdf/importpdf.cpp b/scribus/plugins/import/pdf/importpdf.cpp
+index a359bc5..7347a6f 100644
+--- a/scribus/plugins/import/pdf/importpdf.cpp
++++ b/scribus/plugins/import/pdf/importpdf.cpp
+@@ -378,8 +378,13 @@ bool PdfPlug::convert(const QString& fn)
+ 			bool useMediaBox = true;
+ 			bool crop = true;
+ 			bool printing = false;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++			const PDFRectangle& mediaBox = pdfDoc->getPage(1)->getMediaBox();
++			QRectF mediaRect = QRectF(QPointF(mediaBox.x1, mediaBox.y1), QPointF(mediaBox.x2, mediaBox.y2)).normalized();
++#else
+ 			const PDFRectangle *mediaBox = pdfDoc->getPage(1)->getMediaBox();
+ 			QRectF mediaRect = QRectF(QPointF(mediaBox->x1, mediaBox->y1), QPointF(mediaBox->x2, mediaBox->y2)).normalized();
++#endif
+ 			bool boxesAreDifferent = false;
+ 			if (getCBox(Crop_Box, 1) != mediaRect)
+ 				boxesAreDifferent = true;
+@@ -885,6 +890,21 @@ QImage PdfPlug::readPreview(int pgNum, int width, int height, int box)
+ 
+ QRectF PdfPlug::getCBox(int box, int pgNum)
+ {
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++	PDFRectangle cBox;
++	if (box == Media_Box)
++		cBox = m_pdfDoc->getPage(pgNum)->getMediaBox();
++	else if (box == Bleed_Box)
++		cBox = m_pdfDoc->getPage(pgNum)->getBleedBox();
++	else if (box == Trim_Box)
++		cBox = m_pdfDoc->getPage(pgNum)->getTrimBox();
++	else if (box == Crop_Box)
++		cBox = m_pdfDoc->getPage(pgNum)->getCropBox();
++	else if (box == Art_Box)
++		cBox = m_pdfDoc->getPage(pgNum)->getArtBox();
++	QRectF cRect = QRectF(QPointF(cBox.x1, cBox.y1), QPointF(cBox.x2, cBox.y2)).normalized();
++	return cRect;
++#else
+ 	const PDFRectangle *cBox = nullptr;
+ 	if (box == Media_Box)
+ 		cBox = m_pdfDoc->getPage(pgNum)->getMediaBox();
+@@ -898,6 +918,7 @@ QRectF PdfPlug::getCBox(int box, int pgNum)
+ 		cBox = m_pdfDoc->getPage(pgNum)->getArtBox();
+ 	QRectF cRect = QRectF(QPointF(cBox->x1, cBox->y1), QPointF(cBox->x2, cBox->y2)).normalized();
+ 	return cRect;
++#endif
+ }
+ 
+ QString PdfPlug::UnicodeParsedString(const GooString *s1) const
+diff --git a/scribus/plugins/import/pdf/importpdfconfig.h b/scribus/plugins/import/pdf/importpdfconfig.h
+index cbd5a7e..f9e688c 100644
+--- a/scribus/plugins/import/pdf/importpdfconfig.h
++++ b/scribus/plugins/import/pdf/importpdfconfig.h
+@@ -23,6 +23,12 @@ for which a new license (GPL+exception) is in place.
+ 
+ #if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 5, 0)
+ using SplashCoord = double;
++#endif 
++
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++#define POPPLER_CONST_26_06 const
++#else
++#define POPPLER_CONST_26_06
+ #endif
+ 
+ #endif
+diff --git a/scribus/plugins/import/pdf/slaoutput.cpp b/scribus/plugins/import/pdf/slaoutput.cpp
+index f78ea63..947a153 100644
+--- a/scribus/plugins/import/pdf/slaoutput.cpp
++++ b/scribus/plugins/import/pdf/slaoutput.cpp
+@@ -17,6 +17,7 @@ for which a new license (GPL+exception) is in place.
+ #include <poppler/poppler-config.h>
+ #include <poppler/FileSpec.h>
+ #include <poppler/fofi/FoFiTrueType.h>
++#include <poppler/OptionalContent.h>
+ 
+ #include <QApplication>
+ #include <QFile>
+@@ -189,7 +190,11 @@ void AnoOutputDev::drawString(GfxState *state, const GooString *s)
+ #endif
+ }
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 06, 0)
++QString AnoOutputDev::getColor(GfxColorSpace *color_space, const GfxColor &color, int* shade)
++#else
+ QString AnoOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color, int *shade)
++#endif
+ {
+ 	QString fNam;
+ 	QString namPrefix = "FromPDF";
+@@ -272,7 +277,11 @@ QString AnoOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color
+ 		tmp.setSpotColor(true);
+ 
+ 		fNam = m_doc->PageColors.tryAddColor(name, tmp);
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 06, 0)
++		*shade = qRound(colToDbl(color.c[0]) * 100);
++#else
+ 		*shade = qRound(colToDbl(color->c[0]) * 100);
++#endif
+ 	}
+ 	else
+ 	{
+@@ -660,7 +669,7 @@ bool SlaOutputDev::handleWidgetAnnot(Annot* annota, double xCoor, double yCoor,
+ 		}
+ 		if (retVal)
+ 		{
+-			AnnotAppearanceCharacs *achar = ano->getAppearCharacs();
++			POPPLER_CONST_26_06 AnnotAppearanceCharacs *achar = ano->getAppearCharacs();
+ 			bool fgFound = false;
+ 			bool bgFound = false;
+ 			if (achar)
+@@ -696,8 +705,10 @@ bool SlaOutputDev::handleWidgetAnnot(Annot* annota, double xCoor, double yCoor,
+ 			if (apa || !achar)
+ 			{
+ 				auto annotOutDev = std::make_shared<AnoOutputDev>(m_doc, m_importedColors);
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 4, 0)
+ 				const PDFRectangle& annotaRect = annota->getRect();
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++				auto gfx = std::make_unique<Gfx>(m_pdfDoc, annotOutDev.get(), m_pdfDoc->getPage(m_actPage)->getResourceDict(), annotaRect, nullptr);
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(22, 4, 0)
+ 				auto gfx = std::make_shared<Gfx>(m_pdfDoc, annotOutDev.get(), m_pdfDoc->getPage(m_actPage)->getResourceDict(), &annotaRect, nullptr);
+ #else
+ 				auto gfx = std::make_shared<Gfx>(m_pdfDoc, annotOutDev.get(), m_pdfDoc->getPage(m_actPage)->getResourceDict(), annota->getRect(), nullptr);
+@@ -732,7 +743,7 @@ bool SlaOutputDev::handleWidgetAnnot(Annot* annota, double xCoor, double yCoor,
+ 			}
+ 			ite->setIsAnnotation(true);
+ 			ite->AutoName = false;
+-			AnnotBorder *brd = annota->getBorder();
++			POPPLER_CONST_26_06 AnnotBorder *brd = annota->getBorder();
+ 			if (brd)
+ 			{
+ 				int bsty = brd->getStyle();
+@@ -853,7 +864,11 @@ bool SlaOutputDev::handleWidgetAnnot(Annot* annota, double xCoor, double yCoor,
+ 				{
+ 					if (wtyp == 5)
+ 						ite->annotation().addToFlag(Annotation::Flag_Combo);
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++					size_t co = btn->getChoices().size();
++#else
+ 					int co = btn->getNumChoices();
++#endif
+ 					if (co > 0)
+ 					{
+ 						QString inh = UnicodeParsedString(btn->getChoice(0));
+@@ -958,7 +973,7 @@ void SlaOutputDev::applyTextStyle(PageItem* ite, const QString& fontName, const
+ 
+ void SlaOutputDev::handleActions(PageItem* ite, AnnotWidget *ano)
+ {
+-	LinkAction *Lact = ano->getAction();
++	POPPLER_CONST_26_06 LinkAction *Lact = ano->getAction();
+ 	if (Lact)
+ 	{
+ 		if (Lact->getKind() == actionJavaScript)
+@@ -1508,7 +1523,9 @@ void SlaOutputDev::endTransparencyGroup(GfxState *state)
+ 	m_tmpSel->clear();
+ }
+ 
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 9, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++void SlaOutputDev::setSoftMask(GfxState* /*state*/, const std::array<double, 4>& bbox, bool alpha, Function* transferFunc, const GfxColor& /*backdropColor*/)
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 9, 0)
+ void SlaOutputDev::setSoftMask(GfxState* /*state*/, const std::array<double, 4>& bbox, bool alpha, Function* transferFunc, GfxColor* /*backdropColor*/)
+ #else
+ void SlaOutputDev::setSoftMask(GfxState* /*state*/, const double* bbox, bool alpha, Function* transferFunc, GfxColor* /*backdropColor*/)
+@@ -2303,7 +2320,11 @@ bool SlaOutputDev::tilingPatternFill(GfxState *state, Gfx* /*gfx*/, Catalog *cat
+ 	QTransform mm(mat[0], mat[1], mat[2], mat[3], mat[4], mat[5]);
+ 	QTransform mmx = mm * m_ctm;
+ 
+-	auto gfx = std::make_shared<Gfx>(m_pdfDoc, this, resDict, &box, nullptr);
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++	auto gfx = std::make_unique<Gfx>(m_pdfDoc, this, resDict, box, nullptr);
++#else
++	auto gfx = std::make_unique<Gfx>(m_pdfDoc, this, resDict, &box, nullptr);
++#endif
+ 	m_inPattern++;
+ 	// Unset the clip path as it is unrelated to the pattern's coordinate space.
+ 	QPainterPath savedClip = m_graphicStack.top().clipPath;
+@@ -2551,7 +2572,11 @@ void SlaOutputDev::drawSoftMaskedImage(GfxState *state, Object *ref, Stream *str
+ 	if (matteColor != nullptr)
+ 	{
+ 		GfxRGB matteRgb;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++		colorMap->getColorSpace()->getRGB(*matteColor, &matteRgb);
++#else
+ 		colorMap->getColorSpace()->getRGB(matteColor, &matteRgb);
++#endif
+ 		matteRc = qRound(colToDbl(matteRgb.r) * 255);
+ 		matteGc = qRound(colToDbl(matteRgb.g) * 255);
+ 		matteBc = qRound(colToDbl(matteRgb.b) * 255);
+@@ -2939,10 +2964,18 @@ void SlaOutputDev::beginMarkedContent(const char *name, Object *dictRef)
+ 	m_mcStack.push(mSte);
+ }
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++void SlaOutputDev::beginMarkedContent(const std::string& name, Dict* properties)
++#else
+ void SlaOutputDev::beginMarkedContent(const char *name, Dict *properties)
++#endif
+ {
+ //	qDebug() << "Begin Marked Content with Name " << QString(name);
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++	QString nam = QString::fromStdString(name);
++#else
+ 	QString nam(name);
++#endif
+ 	mContent mSte;
+ 	mSte.name = nam;
+ 	mSte.ocgName = "";
+@@ -3021,16 +3054,31 @@ void SlaOutputDev::endMarkedContent(GfxState *state)
+ 	}
+ }
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++void SlaOutputDev::markPoint(const std::string& name)
++{
++	//	qDebug() << "Begin Marked Point with Name " << QString(name);
++}
++#else
+ void SlaOutputDev::markPoint(const char *name)
+ {
+ //	qDebug() << "Begin Marked Point with Name " << QString(name);
+ }
++#endif
+ 
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++void SlaOutputDev::markPoint(const std::string& name, Dict* properties)
++{
++	//	qDebug() << "Begin Marked Point with Name " << QString(name) << "and Properties";
++	beginMarkedContent(name.c_str(), properties);
++}
++#else
+ void SlaOutputDev::markPoint(const char *name, Dict *properties)
+ {
+ //	qDebug() << "Begin Marked Point with Name " << QString(name) << "and Properties";
+ 	beginMarkedContent(name, properties);
+ }
++#endif
+ 
+ void SlaOutputDev::updateFont(GfxState *state)
+ {
+@@ -3761,6 +3809,13 @@ void SlaOutputDev::endTextObject(GfxState *state)
+ }
+ 
+ QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color, int *shade)
++{
++	if (!color)
++		return CommonStrings::None;
++	return getColor(color_space, *color, shade);
++}
++
++QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor &color, int *shade)
+ {
+ 	QString fNam;
+ 	QString namPrefix = "FromPDF";
+@@ -3777,7 +3832,11 @@ QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color
+ 	if ((color_space->getMode() == csDeviceRGB) || (color_space->getMode() == csCalRGB))
+ 	{
+ 		GfxRGB rgb;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
+ 		color_space->getRGB(color, &rgb);
++#else
++		color_space->getRGB(&color, &rgb);
++#endif
+ 		double Rc = colToDbl(rgb.r);
+ 		double Gc = colToDbl(rgb.g);
+ 		double Bc = colToDbl(rgb.b);
+@@ -3787,7 +3846,11 @@ QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color
+ 	else if (color_space->getMode() == csDeviceCMYK)
+ 	{
+ 		GfxCMYK cmyk;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
+ 		color_space->getCMYK(color, &cmyk);
++#else
++		color_space->getCMYK(&color, &cmyk);
++#endif
+ 		double Cc = colToDbl(cmyk.c);
+ 		double Mc = colToDbl(cmyk.m);
+ 		double Yc = colToDbl(cmyk.y);
+@@ -3798,7 +3861,11 @@ QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color
+ 	else if ((color_space->getMode() == csCalGray) || (color_space->getMode() == csDeviceGray))
+ 	{
+ 		GfxGray gray;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
+ 		color_space->getGray(color, &gray);
++#else
++		color_space->getGray(&color, &gray);
++#endif
+ 		double Kc = 1.0 - colToDbl(gray);
+ 		tmp.setCmykColorF(0, 0, 0, Kc);
+ 		fNam = m_doc->PageColors.tryAddColor(namPrefix+tmp.name(), tmp);
+@@ -3839,7 +3906,11 @@ QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color
+ 		else
+ 		{
+ 			GfxCMYK cmyk;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
+ 			color_space->getCMYK(color, &cmyk);
++#else
++			color_space->getCMYK(&color, &cmyk);
++#endif
+ 			double Cc = colToDbl(cmyk.c);
+ 			double Mc = colToDbl(cmyk.m);
+ 			double Yc = colToDbl(cmyk.y);
+@@ -3849,12 +3920,20 @@ QString SlaOutputDev::getColor(GfxColorSpace *color_space, const GfxColor *color
+ 		tmp.setSpotColor(true);
+ 
+ 		fNam = m_doc->PageColors.tryAddColor(name, tmp);
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 06, 0)
++		*shade = qRound(colToDbl(color.c[0]) * 100);
++#else
+ 		*shade = qRound(colToDbl(color->c[0]) * 100);
++#endif
+ 	}
+ 	else
+ 	{
+ 		GfxRGB rgb;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
+ 		color_space->getRGB(color, &rgb);
++#else
++		color_space->getRGB(&color, &rgb);
++#endif
+ 		double Rc = colToDbl(rgb.r);
+ 		double Gc = colToDbl(rgb.g);
+ 		double Bc = colToDbl(rgb.b);
+@@ -4109,6 +4188,11 @@ void SlaOutputDev::pushGroup(const QString& maskName, bool forSoftMask, bool alp
+ 	m_groupStack.push(gElements);
+ }
+ 
++QString SlaOutputDev::UnicodeParsedString(const GooString& s1) const
++{
++	return UnicodeParsedString(&s1);
++}
++
+ QString SlaOutputDev::UnicodeParsedString(const GooString *s1) const
+ {
+ #if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 10, 0)
+diff --git a/scribus/plugins/import/pdf/slaoutput.h b/scribus/plugins/import/pdf/slaoutput.h
+index 7b3a71d..6952269 100644
+--- a/scribus/plugins/import/pdf/slaoutput.h
++++ b/scribus/plugins/import/pdf/slaoutput.h
+@@ -22,6 +22,7 @@ for which a new license (GPL+exception) is in place.
+ 
+ #include <array>
+ #include <memory>
++#include <string>
+ 
+ #include "fpointarray.h"
+ #include "importpdfconfig.h"
+@@ -156,7 +157,11 @@ public:
+ 	std::unique_ptr<GooString> itemText;
+ 
+ private:
+-	QString getColor(GfxColorSpace *color_space, const GfxColor *color, int *shade);
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 06, 0)
++	QString getColor(GfxColorSpace *color_space, const GfxColor &color, int *shade);
++#else
++	QString getColor(GfxColorSpace *color_space, const GfxColor *color, int* shade);
++#endif
+ 	ScribusDoc* m_doc { nullptr };
+ 	QStringList *m_importedColors { nullptr };
+ };
+@@ -239,11 +244,20 @@ public:
+ 	virtual void endMaskClip(GfxState *state) { qDebug() << "End Mask Clip"; }
+ 
+   //----- grouping operators
+-	void beginMarkedContent(const char *name, Dict *properties) override;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++	void beginMarkedContent(const std::string& name, Dict* properties) override;
++#else
++	void beginMarkedContent(const char* name, Dict* properties) override;
++#endif
+ 	virtual void beginMarkedContent(const char *name, Object *dictRef);
+ 	void endMarkedContent(GfxState *state) override;
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++	void markPoint(const std::string& name) override;
++	void markPoint(const std::string& name, Dict* properties) override;
++#else
+ 	void markPoint(const char *name) override;
+ 	void markPoint(const char *name, Dict *properties) override;
++#endif
+ 
+ 	//----- image drawing
+ 	void drawImageMask(GfxState *state, Object *ref, Stream *str, int width, int height, bool invert, bool interpolate, bool inlineImg) override;
+@@ -275,7 +289,9 @@ public:
+ #endif
+ 	void endTransparencyGroup(GfxState *state) override;
+ 
+-#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 9, 0)
++#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(26, 6, 0)
++	void setSoftMask(GfxState * /*state*/, const std::array<double, 4> & /*bbox*/, bool /*alpha*/, Function * /*transferFunc*/, const GfxColor & /*backdropColor*/) override;
++#elif POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(25, 9, 0)
+ 	void setSoftMask(GfxState * /*state*/, const std::array<double, 4> & /*bbox*/, bool /*alpha*/, Function * /*transferFunc*/, GfxColor * /*backdropColor*/) override;
+ #else
+ 	void setSoftMask(GfxState * /*state*/, const double * /*bbox*/, bool /*alpha*/, Function * /*transferFunc*/, GfxColor * /*backdropColor*/) override;
+@@ -384,10 +400,12 @@ protected:
+ private:
+ 	void getPenState(GfxState *state);
+ 	QString getColor(GfxColorSpace *color_space, const GfxColor *color, int *shade);
++	QString getColor(GfxColorSpace* color_space, const GfxColor &color, int* shade);
+ 	QString getAnnotationColor(const AnnotColor *color);
+ 	QString convertPath(const GfxPath *path);
+ 	int getBlendMode(GfxState *state) const;
+ 	QString UnicodeParsedString(const GooString *s1) const;
++	QString UnicodeParsedString(const GooString &s1) const;
+ 	QString UnicodeParsedString(const std::string& s1) const;
+ 	bool checkClip();
+ 
+-- 
+2.52.0
+

--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,5 +1,5 @@
 VER=1.6.6
-REL=1
+REL=2
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::fdfe3e7cbe84b760b38d0561ed8736f9d25d4923adde6e15e03760d83be6166d"
 CHKUPDATE="anitya::id=4773"

--- a/desktop-kde/kitinerary/autobuild/patches/0001-UPSTREAM-Compile-with-newer-poppler.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0001-UPSTREAM-Compile-with-newer-poppler.patch
@@ -1,9 +1,12 @@
-From ccb01a841fff3f88852fa151e99fe6f41ebf8fbb Mon Sep 17 00:00:00 2001
+From 4afc98c4ea83b613ee27dce6df05ce3036f86e0c Mon Sep 17 00:00:00 2001
 From: Albert Astals Cid <aacid@kde.org>
 Date: Sun, 21 Apr 2024 11:14:42 +0200
-Subject: [PATCH 1/3] Compile with newer poppler
+Subject: [PATCH 01/10] UPSTREAM: Compile with newer poppler
 
 And remove ancient poppler ifdefs
+
+(cherry picked from commit 6a0a4f455d58b96b8965667a7eb057abd244d87e)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  src/lib/pdf/pdfdocument.cpp              | 35 ++------------
  src/lib/pdf/pdfextractoroutputdevice.cpp |  2 -
@@ -270,5 +273,5 @@ index 79e5233b..78c05af6 100644
              qpp.moveTo(subpath->getX(0), subpath->getY(0));
              for (auto j = 1;j < subpath->getNumPoints();) {
 -- 
-2.48.1
+2.52.0
 

--- a/desktop-kde/kitinerary/autobuild/patches/0002-UPSTREAM-Fix-compilation-against-Poppler-25.01.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0002-UPSTREAM-Fix-compilation-against-Poppler-25.01.patch
@@ -1,8 +1,10 @@
-From f14c0e630ae0af777aa3fd5fed0746c3d811b9d3 Mon Sep 17 00:00:00 2001
+From 08a94bdbf409e0989bd6da00e1671a59fbc16fb1 Mon Sep 17 00:00:00 2001
 From: Volker Krause <vkrause@kde.org>
 Date: Sat, 21 Dec 2024 16:44:37 +0100
-Subject: [PATCH 2/3] Fix compilation against Poppler 25.01
+Subject: [PATCH 02/10] UPSTREAM: Fix compilation against Poppler 25.01
 
+(cherry picked from commit bcb009f56f8f1c9c0d1612a0ec9f581907b51534)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  src/lib/pdf/pdfdocument.cpp | 12 +++++++++++-
  1 file changed, 11 insertions(+), 1 deletion(-)
@@ -42,5 +44,5 @@ index 98e0758d..64c840f9 100644
  
  int PdfPage::imageCount() const
 -- 
-2.48.1
+2.52.0
 

--- a/desktop-kde/kitinerary/autobuild/patches/0003-UPSTREAM-Adapt-to-Poppler-25.02-API-changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0003-UPSTREAM-Adapt-to-Poppler-25.02-API-changes.patch
@@ -1,8 +1,10 @@
-From f31d0940c5b7deec57b78993cb5ade25bb6f2445 Mon Sep 17 00:00:00 2001
+From f494d8c697916e6e3beb284004336f06f02a570a Mon Sep 17 00:00:00 2001
 From: Volker Krause <vkrause@kde.org>
 Date: Tue, 21 Jan 2025 18:57:10 +0100
-Subject: [PATCH 3/3] Adapt to Poppler 25.02 API changes
+Subject: [PATCH 03/10] UPSTREAM: Adapt to Poppler 25.02 API changes
 
+(cherry picked from commit 72d074636846c34aac81f5947a8f64992156bb86)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  src/lib/pdf/pdfdocument.cpp | 5 +++++
  1 file changed, 5 insertions(+)
@@ -27,5 +29,5 @@ index 64c840f9..20f77095 100644
  
      return QString::fromUtf8(s->c_str());
 -- 
-2.48.1
+2.52.0
 

--- a/desktop-kde/kitinerary/autobuild/patches/0004-BACKPORT-Adapt-extractor-scripts-to-Poppler-26.01-wh.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0004-BACKPORT-Adapt-extractor-scripts-to-Poppler-26.01-wh.patch
@@ -1,0 +1,442 @@
+From 10778f6c871f49c0f08c2c38eb691eb5c8616d7f Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Fri, 2 Jan 2026 18:11:32 +0100
+Subject: [PATCH 04/10] BACKPORT: Adapt extractor scripts to Poppler 26.01
+ whitespace changes
+
+(cherry picked from commit fae4b523d7d2f3216789886ec3d1dc43b981b683)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/scripts/amtrack.js                  |  2 +-
+ src/lib/scripts/atlatos.js                  |  4 ++-
+ src/lib/scripts/bremer-baeder.js            |  2 +-
+ src/lib/scripts/brusselsairlines-receipt.js |  4 +--
+ src/lib/scripts/cooltix.js                  |  2 +-
+ src/lib/scripts/easyjet.js                  | 27 ++++++++++-----------
+ src/lib/scripts/eventim.js                  |  2 +-
+ src/lib/scripts/flixbus.js                  |  4 +--
+ src/lib/scripts/grimaldi-lines.js           |  2 +-
+ src/lib/scripts/iberia.js                   | 10 ++++----
+ src/lib/scripts/ltg-link.js                 |  2 +-
+ src/lib/scripts/nationalrail.js             |  2 +-
+ src/lib/scripts/ouigo-es.js                 |  4 +--
+ src/lib/scripts/pasazieru-vilciens.js       |  2 +-
+ src/lib/scripts/pretix.js                   |  6 ++---
+ src/lib/scripts/sas-boardingpass.js         |  2 +-
+ src/lib/scripts/sas-receipt.js              |  2 +-
+ src/lib/scripts/sncf.js                     |  6 ++---
+ src/lib/scripts/thalys.js                   |  2 +-
+ src/lib/scripts/ticketmaster.js             |  4 +--
+ src/lib/scripts/viarail.js                  |  3 +--
+ src/lib/scripts/vistara.js                  |  6 ++---
+ 22 files changed, 50 insertions(+), 50 deletions(-)
+
+diff --git a/src/lib/scripts/amtrack.js b/src/lib/scripts/amtrack.js
+index b3ebf446..2711f7bb 100644
+--- a/src/lib/scripts/amtrack.js
++++ b/src/lib/scripts/amtrack.js
+@@ -31,7 +31,7 @@ function parseTicket(pdf, node, triggerNode) {
+         }
+ 
+         // format variant 2
+-        train = text.substr(idx).match(/TRAIN .* DEPARTS +ARRIVES\n *(\d+)  +([A-Z][a-z]{2} \d{1,2}, \d{4})  +(\d{1,2}:\d{2} [AP]M)  +(\d{1,2}:\d{2} [AP]M)\n  +(.*?)  +(.*)\n *\d+ (.*) Seat/);
++        train = text.substr(idx).match(/TRAIN .* DEPARTS +ARRIVES\n+ *(\d+)  +([A-Z][a-z]{2} \d{1,2}, \d{4})  +(\d{1,2}:\d{2} [AP]M)  +(\d{1,2}:\d{2} [AP]M)\n  +(.*?)  +(.*)\n *\d+ (.*) Seat/);
+         if (train) {
+             leg.reservationFor.trainNumber = train[1];
+             leg.reservationFor.departureTime = JsonLd.toDateTime(train[2] + ' ' + train[3], 'MMM d, yyyy h:mm AP', 'en');
+diff --git a/src/lib/scripts/atlatos.js b/src/lib/scripts/atlatos.js
+index bca1a18c..097ed848 100644
+--- a/src/lib/scripts/atlatos.js
++++ b/src/lib/scripts/atlatos.js
+@@ -30,12 +30,14 @@ function extractPdf(pdf)
+     let text = "";
+     for (const page of pdf.pages) {
+         text += page.textInRect(0.0, 0.0, 1.0, 0.9);
++        if (!text.endsWith('\n'))
++            text += '\n';
+     }
+ 
+     let reservations = [];
+     let idx = 0;
+     while (true) {
+-        const flight = text.substr(idx).match(/: +(\S.*\S) +([A-Z0-9]{2})\/([A-Z0-9]{6})\n.*: +(\S.*?), (\S.*(?:\n +.*)*)\n.*(\d\d[\d\.: ]{14}).*\n.* ([A-Z0-9]{2}) (\d{1,4}) .*\n.*\n.*: +(\S.*?), (\S.*(?:\n +.*)*)\n.*(\d\d[\d\.: ]{14}).*\n/);
++        const flight = text.substr(idx).match(/: +(\S.*\S) +([A-Z0-9]{2})\/([A-Z0-9]{6})\n.*: +(\S.*?), (\S.*(?:\n +.*)*)\n.*(\d\d[\d\.: ]{14}).*\n.* ([A-Z0-9]{2}) (\d{1,4}) .*\n+.*\n+.*: +(\S.*?), (\S.*(?:\n +.*)*)\n.*(\d\d[\d\.: ]{14}).*\n/);
+         if (!flight) {
+             break;
+         }
+diff --git a/src/lib/scripts/bremer-baeder.js b/src/lib/scripts/bremer-baeder.js
+index 3d43a14e..b703dd25 100644
+--- a/src/lib/scripts/bremer-baeder.js
++++ b/src/lib/scripts/bremer-baeder.js
+@@ -14,7 +14,7 @@ function parseTicket(pdf, node) {
+     res.reservationNumber = text.match(/Auftrag (\d+)/)[1];
+     res.underName.givenName = text.match(/Vorname: (.*?)\n/)[1];
+     res.underName.familyName = text.match(/Name: (.*?)\n/)[1];
+-    res.reservationFor.name = text.match(/ONLINE-TICKET\n *(.*?) -/)[1];
++    res.reservationFor.name = text.match(/ONLINE-TICKET\n+ *(.*?) -/)[1];
+     res.reservationFor.location.address.addressCountry = "DE"; // to get the right timezone
+     return res;
+ }
+diff --git a/src/lib/scripts/brusselsairlines-receipt.js b/src/lib/scripts/brusselsairlines-receipt.js
+index c9ec4aff..179fb720 100644
+--- a/src/lib/scripts/brusselsairlines-receipt.js
++++ b/src/lib/scripts/brusselsairlines-receipt.js
+@@ -18,10 +18,10 @@ function extractColumn(page, offset) {
+         }
+     }
+ 
+-    var dep = text.match(/Departure time.*\n(\d{1,2} \w+ \d{4})\s+(\d{1,2}:\d{2})/);
++    const dep = text.match(/Departure time.*\n+(\d{1,2} \w+ \d{4})\s+(\d{1,2}:\d{2})/);
+     if (dep)
+         res.reservationFor.departureTime = JsonLd.toDateTime(dep[1] + " " + dep[2], "dd MMMM yyyy hh:mm", "en");
+-    var arr = text.match(/Arrival time.*\n(\d{1,2} \w+ \d{4})\s+(\d{1,2}:\d{2})/);
++    const arr = text.match(/Arrival time.*\n+(\d{1,2} \w+ \d{4})\s+(\d{1,2}:\d{2})/);
+     if (arr)
+         res.reservationFor.arrivalTime = JsonLd.toDateTime(arr[1] + " " + arr[2], "dd MMMM yyyy hh:mm", "en");
+ 
+diff --git a/src/lib/scripts/cooltix.js b/src/lib/scripts/cooltix.js
+index 2df5f74c..4a80049c 100644
+--- a/src/lib/scripts/cooltix.js
++++ b/src/lib/scripts/cooltix.js
+@@ -16,7 +16,7 @@ function extractPdf(pdf, node) {
+         }
+         const page = pdf.pages[i];
+         const leftCol = page.textInRect(0.0, 0.0, 0.33, 1.0);
+-        const event = leftCol.match(/.*\n((?:.*\n)*.*)\n.*\n(.{3} \d\d, \d{4} \d{1,2}:\d\d ..)\n.*\n(.{3} \d\d, \d{4} \d{1,2}:\d\d ..)\n.*\n(.*)\n(.*)\n(.*)\n/);
++        const event = leftCol.match(/.*\n((?:.*\n)*.*)\n.*\n(.{3} \d\d, \d{4} \d{1,2}:\d\d ..)\n+.*\n(.{3} \d\d, \d{4} \d{1,2}:\d\d ..)\n+.*\n(.*)\n(.*)\n(.*)\n/);
+         res.reservationFor.name = event[1].split('|')[0];
+         res.reservationFor.startDate = JsonLd.toDateTime(event[2], 'MMM dd, yyyy h:mm A', 'en');
+         res.reservationFor.endDate = JsonLd.toDateTime(event[3], 'MMM dd, yyyy h:mm A', 'en');
+diff --git a/src/lib/scripts/easyjet.js b/src/lib/scripts/easyjet.js
+index 31675514..e541921d 100644
+--- a/src/lib/scripts/easyjet.js
++++ b/src/lib/scripts/easyjet.js
+@@ -70,20 +70,19 @@ function parsePdfBoardingPass(pdf, node, triggerNode)
+ {
+     var res = triggerNode.result[0];
+ 
+-    var page = pdf.pages[triggerNode.location];
+-    var rightCol = page.textInRect(0.65, 0, 1, 0.25);
+-    var depName = rightCol.match(/(?:from|Flying)\n\([A-Z]{3}\) ([^]*?)\n(?:to|Going)/);
+-    if (depName)
+-        res.reservationFor.departureAirport.name = depName[1];
+-    var arrName = rightCol.match(/(?:to|Going)\n\([A-Z]{3}\) ([^]*?)\ndeparts/);
+-    if (arrName)
+-        res.reservationFor.arrivalAirport.name = arrName[1];
+-    var depTime = rightCol.match(/(?:departs|Flight)\n(\d\d:\d\d)/);
+-    if (depTime)
+-        res.reservationFor.departureTime = JsonLd.toDateTime(depTime[1], "hh:mm", "en");
+-
+-    var leftCol = page.textInRect(0, 0, 0.3, 0.25);
+-    var boarding = leftCol.match(/(?:closes|Gate)\n(\d\d:\d\d)/);
++    const page = pdf.pages[triggerNode.location];
++    const rightCol = page.textInRect(0.65, 0, 1, 0.25)
++        .replace(/(?:\n|  +)/g, ' ')
++        .replace(/(?:from Flying|to Going|departs Flight)/g, '')
++        .trim();
++
++    const airports = rightCol.match(/\([A-Z]{3}\) (.*) \([A-Z]{3}\) (.*) (\d\d:\d\d)/);
++    res.reservationFor.departureAirport.name = airports[1];
++    res.reservationFor.arrivalAirport.name = airports[2];
++    res.reservationFor.departureTime = JsonLd.toDateTime(airports[3], "HH:mm", "en");
++
++    const leftCol = page.textInRect(0, 0, 0.3, 0.25);
++    const boarding = leftCol.match(/(?:closes|Gate)\n+ *(\d\d:\d\d)/);
+     if (boarding)
+         res.reservationFor.boardingTime = JsonLd.toDateTime(boarding[1], "hh:mm", "en");
+ 
+diff --git a/src/lib/scripts/eventim.js b/src/lib/scripts/eventim.js
+index 3b7c0478..692c033b 100644
+--- a/src/lib/scripts/eventim.js
++++ b/src/lib/scripts/eventim.js
+@@ -30,7 +30,7 @@ function parseTicketDirect(pdf, node, triggerNode)
+ 
+     let res = JsonLd.newEventReservation();
+     res.reservationNumber = text.match(/Ticket Nummer: (\d+-\d+)\n/)[1];
+-    const dt = text.match(/([A-Z][a-z]+, \d{2}\.\d{2}\.\d{4}).*\n.*(\d{2}:\d{2}) Uhr(?:.*\n.*?(\d{2}:\d{2}) Uhr.*)?/);
++    const dt = text.match(/([A-Z][a-z]+, \d{2}\.\d{2}\.\d{4}).*\n+.*(\d{2}:\d{2}) Uhr(?:.*\n.*?(\d{2}:\d{2}) Uhr.*)?/);
+ 
+     if (dt[3]) {
+         res.reservationFor.doorTime = JsonLd.toDateTime(dt[1] + dt[2], 'dddd, dd.MM.yyyyhh:mm', 'de');
+diff --git a/src/lib/scripts/flixbus.js b/src/lib/scripts/flixbus.js
+index 4f5bb1b6..653a2160 100644
+--- a/src/lib/scripts/flixbus.js
++++ b/src/lib/scripts/flixbus.js
+@@ -62,8 +62,8 @@ function parsePdfTicket(pdf, node, triggerNode)
+     let idxStations = 0;
+     let reservations = [];
+     while (true) {
+-        const times = timeColumn.substr(idxTime).match(/(\d\d:\d\d)\n([^:]*?\n)?([^:]*?\n)?(\d\d:\d\d)/);
+-        const stations = stationColumn.substr(idxStations).match(/(.*)\n[ ]+(.*)(?:\n|,\n  +(.*)\n)(?:.*\n(?:.*\n)*)?.*(?:Bus|Autobus|Zug) +(.*)\n.*(?:Direction|à destination de|Kierunek|richting|Richtung) (.*)\n(.*)\n(?:[ ]+(.*?)(?:\n|,\n +(.*)\n))?/);
++        const times = timeColumn.substr(idxTime).match(/(\d\d:\d\d)\n+([^:]*?\n)?([^:]*?\n)?(\d\d:\d\d)/);
++        const stations = stationColumn.substr(idxStations).match(/(?:\n|^)([^].*)\n[ ]+(.*)(?:\n+|(,?\n+  +.*)\n+)(?:.*(?:NOTE:|Wagennummerierung|platform|The regional part|Die Bussteignummer|Operated|Platform).(?:.*\n+)+?)?.*(?:Bus|Autobus|Zug|Strecke|Route|Tratta)\s+(\S.+)\n+.*(?:Direction|à destination de|Kierunek|richting|Richtung|Direzione) (.*)\n+(?:.*(?:Operated|Betrieben|Uitgevoerd|Effettuata).*\n+(?:.*Lda\.\n+)?)?(.*)\n+(?:[ ]+(.*?)(?:\n+|(,\n +.*)\n+))?/);
+         if (!times || !stations) {
+             break;
+         }
+diff --git a/src/lib/scripts/grimaldi-lines.js b/src/lib/scripts/grimaldi-lines.js
+index e0870b6a..582411db 100644
+--- a/src/lib/scripts/grimaldi-lines.js
++++ b/src/lib/scripts/grimaldi-lines.js
+@@ -19,7 +19,7 @@ function parsePdfTicket(pdf, node, triggerNode) {
+     let reservations = [res];
+     let tokenPrefix = 10001;
+     while (true) {
+-        const pas = text.substr(idx).match(/  +(\S.*\S)  +[MF]  +\d\d-\d\d-\d{4}\n/);
++        const pas = text.substr(idx).match(/  +(\S.*\S)  +[MF]  +\d\d-\d\d-\d{4}\n?/);
+         if (!pas)
+             break;
+         idx += pas.index + pas[0].length;
+diff --git a/src/lib/scripts/iberia.js b/src/lib/scripts/iberia.js
+index 7e1432b2..e3c9df4d 100644
+--- a/src/lib/scripts/iberia.js
++++ b/src/lib/scripts/iberia.js
+@@ -7,13 +7,13 @@
+ function main(text) {
+     var reservations = new Array();
+ 
+-    var bookingRef = text.match(/Booking code\n.*([0-9A-z]{6})\n/);
++    var bookingRef = text.match(/Booking code\n+.*([0-9A-z]{6})\n/);
+     if (!bookingRef)
+         return reservations;
+ 
+     var pos = bookingRef.index + bookingRef[0].length;
+     while (true) {
+-        var firstLine = text.substr(pos).match(/From +([A-Z]{2})(\d{2,4}) +(\d{1,2}-\w{3}) +(\d{1,2}-\w{3}).*\n/);
++        const firstLine = text.substr(pos).match(/From +([A-Z]{2})(\d{2,4}) +(\d{1,2}-\w{3}) +(\d{1,2}-\w{3}).*\n/);
+         if (!firstLine)
+             break;
+         var index = firstLine.index + firstLine[0].length;
+@@ -23,7 +23,7 @@ function main(text) {
+         res.reservationFor.flightNumber = firstLine[2];
+         res.reservationFor.airline.iataCode = firstLine[1];
+ 
+-        var secondLine = text.substr(pos + index).match(/^ (\w+) \(([A-Z]{3})\) +(\d{2}:\d{2}) + (\d{2}:\d{2}) .*\n/);
++        const secondLine = text.substr(pos + index).match(/^ *(\w+) \(([A-Z]{3})\) +(\d{2}:\d{2}) + (\d{2}:\d{2}) .*\n/);
+         if (!secondLine)
+             break;
+         index += secondLine.index + secondLine[0].length;
+@@ -33,7 +33,7 @@ function main(text) {
+         res.reservationFor.departureTime = JsonLd.toDateTime(firstLine[3] + " " + secondLine[3], "dd-MMM hh:mm", "en");
+         res.reservationFor.arrivalTime = JsonLd.toDateTime(firstLine[4] + " " + secondLine[4], "dd-MMM hh:mm", "en");
+ 
+-        var fourthLine = text.substr(pos + index).match(/^.*\n (\w+) \(([A-Z]{3})\) .*\n/);
++        const fourthLine = text.substr(pos + index).match(/^.*\n *(\w+) \(([A-Z]{3})\) .*\n/);
+         if (!fourthLine)
+             break;
+         index += fourthLine.index + fourthLine[0].length;
+@@ -63,7 +63,7 @@ function extractBoardingPass(pdf, node, barcode)
+     const times = text.match(/\d\d \S+ (\d\d:\d\d) +(?:\d\d \S+)? (\d\d:\d\d)/);
+     res.reservationFor.departureTime = JsonLd.toDateTime(times[1], 'hh:mm', 'en');
+     res.reservationFor.arrivalTime = JsonLd.toDateTime(times[2], 'hh:mm', 'en');
+-    const boarding = text.match(/(?:SEAT|ASIENTO)\n *(\d\d:\d\d) (?:GRUPO (\S*))?/);
++    const boarding = text.match(/(?:SEAT|ASIENTO)\n+ *(\d\d:\d\d) (?:GRUPO (\S*))?/);
+     res.reservationFor.boardingTime = JsonLd.toDateTime(boarding[1], 'hh:mm', 'en');
+     res.boardingGroup = boarding[2];
+     return res;
+diff --git a/src/lib/scripts/ltg-link.js b/src/lib/scripts/ltg-link.js
+index b8002e55..f9019ea9 100644
+--- a/src/lib/scripts/ltg-link.js
++++ b/src/lib/scripts/ltg-link.js
+@@ -13,7 +13,7 @@ function parsePdfTicket(pdf, node, triggerNode) {
+     const dt = text.match(/(\d{4}-\d\d-\d\d)(?:\n.*){1,2}(\d\d:\d\d) - (\d\d:\d\d)/);
+     res.reservationFor.departureTime = JsonLd.toDateTime(dt[1] + ' ' + dt[2], 'yyyy-MM-dd hh:mm', 'lt');
+     res.reservationFor.arrivalTime = JsonLd.toDateTime(dt[1] + ' ' + dt[3], 'yyyy-MM-dd hh:mm', 'lt');
+-    const train = text.match(/SEAT\n *(\S.*?)  +(\S.*?)  +(\S.*?)  +(\S.*)\n/);
++    const train = text.match(/SEAT\n+ *(\S.*?)  +(\S.*?)  +(\S.*?)  +(\S.*)\n/);
+     res.reservationFor.trainNumber = train[1];
+     res.reservedTicket.ticketedSeat.seatingType = train[2];
+     res.reservedTicket.ticketedSeat.seatSection = train[3];
+diff --git a/src/lib/scripts/nationalrail.js b/src/lib/scripts/nationalrail.js
+index 42ffa6f9..0f7cff44 100644
+--- a/src/lib/scripts/nationalrail.js
++++ b/src/lib/scripts/nationalrail.js
+@@ -99,7 +99,7 @@ function parseRSP6(text) {
+ function parseTicket(pdf, node, triggerNode) {
+     const text = pdf.pages[triggerNode.location].text;
+     var res = triggerNode.result[0];
+-    const header = text.match(/ +(\d{2}[ -][A-Z][a-z]{2}[ -]\d{4}) +(?:Out: |Ret: )?([A-Z]{3}) ?- ?([A-Z]{3})\n(.*)  +(.*)/);
++    const header = text.match(/ +(\d{2}[ -][A-Z][a-z]{2}[ -]\d{4}) +(?:Out: |Ret: )?([A-Z]{3}) ?- ?([A-Z]{3})\n+(.*)  +(.*)/);
+     const date = header[1].replace(/-/g, ' ');
+     const itinerary = text.match(/Itinerary.*\n +(.*)\n +(\d{2}:\d{2})\n +([\S\s]*?)\n +(\d{2}:\d{2})\n +(.*)/);
+ 
+diff --git a/src/lib/scripts/ouigo-es.js b/src/lib/scripts/ouigo-es.js
+index d3919a6d..b1995a5f 100644
+--- a/src/lib/scripts/ouigo-es.js
++++ b/src/lib/scripts/ouigo-es.js
+@@ -29,13 +29,13 @@ function parsePdf(pdf, node, triggerNode) {
+     let res = triggerNode.result[0];
+ 
+     const topLeft = page.textInRect(0.0, 0.0, 0.5, 0.5);
+-    const stations = topLeft.match(/\n(.*)\n\d\d:\d\d\n(.*)\n(\d\d:\d\d)/);
++    const stations = topLeft.match(/\n(.*)\n\d\d:\d\d\n+(.*)\n(\d\d:\d\d)/);
+     if (stations) {
+         res.reservationFor.departureStation.name = stations[1];
+         res.reservationFor.arrivalStation.name = stations[2];
+         res.reservationFor.arrivalTime = JsonLd.toDateTime(stations[3], "hh:mm", "es");
+     } else {
+-        const stationsV2 = topLeft.match(/\n\d\d:\d\d\n(.*)\n(\d\d:\d\d)\n(.*)/);
++        const stationsV2 = topLeft.match(/\n* \d\d:\d\d\n+(.*)\n+ *(\d\d:\d\d)\n+(.*)/);
+         res.reservationFor.departureStation.name = stationsV2[1];
+         res.reservationFor.arrivalStation.name = stationsV2[3];
+         res.reservationFor.arrivalTime = JsonLd.toDateTime(stationsV2[2], "hh:mm", "es");
+diff --git a/src/lib/scripts/pasazieru-vilciens.js b/src/lib/scripts/pasazieru-vilciens.js
+index fdabbeb9..8ffecbe4 100644
+--- a/src/lib/scripts/pasazieru-vilciens.js
++++ b/src/lib/scripts/pasazieru-vilciens.js
+@@ -8,7 +8,7 @@ function parseOnePdfTicket(text) {
+     const header = text.match(/(.*)\n +(\d{6})\n(.*)/);
+     res.reservedTicket.ticketToken = 'qrcode:' + header[2];
+     res.reservedTicket.name = header[1] + header[3];
+-    const trip = text.match(/(.*)  +(\d\d:\d\d) +(.*)  +(\d\d:\d\d)\n.* (\d{1,5})  +.*(\d\d\.\d\d.\d{4})/);
++    const trip = text.match(/(.*)  +(\d\d:\d\d) +(.*)  +(\d\d:\d\d)\n+.* (\d{1,5})  +.*(\d\d\.\d\d.\d{4})/);
+     res.reservationFor.departureStation.name = trip[1];
+     res.reservationFor.arrivalStation.name = trip[3];
+     res.reservationFor.arrivalTime = JsonLd.toDateTime(trip[6] + ' ' + trip[4], 'dd.MM.yyyy hh:mm', 'lv');
+diff --git a/src/lib/scripts/pretix.js b/src/lib/scripts/pretix.js
+index 4beedccf..abd24a25 100644
+--- a/src/lib/scripts/pretix.js
++++ b/src/lib/scripts/pretix.js
+@@ -33,13 +33,13 @@ function parsePass(content, node) {
+ function parsePdf(pdf, node, barcode) {
+     let res = JsonLd.newEventReservation();
+     const text = pdf.pages[barcode.location].textInRect(0.0, 0.0, 1.0, 0.4);
+-    const dt = text.match(/(\d{4}.\d\d.\d\d \d\d:\d\d|\d\d.\d\d.\d{4} \d\d:\d\d)\n/);
++    const dt = text.match(/(\d{4}.\d\d.\d\d \d\d:\d\d|\d\d.\d\d.\d{4} \d\d:\d\d)/);
+     res.reservationFor.startDate = JsonLd.toDateTime(dt[1], ['dd.MM.yyyy hh:mm', 'yyyy-MM-dd hh:mm'], 'en');
+ 
+-    const data1 = text.substr(0, dt.index).trim().split(/\n/);
++    const data1 = text.substr(0, dt.index).trim().split(/\n+/);
+     res.reservationFor.name = data1.slice(0, Math.max(data1.length - 2, 1)).join(' ');
+ 
+-    const data2 = text.substr(dt.index + dt[0].length).trim().split(/\n/);
++    const data2 = text.substr(dt.index + dt[0].length).trim().split(/\n+/);
+     res.reservationFor.location.name = data2.slice(0, data2.length - 1).join(' ');
+     res.reservationNumber = data2[data2.length - 1].match(/(\S+) /)[1];
+ 
+diff --git a/src/lib/scripts/sas-boardingpass.js b/src/lib/scripts/sas-boardingpass.js
+index 802ee0a5..29a78b35 100644
+--- a/src/lib/scripts/sas-boardingpass.js
++++ b/src/lib/scripts/sas-boardingpass.js
+@@ -21,7 +21,7 @@ function main(pdf, node, triggerNode) {
+     if (!text.match(/BOARDING PASS/))
+         return null;
+ 
+-    var lines = text.split('\n');
++    const lines = text.split(/\n+/);
+ 
+     var state = 0;
+     var flights = [];
+diff --git a/src/lib/scripts/sas-receipt.js b/src/lib/scripts/sas-receipt.js
+index ffafaf19..7a654a03 100644
+--- a/src/lib/scripts/sas-receipt.js
++++ b/src/lib/scripts/sas-receipt.js
+@@ -17,7 +17,7 @@ function extractInformation(page) {
+     var text = page.textInRect(0, 0, 1, 1);
+     if (text.match(/\s+Electronic Ticket Itinerary and Receipt/)) {
+         var res = new Array();
+-        var lines = text.split("\n");
++        var lines = text.split(/\n+/);
+         var lastFlight = null;
+         var bookingRef = text.match(/Booking Reference:\s* ([A-Z0-9]+)\s/);
+         var issueDate = text.match(/.*Date of Issue:\s([0-9A-Z]+)/);
+diff --git a/src/lib/scripts/sncf.js b/src/lib/scripts/sncf.js
+index b79561e0..8cbe76e7 100644
+--- a/src/lib/scripts/sncf.js
++++ b/src/lib/scripts/sncf.js
+@@ -195,11 +195,11 @@ function parseSecutixPdfItineraryV1(text, res)
+     var reservations = new Array();
+     var pos = 0;
+     while (true) {
+-        var dep = text.substr(pos).match(/Départ [^ ]+ (\d+\.\d+\.\d+) à (\d+:\d+) [^ ]+ (.*)\n/);
++        const dep = text.substr(pos).match(/Départ \S+ (\d+\.\d+\.\d+) à (\d+:\d+) \S+ (.*)\n/);
+         if (!dep)
+             break;
+         pos += dep.index + dep[0].length;
+-        var arr = text.substr(pos).match(/Arrivée [^ ]+ (\d+\.\d+\.\d+) à (\d+:\d+) [^ ]+ (.*)\n\s+(.*)\n/);
++        const arr = text.substr(pos).match(/Arrivée \S+ (\d+\.\d+\.\d+) à (\d+:\d+) \S+ (.*)\n\s*(.*)/);
+         if (!arr)
+             break;
+         pos += arr.index + arr[0].length;
+@@ -225,7 +225,7 @@ function parseSecutixPdfItineraryV2(text, res)
+     var reservations = new Array();
+     var pos = 0;
+     while (true) {
+-        var data = text.substr(pos).match(/ *(\d+h\d+)\n *(.*)\n *(.*)\n(?: *Voiture (\d+) - Place (\d+)\n.*\n.*\n)? *(\d+h\d+)\n(.*)\n/);
++        var data = text.substr(pos).match(/ *(\d+h\d+)\n *(.*)\n+ *(.*)\n+(?: *Voiture (\d+) - Place (\d+)\n.*\n.*\n)? *(\d+h\d+)\n(.*)\n/);
+         if (!data)
+             break;
+         pos += data.index + data[0].length;
+diff --git a/src/lib/scripts/thalys.js b/src/lib/scripts/thalys.js
+index 468049d5..cd4b6758 100644
+--- a/src/lib/scripts/thalys.js
++++ b/src/lib/scripts/thalys.js
+@@ -73,7 +73,7 @@ function parsePdfTicket(pdf, node, triggerNode)
+     res.reservationFor.arrivalStation.name = arr[1];
+     res.reservationFor.arrivalTime = res.reservationFor.departureDay.substr(0, 11) + arr[2];
+ 
+-    const passenger = page.textInRect(0.0, 0.0, 0.35, 0.1).match(/(?:PASSAGER|FAHRGAST|PASSENGER|REIZIGER)\n(.*)\n/);
++    const passenger = page.textInRect(0.0, 0.0, 0.35, 0.1).match(/(?:PASSAGER|FAHRGAST|PASSENGER|REIZIGER)\n+ *(\S.*)/);
+     res.underName.name = passenger[1];
+     res.reservationNumber = page.textInRect(0.8, 0.0, 1.0,  0.2).match(/PNR\n([A-Z0-9]+)/)[1];
+ 
+diff --git a/src/lib/scripts/ticketmaster.js b/src/lib/scripts/ticketmaster.js
+index ea87dac3..f6eb2fda 100644
+--- a/src/lib/scripts/ticketmaster.js
++++ b/src/lib/scripts/ticketmaster.js
+@@ -11,8 +11,8 @@ function parsePdfTicket(pdf, node) {
+         res.reservationNumber = text.match(/Auftragsnummer:\s*(\d+)/)[1];
+         const name = text.match(/gekauft von:.*\n\s*\d.*\d\s*(\S.*)\n/);
+         res.underName.name = name[1];
+-        res.reservationFor.name = text.substr(name.index + name[0].length).match(/(.*)\n/)[1];
+-        const venue = text.match(/Veranstalter:\n.*\n(.*)\n(.*?)(?:  .*)?\n(.*)\n/);
++        res.reservationFor.name = text.substr(name.index + name[0].length).match(/(\S.*)\n/)[1];
++        const venue = text.match(/Veranstalter:\n.*\n+(.*)\n(.*?)(?:  .*)?\n(.*)\n/);
+         res.reservationFor.location.name = venue[1];
+         res.reservationFor.location.address.streetAddress = venue[2];
+         res.reservationFor.location.address.addressLocality = venue[3];
+diff --git a/src/lib/scripts/viarail.js b/src/lib/scripts/viarail.js
+index 1f20cde5..07c0db0e 100644
+--- a/src/lib/scripts/viarail.js
++++ b/src/lib/scripts/viarail.js
+@@ -43,12 +43,11 @@ function parseBarcode(barcode) {
+ function parseBoardingPass(pdf, node, triggerNode) {
+     var res = node.result[0];
+     const text = pdf.pages[triggerNode.location].text;
+-    const stationNames = text.match(/FTR\s*:\s*\d+\n(.*)   +(.*)\n/);
++    const stationNames = text.match(/FTR\s*:\s*\d+\n+(.*)   +(.*)\n/);
+     res.reservationFor.departureStation.name = stationNames[1];
+     res.reservationFor.arrivalStation.name = stationNames[2];
+     const arrivalDate = text.match(/Date\s*:.*Date\s*:\s*\w+\.\s*(.*)\n/);
+     const arrivalTime = text.match(/Arrival\s*:\s*(.*)\n/);
+-    console.log(arrivalDate[1] + ' ' + arrivalTime[1]);
+     res.reservationFor.arrivalTime = JsonLd.toDateTime(arrivalDate[1] + ' ' + arrivalTime[1], 'MMM d, yyyy HH:mm AP', 'en');
+     return res;
+ }
+diff --git a/src/lib/scripts/vistara.js b/src/lib/scripts/vistara.js
+index 86d2d318..97e760d3 100644
+--- a/src/lib/scripts/vistara.js
++++ b/src/lib/scripts/vistara.js
+@@ -7,9 +7,9 @@ function parseBoardingPass(pdf, node, triggerNode) {
+     if (triggerNode.result.length != 1) return;
+     const page = pdf.pages[triggerNode.location];
+     const depText = page.textInRect(0.0, 0.2, 0.5, 0.4);
+-    const dep = depText.match(/DEPARTURE\n *(\d{4})\n *(\d{2}\w{3}\d{4})\n(.*\n)?(.*)\nFLIGHT/);
++    const dep = depText.match(/DEPARTURE\n+ *(\d{4})\n+ *(\d{2}\w{3}\d{4})\n+(.*\n+)?(.*)\n+FLIGHT/);
+     const arrText = page.textInRect(0.5, 0.2, 1.0, 0.4);
+-    const arr = arrText.match(/ *ARRIVAL\n *(\d{4})\n *(\d{2}\w{3}\d{4})\n(.*\n)?(.*)\n *BOARDING TIME .*\n *(\d{4})/);
++    const arr = arrText.match(/ *ARRIVAL\n+ *(\d{4})\n+ *(\d{2}\w{3}\d{4})\n(.*\n)?(.*)\n+ *BOARDING TIME .*\n+ *(\d{4})/);
+ 
+     let res = triggerNode.result[0];
+     res.reservationFor.departureAirport.name = dep[4];
+@@ -18,7 +18,7 @@ function parseBoardingPass(pdf, node, triggerNode) {
+ 
+     res.reservationFor.arrivalAirport.name = arr[4];
+     res.reservationFor.arrivalTime = JsonLd.toDateTime(arr[2] + ' ' + arr[1], 'ddMMMyyyy hhmm', 'en');
+-    res.reservationFor.arrivalTerminal = arr[3];
++    res.reservationFor.arrivalTerminal = arr[3]?.trim();
+ 
+     res.reservationFor.boardingTime = JsonLd.toDateTime(dep[2] + ' ' + arr[5], 'ddMMMyyyy hhmm', 'en');
+     return res;
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0005-UPSTREAM-Adapt-to-Poppler-26.01-API-changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0005-UPSTREAM-Adapt-to-Poppler-26.01-API-changes.patch
@@ -1,0 +1,42 @@
+From 08be31384cc9bb6bbb237d5d5fb4b2eea5486c23 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Mon, 29 Dec 2025 17:55:27 +0100
+Subject: [PATCH 05/10] UPSTREAM: Adapt to Poppler 26.01 API changes
+
+(cherry picked from commit 21d7fedaaab6b2d840c276259072be393b32a499)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/pdf/pdfimage.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/lib/pdf/pdfimage.cpp b/src/lib/pdf/pdfimage.cpp
+index 66f9e2d4..9790bd5f 100644
+--- a/src/lib/pdf/pdfimage.cpp
++++ b/src/lib/pdf/pdfimage.cpp
+@@ -34,7 +34,11 @@ QImage PdfImagePrivate::load(Stream* str, GfxImageColorMap* colorMap)
+ {
+     if (m_format == QImage::Format_Mono) { // bitmasks are not stored as image streams
+         auto img = QImage(m_sourceWidth, m_sourceHeight, QImage::Format_Mono); // TODO implicit Format_Grayscale8 conversion
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(25, 12, 90)
+         str->reset();
++#else
++        str->rewind();
++#endif
+         const int rowSize = (m_sourceWidth + 7) / 8;
+         for (int y = 0; y < m_sourceHeight; ++y) {
+             auto imgData = img.scanLine(y);
+@@ -51,7 +55,11 @@ QImage PdfImagePrivate::load(Stream* str, GfxImageColorMap* colorMap)
+     auto img = QImage(m_sourceWidth, m_sourceHeight, (m_loadingHints & PdfImage::ConvertToGrayscaleHint) ? QImage::Format_Grayscale8 : m_format);
+     const auto bytesPerPixel = colorMap->getNumPixelComps();
+     std::unique_ptr<ImageStream> imgStream(new ImageStream(str, m_sourceWidth, bytesPerPixel, colorMap->getBits()));
++#if KPOPPLER_VERSION <QT_VERSION_CHECK(25, 12, 90)
+     imgStream->reset();
++#else
++    imgStream->rewind();
++#endif
+ 
+     switch (m_format) {
+         case QImage::Format_RGB888:
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0006-BACKPORT-Adapt-to-another-Poppler-26.01-API-change.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0006-BACKPORT-Adapt-to-another-Poppler-26.01-API-change.patch
@@ -1,0 +1,50 @@
+From e50bb247588038727c5da42b69108b7bb9001cbf Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Tue, 6 Jan 2026 17:16:10 +0100
+Subject: [PATCH 06/10] BACKPORT: Adapt to another Poppler 26.01 API change
+
+(cherry picked from commit b9fb439d1e46e7fb735f83edb7a5bd1d6e950f25)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/pdf/pdfdocument.cpp | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/src/lib/pdf/pdfdocument.cpp b/src/lib/pdf/pdfdocument.cpp
+index 20f77095..dc73689d 100644
+--- a/src/lib/pdf/pdfdocument.cpp
++++ b/src/lib/pdf/pdfdocument.cpp
+@@ -42,9 +42,12 @@ void PdfPagePrivate::load()
+ #if KPOPPLER_VERSION < QT_VERSION_CHECK(25, 1, 0)
+     std::unique_ptr<GooString> s(device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2));
+     m_text = QString::fromUtf8(s->c_str());
+-#else
++#elif KPOPPLER_VERSION <QT_VERSION_CHECK(25, 12, 90)
+     const auto s = device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2);
+     m_text = QString::fromUtf8(s.c_str());
++#else
++    const auto s = device.getText(PDFRectangle(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2));
++    m_text = QString::fromUtf8(s.c_str());
+ #endif
+ 
+     m_images = std::move(device.m_images);
+@@ -111,12 +114,15 @@ QString PdfPage::textInRect(double left, double top, double right, double bottom
+ 
+     TextOutputDev device(nullptr, false, 0, false, false);
+     d->m_doc->m_popplerDoc->displayPageSlice(&device, d->m_pageNum + 1, 72, 72, 0, false, true, false, -1, -1, -1, -1);
+-#if KPOPPLER_VERSION <QT_VERSION_CHECK(25, 1, 0)
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(25, 1, 0)
+     std::unique_ptr<GooString> s(device.getText(l, t, r, b));
+     return QString::fromUtf8(s->c_str());
+-#else
++#elif KPOPPLER_VERSION <QT_VERSION_CHECK(25, 12, 90)
+     const auto s = device.getText(l, t, r, b);
+     return QString::fromUtf8(s.c_str());
++#else
++    const auto s = device.getText(PDFRectangle(l, t, r, b));
++    return QString::fromUtf8(s.c_str());
+ #endif
+ }
+ 
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0007-UPSTREAM-Adapt-to-Poppler-26.02-API-removal.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0007-UPSTREAM-Adapt-to-Poppler-26.02-API-removal.patch
@@ -1,0 +1,73 @@
+From 9c58618f5643a93e54e046c4846abedee155f451 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Thu, 8 Jan 2026 19:29:21 +0100
+Subject: [PATCH 07/10] UPSTREAM: Adapt to Poppler 26.02 API removal
+
+(cherry picked from commit c190329a17895f0e793c00910f37a64d0efeb421)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/pdf/pdfextractoroutputdevice.cpp | 21 +++++++++++++++++++++
+ src/lib/pdf/pdfextractoroutputdevice_p.h | 11 +++++++++++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/src/lib/pdf/pdfextractoroutputdevice.cpp b/src/lib/pdf/pdfextractoroutputdevice.cpp
+index da60bced..8142c05c 100644
+--- a/src/lib/pdf/pdfextractoroutputdevice.cpp
++++ b/src/lib/pdf/pdfextractoroutputdevice.cpp
+@@ -279,3 +279,24 @@ void PdfExtractorOutputDevice::processLink(AnnotLink *link)
+     PdfLink l(QString::fromStdString(uriLink->getURI()), QRectF(QPointF(std::min(xu1, xu2), std::min(yu1, yu2)), QPointF(std::max(xu1, xu2), std::max(yu1, yu2))));
+     m_links.push_back(std::move(l));
+ }
++
++#if KPOPPLER_VERSION >= QT_VERSION_CHECK(26, 1, 90)
++void PdfExtractorOutputDevice::setDefaultCTM(const std::array<double, 6> &ctm)
++{
++    TextOutputDev::setDefaultCTM(ctm);
++
++    const double det = 1 / (ctm[0] * ctm[3] - ctm[1] * ctm[2]);
++    m_defICTM[0] = ctm[3] * det;
++    m_defICTM[1] = -ctm[1] * det;
++    m_defICTM[2] = -ctm[2] * det;
++    m_defICTM[3] = ctm[0] * det;
++    m_defICTM[4] = (ctm[2] * ctm[5] - ctm[3] * ctm[4]) * det;
++    m_defICTM[5] = (ctm[1] * ctm[4] - ctm[0] * ctm[5]) * det;
++}
++
++void PdfExtractorOutputDevice::cvtDevToUser(double dx, double dy, double *ux, double *uy) const
++{
++    *ux = m_defICTM[0] * dx + m_defICTM[2] * dy + m_defICTM[4];
++    *uy = m_defICTM[1] * dx + m_defICTM[3] * dy + m_defICTM[5];
++}
++#endif
+diff --git a/src/lib/pdf/pdfextractoroutputdevice_p.h b/src/lib/pdf/pdfextractoroutputdevice_p.h
+index 61b2eb47..a7c42789 100644
+--- a/src/lib/pdf/pdfextractoroutputdevice_p.h
++++ b/src/lib/pdf/pdfextractoroutputdevice_p.h
+@@ -25,6 +25,10 @@ class PdfExtractorOutputDevice : public TextOutputDev
+ public:
+     explicit PdfExtractorOutputDevice();
+ 
++#if KPOPPLER_VERSION >= QT_VERSION_CHECK(26, 1, 90)
++    void setDefaultCTM(const std::array<double, 6> &ctm) override;
++#endif
++
+     // call once displaying has been completed
+     void finalize();
+ 
+@@ -59,6 +63,13 @@ public:
+ 
+     // extracted links
+     std::vector<PdfLink> m_links;
++
++private:
++#if KPOPPLER_VERSION >= QT_VERSION_CHECK(26, 1, 90)
++    // removed in Poppler 26.02
++    void cvtDevToUser(double dx, double dy, double *ux, double *uy) const;
++    std::array<double, 6> m_defICTM;
++#endif
+ };
+ 
+ }
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0008-UPSTREAM-Adapt-to-Poppler-26.02-API-changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0008-UPSTREAM-Adapt-to-Poppler-26.02-API-changes.patch
@@ -1,0 +1,32 @@
+From 953cfb9b8ae32bfbfb3862729eb6707e64e85d09 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Thu, 22 Jan 2026 17:42:51 +0100
+Subject: [PATCH 08/10] UPSTREAM: Adapt to Poppler 26.02 API changes
+
+(cherry picked from commit 8124584d40a3df72f47d3af4cdfde800a901617f)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/pdf/pdfdocument.cpp | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/lib/pdf/pdfdocument.cpp b/src/lib/pdf/pdfdocument.cpp
+index dc73689d..eb1fe4e1 100644
+--- a/src/lib/pdf/pdfdocument.cpp
++++ b/src/lib/pdf/pdfdocument.cpp
+@@ -377,8 +377,12 @@ PdfDocument* PdfDocument::fromData(const QByteArray &data, QObject *parent)
+     std::unique_ptr<PdfDocument> doc(new PdfDocument(parent));
+     doc->d->m_pdfData = data;
+     // PDFDoc takes ownership of stream
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(26, 1, 90)
+     auto stream = new MemStream(const_cast<char*>(doc->d->m_pdfData.constData()), 0, doc->d->m_pdfData.size(), Object());
+-    std::unique_ptr<PDFDoc> popplerDoc(new PDFDoc(stream));
++#else
++    auto stream = std::make_unique<MemStream>(const_cast<char*>(doc->d->m_pdfData.constData()), 0, doc->d->m_pdfData.size(), Object());
++#endif
++    auto popplerDoc = std::make_unique<PDFDoc>(std::move(stream));
+     if (!popplerDoc->isOk()) {
+         qCWarning(Log) << "Got invalid PDF document!" << popplerDoc->getErrorCode();
+         return nullptr;
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0009-UPSTREAM-Adapt-to-Poppler-26.04-API-changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0009-UPSTREAM-Adapt-to-Poppler-26.04-API-changes.patch
@@ -1,0 +1,63 @@
+From a78198240ce1bbce7e4dde7605bfedb6b064050b Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Mon, 30 Mar 2026 21:19:10 +0200
+Subject: [PATCH 09/10] UPSTREAM: Adapt to Poppler 26.04 API changes
+
+(cherry picked from commit e8332ced4af5b4d8772f49d5f625ee4a1aa8ec07)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/pdf/pdfdocument.cpp | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/src/lib/pdf/pdfdocument.cpp b/src/lib/pdf/pdfdocument.cpp
+index eb1fe4e1..b8e6a7a1 100644
+--- a/src/lib/pdf/pdfdocument.cpp
++++ b/src/lib/pdf/pdfdocument.cpp
+@@ -266,8 +266,12 @@ int PdfDocument::fileSize() const
+     return d->m_pdfData.size();
+ }
+ 
+-static QDateTime parsePdfDateTime(const GooString *str)
++[[nodiscard]] static QDateTime parsePdfDateTime(const GooString *str)
+ {
++    if (!str) {
++        return {};
++    }
++
+     int year;
+     int month;
+     int day;
+@@ -278,7 +282,11 @@ static QDateTime parsePdfDateTime(const GooString *str)
+     int tzMins;
+     char tz;
+ 
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(26, 3, 90)
+     if (!parseDateString(str, &year, &month, &day, &hour, &min, &sec, &tz, &tzHours, &tzMins)) {
++#else
++    if (!parseDateString(str->toStr(), &year, &month, &day, &hour, &min, &sec, &tz, &tzHours, &tzMins)) {
++#endif
+         return {};
+     }
+ 
+@@ -300,18 +308,12 @@ static QDateTime parsePdfDateTime(const GooString *str)
+ QDateTime PdfDocument::creationTime() const
+ {
+     std::unique_ptr<GooString> dt(d->m_popplerDoc->getDocInfoCreatDate());
+-    if (!dt) {
+-        return {};
+-    }
+     return parsePdfDateTime(dt.get());
+ }
+ 
+ QDateTime PdfDocument::modificationTime() const
+ {
+     std::unique_ptr<GooString> dt(d->m_popplerDoc->getDocInfoModDate());
+-    if (!dt) {
+-        return {};
+-    }
+     return parsePdfDateTime(dt.get());
+ }
+ 
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/autobuild/patches/0010-UPSTREAM-Adapt-to-Poppler-26.06-API-changes.patch
+++ b/desktop-kde/kitinerary/autobuild/patches/0010-UPSTREAM-Adapt-to-Poppler-26.06-API-changes.patch
@@ -1,0 +1,93 @@
+From e01ed64226780daff851174dd6c73b568a132ea7 Mon Sep 17 00:00:00 2001
+From: Volker Krause <vkrause@kde.org>
+Date: Wed, 27 May 2026 17:37:31 +0200
+Subject: [PATCH 10/10] UPSTREAM: Adapt to Poppler 26.06 API changes
+
+(cherry picked from commit 2c71a8b3d3ed1eb682f5f1a49348a9c88183d4e6)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ src/lib/pdf/pdfdocument.cpp | 30 ++++++++++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/src/lib/pdf/pdfdocument.cpp b/src/lib/pdf/pdfdocument.cpp
+index b8e6a7a1..482a0e63 100644
+--- a/src/lib/pdf/pdfdocument.cpp
++++ b/src/lib/pdf/pdfdocument.cpp
+@@ -42,12 +42,15 @@ void PdfPagePrivate::load()
+ #if KPOPPLER_VERSION < QT_VERSION_CHECK(25, 1, 0)
+     std::unique_ptr<GooString> s(device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2));
+     m_text = QString::fromUtf8(s->c_str());
+-#elif KPOPPLER_VERSION <QT_VERSION_CHECK(25, 12, 90)
++#elif KPOPPLER_VERSION < QT_VERSION_CHECK(25, 12, 90)
+     const auto s = device.getText(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2);
+     m_text = QString::fromUtf8(s.c_str());
+-#else
++#elif KPOPPLER_VERSION < QT_VERSION_CHECK(26, 5, 90)
+     const auto s = device.getText(PDFRectangle(pageRect->x1, pageRect->y1, pageRect->x2, pageRect->y2));
+     m_text = QString::fromUtf8(s.c_str());
++#else
++    const auto s = device.getText(pageRect);
++    m_text = QString::fromUtf8(s.c_str());
+ #endif
+ 
+     m_images = std::move(device.m_images);
+@@ -57,7 +60,11 @@ void PdfPagePrivate::load()
+ 
+     m_links = std::move(device.m_links);
+     for (auto &link : m_links) {
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(26, 5, 90)
+         link.convertToPageRect(pageRect);
++#else
++        link.convertToPageRect(&pageRect);
++#endif
+     }
+ 
+     m_loaded = true;
+@@ -96,16 +103,30 @@ QString PdfPage::textInRect(double left, double top, double right, double bottom
+     double b;
+     switch (page->getRotate()) {
+         case 0:
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(26, 5, 90)
+             l = ratio(pageRect->x1, pageRect->x2, left);
+             t = ratio(pageRect->y1, pageRect->y2, top);
+             r = ratio(pageRect->x1, pageRect->x2, right);
+             b = ratio(pageRect->y1, pageRect->y2, bottom);
++#else
++            l = ratio(pageRect.x1, pageRect.x2, left);
++            t = ratio(pageRect.y1, pageRect.y2, top);
++            r = ratio(pageRect.x1, pageRect.x2, right);
++            b = ratio(pageRect.y1, pageRect.y2, bottom);
++#endif
+             break;
+         case 90:
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(26, 5, 90)
+             l = ratio(pageRect->y1, pageRect->y2, left);
+             t = ratio(pageRect->x1, pageRect->x2, top);
+             r = ratio(pageRect->y1, pageRect->y2, right);
+             b = ratio(pageRect->x1, pageRect->x2, bottom);
++#else
++            l = ratio(pageRect.y1, pageRect.y2, left);
++            t = ratio(pageRect.x1, pageRect.x2, top);
++            r = ratio(pageRect.y1, pageRect.y2, right);
++            b = ratio(pageRect.x1, pageRect.x2, bottom);
++#endif
+             break;
+         default:
+             qCWarning(Log) << "Unsupported page rotation!" << page->getRotate();
+@@ -155,8 +176,13 @@ QVariantList PdfPage::imagesInRect(double left, double top, double right, double
+     const auto pageRect = d->m_doc->m_popplerDoc->getPage(d->m_pageNum + 1)->getCropBox();
+ 
+     for (const auto &img : d->m_images) {
++#if KPOPPLER_VERSION < QT_VERSION_CHECK(26, 5, 90)
+         if ((img.d->m_transform.dx() >= ratio(pageRect->x1, pageRect->x2, left) && img.d->m_transform.dx() <= ratio(pageRect->x1, pageRect->x2, right)) &&
+             (img.d->m_transform.dy() >= ratio(pageRect->y1, pageRect->y2, top)  && img.d->m_transform.dy() <= ratio(pageRect->y1, pageRect->y2, bottom)))
++#else
++        if ((img.d->m_transform.dx() >= ratio(pageRect.x1, pageRect.x2, left) && img.d->m_transform.dx() <= ratio(pageRect.x1, pageRect.x2, right)) &&
++            (img.d->m_transform.dy() >= ratio(pageRect.y1, pageRect.y2, top)  && img.d->m_transform.dy() <= ratio(pageRect.y1, pageRect.y2, bottom)))
++#endif
+         {
+             l.push_back(QVariant::fromValue(img));
+         }
+-- 
+2.52.0
+

--- a/desktop-kde/kitinerary/spec
+++ b/desktop-kde/kitinerary/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=8
+REL=9
 SRCS="tbl::https://download.kde.org/stable/release-service/$VER/src/kitinerary-$VER.tar.xz"
 CHKSUMS="sha256::aebd2002fe8198cc95884af261882cce8fe0818ebcc34b1ce9a4715cf4e178a8"
 CHKUPDATE="anitya::id=8763"

--- a/desktop-trinity/tdegraphics/autobuild/patches/0001-UPSTREAM-Add-support-for-Poppler-25.10.patch
+++ b/desktop-trinity/tdegraphics/autobuild/patches/0001-UPSTREAM-Add-support-for-Poppler-25.10.patch
@@ -1,0 +1,120 @@
+From fc0c0c02ebfa4f7d4e09c7aa79482527fc16f727 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Sl=C3=A1vek=20Banko?= <slavek.banko@axis.cz>
+Date: Mon, 3 Nov 2025 15:50:00 +0100
+Subject: [PATCH 1/5] UPSTREAM: Add support for Poppler >= 25.10.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix confusing formatting in DocumentData::addTocChildren.
+
+Signed-off-by: Slávek Banko <slavek.banko@axis.cz>
+
+(cherry picked from commit 7de16ecd1e7afda4fd043128289cc9f9cd75aa22)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../poppler-tqt/poppler-document.cpp          | 14 +++++-
+ .../poppler-tqt/poppler-private.cpp           | 45 ++++++++++++-------
+ 2 files changed, 42 insertions(+), 17 deletions(-)
+
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp
+index 5ed02af6..81c6b04a 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp
+@@ -88,7 +88,10 @@ bool Document::unlock(const TQCString &password)
+ {
+   if (data->locked) {
+     /* racier then it needs to be */
+-#   if (POPPLER_VERSION_C >= 22003000)
++#   if (POPPLER_VERSION_C >= 25010000)
++    DocumentData *doc2 = new DocumentData(data->doc.getFileName()->copy(),
++                                          GooString(password.data()));
++#   elif (POPPLER_VERSION_C >= 22003000)
+     DocumentData *doc2 = new DocumentData(std::make_unique<GooString>(data->doc.getFileName()),
+                                           GooString(password.data()));
+ #   else
+@@ -225,7 +228,14 @@ TQString Document::getInfo( const TQString & type ) const
+       isUnicode = gFalse;
+       i = 0;
+     }
+-    while ( i < obj.getString()->getLength() )
++    while
++    (
++#       if (POPPLER_VERSION_C >= 25010000)
++        i < obj.getString()->size()
++#       else
++        i < obj.getString()->getLength()
++#       endif
++    )
+     {
+       if ( isUnicode )
+       {
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp
+index 42ec0899..d5c028d1 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp
+@@ -57,7 +57,14 @@ TQString UnicodeParsedString(CONST_064 GooString *s1)
+         isUnicode = gFalse;
+         i = 0;
+     }
+-    while ( i < s1->getLength() )
++    while
++    (
++#       if (POPPLER_VERSION_C >= 25010000)
++        i < s1->size()
++#       else
++        i < s1->getLength()
++#       endif
++    )
+     {
+         if ( isUnicode )
+         {
+@@ -129,23 +136,31 @@ void DocumentData::addTocChildren( TQDomDocument * docSyn, TQDomNode * parent, O
+                 // get the destination for the page now, but it's VERY time consuming,
+                 // so better storing the reference and provide the viewport on demand
+                 CONST_064 GooString *s = g->getNamedDest();
+-                TQChar *charArray = new TQChar[s->getLength()];
+-                for (int i = 0; i < s->getLength(); ++i) charArray[i] = TQChar(s->GOO_GET_CSTR()[i]);
+-                    TQString aux(charArray, s->getLength());
+-                    item.setAttribute( "DestinationName", aux );
+-                    delete[] charArray;
+-                }
+-                else if ( destination && destination->isOk() )
+-                {
+-                    LinkDestinationData ldd(destination, NULL, this);
+-                    item.setAttribute( "Destination", LinkDestination(ldd).toString() );
+-                }
+-                if ( a->getKind() == actionGoToR )
++#               if (POPPLER_VERSION_C >= 25010000)
++                int sLen = s->size();
++#               else
++                int sLen = s->getLength();
++#               endif
++                TQChar *charArray = new TQChar[sLen];
++                for (int i = 0; i < sLen; ++i)
+                 {
+-                    CONST_064 LinkGoToR * g2 = static_cast< CONST_064 LinkGoToR * >( a );
+-                    item.setAttribute( "ExternalFileName", g2->getFileName()->GOO_GET_CSTR() );
++                    charArray[i] = TQChar(s->GOO_GET_CSTR()[i]);
+                 }
++                TQString aux(charArray, sLen);
++                item.setAttribute( "DestinationName", aux );
++                delete[] charArray;
++            }
++            else if ( destination && destination->isOk() )
++            {
++                LinkDestinationData ldd(destination, NULL, this);
++                item.setAttribute( "Destination", LinkDestination(ldd).toString() );
++            }
++            if ( a->getKind() == actionGoToR )
++            {
++                CONST_064 LinkGoToR * g2 = static_cast< CONST_064 LinkGoToR * >( a );
++                item.setAttribute( "ExternalFileName", g2->getFileName()->GOO_GET_CSTR() );
+             }
++        }
+ 
+         // 3. recursively descend over children
+         outlineItem->open();
+-- 
+2.52.0
+

--- a/desktop-trinity/tdegraphics/autobuild/patches/0002-UPSTREAM-tdefile-plugins-add-support-for-poppler-25..patch
+++ b/desktop-trinity/tdegraphics/autobuild/patches/0002-UPSTREAM-tdefile-plugins-add-support-for-poppler-25..patch
@@ -1,0 +1,35 @@
+From 56b673d36cbd8d05c3d477bcfe796d13fb5b8ab8 Mon Sep 17 00:00:00 2001
+From: Alexander Golubev <fatzer2@gmail.com>
+Date: Sat, 7 Feb 2026 22:43:45 +0300
+Subject: [PATCH 2/5] UPSTREAM: tdefile-plugins: add support for poppler >=
+ 25.12.0
+
+Bug: https://mirror.git.trinitydesktop.org/gitea/TDE/tdegraphics/issues/149
+Signed-off-by: Alexander Golubev <fatzer2@gmail.com>
+
+(cherry picked from commit 8c9531623193493479846961e3880d2eba095ba8)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
+index a2463362..7a64af81 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
+@@ -194,8 +194,12 @@ TQValueList<TextBox*> Page::textList() const
+     return output_list;
+   }
+ 
++# if (POPPLER_VERSION_C >= 25012000)
++  for (TextWord *word: word_list->getWords()) {
++# else
+   for (int i = 0; i < word_list->getLength(); i++) {
+     TextWord *word = word_list->get(i);
++# endif
+     GooString *word_str = word->getText();
+     TQString string = TQString::fromUtf8(word_str->GOO_GET_CSTR());
+     delete word_str;
+-- 
+2.52.0
+

--- a/desktop-trinity/tdegraphics/autobuild/patches/0003-UPSTREAM-tdefile-plugins-add-support-for-poppler-26..patch
+++ b/desktop-trinity/tdegraphics/autobuild/patches/0003-UPSTREAM-tdefile-plugins-add-support-for-poppler-26..patch
@@ -1,0 +1,74 @@
+From 700c583163201708f3544d0fe6bd0fa40ad1e422 Mon Sep 17 00:00:00 2001
+From: Alexander Golubev <fatzer2@gmail.com>
+Date: Sat, 7 Feb 2026 22:44:48 +0300
+Subject: [PATCH 3/5] UPSTREAM: tdefile-plugins: add support for poppler >=
+ 26.01.0
+
+Closes: https://mirror.git.trinitydesktop.org/gitea/TDE/tdegraphics/issues/149
+Signed-off-by: Alexander Golubev <fatzer2@gmail.com>
+
+(cherry picked from commit 2a26f8bf97c534e9c85ca936eb71d65fddd7fa82)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../dependencies/poppler-tqt/poppler-page.cpp        | 12 ++++++++++++
+ .../dependencies/poppler-tqt/poppler-private.cpp     |  2 ++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
+index 7a64af81..75bd59a3 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
+@@ -144,7 +144,11 @@ TQString Page::getText(const Rectangle &r) const
+   if (r.isNull())
+   {
+     rect = p->getCropBox();
++#if (POPPLER_VERSION_C >= 26001000)
++    s = output_dev->getText(PDFRectangle(rect->x1, rect->y1, rect->x2, rect->y2));
++#else
+     s = output_dev->getText(rect->x1, rect->y1, rect->x2, rect->y2);
++#endif
+   }
+   else
+   {
+@@ -152,7 +156,11 @@ TQString Page::getText(const Rectangle &r) const
+     height = p->getCropHeight();
+     y1 = height - r.m_y2;
+     y2 = height - r.m_y1;
++#if (POPPLER_VERSION_C >= 26001000)
++    s = output_dev->getText(PDFRectangle(r.m_x1, y1, r.m_x2, y2));
++#else
+     s = output_dev->getText(r.m_x1, y1, r.m_x2, y2);
++#endif
+   }
+ 
+ # if (POPPLER_VERSION_C >= 25001000)
+@@ -200,9 +208,13 @@ TQValueList<TextBox*> Page::textList() const
+   for (int i = 0; i < word_list->getLength(); i++) {
+     TextWord *word = word_list->get(i);
+ # endif
++# if (POPPLER_VERSION_C >= 26001000)
++    TQString string = TQString::fromUtf8(word->getText()->c_str());
++# else
+     GooString *word_str = word->getText();
+     TQString string = TQString::fromUtf8(word_str->GOO_GET_CSTR());
+     delete word_str;
++# endif
+     double xMin, yMin, xMax, yMax;
+     word->getBBox(&xMin, &yMin, &xMax, &yMax);
+ 
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp
+index d5c028d1..16312a34 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-private.cpp
+@@ -25,6 +25,8 @@
+ 
+ #include <tqstring.h>
+ 
++#include <goo/gmem.h>
++
+ #include <Outline.h>
+ #include <Link.h>
+ 
+-- 
+2.52.0
+

--- a/desktop-trinity/tdegraphics/autobuild/patches/0004-UPSTREAM-tdefile-plugins-add-support-for-poppler-26..patch
+++ b/desktop-trinity/tdegraphics/autobuild/patches/0004-UPSTREAM-tdefile-plugins-add-support-for-poppler-26..patch
@@ -1,0 +1,90 @@
+From e9a06ba2d119b844a72779efce4e8243fbcd11cb Mon Sep 17 00:00:00 2001
+From: Alexander Golubev <fatzer2@gmail.com>
+Date: Wed, 15 Apr 2026 12:25:19 +0300
+Subject: [PATCH 4/5] UPSTREAM: tdefile-plugins: add support for poppler >=
+ 26.04.0
+
+Signed-off-by: Alexander Golubev <fatzer2@gmail.com>
+
+(cherry picked from commit 341f9421fd05ea99f6ea72757d148fca308a0f9b)
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../poppler-tqt/poppler-document.cpp          | 23 +++++++++++++------
+ 1 file changed, 16 insertions(+), 7 deletions(-)
+
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp
+index 81c6b04a..a7c855d0 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-document.cpp
+@@ -204,7 +204,6 @@ TQString Document::getInfo( const TQString & type ) const
+ 
+   TQString result;
+   Object obj;
+-  CONST_064 GooString *s1;
+   GBool isUnicode;
+   Unicode u;
+   int i;
+@@ -217,8 +216,13 @@ TQString Document::getInfo( const TQString & type ) const
+ #endif
+   if (!obj.isNull() && obj.isString())
+   {
+-    s1 = obj.getString();
+-    if ( ( s1->getChar(0) & 0xff ) == 0xfe && ( s1->getChar(1) & 0xff ) == 0xff )
++#   if (POPPLER_VERSION_C >= 26004000)
++#   define GETCHAR(s,n) (s)[n]
++#   else
++#   define GETCHAR(s,n) (s)->getChar(n)
++#   endif
++    auto s1 = obj.getString();
++    if ( ( GETCHAR(s1, 0) & 0xff ) == 0xfe && ( GETCHAR(s1, 1) & 0xff ) == 0xff )
+     {
+       isUnicode = gTrue;
+       i = 2;
+@@ -230,7 +234,9 @@ TQString Document::getInfo( const TQString & type ) const
+     }
+     while
+     (
+-#       if (POPPLER_VERSION_C >= 25010000)
++#       if (POPPLER_VERSION_C >= 26004000)
++        i < obj.getString().size()
++#       elif (POPPLER_VERSION_C >= 25010000)
+         i < obj.getString()->size()
+ #       else
+         i < obj.getString()->getLength()
+@@ -239,12 +245,12 @@ TQString Document::getInfo( const TQString & type ) const
+     {
+       if ( isUnicode )
+       {
+-	u = ( ( s1->getChar(i) & 0xff ) << 8 ) | ( s1->getChar(i+1) & 0xff );
++	u = ( ( GETCHAR(s1, i) & 0xff ) << 8 ) | ( GETCHAR(s1, i+1) & 0xff );
+ 	i += 2;
+       }
+       else
+       {
+-	u = s1->getChar(i) & 0xff;
++	u = GETCHAR(s1, i) & 0xff;
+ 	++i;
+       }
+       result += unicodeToTQString( &u, 1 );
+@@ -254,6 +260,7 @@ TQString Document::getInfo( const TQString & type ) const
+     info.free();
+ #   endif
+     return result;
++#   undef GETCHAR
+   }
+ # if (POPPLER_VERSION_C < 58000)
+   obj.free();
+@@ -295,7 +302,9 @@ TQDateTime Document::getDate( const TQString & type ) const
+ #endif
+   if (!obj.isNull() && obj.isString())
+   {
+-#   if (POPPLER_VERSION_C >= 21008000)
++#   if (POPPLER_VERSION_C >= 26004000)
++    const std::string &s = obj.getString();
++#   elif (POPPLER_VERSION_C >= 21008000)
+     const GooString *s = obj.getString();
+ #   else
+     TQString tqs = UnicodeParsedString(obj.getString());
+-- 
+2.52.0
+

--- a/desktop-trinity/tdegraphics/autobuild/patches/0005-AOSCOS-tdefile-plugins-add-support-for-poppler-26.06.patch
+++ b/desktop-trinity/tdegraphics/autobuild/patches/0005-AOSCOS-tdefile-plugins-add-support-for-poppler-26.06.patch
@@ -1,0 +1,57 @@
+From 28cfb8616554f1526eb3decc82059f388a4eaf02 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Sat, 13 Jun 2026 01:13:08 +0800
+Subject: [PATCH 5/5] AOSCOS: tdefile-plugins: add support for poppler >=
+ 26.06.0
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp | 8 +++++++-
+ .../dependencies/poppler-tqt/poppler-private.h            | 4 ++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp b/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
+index 75bd59a3..8d666844 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-page.cpp
+@@ -129,7 +129,11 @@ TQString Page::getText(const Rectangle &r) const
+ # else
+   GooString *s;
+ # endif
++# if (POPPLER_VERSION_C >= 26006000)
++  PDFRectangle rect;
++# else
+   const PDFRectangle *rect;
++# endif
+   TQString result;
+   ::Page *p;
+ 
+@@ -144,7 +148,9 @@ TQString Page::getText(const Rectangle &r) const
+   if (r.isNull())
+   {
+     rect = p->getCropBox();
+-#if (POPPLER_VERSION_C >= 26001000)
++#if (POPPLER_VERSION_C >= 26006000)
++    s = output_dev->getText(PDFRectangle(rect.x1, rect.y1, rect.x2, rect.y2));
++#elif (POPPLER_VERSION_C >= 26001000)
+     s = output_dev->getText(PDFRectangle(rect->x1, rect->y1, rect->x2, rect->y2));
+ #else
+     s = output_dev->getText(rect->x1, rect->y1, rect->x2, rect->y2);
+diff --git a/tdefile-plugins/dependencies/poppler-tqt/poppler-private.h b/tdefile-plugins/dependencies/poppler-tqt/poppler-private.h
+index d3487ef1..2bde9a01 100644
+--- a/tdefile-plugins/dependencies/poppler-tqt/poppler-private.h
++++ b/tdefile-plugins/dependencies/poppler-tqt/poppler-private.h
+@@ -30,6 +30,10 @@
+ #include <PDFDoc.h>
+ #include <FontInfo.h>
+ 
++#if (POPPLER_VERSION_C >= 26006000)
++#include <CharTypes.h>
++#endif
++
+ #if defined(HAVE_SPLASH)
+ # undef HAVE_SPLASH
+ #endif
+-- 
+2.52.0
+

--- a/desktop-trinity/tdegraphics/spec
+++ b/desktop-trinity/tdegraphics/spec
@@ -1,5 +1,5 @@
 VER=14.1.5
-REL=1
+REL=2
 SRCS="tbl::https://mirror.ppa.trinitydesktop.org/trinity/releases/R$VER/main/core/tdegraphics-trinity-$VER.tar.xz"
 CHKSUMS="sha256::5c28bb2a9317771dc2d014c14c244998db31e02103e6cb57f18e07b231d8f6f3"
 CHKUPDATE="anitya::id=16065"

--- a/runtime-doc/libcupsfilters/spec
+++ b/runtime-doc/libcupsfilters/spec
@@ -1,5 +1,5 @@
 VER=2.1.1
-REL=2
+REL=3
 SRCS="git::commit=tags/$VER::https://github.com/OpenPrinting/libcupsfilters"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=327181"

--- a/runtime-doc/poppler/autobuild/defines
+++ b/runtime-doc/poppler/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=poppler
 PKGSEC=libs
-PKGDES="A PDF rendering library and command line tools used to manipulate PDF files"
+PKGDES="PDF rendering library and command line tools used to manipulate PDF files"
 PKGDEP="cairo curl fontconfig gcc-runtime lcms2 libjpeg-turbo nss openjpeg \
         poppler-data gpgmepp boost freetype libpng libtiff nss"
 BUILDDEP="vim gtk-doc gtk-3 gobject-introspection nss icu qt-5 qt-6 glib"
@@ -8,33 +8,29 @@ PKGDEP__RETRO="cairo curl fontconfig gcc-runtime lcms2 libjpeg-turbo nss openjpe
                poppler-data gpgmepp freetype libpng libtiff"
 BUILDDEP__RETRO="glib gtk-3"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
-	"-DENABLE_UNSTABLE_API_ABI_HEADERS=ON"
-	"-DENABLE_GTK_DOC=OFF"
-	"-DENABLE_BOOST=ON"
-	"-DENABLE_QT5=ON"
-	"-DENABLE_QT6=ON"
+	'-DENABLE_UNSTABLE_API_ABI_HEADERS=ON'
+	'-DENABLE_GTK_DOC=OFF'
+	'-DENABLE_BOOST=ON'
+	'-DENABLE_QT5=ON'
+	'-DENABLE_QT6=ON'
 )
 CMAKE_AFTER__RETRO=(
 	"${CMAKE_AFTER[@]}"
-	"-DENABLE_BOOST=OFF"
-	"-DENABLE_QT5=OFF"
-	"-DENABLE_QT6=OFF"
+	'-DENABLE_BOOST=OFF'
+	'-DENABLE_QT5=OFF'
+	'-DENABLE_QT6=OFF'
 )
 
 PKGBREAK="atril<=1.28.1 cantor<=23.08.5 evince<=42.3-1 \
-          gdal<=3.10.3-1 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
-          graphviz<=12.2.1 inkscape<=1.4.1-4 kfilemetadata<=5.115.0-1 \
-          kitinerary<=23.08.5-6 koffice-trinity<=14.1.2-5 krita<=5.2.2-1 \
-          libcupsfilters<=2.0.0-1 libreoffice<=25.2.4.3-1 okular<=23.08.5-2 \
-          openscenegraph<=3:3.6.5-4 pdfgrep<=2.1.2-4 \
+          gdal<=3.13.0 gegl-0.4<=0.0.48-2 gimp<=2.10.38 \
+          graphviz<=12.2.1 inkscape<=1.4.3-6 kfilemetadata<=5.115.0-1 \
+          kitinerary<=23.08.5-8 koffice-trinity<=14.1.2-5 krita<=5.2.2-1 \
+          libcupsfilters<=2.1.1-2 libreoffice<=26.2.4.2 okular<=23.08.5-2 \
+          openscenegraph<=3:3.6.5-4 pdfgrep<=2.1.2-5 openboard<=1.7.7-1 \
           python-poppler-qt5<=21.1.0+git20210304-3 rnote<=0.11.0 \
-          sane-backends<=1.0.32-2 scribus<=1.6.3-3 tdegraphics<=14.1.2-4 \
+          sane-backends<=1.0.32-2 scribus<=1.6.6-1 tdegraphics<=14.1.5-1 \
           texstudio<=4.0.2-4 texworks<=0.6.6-4 tracker-miners<=3.3.1-3 \
           tumbler<=4.20.0 xournalpp<=1.2.5 xreader<=4.2.2 \
           zathura-pdf-poppler<=0.3.3"
-
-AB_FLAGS_EXC=0
-AB_FLAGS_SPECS=0
-
-PKGEPOCH=1

--- a/runtime-doc/poppler/spec
+++ b/runtime-doc/poppler/spec
@@ -1,5 +1,5 @@
-VER=25.07.0
+VER=26.06.0
 SRCS="tbl::https://poppler.freedesktop.org/poppler-$VER.tar.xz"
-CHKSUMS="sha256::c504a9066dbdfebe377ad53cec641fd971ee96c4e1e8ca74e6c9c03d46d817ae"
+CHKSUMS="sha256::4cb4e5a3dc8cb5eec751c8a23c8ba19f61f96dedc0cd07d2aee6b0c8e2cf6ba4"
 CHKUPDATE="anitya::id=3686"
-REL=6
+EPOCH=1

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -1,4 +1,4 @@
-VER=3.13.0
+VER=3.13.1
 SRCS="git::commit=tags/v${VER}::https://github.com/OSGeo/gdal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=881"


### PR DESCRIPTION
Topic Description
-----------------

- tdegraphics: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- scribus: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- openboard: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libreoffice: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- kitinerary: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- inkscape: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- gdal: bump REL due to poppler update to 1:26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- poppler: update to 26.06.0
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- gdal: 3.12.1-6
- inkscape: 1.4.3-7
- kitinerary: 23.08.5-9
- libreoffice: 26.2.4.1-1
- openboard: 1.7.7-2
- poppler: 26.06.0
- scribus: 1.6.6-2
- tdegraphics: 14.1.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit poppler:-pkgbreak gdal inkscape kitinerary libreoffice openboard scribus tdegraphics libcupsfilters pdfgrep poppler
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
