### PR TITLE
boost 1.91.0 rework for znc

### DIFF
--- a/app-web/znc/spec
+++ b/app-web/znc/spec
@@ -1,4 +1,5 @@
 VER=1.10.2
+REL=1
 SRCS="git::commit=tags/znc-$VER::https://github.com/znc/znc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5305"

--- a/groups/boost-rebuild
+++ b/groups/boost-rebuild
@@ -59,4 +59,5 @@ tdeedu
 thin-provisioning-tools
 thunderbolt-software-user-space
 wesnoth
+znc
 zxtune

--- a/runtime-common/boost/autobuild/defines
+++ b/runtime-common/boost/autobuild/defines
@@ -32,7 +32,7 @@ PKGBREAK="0ad<=0.0.23 abyss<=2.0.3 aegisub<=3.2.2-8 aptitude<=0.8.10-1 \
           rlvm<=0.14-4 scribus<=1.4.6-4 sdcc<=3.6.0 \
           source-highlight<=3.1.8-4 swift-im<=3.0 synfig<=1.2.1 \
           tdepim<=14.0.4-2 vera++<=1.3.0-1 websocketpp<=0.7.0-3 \
-          wesnoth<=1.12.6-1 yaml-cpp<=0.6.2"
+          wesnoth<=1.12.6-1 yaml-cpp<=0.6.2 znc<=1.10.2"
 
 AB_FLAGS_O3=1
 

--- a/runtime-common/boost/spec
+++ b/runtime-common/boost/spec
@@ -1,4 +1,5 @@
 VER=1.91.0
+REL=1
 SRCS="tbl::https://archives.boost.io/release/$VER/source/boost_${VER//./_}.tar.bz2"
 CHKSUMS="sha256::de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5"
 CHKUPDATE="anitya::id=6845"


### PR DESCRIPTION
Topic Description
-----------------

- boost: add PKGBREAK for old znc
    The \`znc\` package was missing in the rebuild list of boost.
    Add a PKGBREAK for it to boost.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- groups/boost-rebuild: add znc
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- znc: rebuild for boost 1.91.0
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- boost: 1:1.91.0
- znc: 1.10.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit znc boost
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
