### PR TITLE
ldns: security update to 1.9.2

### DIFF
--- a/runtime-network/ldns/autobuild/defines
+++ b/runtime-network/ldns/autobuild/defines
@@ -5,30 +5,21 @@ BUILDDEP="swig perl-devel-checklib"
 PKGDES="Fast DNS library supporting recent RFCs"
 
 ABTYPE=autotools
-# FIXME: --without-pyldns, --without-pyldnsx
-#
-# Incompatibility with newer SWIG:
-#
-# .../ldns-1.8.4/contrib/python/ldns_wrapper.c:8421:15: error: too few arguments to function 'SWIG_Python_AppendOutput'
-#  8421 |   resultobj = SWIG_Python_AppendOutput(resultobj,
-#       |               ^~~~~~~~~~~~~~~~~~~~~~~~
 AUTOTOOLS_AFTER=(
     '--disable-static'
     '--disable-rpath'
     '--with-drill'
-    '--with-examples'
-    '--without-pyldns'
-    '--without-pyldnsx'
     '--with-p5-dns-ldns'
+    '--without-examples'
     '--with-trust-anchor=/etc/unbound/trusted-key.key'
     '--with-ca-file=/etc/ssl/certs/ca-certificates.crt'
     '--with-ca-path=/etc/ssl/certs/'
 )
 # FIXME:
 # Can't link/include C library 'ldns', 'ldns', aborting.
-# cd /var/cache/acbs/build/acbs.ruw_9t9h/ldns-1.8.4/contrib/DNS-LDNS; make
-# make[1]: Entering directory '/var/cache/acbs/build/acbs.ruw_9t9h/ldns-1.8.4/contrib/DNS-LDNS'
+# cd /var/cache/acbs/build/acbs.y6oirda_/ldns-1.9.2/contrib/DNS-LDNS; make
+# make[1]: Entering directory '/var/cache/acbs/build/acbs.y6oirda_/ldns-1.9.2/contrib/DNS-LDNS'
 # make[1]: *** No targets specified and no makefile found.  Stop.
-NOPARALLEL__RISCV64=1
+NOPARALLEL=1
 
 PKGBREAK="dnscrypt<=2.0.39-1 openssh<=8.1p1 openssh-hpn<=7.8p1"

--- a/runtime-network/ldns/spec
+++ b/runtime-network/ldns/spec
@@ -1,5 +1,4 @@
-VER=1.8.4
+VER=1.9.2
 SRCS="tbl::https://www.nlnetlabs.nl/downloads/ldns/ldns-$VER.tar.gz"
-CHKSUMS="sha256::838b907594baaff1cd767e95466a7745998ae64bc74be038dccc62e2de2e4247"
+CHKSUMS="sha256::b524fa21994b6e834200ceb8c27f1b84bda5982fe35706f058196c079db94d5d"
 CHKUPDATE="anitya::id=14817"
-REL="2"

--- a/topics/ldns-1.9.2.toml
+++ b/topics/ldns-1.9.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "ldns 1.9.2"
+
+[caution]
+default = "Fixes an Origin Validation Error vulnerability (CVE-2026-10846, severity: High)"
+zh_CN = "修复一个源验证错误漏洞（漏洞编号 CVE-2026-10846，严重性：高）"
+
+[packages-v2]
+"ldns" = "< 1.9.2"


### PR DESCRIPTION
Topic Description
-----------------

- ldns: security update to 1.9.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- ldns: 1.9.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit ldns
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
