### PR TITLE
boost 1.91.0 rework for guitarix

### DIFF
--- a/app-multimedia/guitarix/autobuild/patches/0001-BACKPORT-UPSTREAM-wscript-improve-boost-check.patch
+++ b/app-multimedia/guitarix/autobuild/patches/0001-BACKPORT-UPSTREAM-wscript-improve-boost-check.patch
@@ -1,0 +1,65 @@
+From ae101d832460930e5f199c091cd77307a680370e Mon Sep 17 00:00:00 2001
+From: Alexander Tsoy <alexander@tsoy.me>
+Date: Wed, 26 Nov 2025 14:11:42 +0300
+Subject: [PATCH] BACKPORT: UPSTREAM: wscript: improve boost check
+
+Make neccessary boost checks mandatory again. Reuse BOOST_SYSTEM
+parameters in all checks instead of explicitly depending on
+boost_system.
+
+[Icenowy: rebased on top of v0.47.0, remove trunk/]
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ wscript | 21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/wscript b/trunk/wscript
+index 066d3f00..45ca642f 100644
+--- a/wscript
++++ b/wscript
+@@ -186,8 +186,13 @@ def check_boost(conf):
+     #include <boost/system/error_code.hpp>
+     int main() { boost::system::error_code c; }
+     """
+-    msg = "Checking for boost-system "
+-    conf.check_cxx(msg = msg, fragment=code, lib="boost_system", uselib_store="BOOST_SYSTEM", mandatory=1,includes='/opt/local/include', libpath='/opt/local/lib')
++    msg = "Checking for boost-system"
++    # boost_system is a stub library since boost 1.69 and is completely removed in boost 1.89
++    try:
++        conf.check_cxx(msg = msg, fragment=code, uselib_store="BOOST_SYSTEM", includes='/opt/local/include', libpath='/opt/local/lib')
++    except ConfigurationError:
++        conf.check_cxx(msg = msg, fragment=code, lib="boost_system", uselib_store="BOOST_SYSTEM", includes='/opt/local/include', libpath='/opt/local/lib')
++        #conf.check_cxx(msg = msg, fragment=code, lib="boost_system-mt", uselib_store="BOOST_SYSTEM", includes='/opt/local/include', libpath='/opt/local/lib')
+     # some boost (>1.49) versions depend on boost-system so we will check for it first
+     # and later link against boost_system were boost headers are included.
+     boost_atleast_version = 104200
+@@ -202,13 +207,11 @@ def check_boost(conf):
+     int main(){ return 0; }
+     """ % boost_atleast_version
+     msg = "Checking for boost >= %s" % boost_atleast_vermsg
+-    conf.check_cxx(msg = msg, fragment=code, lib="boost_system", mandatory=1)
+-    #conf.check_cxx(msg = msg, fragment=code, lib="boost_system-mt", mandatory=1,includes='/opt/local/include', libpath='/opt/local/lib')
++    conf.check_cxx(msg = msg, fragment=code, use='BOOST_SYSTEM', mandatory=1)
++
++    msg = "Checking for boost_iostreams"
++    conf.check_cxx(msg = msg, fragment=code, lib=["boost_iostreams"], use='BOOST_SYSTEM', uselib_store="BOOST_IOSTREAMS", mandatory=1)
+ 
+-    msg = "Checking for boost_iostreams >= %s" % boost_atleast_vermsg
+-    conf.check_cxx(msg = msg, fragment=code, lib=["boost_iostreams","boost_system"], uselib_store="BOOST_IOSTREAMS", mandatory=1)
+-    #conf.check_cxx(msg = msg, fragment=code, lib=["boost_iostreams","boost_system-mt"], uselib_store="BOOST_IOSTREAMS", mandatory=1, includes='/opt/local/include', libpath='/opt/local/lib')
+- 
+     #try:
+     #    conf.check_cxx(
+     #        msg = msg % "", fragment=code, lib="boost_thread", uselib_store="BOOST_THREAD",
+@@ -217,7 +220,7 @@ def check_boost(conf):
+     #    conf.check_cxx(
+     #        msg = msg % "-mt",fragment=code, lib="boost_thread-mt",
+     #        uselib_store="BOOST_THREAD", mandatory=1)
+-    
++
+     # not needed: with boost 1.42 Guitarix doesn't generate code which
+     #             references the boost threading lib
+     #msg = "Checking for boost_thread%%s >= %s" % boost_atleast_vermsg
+-- 
+2.52.0
+

--- a/app-multimedia/guitarix/spec
+++ b/app-multimedia/guitarix/spec
@@ -1,5 +1,5 @@
 VER=0.47.0
-REL=1
+REL=2
 SRCS="tbl::https://github.com/brummer10/guitarix/releases/download/V${VER}/guitarix2-${VER}.tar.xz"
 CHKSUMS="sha256::f18abd3bd2cb05960d00f15f36c63f97eb1759f9571977e3e42191ff16b9b467"
 CHKUPDATE="anitya::id=10599"

--- a/groups/boost-rebuild
+++ b/groups/boost-rebuild
@@ -17,6 +17,7 @@ freecad
 source-highlight
 gdb
 gpick
+guitarix
 heaptrack
 vigra
 hugin

--- a/runtime-common/boost/autobuild/defines
+++ b/runtime-common/boost/autobuild/defines
@@ -32,7 +32,8 @@ PKGBREAK="0ad<=0.0.23 abyss<=2.0.3 aegisub<=3.2.2-8 aptitude<=0.8.10-1 \
           rlvm<=0.14-4 scribus<=1.4.6-4 sdcc<=3.6.0 \
           source-highlight<=3.1.8-4 swift-im<=3.0 synfig<=1.2.1 \
           tdepim<=14.0.4-2 vera++<=1.3.0-1 websocketpp<=0.7.0-3 \
-          wesnoth<=1.12.6-1 yaml-cpp<=0.6.2 znc<=1.10.2"
+          wesnoth<=1.12.6-1 yaml-cpp<=0.6.2 znc<=1.10.2 \
+          guitarix<=0.47.0-1"
 
 AB_FLAGS_O3=1
 

--- a/runtime-common/boost/spec
+++ b/runtime-common/boost/spec
@@ -1,5 +1,5 @@
 VER=1.91.0
-REL=1
+REL=2
 SRCS="tbl::https://archives.boost.io/release/$VER/source/boost_${VER//./_}.tar.bz2"
 CHKSUMS="sha256::de5e6b0e4913395c6bdfa90537febd9028ea4c0735d2cdb0cd9b45d5f51264f5"
 CHKUPDATE="anitya::id=6845"


### PR DESCRIPTION
Topic Description
-----------------

- boost: add guitarix PKGBREAK
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- groups/boost-rebuild: add guitarix
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- guitarix: rebuild for boost 1.91.0
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- boost: 1:1.91.0-2
- guitarix: 0.47.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit guitarix boost
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
