### PR TITLE
MoveIt Survey

### DIFF
--- a/app-devel/iwyu/autobuild/defines
+++ b/app-devel/iwyu/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=iwyu
 PKGSEC=libs
-PKGDEP="llvm-22 python-3"
-PKGDES="Tool for use with clang to analyze #includes in C and C++ source files"
+PKGDEP="llvm python-3"
+PKGDES="Tool to analyze #includes in C/C++ source files using Clang"
 
 ABTYPE=cmakeninja
 USECLANG=1

--- a/app-devel/iwyu/autobuild/defines
+++ b/app-devel/iwyu/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=iwyu
+PKGSEC=libs
+PKGDEP="llvm-22 python-3"
+PKGDES="Tool for use with clang to analyze #includes in C and C++ source files"
+
+ABTYPE=cmakeninja
+USECLANG=1

--- a/app-devel/iwyu/autobuild/prepare
+++ b/app-devel/iwyu/autobuild/prepare
@@ -1,0 +1,4 @@
+abinfo "Switching to LLVM 22 ..."
+# FIXME: require newest major version of LLVM
+export CC=$(readlink -f $(which clang-22))
+export CXX=$(readlink -f $(which clang++-22))

--- a/app-devel/iwyu/spec
+++ b/app-devel/iwyu/spec
@@ -1,4 +1,4 @@
-VER=0.26
+VER=0.24
 SRCS="git::commit=tags/$VER::https://github.com/include-what-you-use/include-what-you-use"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7521"

--- a/app-devel/iwyu/spec
+++ b/app-devel/iwyu/spec
@@ -1,0 +1,4 @@
+VER=0.26
+SRCS="git::commit=tags/$VER::https://github.com/include-what-you-use/include-what-you-use"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=7521"

--- a/app-devel/lcov/autobuild/build
+++ b/app-devel/lcov/autobuild/build
@@ -1,0 +1,1 @@
+make install DESTDIR="$PKGDIR" PREFIX=/usr CFG_DIR=/etc LIBDIR=/lib

--- a/app-devel/lcov/autobuild/defines
+++ b/app-devel/lcov/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=lcov
+PKGSEC=libs
+PKGDEP="perl"
+PKGDES="Tool to manipulate and display information about what parts of a program are actually executed"
+
+ABTYPE=self
+ABHOST=noarch

--- a/app-devel/lcov/spec
+++ b/app-devel/lcov/spec
@@ -1,0 +1,4 @@
+VER=2.4
+SRCS="git::commit=tags/v$VER::https://github.com/linux-test-project/lcov"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=346328"

--- a/runtime-common/fcl/autobuild/defines
+++ b/runtime-common/fcl/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=fcl
+PKGSEC=libs
+PKGDEP="libccd octomap"
+BUILDDEP="eigen-3"
+PKGDES="Library for performing three types of proximity queries on a pair of geometric models composed of triangles"
+
+ABTYPE=cmakeninja

--- a/runtime-common/fcl/spec
+++ b/runtime-common/fcl/spec
@@ -1,0 +1,4 @@
+VER=0.7.0
+SRCS="git::commit=tags/$VER::https://github.com/flexible-collision-library/fcl"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=12257"

--- a/runtime-common/libccd/autobuild/defines
+++ b/runtime-common/libccd/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=libccd
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="Library for collision detection between two convex shapes"
+
+ABTYPE=cmakeninja

--- a/runtime-common/libccd/spec
+++ b/runtime-common/libccd/spec
@@ -1,0 +1,4 @@
+VER=2.1
+SRCS="git::commit=tags/v$VER::https://github.com/danfis/libccd"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=1571"

--- a/runtime-common/octomap/autobuild/defines
+++ b/runtime-common/octomap/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=octomap
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="Efficient Probabilistic 3D Mapping Framework Based on Octrees"
+
+ABTYPE=cmakeninja
+NOSTATIC=0

--- a/runtime-common/octomap/autobuild/patches/0001.patch
+++ b/runtime-common/octomap/autobuild/patches/0001.patch
@@ -1,0 +1,511 @@
+From 8178b4f28c72a8c7b84ece25bda7a59df8d14eb8 Mon Sep 17 00:00:00 2001
+From: SpaceIm <30052553+SpaceIm@users.noreply.github.com>
+Date: Tue, 23 May 2023 21:04:12 +0200
+Subject: [PATCH] Fix errors with recent compilers and C++17/20 standard (#394)
+
+- fix definition of OcTreeBase(double res) constructor (it fixes gcc12/C++20 compilation errors)
+- more robust detection of C++11 for Visual Studio (it fixes Visual Studio2022/C++17 compilation errors)
+- remove several illegal semicolon (unlikely the reason of compilation errors, but it's neater to fix that)
+---
+ octomap/include/octomap/AbstractOcTree.h      |  2 +-
+ .../include/octomap/AbstractOccupancyOcTree.h |  2 +-
+ octomap/include/octomap/ColorOcTree.h         |  2 +-
+ octomap/include/octomap/CountingOcTree.h      |  2 +-
+ octomap/include/octomap/OcTree.h              |  4 ++--
+ octomap/include/octomap/OcTreeBase.h          |  2 +-
+ octomap/include/octomap/OcTreeBaseImpl.h      |  8 +++----
+ octomap/include/octomap/OcTreeDataNode.h      |  4 ++--
+ octomap/include/octomap/OcTreeIterator.hxx    | 10 ++++----
+ octomap/include/octomap/OcTreeStamped.h       |  2 +-
+ octomap/include/octomap/ScanGraph.h           |  2 +-
+ octomap/src/Pointcloud.cpp                    |  4 ++--
+ octomap/src/compare_octrees.cpp               |  2 +-
+ octovis/include/octovis/OcTreeDrawer.h        | 10 ++++----
+ octovis/include/octovis/SceneObject.h         |  8 +++----
+ octovis/include/octovis/ViewerSettings.h      | 12 +++++-----
+ .../src/extern/QGLViewer/VRender/Exporter.h   |  8 +++----
+ octovis/src/extern/QGLViewer/camera.cpp       |  4 ++--
+ octovis/src/extern/QGLViewer/constraint.h     | 24 +++++++++----------
+ 19 files changed, 56 insertions(+), 56 deletions(-)
+
+diff --git a/octomap/include/octomap/AbstractOcTree.h b/octomap/include/octomap/AbstractOcTree.h
+index e396d28a..c1e93235 100644
+--- a/octomap/include/octomap/AbstractOcTree.h
++++ b/octomap/include/octomap/AbstractOcTree.h
+@@ -51,7 +51,7 @@ namespace octomap {
+     friend class StaticMapInit;
+   public:
+     AbstractOcTree();
+-    virtual ~AbstractOcTree() {};
++    virtual ~AbstractOcTree() {}
+ 
+     /// virtual constructor: creates a new object of same type
+     virtual AbstractOcTree* create() const = 0;
+diff --git a/octomap/include/octomap/AbstractOccupancyOcTree.h b/octomap/include/octomap/AbstractOccupancyOcTree.h
+index 240aedec..dd38571f 100644
+--- a/octomap/include/octomap/AbstractOccupancyOcTree.h
++++ b/octomap/include/octomap/AbstractOccupancyOcTree.h
+@@ -52,7 +52,7 @@ namespace octomap {
+   class AbstractOccupancyOcTree : public AbstractOcTree {
+   public:
+     AbstractOccupancyOcTree();
+-    virtual ~AbstractOccupancyOcTree() {};
++    virtual ~AbstractOccupancyOcTree() {}
+ 
+     //-- IO
+ 
+diff --git a/octomap/include/octomap/ColorOcTree.h b/octomap/include/octomap/ColorOcTree.h
+index 03f8b904..5026a07b 100644
+--- a/octomap/include/octomap/ColorOcTree.h
++++ b/octomap/include/octomap/ColorOcTree.h
+@@ -192,7 +192,7 @@ namespace octomap {
+          * StaticMemberInitializer, causing this tree failing to register.
+          * Needs to be called from the constructor of this octree.
+          */
+-         void ensureLinking() {};
++         void ensureLinking() {}
+     };
+     /// static member to ensure static initialization (only once)
+     static StaticMemberInitializer colorOcTreeMemberInit;
+diff --git a/octomap/include/octomap/CountingOcTree.h b/octomap/include/octomap/CountingOcTree.h
+index f7ab115c..2b06cc7e 100644
+--- a/octomap/include/octomap/CountingOcTree.h
++++ b/octomap/include/octomap/CountingOcTree.h
+@@ -110,7 +110,7 @@ namespace octomap {
+          * StaticMemberInitializer, causing this tree failing to register.
+          * Needs to be called from the constructor of this octree.
+          */
+-         void ensureLinking() {};
++         void ensureLinking() {}
+     };
+     /// static member to ensure static initialization (only once)
+     static StaticMemberInitializer countingOcTreeMemberInit;
+diff --git a/octomap/include/octomap/OcTree.h b/octomap/include/octomap/OcTree.h
+index dcd5ac79..725ec762 100644
+--- a/octomap/include/octomap/OcTree.h
++++ b/octomap/include/octomap/OcTree.h
+@@ -59,7 +59,7 @@ namespace octomap {
+      */
+     OcTree(std::string _filename);
+ 
+-    virtual ~OcTree(){};
++    virtual ~OcTree(){}
+ 
+     /// virtual constructor: creates a new object of same type
+     /// (Covariant return type requires an up-to-date compiler)
+@@ -89,7 +89,7 @@ namespace octomap {
+ 	     * StaticMemberInitializer, causing this tree failing to register.
+ 	     * Needs to be called from the constructor of this octree.
+ 	     */
+-	    void ensureLinking() {};
++	    void ensureLinking() {}
+     };
+ 
+     /// to ensure static initialization (only once)
+diff --git a/octomap/include/octomap/OcTreeBase.h b/octomap/include/octomap/OcTreeBase.h
+index d53b4056..1e600494 100644
+--- a/octomap/include/octomap/OcTreeBase.h
++++ b/octomap/include/octomap/OcTreeBase.h
+@@ -43,7 +43,7 @@ namespace octomap {
+   template <class NODE>
+   class OcTreeBase : public OcTreeBaseImpl<NODE,AbstractOcTree> {
+   public:
+-    OcTreeBase<NODE>(double res) : OcTreeBaseImpl<NODE,AbstractOcTree>(res) {};
++    OcTreeBase(double res) : OcTreeBaseImpl<NODE,AbstractOcTree>(res) {}
+ 
+     /// virtual constructor: creates a new object of same type
+     /// (Covariant return type requires an up-to-date compiler)
+diff --git a/octomap/include/octomap/OcTreeBaseImpl.h b/octomap/include/octomap/OcTreeBaseImpl.h
+index 74711c2d..7109d9cc 100644
+--- a/octomap/include/octomap/OcTreeBaseImpl.h
++++ b/octomap/include/octomap/OcTreeBaseImpl.h
+@@ -244,7 +244,7 @@ namespace octomap {
+     virtual size_t memoryUsage() const;
+ 
+     /// \return Memory usage of a single octree node
+-    virtual inline size_t memoryUsageNode() const {return sizeof(NODE); };
++    virtual inline size_t memoryUsageNode() const {return sizeof(NODE); }
+ 
+     /// \return Memory usage of a full grid of the same size as the OcTree in bytes (for comparison)
+     /// \note this can be larger than the adressable memory - size_t may not be enough to hold it!
+@@ -324,12 +324,12 @@ namespace octomap {
+     typedef leaf_iterator iterator;
+ 
+     /// @return beginning of the tree as leaf iterator
+-    iterator begin(unsigned char maxDepth=0) const {return iterator(this, maxDepth);};
++    iterator begin(unsigned char maxDepth=0) const {return iterator(this, maxDepth);}
+     /// @return end of the tree as leaf iterator
+-    const iterator end() const {return leaf_iterator_end;}; // TODO: RVE?
++    const iterator end() const {return leaf_iterator_end;} // TODO: RVE?
+ 
+     /// @return beginning of the tree as leaf iterator
+-    leaf_iterator begin_leafs(unsigned char maxDepth=0) const {return leaf_iterator(this, maxDepth);};
++    leaf_iterator begin_leafs(unsigned char maxDepth=0) const {return leaf_iterator(this, maxDepth);}
+     /// @return end of the tree as leaf iterator
+     const leaf_iterator end_leafs() const {return leaf_iterator_end;}
+ 
+diff --git a/octomap/include/octomap/OcTreeDataNode.h b/octomap/include/octomap/OcTreeDataNode.h
+index febe0384..1ecdf808 100644
+--- a/octomap/include/octomap/OcTreeDataNode.h
++++ b/octomap/include/octomap/OcTreeDataNode.h
+@@ -100,9 +100,9 @@ namespace octomap {
+     OCTOMAP_DEPRECATED(bool hasChildren() const);
+ 
+     /// @return value stored in the node
+-    T getValue() const{return value;};
++    T getValue() const{return value;}
+     /// sets value to be stored in the node
+-    void setValue(T v) {value = v;};
++    void setValue(T v) {value = v;}
+ 
+     // file IO:
+ 
+diff --git a/octomap/include/octomap/OcTreeIterator.hxx b/octomap/include/octomap/OcTreeIterator.hxx
+index 5f2dd7e5..64cbdd7a 100644
+--- a/octomap/include/octomap/OcTreeIterator.hxx
++++ b/octomap/include/octomap/OcTreeIterator.hxx
+@@ -102,7 +102,7 @@
+         maxDepth = other.maxDepth;
+         stack = other.stack;
+         return *this;
+-      };
++      }
+ 
+       /// Ptr operator will return the current node in the octree which the
+       /// iterator is referring to
+@@ -220,7 +220,7 @@
+        * @param ptree OcTreeBaseImpl on which the iterator is used on
+        * @param depth Maximum depth to traverse the tree. 0 (default): unlimited
+        */
+-      tree_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, uint8_t depth=0) : iterator_base(ptree, depth) {};
++      tree_iterator(OcTreeBaseImpl<NodeType,INTERFACE> const* ptree, uint8_t depth=0) : iterator_base(ptree, depth) {}
+ 
+       /// postfix increment operator of iterator (it++)
+       tree_iterator operator++(int){
+@@ -287,7 +287,7 @@
+             }
+           }
+ 
+-          leaf_iterator(const leaf_iterator& other) : iterator_base(other) {};
++          leaf_iterator(const leaf_iterator& other) : iterator_base(other) {}
+ 
+           /// postfix increment operator of iterator (it++)
+           leaf_iterator operator++(int){
+@@ -341,7 +341,7 @@
+      */
+     class leaf_bbx_iterator : public iterator_base {
+     public:
+-      leaf_bbx_iterator() : iterator_base() {};
++      leaf_bbx_iterator() : iterator_base() {}
+       /**
+       * Constructor of the iterator. The bounding box corners min and max are
+       * converted into an OcTreeKey first.
+@@ -432,7 +432,7 @@
+ 
+ 
+         return *this;
+-      };
++      }
+ 
+     protected:
+ 
+diff --git a/octomap/include/octomap/OcTreeStamped.h b/octomap/include/octomap/OcTreeStamped.h
+index 21cf6463..3fa648c3 100644
+--- a/octomap/include/octomap/OcTreeStamped.h
++++ b/octomap/include/octomap/OcTreeStamped.h
+@@ -116,7 +116,7 @@ namespace octomap {
+       * StaticMemberInitializer, causing this tree failing to register.
+       * Needs to be called from the constructor of this octree.
+       */
+-      void ensureLinking() {};
++      void ensureLinking() {}
+     };
+     /// to ensure static initialization (only once)
+     static StaticMemberInitializer ocTreeStampedMemberInit;
+diff --git a/octomap/include/octomap/ScanGraph.h b/octomap/include/octomap/ScanGraph.h
+index 0ababe41..7652362d 100644
+--- a/octomap/include/octomap/ScanGraph.h
++++ b/octomap/include/octomap/ScanGraph.h
+@@ -115,7 +115,7 @@ namespace octomap {
+ 
+    public:
+ 
+-    ScanGraph() {};
++    ScanGraph() {}
+     ~ScanGraph();
+ 
+     /// Clears all nodes and edges, and will delete the corresponding objects
+diff --git a/octomap/src/Pointcloud.cpp b/octomap/src/Pointcloud.cpp
+index a6d4a745..87c9e05e 100644
+--- a/octomap/src/Pointcloud.cpp
++++ b/octomap/src/Pointcloud.cpp
+@@ -38,7 +38,7 @@
+ 
+ #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
+   #include <algorithm>
+-  #if __cplusplus > 199711L
++  #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201103L) || __cplusplus >= 201103L)
+     #include <random>
+   #endif
+ #else
+@@ -213,7 +213,7 @@ namespace octomap {
+   #if defined(_MSC_VER) || defined(_LIBCPP_VERSION)
+     samples.reserve(this->size());
+     samples.insert(samples.end(), this->begin(), this->end());
+-    #if __cplusplus > 199711L
++    #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201103L) || __cplusplus >= 201103L)
+       std::random_device r;
+       std::mt19937 urbg(r());
+       std::shuffle(samples.begin(), samples.end(), urbg);
+diff --git a/octomap/src/compare_octrees.cpp b/octomap/src/compare_octrees.cpp
+index 0ab8c26b..c02ceea8 100644
+--- a/octomap/src/compare_octrees.cpp
++++ b/octomap/src/compare_octrees.cpp
+@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
+       else
+         kld +=log(p1/p2)*p1 + log((1-p1)/(1-p2))*(1-p1);
+ 
+-#if __cplusplus >= 201103L
++#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201103L) || __cplusplus >= 201103L)
+       if (std::isnan(kld)){
+ #else
+       if (isnan(kld)){
+diff --git a/octovis/include/octovis/OcTreeDrawer.h b/octovis/include/octovis/OcTreeDrawer.h
+index 34d719a3..5d444057 100644
+--- a/octovis/include/octovis/OcTreeDrawer.h
++++ b/octovis/include/octovis/OcTreeDrawer.h
+@@ -62,14 +62,14 @@ namespace octomap {
+     void setAlternativeDrawing(bool flag){m_alternativeDrawing = flag;}
+ 
+     void enableOcTree(bool enabled = true);
+-    void enableOcTreeCells(bool enabled = true) { m_update = true; m_drawOccupied = enabled; };
+-    void enableFreespace(bool enabled = true) { m_update = true; m_drawFree = enabled; };
+-    void enableSelection(bool enabled = true) { m_update = true; m_drawSelection = enabled; };
+-    void setMax_tree_depth(unsigned int max_tree_depth) { m_update = true; m_max_tree_depth = max_tree_depth;};
++    void enableOcTreeCells(bool enabled = true) { m_update = true; m_drawOccupied = enabled; }
++    void enableFreespace(bool enabled = true) { m_update = true; m_drawFree = enabled; }
++    void enableSelection(bool enabled = true) { m_update = true; m_drawSelection = enabled; }
++    void setMax_tree_depth(unsigned int max_tree_depth) { m_update = true; m_max_tree_depth = max_tree_depth;}
+ 
+     // set new origin (move object)
+     void setOrigin(octomap::pose6d t);
+-    void enableAxes(bool enabled = true) { m_update = true; m_displayAxes = enabled; };
++    void enableAxes(bool enabled = true) { m_update = true; m_displayAxes = enabled; }
+ 
+   protected:
+     //void clearOcTree();
+diff --git a/octovis/include/octovis/SceneObject.h b/octovis/include/octovis/SceneObject.h
+index 240c4650..d0298ab0 100644
+--- a/octovis/include/octovis/SceneObject.h
++++ b/octovis/include/octovis/SceneObject.h
+@@ -57,7 +57,7 @@ namespace octomap {
+ 
+   public:
+     SceneObject();
+-    virtual ~SceneObject(){};
++    virtual ~SceneObject(){}
+ 
+     /**
+     * Actual draw function which will be called to visualize the object
+@@ -67,7 +67,7 @@ namespace octomap {
+     /**
+     * Clears the object's representation (will be called when it gets invalid)
+     */
+-    virtual void clear(){};
++    virtual void clear(){}
+ 
+   public:
+     //! the color mode has to be set before calling OcTreDrawer::setMap()
+@@ -95,8 +95,8 @@ namespace octomap {
+   */
+   class ScanGraphDrawer : public SceneObject {
+   public:
+-    ScanGraphDrawer(): SceneObject(){};
+-    virtual ~ScanGraphDrawer(){};
++    ScanGraphDrawer(): SceneObject(){}
++    virtual ~ScanGraphDrawer(){}
+ 
+     /**
+     * Notifies drawer of a new or changed ScanGraph, so that the internal
+diff --git a/octovis/include/octovis/ViewerSettings.h b/octovis/include/octovis/ViewerSettings.h
+index 2d9e94e3..55708682 100644
+--- a/octovis/include/octovis/ViewerSettings.h
++++ b/octovis/include/octovis/ViewerSettings.h
+@@ -40,12 +40,12 @@ class ViewerSettings : public QDialog
+ public:
+     ViewerSettings(QWidget *parent = 0);
+     ~ViewerSettings();
+-    double getResolution(){return ui.resolution->value(); };
+-    void setResolution(double resolution){ui.resolution->setValue(resolution);};
+-    unsigned int getLaserType(){return ui.laserType->currentIndex(); };
+-    void setLaserType(int type){ui.laserType->setCurrentIndex(type); };
+-    double getMaxRange(){return ui.maxRange->value(); };
+-    void setMaxRange(double range){ui.maxRange->setValue(range); };
++    double getResolution(){return ui.resolution->value(); }
++    void setResolution(double resolution){ui.resolution->setValue(resolution);}
++    unsigned int getLaserType(){return ui.laserType->currentIndex(); }
++    void setLaserType(int type){ui.laserType->setCurrentIndex(type); }
++    double getMaxRange(){return ui.maxRange->value(); }
++    void setMaxRange(double range){ui.maxRange->setValue(range); }
+ 
+ private:
+     Ui::ViewerSettingsClass ui;
+diff --git a/octovis/src/extern/QGLViewer/VRender/Exporter.h b/octovis/src/extern/QGLViewer/VRender/Exporter.h
+index e01b7eea..4bf5669b 100644
+--- a/octovis/src/extern/QGLViewer/VRender/Exporter.h
++++ b/octovis/src/extern/QGLViewer/VRender/Exporter.h
+@@ -60,7 +60,7 @@ namespace vrender
+ 	{
+ 		public:
+ 			Exporter() ;
+-			virtual ~Exporter() {};
++			virtual ~Exporter() {}
+ 
+ 			virtual void exportToFile(const QString& filename,const std::vector<PtrPrimitive>&,VRenderParams&) ;
+ 
+@@ -92,7 +92,7 @@ namespace vrender
+ 	{
+ 		public:
+ 			EPSExporter() ;
+-			virtual ~EPSExporter() {};
++			virtual ~EPSExporter() {}
+ 
+ 		protected:
+ 			virtual void spewPoint(const Point *, QTextStream& out) ;
+@@ -120,7 +120,7 @@ namespace vrender
+ 	class PSExporter: public EPSExporter
+ 	{
+ 		public:
+-			virtual ~PSExporter() {};
++			virtual ~PSExporter() {}
+ 		protected:
+ 			virtual void writeFooter(QTextStream& out) const ;
+ 	};
+@@ -129,7 +129,7 @@ namespace vrender
+ 	{
+ 		public:
+ 			FIGExporter() ;
+-			virtual ~FIGExporter() {};
++			virtual ~FIGExporter() {}
+ 
+ 		protected:
+ 			virtual void spewPoint(const Point *, QTextStream& out) ;
+diff --git a/octovis/src/extern/QGLViewer/camera.cpp b/octovis/src/extern/QGLViewer/camera.cpp
+index 70dde8e3..45f028ce 100644
+--- a/octovis/src/extern/QGLViewer/camera.cpp
++++ b/octovis/src/extern/QGLViewer/camera.cpp
+@@ -199,8 +199,8 @@ void Camera::setScreenWidthAndHeight(int width, int height)
+  \code
+  class myCamera :: public qglviewer::Camera
+  {
+-   virtual qreal Camera::zNear() const { return 0.001; };
+-   virtual qreal Camera::zFar() const { return 100.0; };
++   virtual qreal Camera::zNear() const { return 0.001; }
++   virtual qreal Camera::zFar() const { return 100.0; }
+  }
+  \endcode
+ 
+diff --git a/octovis/src/extern/QGLViewer/constraint.h b/octovis/src/extern/QGLViewer/constraint.h
+index d90d8203..cc1d8ad1 100644
+--- a/octovis/src/extern/QGLViewer/constraint.h
++++ b/octovis/src/extern/QGLViewer/constraint.h
+@@ -197,7 +197,7 @@ class QGLVIEWER_EXPORT AxisPlaneConstraint : public Constraint
+ 		  case MyAxisPlaneConstraint::FREE: ... break;
+ 		  case MyAxisPlaneConstraint::CUSTOM: ... break;
+ 		}
+-	  };
++	  }
+ 
+ 	  MyAxisPlaneConstraint* c = new MyAxisPlaneConstraint();
+ 	  // Note the Type conversion
+@@ -209,11 +209,11 @@ class QGLVIEWER_EXPORT AxisPlaneConstraint : public Constraint
+ 	/*! @name Translation constraint */
+ 	//@{
+ 	/*! Overloading of Constraint::constrainTranslation(). Empty */
+-	virtual void constrainTranslation(Vec& translation, Frame* const frame) { Q_UNUSED(translation); Q_UNUSED(frame); };
++	virtual void constrainTranslation(Vec& translation, Frame* const frame) { Q_UNUSED(translation); Q_UNUSED(frame); }
+ 
+ 	void setTranslationConstraint(Type type, const Vec& direction);
+ 	/*! Sets the Type() of the translationConstraintType(). Default is AxisPlaneConstraint::FREE. */
+-	void setTranslationConstraintType(Type type) { translationConstraintType_ = type; };
++	void setTranslationConstraintType(Type type) { translationConstraintType_ = type; }
+ 	void setTranslationConstraintDirection(const Vec& direction);
+ 
+ 	/*! Returns the translation constraint Type().
+@@ -225,7 +225,7 @@ class QGLVIEWER_EXPORT AxisPlaneConstraint : public Constraint
+ 
+ 	Use Frame::setPosition() to define the position of the constrained Frame before it gets
+ 	constrained. */
+-	Type translationConstraintType() const { return translationConstraintType_; };
++	Type translationConstraintType() const { return translationConstraintType_; }
+ 	/*! Returns the direction used by the translation constraint.
+ 
+ 	It represents the axis direction (AxisPlaneConstraint::AXIS) or the plane normal
+@@ -235,20 +235,20 @@ class QGLVIEWER_EXPORT AxisPlaneConstraint : public Constraint
+ 	The AxisPlaneConstraint derived classes express this direction in different coordinate system
+ 	(camera for CameraConstraint, local for LocalConstraint, and world for WorldConstraint). This
+ 	value can be modified with setTranslationConstraintDirection(). */
+-	Vec translationConstraintDirection() const { return translationConstraintDir_; };
++	Vec translationConstraintDirection() const { return translationConstraintDir_; }
+ 	//@}
+ 
+ 	/*! @name Rotation constraint */
+ 	//@{
+ 	/*! Overloading of Constraint::constrainRotation(). Empty. */
+-	virtual void constrainRotation(Quaternion& rotation, Frame* const frame) { Q_UNUSED(rotation); Q_UNUSED(frame); };
++	virtual void constrainRotation(Quaternion& rotation, Frame* const frame) { Q_UNUSED(rotation); Q_UNUSED(frame); }
+ 
+ 	void setRotationConstraint(Type type, const Vec& direction);
+ 	void setRotationConstraintType(Type type);
+ 	void setRotationConstraintDirection(const Vec& direction);
+ 
+ 	/*! Returns the rotation constraint Type(). */
+-	Type rotationConstraintType() const { return rotationConstraintType_; };
++	Type rotationConstraintType() const { return rotationConstraintType_; }
+ 	/*! Returns the axis direction used by the rotation constraint.
+ 
+ 	This direction is defined only when rotationConstraintType() is AxisPlaneConstraint::AXIS.
+@@ -256,7 +256,7 @@ class QGLVIEWER_EXPORT AxisPlaneConstraint : public Constraint
+ 	The AxisPlaneConstraint derived classes express this direction in different coordinate system
+ 	(camera for CameraConstraint, local for LocalConstraint, and world for WorldConstraint). This
+ 	value can be modified with setRotationConstraintDirection(). */
+-	Vec rotationConstraintDirection() const { return rotationConstraintDir_; };
++	Vec rotationConstraintDirection() const { return rotationConstraintDir_; }
+ 	//@}
+ 
+ private:
+@@ -280,7 +280,7 @@ class QGLVIEWER_EXPORT LocalConstraint : public AxisPlaneConstraint
+ {
+ public:
+ 	/*! Virtual destructor. Empty. */
+-	virtual ~LocalConstraint() {};
++	virtual ~LocalConstraint() {}
+ 
+ 	virtual void constrainTranslation(Vec&     translation, Frame* const frame);
+ 	virtual void constrainRotation   (Quaternion& rotation, Frame* const frame);
+@@ -300,7 +300,7 @@ class QGLVIEWER_EXPORT WorldConstraint : public AxisPlaneConstraint
+ {
+ public:
+ 	/*! Virtual destructor. Empty. */
+-	virtual ~WorldConstraint() {};
++	virtual ~WorldConstraint() {}
+ 
+ 	virtual void constrainTranslation(Vec&     translation, Frame* const frame);
+ 	virtual void constrainRotation   (Quaternion& rotation, Frame* const frame);
+@@ -321,13 +321,13 @@ class QGLVIEWER_EXPORT CameraConstraint : public AxisPlaneConstraint
+ public:
+ 	explicit CameraConstraint(const Camera* const camera);
+ 	/*! Virtual destructor. Empty. */
+-	virtual ~CameraConstraint() {};
++	virtual ~CameraConstraint() {}
+ 
+ 	virtual void constrainTranslation(Vec&     translation, Frame* const frame);
+ 	virtual void constrainRotation   (Quaternion& rotation, Frame* const frame);
+ 
+ 	/*! Returns the associated Camera. Set using the CameraConstraint constructor. */
+-	const Camera* camera() const { return camera_; };
++	const Camera* camera() const { return camera_; }
+ 
+ private:
+ 	const Camera* const camera_;
+

--- a/runtime-common/octomap/spec
+++ b/runtime-common/octomap/spec
@@ -1,0 +1,4 @@
+VER=1.9.8
+SRCS="git::commit=tags/v$VER::https://github.com/OctoMap/octomap"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=2530"

--- a/runtime-ros/ros-jazzy-chomp-motion-planner/autobuild/defines
+++ b/runtime-ros/ros-jazzy-chomp-motion-planner/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-chomp-motion-planner
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-rclcpp ros-jazzy-rsl ros-jazzy-trajectory-msgs"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="CHOMP motion planner algorithm for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-chomp-motion-planner/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-chomp-motion-planner/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-chomp-motion-planner/spec
+++ b/runtime-ros/ros-jazzy-chomp-motion-planner/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/chomp_motion_planner/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/chomp_motion_planner/.*"

--- a/runtime-ros/ros-jazzy-control-toolbox/autobuild/defines
+++ b/runtime-ros/ros-jazzy-control-toolbox/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-control-toolbox
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-control-msgs eigen ros-jazzy-filters ros-jazzy-generate-parameter-library ros-jazzy-geometry-msgs tl-expected ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rcutils ros-jazzy-realtime-tools ros-jazzy-rsl ros-jazzy-tf2 ros-jazzy-tf2-ros ros-jazzy-tf2-geometry-msgs fmt pyyaml"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-rclcpp-lifecycle"
+PKGDES="Common modules and tools of ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-control-toolbox/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-control-toolbox/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-control-toolbox/spec
+++ b/runtime-ros/ros-jazzy-control-toolbox/spec
@@ -1,0 +1,4 @@
+VER=4.11.0+1
+SRCS="git::commit=tags/release/jazzy/control_toolbox/${VER/+/-}::https://github.com/ros2-gbp/control_toolbox-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/control_toolbox-release;pattern=release/jazzy/control_toolbox/.*"

--- a/runtime-ros/ros-jazzy-eigen-stl-containers/autobuild/defines
+++ b/runtime-ros/ros-jazzy-eigen-stl-containers/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-eigen-stl-containers
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace eigen"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Eigen datatypes definitions in Standard Template Library (STL) containers"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-eigen-stl-containers/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-eigen-stl-containers/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-eigen-stl-containers/spec
+++ b/runtime-ros/ros-jazzy-eigen-stl-containers/spec
@@ -1,0 +1,4 @@
+VER=1.1.0+1
+SRCS="git::commit=tags/release/jazzy/eigen_stl_containers/${VER/+/-}::https://github.com/ros2-gbp/eigen_stl_containers-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/eigen_stl_containers-release;pattern=release/jazzy/eigen_stl_containers/.*"

--- a/runtime-ros/ros-jazzy-filters/autobuild/defines
+++ b/runtime-ros/ros-jazzy-filters/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-filters
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace boost ros-jazzy-pluginlib ros-jazzy-rclcpp"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-cppcheck ros-jazzy-ament-cmake-cpplint ros-jazzy-ament-cmake-uncrustify ros-jazzy-ament-cmake-xmllint"
+PKGDES="Standardized interface to process sequential data in ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-filters/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-filters/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-filters/spec
+++ b/runtime-ros/ros-jazzy-filters/spec
@@ -1,0 +1,4 @@
+VER=2.2.2+1
+SRCS="git::commit=tags/release/jazzy/filters/${VER/+/-}::https://github.com/ros2-gbp/filters-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/filters-release;pattern=release/jazzy/filters/.*"

--- a/runtime-ros/ros-jazzy-forward-command-controller/autobuild/defines
+++ b/runtime-ros/ros-jazzy-forward-command-controller/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-forward-command-controller
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-controller-interface ros-jazzy-generate-parameter-library ros-jazzy-hardware-interface ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-lifecycle ros-jazzy-realtime-tools ros-jazzy-std-msgs"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-controller-manager ros-jazzy-hardware-interface-testing ros-jazzy-ros2-control-test-assets"
+PKGDES="Forwards standard multi-array commands directly to joint or hardware interfaces"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-forward-command-controller/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-forward-command-controller/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-forward-command-controller/spec
+++ b/runtime-ros/ros-jazzy-forward-command-controller/spec
@@ -1,0 +1,4 @@
+VER=4.40.1+1
+SRCS="git::commit=tags/release/jazzy/forward_command_controller/${VER/+/-}::https://github.com/ros2-gbp/ros2_controllers-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_controllers-release;pattern=release/jazzy/forward_command_controller/.*"

--- a/runtime-ros/ros-jazzy-geometric-shapes/autobuild/defines
+++ b/runtime-ros/ros-jazzy-geometric-shapes/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-geometric-shapes
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-rclcpp ros-jazzy-eigen-stl-containers ros-jazzy-console-bridge-vendor octomap ros-jazzy-random-numbers ros-jazzy-resource-retriever ros-jazzy-shape-msgs ros-jazzy-geometry-msgs ros-jazzy-visualization-msgs assimp ros-jazzy-rosidl-default-runtime fcl qhull eigen boost ros-jazzy-eigen3-cmake-module"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators pkg-config ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-cmake ros-jazzy-ament-cmake-copyright"
+PKGDES="Generic definitions and tools to work with generic geometric shapes for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-geometric-shapes/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-geometric-shapes/autobuild/prepare
@@ -1,0 +1,15 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh
+
+# FIXME:
+# In file included from /usr/include/fcl/geometry/shape/convex.h:276,
+# from /usr/include/fcl/geometry/shape/utility-inl.h:49,
+# from /usr/include/fcl/geometry/shape/utility.h:130,
+# from /var/cache/acbs/build/acbs.te56wm5m/ros-jazzy-geometric-shapes/src/aabb.cpp:33:
+# /usr/include/fcl/geometry/shape/convex-inl.h: In constructor ‘fcl::Convex<S_>::Convex(const std::shared_ptr<const std::vector<Eigen::Matrix<Type, 3, 1> > >&, int, const std::shared_ptr<const std::vector<int> >&, bool)’:
+# /usr/include/fcl/geometry/shape/convex-inl.h:68:3: error: there are no arguments to ‘assert’ that depend on a template parameter, so a declaration of ‘assert’ must be available [-Wtemplate-body]
+# 68 | assert(faces != nullptr);
+# | ^~~~~~
+# /usr/include/fcl/geometry/shape/convex-inl.h:68:3: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
+export CXXFLAGS="${CXXFLAGS} -fpermissive"

--- a/runtime-ros/ros-jazzy-geometric-shapes/spec
+++ b/runtime-ros/ros-jazzy-geometric-shapes/spec
@@ -1,0 +1,4 @@
+VER=2.3.2+1
+SRCS="git::commit=tags/release/jazzy/geometric_shapes/${VER/+/-}::https://github.com/ros2-gbp/geometric_shapes-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/geometric_shapes-release;pattern=release/jazzy/geometric_shapes/.*"

--- a/runtime-ros/ros-jazzy-gripper-controllers/autobuild/defines
+++ b/runtime-ros/ros-jazzy-gripper-controllers/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-gripper-controllers
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-control-msgs ros-jazzy-control-toolbox ros-jazzy-controller-interface ros-jazzy-generate-parameter-library ros-jazzy-hardware-interface ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-realtime-tools"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-controller-manager ros-jazzy-hardware-interface-testing ros-jazzy-ros2-control-test-assets"
+PKGDES="Generalized action controllers to manage robotic hands and grippers"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-gripper-controllers/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-gripper-controllers/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-gripper-controllers/spec
+++ b/runtime-ros/ros-jazzy-gripper-controllers/spec
@@ -1,0 +1,4 @@
+VER=4.40.1+1
+SRCS="git::commit=tags/release/jazzy/gripper_controllers/${VER/+/-}::https://github.com/ros2-gbp/ros2_controllers-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_controllers-release;pattern=release/jazzy/gripper_controllers/.*"

--- a/runtime-ros/ros-jazzy-launch-param-builder/autobuild/defines
+++ b/runtime-ros/ros-jazzy-launch-param-builder/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-launch-param-builder
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-python yaml ros-jazzy-xacro ros-jazzy-rclpy"
+BUILDDEP="ros-jazzy-ament-copyright pytest"
+PKGDES="Library to load parameters in ROS 2 launch files"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-launch-param-builder/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-launch-param-builder/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-launch-param-builder/spec
+++ b/runtime-ros/ros-jazzy-launch-param-builder/spec
@@ -1,0 +1,4 @@
+VER=0.1.1+4
+SRCS="git::commit=tags/release/jazzy/launch_param_builder/${VER/+/-}::https://github.com/ros2-gbp/launch_param_builder-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/launch_param_builder-release;pattern=release/jazzy/launch_param_builder/.*"

--- a/runtime-ros/ros-jazzy-moveit-common/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-common/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-common
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Support functionalities used by MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-common/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-common/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-common/spec
+++ b/runtime-ros/ros-jazzy-moveit-common/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_common/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_common/.*"

--- a/runtime-ros/ros-jazzy-moveit-configs-utils/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-configs-utils/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-moveit-configs-utils
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-python ros-jazzy-launch-param-builder ros-jazzy-launch ros-jazzy-launch-ros ros-jazzy-srdfdom"
+
+PKGDES="Load MoveIt 2 configuration parameters in ROS 2 launch files"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-moveit-configs-utils/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-configs-utils/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-configs-utils/spec
+++ b/runtime-ros/ros-jazzy-moveit-configs-utils/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_configs_utils/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_configs_utils/.*"

--- a/runtime-ros/ros-jazzy-moveit-core/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-core/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-core
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-angles assimp boost bullet ros-jazzy-common-interfaces eigen ros-jazzy-eigen-stl-containers ros-jazzy-generate-parameter-library ros-jazzy-geometric-shapes ros-jazzy-geometry-msgs ros-jazzy-google-benchmark-vendor ros-jazzy-kdl-parser fcl ros-jazzy-moveit-common ros-jazzy-moveit-msgs octomap ros-jazzy-octomap-msgs ros-jazzy-osqp-vendor ros-jazzy-pluginlib ros-jazzy-random-numbers ros-jazzy-rclcpp ros-jazzy-rsl ros-jazzy-ruckig ros-jazzy-sensor-msgs ros-jazzy-shape-msgs ros-jazzy-srdfdom ros-jazzy-std-msgs ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-kdl ros-jazzy-trajectory-msgs ros-jazzy-urdf ros-jazzy-urdfdom ros-jazzy-urdfdom-headers ros-jazzy-visualization-msgs ros-jazzy-eigen3-cmake-module"
+BUILDDEP="ros-jazzy-ament-cmake pkg-config ros-jazzy-moveit-resources-panda-moveit-config ros-jazzy-moveit-resources-pr2-description ros-jazzy-orocos-kdl-vendor ros-jazzy-ament-cmake-google-benchmark ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-gmock ros-jazzy-ament-index-cpp ros-jazzy-launch-testing-ament-cmake ros-jazzy-rclpy ros-jazzy-rcl-interfaces"
+PKGDES="Core libraries for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-core/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-core/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,10 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index 8475da4b4..9daa70441 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -10,5 +10,4 @@ find_package(
+   program_options
+   regex
+   serialization
+-  system
+   thread)

--- a/runtime-ros/ros-jazzy-moveit-core/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-core/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-core/spec
+++ b/runtime-ros/ros-jazzy-moveit-core/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_core/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_core/.*"

--- a/runtime-ros/ros-jazzy-moveit-kinematics/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-kinematics/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-kinematics
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-class-loader ros-jazzy-pluginlib ros-jazzy-generate-parameter-library eigen ros-jazzy-tf2 ros-jazzy-tf2-kdl ros-jazzy-orocos-kdl-vendor ros-jazzy-moveit-msgs ros-jazzy-moveit-ros-planning ros-jazzy-rsl ros-jazzy-urdfdom lxml"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-moveit-resources-fanuc-description ros-jazzy-moveit-resources-fanuc-moveit-config ros-jazzy-moveit-resources-panda-description ros-jazzy-moveit-resources-panda-moveit-config ros-jazzy-ament-cmake-gtest ros-jazzy-ros-testing ros-jazzy-moveit-configs-utils ros-jazzy-launch-param-builder"
+PKGDES="C++ plugins for forward and inverse kinematics (FK & IK) solvers for robotic arms"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-kinematics/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-kinematics/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,9 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index adca88d82..cbe96e25b 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -1,3 +1,3 @@
+ # Extras module needed for dependencies to find boost components
+ 
+-find_package(Boost REQUIRED program_options system)
++find_package(Boost REQUIRED program_options)

--- a/runtime-ros/ros-jazzy-moveit-kinematics/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-kinematics/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-kinematics/spec
+++ b/runtime-ros/ros-jazzy-moveit-kinematics/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_kinematics/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_kinematics/.*"

--- a/runtime-ros/ros-jazzy-moveit-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-msgs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-msgs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-octomap-msgs ros-jazzy-action-msgs ros-jazzy-sensor-msgs ros-jazzy-geometry-msgs ros-jazzy-trajectory-msgs ros-jazzy-shape-msgs ros-jazzy-object-recognition-msgs ros-jazzy-std-msgs ros-jazzy-rosidl-default-runtime"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-cmake"
+PKGDES="Messages, services, and actions for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-msgs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-msgs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-msgs/spec
+++ b/runtime-ros/ros-jazzy-moveit-msgs/spec
@@ -1,0 +1,4 @@
+VER=2.6.0+1
+SRCS="git::commit=tags/release/jazzy/moveit_msgs/${VER/+/-}::https://github.com/ros2-gbp/moveit_msgs-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit_msgs-release;pattern=release/jazzy/moveit_msgs/.*"

--- a/runtime-ros/ros-jazzy-moveit-planners-chomp/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-planners-chomp/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-planners-chomp
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-chomp-motion-planner ros-jazzy-moveit-core ros-jazzy-pluginlib ros-jazzy-rclcpp"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Interface to use CHOMP motion planner within MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-planners-chomp/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-planners-chomp/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-planners-chomp/spec
+++ b/runtime-ros/ros-jazzy-moveit-planners-chomp/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_planners_chomp/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_planners_chomp/.*"

--- a/runtime-ros/ros-jazzy-moveit-planners-ompl/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-planners-ompl/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-planners-ompl
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-moveit-msgs ros-jazzy-moveit-ros-planning ros-jazzy-ompl ros-jazzy-rclcpp ros-jazzy-tf2-eigen ros-jazzy-tf2-ros llvm ros-jazzy-pluginlib"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-eigen3-cmake-module ros-jazzy-moveit-resources-pr2-description ros-jazzy-moveit-resources-fanuc-moveit-config ros-jazzy-moveit-resources-panda-moveit-config eigen ros-jazzy-ament-cmake-gtest"
+PKGDES="Interface to use OMPL motion planner within MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-planners-ompl/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-planners-ompl/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 646289474..b6fd6ca62 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -8,7 +8,6 @@ moveit_package()
+ find_package(
+   Boost
+   REQUIRED
+-  system
+   filesystem
+   date_time
+   thread

--- a/runtime-ros/ros-jazzy-moveit-planners-ompl/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-planners-ompl/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-planners-ompl/spec
+++ b/runtime-ros/ros-jazzy-moveit-planners-ompl/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_planners_ompl/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_planners_ompl/.*"

--- a/runtime-ros/ros-jazzy-moveit-planners-stomp/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-planners-stomp/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-planners-stomp
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-generate-parameter-library ros-jazzy-stomp ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-std-msgs ros-jazzy-tf2-eigen ros-jazzy-visualization-msgs ros-jazzy-rsl pyyaml"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Interface to use STOMP motion planner within MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-planners-stomp/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-planners-stomp/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-planners-stomp/spec
+++ b/runtime-ros/ros-jazzy-moveit-planners-stomp/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_planners_stomp/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_planners_stomp/.*"

--- a/runtime-ros/ros-jazzy-moveit-planners/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-planners/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-planners
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-planners-chomp ros-jazzy-moveit-planners-ompl ros-jazzy-moveit-planners-stomp ros-jazzy-pilz-industrial-motion-planner"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Meta package for all motion planners for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-planners/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-planners/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-planners/spec
+++ b/runtime-ros/ros-jazzy-moveit-planners/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_planners/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_planners/.*"

--- a/runtime-ros/ros-jazzy-moveit-plugins/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-plugins/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-plugins
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-simple-controller-manager"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Meta package for MoveIt 2 plugins"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-plugins/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-plugins/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-plugins/spec
+++ b/runtime-ros/ros-jazzy-moveit-plugins/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_plugins/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_plugins/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-fanuc-description/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-fanuc-description/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-fanuc-description
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="FANUC resources to test MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-fanuc-description/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-fanuc-description/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-fanuc-description/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-fanuc-description/spec
@@ -1,0 +1,4 @@
+VER=3.1.0+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_fanuc_description/${VER/+/-}::https://github.com/ros2-gbp/moveit_resources-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit_resources-release;pattern=release/jazzy/moveit_resources_fanuc_description/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-fanuc-moveit-config/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-fanuc-moveit-config/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-fanuc-moveit-config
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ros2cli-common-extensions ros-jazzy-joint-state-publisher ros-jazzy-robot-state-publisher ros-jazzy-tf2-ros ros-jazzy-controller-manager ros-jazzy-position-controllers ros-jazzy-xacro ros-jazzy-moveit-resources-fanuc-description"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="FANUC configuration resources to test MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-fanuc-moveit-config/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-fanuc-moveit-config/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-fanuc-moveit-config/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-fanuc-moveit-config/spec
@@ -1,0 +1,4 @@
+VER=3.1.0+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_fanuc_moveit_config/${VER/+/-}::https://github.com/ros2-gbp/moveit_resources-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit_resources-release;pattern=release/jazzy/moveit_resources_fanuc_moveit_config/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-panda-description/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-panda-description/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-panda-description
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Panda robot resources to test MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-panda-description/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-panda-description/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-panda-description/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-panda-description/spec
@@ -1,0 +1,4 @@
+VER=3.1.0+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_panda_description/${VER/+/-}::https://github.com/ros2-gbp/moveit_resources-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit_resources-release;pattern=release/jazzy/moveit_resources_panda_description/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-panda-moveit-config/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-panda-moveit-config/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-panda-moveit-config
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-resources-panda-description ros-jazzy-ros2cli-common-extensions ros-jazzy-joint-state-publisher ros-jazzy-joint-state-publisher-gui ros-jazzy-robot-state-publisher ros-jazzy-controller-manager ros-jazzy-gripper-controllers ros-jazzy-position-controllers ros-jazzy-xacro ros-jazzy-topic-tools"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Panda robot configuration resources to test MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-panda-moveit-config/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-panda-moveit-config/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-panda-moveit-config/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-panda-moveit-config/spec
@@ -1,0 +1,4 @@
+VER=3.1.0+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_panda_moveit_config/${VER/+/-}::https://github.com/ros2-gbp/moveit_resources-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit_resources-release;pattern=release/jazzy/moveit_resources_panda_moveit_config/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-pr2-description/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-pr2-description/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-pr2-description
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="PR2 robot resources to test MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-pr2-description/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-pr2-description/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-pr2-description/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-pr2-description/spec
@@ -1,0 +1,4 @@
+VER=3.1.0+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_pr2_description/${VER/+/-}::https://github.com/ros2-gbp/moveit_resources-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit_resources-release;pattern=release/jazzy/moveit_resources_pr2_description/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-tf2-geometry-msgs ros-jazzy-generate-parameter-library ros-jazzy-moveit-core ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-tf2-kdl pyyaml"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-kdl"
+PKGDES="IKFast manipulator plugin for PRBT robot in MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_prbt_ikfast_manipulator_plugin/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_resources_prbt_ikfast_manipulator_plugin/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-moveit-config/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-moveit-config/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-prbt-moveit-config
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-joint-state-publisher ros-jazzy-robot-state-publisher ros-jazzy-xacro ros-jazzy-rviz2 ros-jazzy-moveit-resources-prbt-support ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin ros-jazzy-moveit-ros-move-group"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="MoveIt 2 robot configuration resources for PRBT robot"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-moveit-config/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-moveit-config/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-moveit-config/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-moveit-config/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_prbt_moveit_config/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_resources_prbt_moveit_config/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-pg70-support/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-pg70-support/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-prbt-pg70-support
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-resources-prbt-support ros-jazzy-moveit-resources-prbt-ikfast-manipulator-plugin ros-jazzy-moveit-resources-prbt-moveit-config ros-jazzy-xacro"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Schunk PG70 gripper support for PRBT robot in MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-pg70-support/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-pg70-support/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-pg70-support/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-pg70-support/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_prbt_pg70_support/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_resources_prbt_pg70_support/.*"

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-support/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-support/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-resources-prbt-support
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-xacro"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Mechanical, kinematic, and visual description for PRBT robot"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-support/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-support/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-resources-prbt-support/spec
+++ b/runtime-ros/ros-jazzy-moveit-resources-prbt-support/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_resources_prbt_support/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_resources_prbt_support/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-benchmarks/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-benchmarks/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-benchmarks
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-ros-planning ros-jazzy-moveit-ros-warehouse ros-jazzy-rclcpp ros-jazzy-tf2-eigen ros-jazzy-pluginlib boost ros-jazzy-moveit-configs-utils ros-jazzy-launch-param-builder"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-moveit-core"
+PKGDES="Benchmarking tools for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-benchmarks/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-benchmarks/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-benchmarks/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-benchmarks/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_benchmarks/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_benchmarks/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-move-group/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-move-group/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-move-group
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-moveit-ros-occupancy-map-monitor ros-jazzy-moveit-ros-planning ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclcpp-action ros-jazzy-std-srvs ros-jazzy-tf2 ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-ros fmt ros-jazzy-moveit-kinematics"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-moveit-resources-fanuc-moveit-config ros-jazzy-ament-cmake-gtest ros-jazzy-moveit-configs-utils ros-jazzy-moveit-resources-panda-moveit-config ros-jazzy-ros-testing"
+PKGDES="Core executable node for MoveIt Motion Planning Framework (\`move_group\`)"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-move-group/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-ros-move-group/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,12 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index 30817cf00..66d025af4 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -3,7 +3,6 @@
+ find_package(
+   Boost
+   REQUIRED
+-  system
+   filesystem
+   date_time
+   program_options

--- a/runtime-ros/ros-jazzy-moveit-ros-move-group/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-move-group/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-move-group/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-move-group/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_move_group/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_move_group/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-occupancy-map-monitor/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-occupancy-map-monitor/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-occupancy-map-monitor
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-rclcpp ros-jazzy-moveit-core ros-jazzy-moveit-msgs octomap ros-jazzy-pluginlib ros-jazzy-tf2-ros ros-jazzy-geometric-shapes eigen ros-jazzy-eigen3-cmake-module"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gmock"
+PKGDES="Manages 3D perception environment data (occupancy map) for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-occupancy-map-monitor/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-occupancy-map-monitor/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-occupancy-map-monitor/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-occupancy-map-monitor/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_occupancy_map_monitor/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_occupancy_map_monitor/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-planning-interface/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning-interface/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-planning-interface
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-moveit-ros-planning ros-jazzy-moveit-ros-warehouse ros-jazzy-moveit-ros-move-group ros-jazzy-rclcpp ros-jazzy-rclpy ros-jazzy-rclcpp-action ros-jazzy-geometry-msgs ros-jazzy-moveit-msgs ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-ros python-3"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-eigen3-cmake-module eigen ros-jazzy-moveit-resources-fanuc-moveit-config ros-jazzy-moveit-resources-panda-moveit-config ros-jazzy-moveit-simple-controller-manager ros-jazzy-rviz2 ros-jazzy-ros-testing ros-jazzy-ament-cmake-gtest ros-jazzy-moveit-configs-utils"
+PKGDES="Remote planning and execution interfaces for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-planning-interface/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning-interface/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,10 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index 63a5f425e..05ffe2fb2 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -8,4 +8,4 @@ find_package(
+   Boost REQUIRED
+   COMPONENTS date_time filesystem program_options
+              # ${BOOST_PYTHON_COMPONENT}
+-             system thread)
++             thread)

--- a/runtime-ros/ros-jazzy-moveit-ros-planning-interface/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning-interface/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-planning-interface/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning-interface/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_planning_interface/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_planning_interface/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-planning/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-planning
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-pluginlib ros-jazzy-ament-index-cpp eigen fmt ros-jazzy-generate-parameter-library ros-jazzy-message-filters ros-jazzy-moveit-core ros-jazzy-moveit-msgs ros-jazzy-moveit-ros-occupancy-map-monitor ros-jazzy-rclcpp-action ros-jazzy-rclcpp-components ros-jazzy-rclcpp ros-jazzy-srdfdom ros-jazzy-std-msgs ros-jazzy-tf2-eigen ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-msgs ros-jazzy-tf2-ros ros-jazzy-tf2 ros-jazzy-urdf ros-jazzy-eigen3-cmake-module"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-ament-cmake-gtest ros-jazzy-moveit-configs-utils ros-jazzy-ros-testing ros-jazzy-launch-testing-ament-cmake ros-jazzy-moveit-resources-panda-moveit-config"
+PKGDES="MoveIt 2 core function integration with ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-planning/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,12 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index 3a527d95c..b101f9b1f 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -3,7 +3,6 @@
+ find_package(
+   Boost
+   REQUIRED
+-  system
+   filesystem
+   date_time
+   program_options

--- a/runtime-ros/ros-jazzy-moveit-ros-planning/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-planning/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-planning/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_planning/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_planning/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-robot-interaction/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-robot-interaction/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-robot-interaction
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-moveit-ros-planning ros-jazzy-rclcpp ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-ros ros-jazzy-interactive-markers"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest"
+PKGDES="Robot interaction components with interactive markers for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-robot-interaction/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-robot-interaction/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-robot-interaction/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-robot-interaction/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_robot_interaction/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_robot_interaction/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-visualization/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-visualization/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-visualization
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-geometric-shapes ros-jazzy-interactive-markers ros-jazzy-moveit-ros-robot-interaction ros-jazzy-moveit-ros-planning-interface ros-jazzy-moveit-ros-warehouse ros-jazzy-object-recognition-msgs ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rclpy ros-jazzy-rviz2 ros-jazzy-tf2-eigen"
+BUILDDEP="ros-jazzy-ament-cmake pkg-config ros-jazzy-class-loader eigen qt-5"
+PKGDES="Visualization components of MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-visualization/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-ros-visualization/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,9 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index ddda76085..3b7b9699c 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -1,3 +1,3 @@
+ # Extras module needed for dependencies to find boost components
+ 
+-find_package(Boost REQUIRED thread date_time system filesystem)
++find_package(Boost REQUIRED thread date_time filesystem)

--- a/runtime-ros/ros-jazzy-moveit-ros-visualization/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-visualization/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-visualization/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-visualization/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_visualization/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_visualization/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros-warehouse/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros-warehouse/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros-warehouse
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-rclcpp ros-jazzy-moveit-core ros-jazzy-warehouse-ros ros-jazzy-moveit-ros-planning ros-jazzy-tf2-eigen ros-jazzy-tf2-ros fmt"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Database connectivity and ROS warehouse components for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros-warehouse/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-moveit-ros-warehouse/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,12 @@
+diff --git a/ConfigExtras.cmake b/ConfigExtras.cmake
+index 22f3754b5..aafdf62f8 100644
+--- a/ConfigExtras.cmake
++++ b/ConfigExtras.cmake
+@@ -4,7 +4,6 @@ find_package(
+   Boost
+   REQUIRED
+   thread
+-  system
+   filesystem
+   regex
+   date_time

--- a/runtime-ros/ros-jazzy-moveit-ros-warehouse/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros-warehouse/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros-warehouse/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros-warehouse/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros_warehouse/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros_warehouse/.*"

--- a/runtime-ros/ros-jazzy-moveit-ros/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-ros/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-ros
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-ros-planning ros-jazzy-moveit-ros-warehouse ros-jazzy-moveit-ros-benchmarks ros-jazzy-moveit-ros-robot-interaction ros-jazzy-moveit-ros-planning-interface ros-jazzy-moveit-ros-visualization ros-jazzy-moveit-ros-move-group"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="ROS 2 integrations to control robotic manipulators with MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-ros/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-ros/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-ros/spec
+++ b/runtime-ros/ros-jazzy-moveit-ros/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_ros/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_ros/.*"

--- a/runtime-ros/ros-jazzy-moveit-setup-app-plugins/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-setup-app-plugins/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-setup-app-plugins
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp ros-jazzy-moveit-configs-utils ros-jazzy-moveit-ros-visualization ros-jazzy-moveit-setup-framework ros-jazzy-pluginlib ros-jazzy-rclcpp"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest"
+PKGDES="Specialty plugins for MoveIt 2 Setup Assistant"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-setup-app-plugins/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-setup-app-plugins/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-setup-app-plugins/spec
+++ b/runtime-ros/ros-jazzy-moveit-setup-app-plugins/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_setup_app_plugins/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_setup_app_plugins/.*"

--- a/runtime-ros/ros-jazzy-moveit-setup-assistant/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-setup-assistant/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-setup-assistant
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp ros-jazzy-pluginlib qt-5 ros-jazzy-rclcpp ros-jazzy-moveit-setup-framework ros-jazzy-moveit-setup-srdf-plugins ros-jazzy-moveit-configs-utils ros-jazzy-moveit-setup-controllers ros-jazzy-moveit-setup-core-plugins ros-jazzy-moveit-setup-app-plugins"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-moveit-resources-panda-moveit-config ros-jazzy-ament-cmake-gtest"
+PKGDES="Setup Assistant GUI to generate configuration packages for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-setup-assistant/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-setup-assistant/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-setup-assistant/spec
+++ b/runtime-ros/ros-jazzy-moveit-setup-assistant/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_setup_assistant/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_setup_assistant/.*"

--- a/runtime-ros/ros-jazzy-moveit-setup-controllers/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-setup-controllers/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-setup-controllers
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp ros-jazzy-moveit-setup-framework ros-jazzy-pluginlib ros-jazzy-rclcpp"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-moveit-configs-utils ros-jazzy-moveit-resources-fanuc-moveit-config ros-jazzy-moveit-resources-panda-moveit-config"
+PKGDES="Setup steps for ROS 2 control in MoveIt 2 Setup Assistant"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-setup-controllers/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-setup-controllers/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-setup-controllers/spec
+++ b/runtime-ros/ros-jazzy-moveit-setup-controllers/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_setup_controllers/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_setup_controllers/.*"

--- a/runtime-ros/ros-jazzy-moveit-setup-core-plugins/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-setup-core-plugins/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-setup-core-plugins
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp ros-jazzy-moveit-ros-visualization ros-jazzy-moveit-setup-framework ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-srdfdom ros-jazzy-urdf"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Core plugins for MoveIt 2 Setup Assistant"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-setup-core-plugins/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-setup-core-plugins/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-setup-core-plugins/spec
+++ b/runtime-ros/ros-jazzy-moveit-setup-core-plugins/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_setup_core_plugins/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_setup_core_plugins/.*"

--- a/runtime-ros/ros-jazzy-moveit-setup-framework/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-setup-framework/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-setup-framework
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-cpp ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-moveit-ros-planning ros-jazzy-moveit-ros-visualization ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-rviz-common ros-jazzy-rviz-rendering ros-jazzy-srdfdom ros-jazzy-urdf fmt"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="C++ interface to define setup steps for MoveIt 2 Setup Assistant"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-setup-framework/autobuild/patches/0001-fmt-11.patch
+++ b/runtime-ros/ros-jazzy-moveit-setup-framework/autobuild/patches/0001-fmt-11.patch
@@ -1,0 +1,12 @@
+diff --git a/src/urdf_config.cpp b/src/urdf_config.cpp
+index eab682326..5d17cec95 100644
+--- a/src/urdf_config.cpp
++++ b/src/urdf_config.cpp
+@@ -36,6 +36,7 @@
+ #include <moveit_setup_framework/utilities.hpp>
+ #include <moveit/rdf_loader/rdf_loader.hpp>
+ #include <fmt/format.h>
++#include <fmt/ranges.h>
+ 
+ namespace moveit_setup
+ {

--- a/runtime-ros/ros-jazzy-moveit-setup-framework/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-setup-framework/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-setup-framework/spec
+++ b/runtime-ros/ros-jazzy-moveit-setup-framework/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_setup_framework/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_setup_framework/.*"

--- a/runtime-ros/ros-jazzy-moveit-setup-srdf-plugins/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-setup-srdf-plugins/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-setup-srdf-plugins
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-setup-framework ros-jazzy-pluginlib"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-moveit-resources-fanuc-description"
+PKGDES="SRDF-based plugins for MoveIt 2 Setup Assistant"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-setup-srdf-plugins/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-setup-srdf-plugins/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-setup-srdf-plugins/spec
+++ b/runtime-ros/ros-jazzy-moveit-setup-srdf-plugins/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_setup_srdf_plugins/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_setup_srdf_plugins/.*"

--- a/runtime-ros/ros-jazzy-moveit-simple-controller-manager/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit-simple-controller-manager/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit-simple-controller-manager
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-moveit-core ros-jazzy-rclcpp ros-jazzy-pluginlib ros-jazzy-control-msgs ros-jazzy-rclcpp-action"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Generic controller manager plugin for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit-simple-controller-manager/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit-simple-controller-manager/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit-simple-controller-manager/spec
+++ b/runtime-ros/ros-jazzy-moveit-simple-controller-manager/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit_simple_controller_manager/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit_simple_controller_manager/.*"

--- a/runtime-ros/ros-jazzy-moveit/autobuild/defines
+++ b/runtime-ros/ros-jazzy-moveit/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-moveit
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-core ros-jazzy-moveit-planners ros-jazzy-moveit-plugins ros-jazzy-moveit-ros ros-jazzy-moveit-setup-assistant"
+BUILDDEP="ros-jazzy-ament-cmake"
+PKGDES="Meta package for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-moveit/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-moveit/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-moveit/spec
+++ b/runtime-ros/ros-jazzy-moveit/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/moveit/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/moveit/.*"

--- a/runtime-ros/ros-jazzy-object-recognition-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-object-recognition-msgs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-object-recognition-msgs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-rosidl-default-runtime ros-jazzy-action-msgs ros-jazzy-geometry-msgs ros-jazzy-sensor-msgs ros-jazzy-shape-msgs ros-jazzy-std-msgs"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators"
+PKGDES="Messages and actions for ROS 2 object recognition"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-object-recognition-msgs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-object-recognition-msgs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-object-recognition-msgs/spec
+++ b/runtime-ros/ros-jazzy-object-recognition-msgs/spec
@@ -1,0 +1,4 @@
+VER=2.0.0+5
+SRCS="git::commit=tags/release/jazzy/object_recognition_msgs/${VER/+/-}::https://github.com/ros2-gbp/object_recognition_msgs-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/object_recognition_msgs-release;pattern=release/jazzy/object_recognition_msgs/.*"

--- a/runtime-ros/ros-jazzy-octomap-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-octomap-msgs/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-octomap-msgs
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-std-msgs ros-jazzy-geometry-msgs ros-jazzy-rosidl-default-runtime"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators"
+PKGDES="Messages and serialization tools for OctoMap"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-octomap-msgs/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-octomap-msgs/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-octomap-msgs/spec
+++ b/runtime-ros/ros-jazzy-octomap-msgs/spec
@@ -1,0 +1,4 @@
+VER=2.0.1+1
+SRCS="git::commit=tags/release/jazzy/octomap_msgs/${VER/+/-}::https://github.com/ros2-gbp/octomap_msgs-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/octomap_msgs-release;pattern=release/jazzy/octomap_msgs/.*"

--- a/runtime-ros/ros-jazzy-ompl/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ompl/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-ompl
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace boost eigen flann"
+BUILDDEP="cmake pkg-config"
+PKGDES="Open Motion Planning Library (OMPL)' # TODO"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-ompl/autobuild/patches/0001-remove-boost_system.patch
+++ b/runtime-ros/ros-jazzy-ompl/autobuild/patches/0001-remove-boost_system.patch
@@ -1,0 +1,69 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index bb7797b..bc65550 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -47,7 +47,7 @@ set_package_properties(Boost PROPERTIES
+     URL "https://www.boost.org"
+     PURPOSE "Used throughout OMPL for data serialization, graphs, etc.")
+ set(Boost_USE_MULTITHREADED ON)
+-find_package(Boost 1.68 REQUIRED COMPONENTS serialization filesystem system program_options)
++find_package(Boost 1.68 REQUIRED COMPONENTS serialization filesystem program_options)
+ 
+ # on macOS we need to check whether to use libc++ or libstdc++ with clang++
+ if(CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
+diff --git a/CMakeModules/OMPLUtils.cmake b/CMakeModules/OMPLUtils.cmake
+index ddd6f9a..9a63df7 100644
+--- a/CMakeModules/OMPLUtils.cmake
++++ b/CMakeModules/OMPLUtils.cmake
+@@ -5,7 +5,6 @@ macro(add_ompl_test test_name)
+     Boost::program_options
+     Boost::serialization
+     Boost::filesystem
+-    Boost::system
+     Boost::unit_test_framework)
+   add_test(NAME ${test_name} COMMAND $<TARGET_FILE:${test_name}>)
+ endmacro(add_ompl_test)
+diff --git a/demos/CMakeLists.txt b/demos/CMakeLists.txt
+index 0de3222..4754727 100644
+--- a/demos/CMakeLists.txt
++++ b/demos/CMakeLists.txt
+@@ -12,7 +12,6 @@ if (OMPL_BUILD_DEMOS)
+             ompl::ompl
+             Eigen3::Eigen
+             Boost::filesystem
+-            Boost::system
+             Boost::program_options)
+     endmacro(add_ompl_demo)
+ 
+diff --git a/omplConfig.cmake.in b/omplConfig.cmake.in
+index f1d4785..ba025e1 100644
+--- a/omplConfig.cmake.in
++++ b/omplConfig.cmake.in
+@@ -12,7 +12,7 @@ set_and_check(OMPL_INCLUDE_DIRS @PACKAGE_INCLUDE_INSTALL_DIR@)
+ 
+ include ("${CMAKE_CURRENT_LIST_DIR}/omplExport.cmake" )
+ include(CMakeFindDependencyMacro)
+-set(_@PROJECT_NAME@_boost_components serialization filesystem system)
++set(_@PROJECT_NAME@_boost_components serialization filesystem)
+ find_dependency(Boost REQUIRED COMPONENTS ${_@PROJECT_NAME@_boost_components})
+ if(Boost_FOUND)
+     foreach(_comp ${_@PROJECT_NAME@_boost_components})
+@@ -101,4 +101,4 @@ list(REMOVE_DUPLICATES OMPL_LIBRARY_DIRS)
+ set(OMPL_LIBRARY_DIRS "${OMPL_LIBRARY_DIRS}" CACHE STRING "Library path for OMPL and its dependencies - DEPRECATED")
+ 
+ include(FindPackageHandleStandardArgs)
+-find_package_handle_standard_args(ompl DEFAULT_MSG OMPL_INCLUDE_DIRS OMPL_LIBRARIES)
+\ No newline at end of file
++find_package_handle_standard_args(ompl DEFAULT_MSG OMPL_INCLUDE_DIRS OMPL_LIBRARIES)
+diff --git a/src/ompl/CMakeLists.txt b/src/ompl/CMakeLists.txt
+index 463930c..82911ef 100644
+--- a/src/ompl/CMakeLists.txt
++++ b/src/ompl/CMakeLists.txt
+@@ -44,7 +44,6 @@ target_link_libraries(ompl
+     PUBLIC
+         Boost::filesystem
+         Boost::serialization
+-        Boost::system
+         Eigen3::Eigen
+         "$<$<BOOL:${Threads_FOUND}>:Threads::Threads>"
+         "$<$<BOOL:${OMPL_HAVE_FLANN}>:flann::flann>"

--- a/runtime-ros/ros-jazzy-ompl/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ompl/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ompl/spec
+++ b/runtime-ros/ros-jazzy-ompl/spec
@@ -1,0 +1,4 @@
+VER=1.7.0+2
+SRCS="git::commit=tags/release/jazzy/ompl/${VER/+/-}::https://github.com/ros2-gbp/ompl-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ompl-release;pattern=release/jazzy/ompl/.*"

--- a/runtime-ros/ros-jazzy-osqp-vendor/autobuild/defines
+++ b/runtime-ros/ros-jazzy-osqp-vendor/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-osqp-vendor
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="catkin-pkg ros-jazzy-ament-cmake git ros-jazzy-ros-environment ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
+PKGDES="ROS 2 wrapper for Operator Splitting QP Solver (OSQP)"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-osqp-vendor/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-osqp-vendor/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-osqp-vendor/spec
+++ b/runtime-ros/ros-jazzy-osqp-vendor/spec
@@ -1,0 +1,4 @@
+VER=0.2.0+4
+SRCS="git::commit=tags/release/jazzy/osqp_vendor/${VER/+/-}::https://github.com/ros2-gbp/osqp_vendor-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/osqp_vendor-release;pattern=release/jazzy/osqp_vendor/.*"

--- a/runtime-ros/ros-jazzy-pilz-industrial-motion-planner-testutils/autobuild/defines
+++ b/runtime-ros/ros-jazzy-pilz-industrial-motion-planner-testutils/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-pilz-industrial-motion-planner-testutils
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-rclcpp ros-jazzy-moveit-core ros-jazzy-moveit-msgs ros-jazzy-eigen3-cmake-module"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-tf2-eigen"
+PKGDES="Test utilities for Pilz industrial motion planner in MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-pilz-industrial-motion-planner-testutils/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-pilz-industrial-motion-planner-testutils/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-pilz-industrial-motion-planner-testutils/spec
+++ b/runtime-ros/ros-jazzy-pilz-industrial-motion-planner-testutils/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/pilz_industrial_motion_planner_testutils/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/pilz_industrial_motion_planner_testutils/.*"

--- a/runtime-ros/ros-jazzy-pilz-industrial-motion-planner/autobuild/defines
+++ b/runtime-ros/ros-jazzy-pilz-industrial-motion-planner/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-pilz-industrial-motion-planner
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-moveit-common ros-jazzy-generate-parameter-library ros-jazzy-geometry-msgs ros-jazzy-moveit-msgs ros-jazzy-moveit-core ros-jazzy-moveit-ros-planning ros-jazzy-moveit-ros-move-group ros-jazzy-orocos-kdl-vendor ros-jazzy-pluginlib ros-jazzy-rclcpp ros-jazzy-tf2 ros-jazzy-tf2-eigen ros-jazzy-tf2-geometry-msgs ros-jazzy-tf2-kdl ros-jazzy-tf2-eigen-kdl ros-jazzy-tf2-ros ros-jazzy-eigen3-cmake-module"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-pilz-industrial-motion-planner-testutils ros-jazzy-moveit-resources-panda-moveit-config ros-jazzy-moveit-resources-prbt-moveit-config ros-jazzy-moveit-resources-prbt-support ros-jazzy-moveit-resources-prbt-pg70-support ros-jazzy-moveit-configs-utils ros-jazzy-launch-param-builder boost ros-jazzy-ament-cmake-gmock ros-jazzy-ament-cmake-gtest ros-jazzy-ros-testing"
+PKGDES="Plugin to generate industrial trajectories (PTP, LIN, CIRC) for MoveIt 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-pilz-industrial-motion-planner/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-pilz-industrial-motion-planner/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-pilz-industrial-motion-planner/spec
+++ b/runtime-ros/ros-jazzy-pilz-industrial-motion-planner/spec
@@ -1,0 +1,4 @@
+VER=2.12.4+1
+SRCS="git::commit=tags/release/jazzy/pilz_industrial_motion_planner/${VER/+/-}::https://github.com/ros2-gbp/moveit2-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/moveit2-release;pattern=release/jazzy/pilz_industrial_motion_planner/.*"

--- a/runtime-ros/ros-jazzy-position-controllers/autobuild/defines
+++ b/runtime-ros/ros-jazzy-position-controllers/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-position-controllers
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-backward-ros ros-jazzy-forward-command-controller ros-jazzy-pluginlib ros-jazzy-rclcpp"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ros2-control-cmake ros-jazzy-ament-cmake-gmock ros-jazzy-controller-manager ros-jazzy-hardware-interface-testing ros-jazzy-hardware-interface ros-jazzy-ros2-control-test-assets"
+PKGDES="Control joints using the `position` interface in ROS 2 control"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-position-controllers/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-position-controllers/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-position-controllers/spec
+++ b/runtime-ros/ros-jazzy-position-controllers/spec
@@ -1,0 +1,4 @@
+VER=4.40.1+1
+SRCS="git::commit=tags/release/jazzy/position_controllers/${VER/+/-}::https://github.com/ros2-gbp/ros2_controllers-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros2_controllers-release;pattern=release/jazzy/position_controllers/.*"

--- a/runtime-ros/ros-jazzy-random-numbers/autobuild/defines
+++ b/runtime-ros/ros-jazzy-random-numbers/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-random-numbers
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace boost"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-cmake"
+PKGDES="Generate random values and quaternions in ROS 2 with \`boost\`"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-random-numbers/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-random-numbers/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-random-numbers/spec
+++ b/runtime-ros/ros-jazzy-random-numbers/spec
@@ -1,0 +1,4 @@
+VER=2.0.1+5
+SRCS="git::commit=tags/release/jazzy/random_numbers/${VER/+/-}::https://github.com/ros2-gbp/random_numbers-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/random_numbers-release;pattern=release/jazzy/random_numbers/.*"

--- a/runtime-ros/ros-jazzy-ros-industrial-cmake-boilerplate/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ros-industrial-cmake-boilerplate/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-ros-industrial-cmake-boilerplate
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="cmake gtest lcov llvm iwyu cppcheck"
+PKGDES="Boilerplate CMake scripts, macros, and utilities (usage not limited to ROS 2 projects)"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-ros-industrial-cmake-boilerplate/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ros-industrial-cmake-boilerplate/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ros-industrial-cmake-boilerplate/spec
+++ b/runtime-ros/ros-jazzy-ros-industrial-cmake-boilerplate/spec
@@ -1,0 +1,4 @@
+VER=0.5.4+3
+SRCS="git::commit=tags/release/jazzy/ros_industrial_cmake_boilerplate/${VER/+/-}::https://github.com/ros2-gbp/ros_industrial_cmake_boilerplate-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ros_industrial_cmake_boilerplate-release;pattern=release/jazzy/ros_industrial_cmake_boilerplate/.*"

--- a/runtime-ros/ros-jazzy-ruckig/autobuild/defines
+++ b/runtime-ros/ros-jazzy-ruckig/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-ruckig
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace"
+BUILDDEP="cmake"
+PKGDES="On-the-fly motion generation, allows instant robot reaction to sensor input"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-ruckig/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-ruckig/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-ruckig/spec
+++ b/runtime-ros/ros-jazzy-ruckig/spec
@@ -1,0 +1,4 @@
+VER=0.9.2+5
+SRCS="git::commit=tags/release/jazzy/ruckig/${VER/+/-}::https://github.com/ros2-gbp/ruckig-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/ruckig-release;pattern=release/jazzy/ruckig/.*"

--- a/runtime-ros/ros-jazzy-srdfdom/autobuild/defines
+++ b/runtime-ros/ros-jazzy-srdfdom/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-srdfdom
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-console-bridge-vendor console-bridge ros-jazzy-tinyxml2-vendor ros-jazzy-urdf ros-jazzy-urdfdom-py"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-python boost ros-jazzy-urdfdom-headers ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-pytest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-cmake"
+PKGDES="Semantic Robot Description Format (SRDF) parser for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-srdfdom/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-srdfdom/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-srdfdom/spec
+++ b/runtime-ros/ros-jazzy-srdfdom/spec
@@ -1,0 +1,4 @@
+VER=2.0.7+1
+SRCS="git::commit=tags/release/jazzy/srdfdom/${VER/+/-}::https://github.com/ros2-gbp/srdfdom-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/srdfdom-release;pattern=release/jazzy/srdfdom/.*"

--- a/runtime-ros/ros-jazzy-stomp/autobuild/defines
+++ b/runtime-ros/ros-jazzy-stomp/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-stomp
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace console-bridge eigen"
+BUILDDEP="cmake ros-jazzy-ros-industrial-cmake-boilerplate gtest"
+PKGDES="Stochastic Trajectory Optimization for Motion Planning (STOMP) algorithm for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-stomp/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-stomp/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-stomp/spec
+++ b/runtime-ros/ros-jazzy-stomp/spec
@@ -1,0 +1,4 @@
+VER=0.1.2+4
+SRCS="git::commit=tags/release/jazzy/stomp/${VER/+/-}::https://github.com/ros2-gbp/stomp-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/stomp-release;pattern=release/jazzy/stomp/.*"

--- a/runtime-ros/ros-jazzy-tf2-eigen-kdl/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tf2-eigen-kdl/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=ros-jazzy-tf2-eigen-kdl
 PKGSEC=ros
 PKGDEP="ros-jazzy-ros-workspace ros-jazzy-orocos-kdl-vendor ros-jazzy-tf2 eigen"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
-PKGDES="ROS 2 module to convert between Eigen and KDL"
+PKGDES="Convert between Eigen and KDL math types"
 
 ABTYPE=cmakeninja
 PREFIX="/opt/ros/jazzy"

--- a/runtime-ros/ros-jazzy-tf2-eigen/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tf2-eigen/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=ros-jazzy-tf2-eigen
 PKGSEC=ros
 PKGDEP="ros-jazzy-ros-workspace ros-jazzy-geometry-msgs ros-jazzy-tf2 ros-jazzy-tf2-ros eigen"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
-PKGDES="ROS 2 module to convert between Eigen math types and tf2 message types"
+PKGDES="Convert between Eigen math types and tf2 messages"
 
 ABTYPE=cmakeninja
 PREFIX="/opt/ros/jazzy"

--- a/runtime-ros/ros-jazzy-topic-tools-interfaces/autobuild/defines
+++ b/runtime-ros/ros-jazzy-topic-tools-interfaces/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-topic-tools-interfaces
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-builtin-interfaces ros-jazzy-rosidl-default-runtime"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-rosidl-default-generators ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
+PKGDES="Messages and services for ROS 2 `topic_tools`"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-topic-tools-interfaces/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-topic-tools-interfaces/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-topic-tools-interfaces/spec
+++ b/runtime-ros/ros-jazzy-topic-tools-interfaces/spec
@@ -1,0 +1,4 @@
+VER=1.3.4+1
+SRCS="git::commit=tags/release/jazzy/topic_tools_interfaces/${VER/+/-}::https://github.com/ros2-gbp/topic_tools-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/topic_tools-release;pattern=release/jazzy/topic_tools_interfaces/.*"

--- a/runtime-ros/ros-jazzy-topic-tools/autobuild/defines
+++ b/runtime-ros/ros-jazzy-topic-tools/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-topic-tools
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-rclcpp ros-jazzy-rclcpp-components ros-jazzy-topic-tools-interfaces ros-jazzy-rclpy ros-jazzy-ros2cli ros-jazzy-rosidl-runtime-py"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-python ros-jazzy-rosidl-default-generators ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common ros-jazzy-ament-cmake-gtest ros-jazzy-std-msgs"
+PKGDES="Tools to direct, throttle, and manipulate ROS 2 topics"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-topic-tools/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-topic-tools/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-topic-tools/spec
+++ b/runtime-ros/ros-jazzy-topic-tools/spec
@@ -1,0 +1,4 @@
+VER=1.3.4+1
+SRCS="git::commit=tags/release/jazzy/topic_tools/${VER/+/-}::https://github.com/ros2-gbp/topic_tools-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/topic_tools-release;pattern=release/jazzy/topic_tools/.*"

--- a/runtime-ros/ros-jazzy-urdfdom-py/autobuild/defines
+++ b/runtime-ros/ros-jazzy-urdfdom-py/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=ros-jazzy-urdfdom-py
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-rclpy lxml yaml"
+
+PKGDES="URDF parser for ROS 2 in Python"
+
+ABTYPE=python
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOPYTHON2=1
+ABHOST=noarch

--- a/runtime-ros/ros-jazzy-urdfdom-py/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-urdfdom-py/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-urdfdom-py/spec
+++ b/runtime-ros/ros-jazzy-urdfdom-py/spec
@@ -1,0 +1,4 @@
+VER=1.2.1+3
+SRCS="git::commit=tags/release/jazzy/urdfdom_py/${VER/+/-}::https://github.com/ros2-gbp/urdfdom_py-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/urdfdom_py-release;pattern=release/jazzy/urdfdom_py/.*"

--- a/runtime-ros/ros-jazzy-warehouse-ros/autobuild/defines
+++ b/runtime-ros/ros-jazzy-warehouse-ros/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-warehouse-ros
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace boost openssl ros-jazzy-rclcpp ros-jazzy-std-msgs ros-jazzy-geometry-msgs ros-jazzy-pluginlib ros-jazzy-tf2 ros-jazzy-tf2-ros ros-jazzy-tf2-geometry-msgs"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-lint-auto ros-jazzy-ament-cmake-copyright"
+PKGDES="Persistent ROS 2 messages database based on MongoDB"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-warehouse-ros/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-warehouse-ros/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-warehouse-ros/spec
+++ b/runtime-ros/ros-jazzy-warehouse-ros/spec
@@ -1,0 +1,4 @@
+VER=2.0.5+1
+SRCS="git::commit=tags/release/jazzy/warehouse_ros/${VER/+/-}::https://github.com/ros2-gbp/warehouse_ros-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/warehouse_ros-release;pattern=release/jazzy/warehouse_ros/.*"

--- a/runtime-ros/ros-jazzy-xacro/autobuild/defines
+++ b/runtime-ros/ros-jazzy-xacro/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=ros-jazzy-xacro
+PKGSEC=ros
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-ament-index-python yaml"
+BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-python ros-jazzy-ament-lint-auto ros-jazzy-ament-cmake-pytest"
+PKGDES="XML macro language (Xacro) parser for ROS 2"
+
+ABTYPE=cmakeninja
+PREFIX="/opt/ros/jazzy"
+ABSPLITDBG=0
+NOSTATIC=0
+CMAKE_AFTER=(
+    "-DCMAKE_PREFIX_PATH=/opt/ros/jazzy"
+    "-DBUILD_TESTING=OFF"
+)

--- a/runtime-ros/ros-jazzy-xacro/autobuild/prepare
+++ b/runtime-ros/ros-jazzy-xacro/autobuild/prepare
@@ -1,0 +1,3 @@
+export PYTHONPATH=/opt/ros/jazzy/lib/python${ABPY3VER}/site-packages/
+export PKG_CONFIG_PATH=/opt/ros/jazzy/lib/pkgconfig
+. /opt/ros/jazzy/setup.sh

--- a/runtime-ros/ros-jazzy-xacro/spec
+++ b/runtime-ros/ros-jazzy-xacro/spec
@@ -1,0 +1,4 @@
+VER=2.1.1+1
+SRCS="git::commit=tags/release/jazzy/xacro/${VER/+/-}::https://github.com/ros2-gbp/xacro-release.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=ros2-gbp/xacro-release;pattern=release/jazzy/xacro/.*"


### PR DESCRIPTION
Topic Description
-----------------

- iwyu downgrade to 0.24 temporarily because there are something wrong with llvm-22
    Signed-off-by: stydxm <stydxm@outlook.com>
- ros-jazzy-moveit: new, 2.12.4+1
- ros-jazzy-moveit-setup-assistant: new, 2.12.4+1
- ros-jazzy-moveit-setup-app-plugins: new, 2.12.4+1
- ros-jazzy-moveit-setup-core-plugins: new, 2.12.4+1
- ros-jazzy-moveit-setup-controllers: new, 2.12.4+1
- ros-jazzy-moveit-setup-srdf-plugins: new, 2.12.4+1
- ros-jazzy-moveit-setup-framework: new, 2.12.4+1
- ros-jazzy-moveit-ros: new, 2.12.4+1
- ros-jazzy-moveit-ros-visualization: new, 2.12.4+1

... and 59 more commits

Package(s) Affected
-------------------

- ros-jazzy-moveit: 2.12.4+1
- ros-jazzy-tf2-eigen: 0.36.20+1-1
- ros-jazzy-tf2-eigen-kdl: 0.36.20+1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-kdl ros-jazzy-moveit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
