### PR TITLE
silicon: new, 0.5.3

### DIFF
--- a/app-utils/silicon/autobuild/defines
+++ b/app-utils/silicon/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=silicon
+PKGSEC=utils
+PKGDEP="glibc gcc-runtime fontconfig freetype harfbuzz libxcb onig xclip wl-clipboard"
+BUILDDEP="rustc llvm"
+PKGDES="Utility to create stylized screenshots of source code"

--- a/app-utils/silicon/autobuild/prepare
+++ b/app-utils/silicon/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Forcing onig_sys crate to use system onig package ..."
+export RUSTONIG_DYNAMIC_LIBONIG=1

--- a/app-utils/silicon/spec
+++ b/app-utils/silicon/spec
@@ -1,0 +1,4 @@
+VER=0.5.3
+SRCS="git::commit=tags/v$VER::https://github.com/aloxaf/silicon.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390606"


### PR DESCRIPTION
Topic Description
-----------------

- silicon: new, 0.5.3

Package(s) Affected
-------------------

- silicon: 0.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit silicon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
