### PR TITLE
deb-installer: update to 0.3.1

### DIFF
--- a/app-admin/deb-installer/autobuild/beyond
+++ b/app-admin/deb-installer/autobuild/beyond
@@ -4,7 +4,6 @@ install -Dvm644 "$SRCDIR"/data/io.aosc.deb_installer.conf \
 
 abinfo "Installing icon files ..."
 install -Dvm644 \
-    "$SRCDIR"/data/io.aosc.deb_installer.png \
     "$SRCDIR"/data/io.aosc.deb_installer.svg \
     -t "$PKGDIR"/usr/share/pixmaps/
 

--- a/app-admin/deb-installer/autobuild/defines
+++ b/app-admin/deb-installer/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=deb-installer
 PKGSEC=admin
-PKGDEP="apt debconf-kde openssl qt-5"
+PKGDEP="apt debconf-kde kirigami2 openssl qqc2-desktop-style"
 BUILDDEP="rustc llvm"
 PKGDES="Graphical .deb package installation wizard"
 
-# FIXME: LTO causes mysterious failure in proc-macro.
-NOLTO=1
+USECLANG=1
+
+ABTYPE=rust

--- a/app-admin/deb-installer/autobuild/prepare
+++ b/app-admin/deb-installer/autobuild/prepare
@@ -1,2 +1,5 @@
 abinfo "Enabling Gettext catalog generation ..."
 export GEN_GETTEXT=1
+
+abinfo "Setting Qt 5 as the target ..."
+export QMAKE=/usr/bin/qmake-qt5

--- a/app-admin/deb-installer/spec
+++ b/app-admin/deb-installer/spec
@@ -1,4 +1,4 @@
-VER=0.1.10
+VER=0.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/deb-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375467"


### PR DESCRIPTION
Topic Description
-----------------

- deb-installer: update to 0.3.1
    Re-written in QtQuick \(Kirigami\).

Package(s) Affected
-------------------

- deb-installer: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deb-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
