### PR TITLE
[FLIGHT] x265: update to 4.2 unrelease, test LoongArch64 Vector

### DIFF
--- a/runtime-multimedia/x265/spec
+++ b/runtime-multimedia/x265/spec
@@ -1,5 +1,4 @@
-VER=3.6
-REL=1
-SRCS="git::commit=tags/$VER::https://bitbucket.org/multicoreware/x265_git"
+VER=4.2-unrelease
+SRCS="git::commit=3f156cd09d2044c434b13ec207650433bb93e622::https://github.com/Multicorewareinc/x265.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7275"


### PR DESCRIPTION
Topic Description
-----------------

- x265: update to 4.2-unrelease

Package(s) Affected
-------------------

- x265: 4.2-unrelease

Security Update?
----------------

No

Build Order
-----------

```
#buildit x265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
