### PR TITLE
zhaoxin-linux-graphics-driver-dri: patches for Linux 7.0 build and runtime issues

### DIFF
--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0001-fix-kbuild-replace-EXTRA_CFLAGS-with-ccflags-y.patch
@@ -1,7 +1,7 @@
 From 6065be81b4f240969e3f6850fd15ea96203db08c Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 15:50:52 +0800
-Subject: [PATCH 1/9] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
+Subject: [PATCH 01/18] fix: kbuild: replace EXTRA_CFLAGS with ccflags-y
 
 EXTRA_*FLAGS support was deprecated in 2007 and removed in 2025.
 
@@ -63,5 +63,5 @@ index a2b2900..277d1cf 100644
               -I${ZXGPU_FULL_PATH}/src/cbios/Device \
               -I${ZXGPU_FULL_PATH}/src/cbios/Device/Port \
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0002-chore-dkms-remove-useless-variables.patch
@@ -1,7 +1,7 @@
 From f3c87195ce735171e6f6a487beab243e48475156 Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:50:19 +0800
-Subject: [PATCH 2/9] chore: dkms: remove useless variables
+Subject: [PATCH 02/18] chore: dkms: remove useless variables
 
 REMAKE_INITRD was deprecated. SKIP_IMMD_MODPROBE is not standard.
 
@@ -37,5 +37,5 @@ index 10e3350..de2cefb 100644
  MAKE[0]="make -j$(num_cpu_cores) LINUXDIR=$kernel_source_dir -C $kernel_source_dir M=$dkms_tree/$module/$module_version/build"
 -#POST_REMOVE="post-remove.sh $kernelver"
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0003-fix-kernel-6.15.patch
@@ -1,7 +1,7 @@
 From ff9194d472e29eefd5b1a0c440f81947f5b1d7db Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 3/9] fix: kernel: 6.15
+Subject: [PATCH 03/18] fix: kernel: 6.15
 
 Make it compatible with Linux kernel 6.15.
 
@@ -43,5 +43,5 @@ index 89a7819..48706c2 100644
      .fb_dirty           = zxfb_dirty,
  #endif
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0004-fix-kernel-6.16.patch
@@ -1,7 +1,7 @@
 From 74abbff6fd42b951de65daaee59716f2f4f3422d Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:54:46 +0800
-Subject: [PATCH 4/9] fix: kernel: 6.16
+Subject: [PATCH 04/18] fix: kernel: 6.16
 
 Make it compatible with Linux kernel 6.16.
 
@@ -39,5 +39,5 @@ index 84ff1da..4e91f71 100644
      struct pci_dev*    pdev    = to_pci_dev(kobj_to_dev(kobj));
      struct drm_device* drm_dev = pci_get_drvdata(pdev);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0005-fix-kernel-6.17.patch
@@ -1,7 +1,7 @@
 From dd71d8af6ed71866597ea70073c4b5175a82737b Mon Sep 17 00:00:00 2001
 From: Aether Chen <15167799+chenjunyu19@users.noreply.github.com>
 Date: Sat, 1 Nov 2025 16:59:24 +0800
-Subject: [PATCH 5/9] fix: kernel: 6.17
+Subject: [PATCH 05/18] fix: kernel: 6.17
 
 Make it compatible with Linux kernel 6.17.
 
@@ -134,5 +134,5 @@ index e42435d..44f6ae7 100644
  #else
  typedef struct {
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0006-fix-kernel-6.18.patch
@@ -1,7 +1,7 @@
 From 0f6cf34ca0dae84d1a4fb384a1589c789117fc1b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 23:49:24 +0800
-Subject: [PATCH 6/9] fix: kernel: 6.18
+Subject: [PATCH 06/18] fix: kernel: 6.18
 
 In the 6.18 cycle, Intel moved `struct_mutex' from the public `drm_device'
 struct to `drm_i915_private'. As this was really only used by Intel to
@@ -42,5 +42,5 @@ index 6eecac4..b55023e 100644
  }
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0007-chore-import-.gitignore-from-loonggpu-kernel-dkms.patch
@@ -1,7 +1,7 @@
 From 685add8c5611e324d78d731233c26c58e398f8b0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:34 +0800
-Subject: [PATCH 7/9] chore: import .gitignore from loonggpu-kernel-dkms
+Subject: [PATCH 07/18] chore: import .gitignore from loonggpu-kernel-dkms
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 ---
@@ -24,5 +24,5 @@ index 0000000..223542a
 +*.order
 +conftest
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0008-refactor-NFC-rename-zxfb_create-to-zx_fbdev_probe.patch
@@ -1,7 +1,7 @@
 From 4d190581c59c17c54450e383d0a0c541e3409b3e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 18:42:48 +0800
-Subject: [PATCH 8/9] refactor (NFC): rename zxfb_create to zx_fbdev_probe
+Subject: [PATCH 08/18] refactor (NFC): rename zxfb_create to zx_fbdev_probe
 
 Make it more similar to reference implementations.
 
@@ -33,5 +33,5 @@ index b55023e..96a1456 100644
  #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
      .fb_dirty           = zxfb_dirty,
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0009-fix-run-DRM-default-client-setup-on-Linux-6.15.patch
@@ -1,7 +1,7 @@
 From 1f2895b78cf6bc047e636f2191d1dae716e2bc4f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 12 Nov 2025 19:07:04 +0800
-Subject: [PATCH 9/9] fix: run DRM default client setup on Linux >= 6.15
+Subject: [PATCH 09/18] fix: run DRM default client setup on Linux >= 6.15
 
 Call drm_client_setup() to run the kernel's default client setup
 for DRM. Set fbdev_probe in struct drm_driver, so that the client
@@ -93,5 +93,5 @@ index a989f9a..8fe5d35 100644
  
  err_pci:
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0010-fix-adapt-for-shmem_file_setup-parameter-change-in-L.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0010-fix-adapt-for-shmem_file_setup-parameter-change-in-L.patch
@@ -1,0 +1,36 @@
+From ab613bd736783ad6c126d0604016c43d7265ad60 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 9 Jun 2026 21:47:37 +0800
+Subject: [PATCH 10/18] fix: adapt for shmem_file_setup() parameter change in
+ Linux 7.0
+
+Link: https://git.kernel.org/torvalds/c/590d356aa433
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/os_interface.c | 8 +++++++-
+ 1 file changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/src/os_interface.c b/src/os_interface.c
+index da9851f..8e2bd7f 100644
+--- a/src/os_interface.c
++++ b/src/os_interface.c
+@@ -2165,9 +2165,15 @@ int zx_query_platform_caps(void *dev, platform_caps_t *caps)
+     return 0;
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
++#define SHMEM_FILE_SETUP_EMPTY_FLAG EMPTY_VMA_FLAGS
++#else
++#define SHMEM_FILE_SETUP_EMPTY_FLAG 0
++#endif
++
+ void *zx_pages_memory_swapout(struct os_pages_memory *pages_memory)
+ {
+-    struct file          *file_storage = shmem_file_setup("zx gmem", pages_memory->size, 0);
++    struct file          *file_storage = shmem_file_setup("zx gmem", pages_memory->size, SHMEM_FILE_SETUP_EMPTY_FLAG);
+     struct address_space *file_addr_space;
+     struct page          **pages;
+     struct page          *src_page, *dst_page;
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0011-fix-loonggpu-remove-zx_drm_last_close-on-Linux-6.12.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0011-fix-loonggpu-remove-zx_drm_last_close-on-Linux-6.12.patch
@@ -1,0 +1,37 @@
+From 8d70c8b7ffe6404a9f51cea57fd6c294e2c7d6cd Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 9 Jun 2026 21:52:45 +0800
+Subject: [PATCH 11/18] fix: loonggpu: remove zx_drm_last_close on Linux >=
+ 6.12
+
+This is not used on Linux >= 6.12, and it fails to build on Linux 6.19.
+
+Link: https://git.kernel.org/torvalds/c/943240d342f1
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_pcie.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/zx_pcie.c b/src/zx_pcie.c
+index 8fe5d35..ae27cc0 100644
+--- a/src/zx_pcie.c
++++ b/src/zx_pcie.c
+@@ -408,6 +408,7 @@ static void zx_drm_postclose(struct drm_device *dev, struct drm_file *file)
+     file->driver_priv = NULL;
+ }
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ void  zx_drm_last_close(struct drm_device* dev)
+ {
+     zx_card_t *zx = dev->dev_private;
+@@ -420,6 +421,7 @@ void  zx_drm_last_close(struct drm_device* dev)
+ 
+     drm_fb_helper_restore_fbdev_mode_unlocked(&fbdev->helper);
+ }
++#endif
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4,11,0)
+ static int zx_drm_device_is_agp(struct drm_device * dev)
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0012-fix-adapt-for-drm_fb_helper_alloc_info-removal-in-Li.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0012-fix-adapt-for-drm_fb_helper_alloc_info-removal-in-Li.patch
@@ -1,0 +1,34 @@
+From a7b4dd6ec5df21f218dce4beea23861f88f4b553 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Tue, 9 Jun 2026 21:58:17 +0800
+Subject: [PATCH 12/18] fix: adapt for drm_fb_helper_alloc_info removal in
+ Linux 6.19
+
+On Linux >= 6.19 it's called by the DRM generic code and no longer
+exported for the drivers.
+
+Link: https://git.kernel.org/torvalds/c/63c971af4036
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 58d5edf..90eb614 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -205,8 +205,10 @@ int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_si
+ #else
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     info = drm_fb_helper_alloc_fbi(helper);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+     info = drm_fb_helper_alloc_info(helper);
++#else
++	info = helper->info;
+ #endif
+     info->par = helper;
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0013-refactor-make-the-fbdev-ptr-in-zx_card_t-typed.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0013-refactor-make-the-fbdev-ptr-in-zx_card_t-typed.patch
@@ -1,0 +1,38 @@
+From f4f1a1d34856ab42b5ef8129b8b8503f974bc5b1 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 17:20:35 +0800
+Subject: [PATCH 13/18] refactor: make the fbdev ptr in zx_card_t typed
+
+I don't know why they must have used void ptr here.  Maybe they simply
+didn't know foward declarations in C.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_driver.h | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/zx_driver.h b/src/zx_driver.h
+index d212a5b..ff399ed 100644
+--- a/src/zx_driver.h
++++ b/src/zx_driver.h
+@@ -34,6 +34,8 @@ typedef int (*zx_ioctl_t)(zx_file_t* priv, unsigned int cmd, unsigned long arg);
+ 
+ typedef int (*irq_func_t)(void*);
+ 
++struct zx_fbdev;
++
+ typedef struct
+ {
+     void              *adapter;
+@@ -67,7 +69,7 @@ typedef struct
+     int                 keyboard_rc_keynum;
+     void                *debugfs_dev;
+     struct device       *hwmon_dev;
+-    void                *fbdev;
++    struct zx_fbdev     *fbdev;
+     struct backlight_device *backlight_dev;
+ 
+     struct device      *pci_device;  //used when do dma page map.
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0014-refactor-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0014-refactor-Remove-load-callback-from-kms_driver.patch
@@ -1,0 +1,52 @@
+From 6b55280e3f263a7392818d1a13155e6c222a8f5a Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 19:53:26 +0800
+Subject: [PATCH 14/18] refactor: Remove load callback from kms_driver
+
+The ".load" callback in "struct drm_driver" is deprecated. In order to
+remove the callback, we have to manually call "zx_drm_load" instead.
+
+Following up the reference implementation change.  Also remove the
+unused argument.
+
+Link: https://github.com/AOSC-Tracking/loonggpu-kernel-dkms/commit/5ec181b08ee1
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_pcie.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/zx_pcie.c b/src/zx_pcie.c
+index ae27cc0..281be89 100644
+--- a/src/zx_pcie.c
++++ b/src/zx_pcie.c
+@@ -256,7 +256,7 @@ static int zx_drm_resume(struct drm_device *dev)
+     return 0;
+ }
+ 
+-static int zx_drm_load(struct drm_device *dev, unsigned long flags)
++static int zx_drm_load(struct drm_device *dev)
+ {
+     struct pci_dev *pdev = to_pci_dev(dev->dev);
+     zx_card_t  *zx = NULL;
+@@ -571,7 +571,6 @@ static struct drm_zx_driver zx_drm_driver = {
+     #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+         .driver_features = ZX_DRM_FEATURE | DRIVER_ATOMIC,
+     #endif
+-        .load               = zx_drm_load,
+         .open               = zx_drm_open,
+ 
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(5,11,0)
+@@ -680,6 +679,10 @@ static int zx_pcie_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 
+     pci_set_drvdata(pdev, dev);
+ 
++    ret = zx_drm_load(dev);
++    if (ret)
++            goto err_pci;
++
+     ret = drm_dev_register(dev, ent->driver_data);
+     if (ret)
+             goto err_pci;
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0015-refactor-make-to_zx_fbdev-use-the-helper-ptr-stored-.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0015-refactor-make-to_zx_fbdev-use-the-helper-ptr-stored-.patch
@@ -1,0 +1,57 @@
+From b690cb65a7ee6d6c45adf4b89ad50fde31ee1362 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 20:03:00 +0800
+Subject: [PATCH 15/18] refactor: make to_zx_fbdev use the helper ptr stored in
+ zx_card_t
+
+So we will be able to move the helper out of zx_fbdev later, as
+drm_client_setup wants to allocate its own helper and warns if we have
+to use our own helper.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 2 +-
+ src/zx_fbdev.h | 6 +++++-
+ 2 files changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 90eb614..a78454a 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -328,6 +328,7 @@ int zx_fbdev_init(zx_card_t *zx)
+ 
+     fbdev = zx_calloc(sizeof(*fbdev));
+     zx_assert(fbdev != NULL);
++    zx->fbdev = fbdev;
+ 
+     ret = zx_core_interface->create_device(zx->adapter, NULL, &fbdev->gpu_device);
+     zx_assert(ret == 0);
+@@ -359,7 +360,6 @@ int zx_fbdev_init(zx_card_t *zx)
+     drm_fb_helper_initial_config(&fbdev->helper);
+ #endif
+ 
+-    zx->fbdev = fbdev;
+ 
+     return 0;
+ }
+diff --git a/src/zx_fbdev.h b/src/zx_fbdev.h
+index 6c56455..997dc99 100644
+--- a/src/zx_fbdev.h
++++ b/src/zx_fbdev.h
+@@ -11,8 +11,12 @@ struct zx_fbdev
+     zx_device_debug_info_t *debug;
+ };
+ 
+-#define to_zx_fbdev(helper) container_of(helper, struct zx_fbdev, helper)
++static inline struct zx_fbdev *to_zx_fbdev(struct drm_fb_helper *helper)
++{
++    zx_card_t *zx = helper->client.dev->dev_private;
+ 
++    return zx->fbdev;
++}
+ 
+ void zx_fbdev_disable_vesa(zx_card_t *zx);
+ int zx_fbdev_init(zx_card_t *zx);
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0016-refactor-make-zx_fbdev_set_suspend-no-op-on-Linux-6..patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0016-refactor-make-zx_fbdev_set_suspend-no-op-on-Linux-6..patch
@@ -1,0 +1,38 @@
+From 65b9b64c8a243e33aa6d22624a0d3e7818d062f1 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Wed, 10 Jun 2026 21:45:16 +0800
+Subject: [PATCH 16/18] refactor: make zx_fbdev_set_suspend no-op on Linux >=
+ 6.15
+
+On Linux >= 6.15 we use FB console based on DRM client, which already
+handles the suspend/resume in a generic way.  So we don't need to
+duplicate the logic.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index a78454a..ef01a91 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -432,6 +432,7 @@ int zx_fbdev_deinit(zx_card_t *zx)
+ 
+ void zx_fbdev_set_suspend(zx_card_t *zx, int state)
+ {
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     struct zx_fbdev *fbdev = zx->fbdev;
+     struct fb_info *info;
+ 
+@@ -456,6 +457,7 @@ void zx_fbdev_set_suspend(zx_card_t *zx, int state)
+ 
+         console_unlock();
+     }
++#endif
+ }
+ 
+ void zx_fbdev_poll_changed(struct drm_device *dev)
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0017-refactor-use-helper-instead-of-fbdev-helper-in-zx_fb.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0017-refactor-use-helper-instead-of-fbdev-helper-in-zx_fb.patch
@@ -1,0 +1,41 @@
+From d886c268da0daefade256bdd7de2c15f89ae05b3 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Jun 2026 16:04:59 +0800
+Subject: [PATCH 17/18] refactor: use helper instead of &fbdev->helper in
+ zx_fbdev_probe
+
+It will be needed to move helper out of struct zx_fbdev.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ src/zx_fbdev.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index ef01a91..1c35376 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -222,9 +222,9 @@ int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_si
+ #endif
+ 
+     info->skip_vt_switch = true;
+-    fbdev->helper.fb = &fb->base;
++    helper->fb = &fb->base;
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+-    fbdev->helper.funcs = &zx_fb_helper_funcs,
++    helper->funcs = &zx_fb_helper_funcs,
+ #endif
+     zx_vsprintf(info->fix.id, "%s", "zxfb");
+ 
+@@ -246,7 +246,7 @@ int zx_fbdev_probe(struct drm_fb_helper *helper, struct drm_fb_helper_surface_si
+     drm_fb_helper_fill_fix(info, fb->base.pitches[0], fb->base.format->depth);
+     drm_fb_helper_fill_var(info, &fbdev->helper, sizes->fb_width, sizes->fb_height);
+ #else
+-    drm_fb_helper_fill_info(info, &fbdev->helper, sizes);
++    drm_fb_helper_fill_info(info, helper, sizes);
+ #endif
+ 
+     DRM_DEBUG_KMS("screen_base=0x%p,screen_size=0x%lx,smem_start=0x%lx,smem_len=0x%x,xres=%d,yres=%d\n",
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0018-fix-take-out-embedded-fb_helper-in-zx_fbdev-with-Lin.patch
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/autobuild/module-patches/0018-fix-take-out-embedded-fb_helper-in-zx_fbdev-with-Lin.patch
@@ -1,0 +1,143 @@
+From 4726c473b2a82ad238e6f5466712d22bd557ef3b Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Jun 2026 20:20:06 +0800
+Subject: [PATCH 18/18] fix: take out embedded fb_helper in zx_fbdev with Linux
+ >= 6.15
+
+With Linux 6.18, an "fb_helper is already set" warning had already
+indicated we were doing something unsupported.  And we've stopped
+"happening to work" with Linux 7.0.  So take out the embedded fb_helper
+and let DRM client framebuffer implementation to manage its own helper.
+Test shows this solved both the warning and the runtime crash on 7.0
+kernel.
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site:
+---
+ src/zx_fbdev.c | 32 ++++++++++++++++++++++++++------
+ src/zx_fbdev.h |  2 ++
+ 2 files changed, 28 insertions(+), 6 deletions(-)
+
+diff --git a/src/zx_fbdev.c b/src/zx_fbdev.c
+index 1c35376..d12cab4 100644
+--- a/src/zx_fbdev.c
++++ b/src/zx_fbdev.c
+@@ -56,6 +56,18 @@ FB_GEN_DEFAULT_DEFERRED_IOMEM_OPS(zx, drm_fb_helper_damage_range, drm_fb_helper_
+ FB_GEN_DEFAULT_DEFERRED_IO_OPS(zx, drm_fb_helper_damage_range, drm_fb_helper_damage_area)
+ #endif
+ 
++#if DRM_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
++static void zx_fbdev_fb_destroy(struct fb_info *info)
++{
++    struct drm_fb_helper *fb_helper = info->par;
++    struct zx_fbdev *zxfb = to_zx_fbdev(fb_helper);
++
++    drm_fb_helper_fini(fb_helper);
++    drm_framebuffer_remove(fb_helper->fb);
++    drm_client_release(&fb_helper->client);
++}
++#endif
++
+ static struct fb_ops zxfb_ops = {
+     .owner = THIS_MODULE,
+ #if DRM_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
+@@ -85,6 +97,9 @@ static struct fb_ops zxfb_ops = {
+     .fb_imageblit = cfb_imageblit,
+ #endif
+     .fb_mmap    = zxfb_mmap,
++#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 15, 0)
++    .fb_destroy = zx_fbdev_fb_destroy,
++#endif
+ };
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+@@ -335,6 +350,7 @@ int zx_fbdev_init(zx_card_t *zx)
+ 
+     fbdev->debug = zx_debugfs_add_device_node(zx->debugfs_dev, zx_get_current_pid(), fbdev->gpu_device);
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+     drm_fb_helper_prepare(zx->drm_dev, &fbdev->helper, &zx_fb_helper_funcs);
+ #else
+@@ -359,7 +375,7 @@ int zx_fbdev_init(zx_card_t *zx)
+ #else
+     drm_fb_helper_initial_config(&fbdev->helper);
+ #endif
+-
++#endif // 6.15.0
+ 
+     return 0;
+ }
+@@ -369,7 +385,6 @@ int zx_fbdev_deinit(zx_card_t *zx)
+ {
+     struct zx_fbdev *fbdev = zx->fbdev;
+     struct drm_zx_framebuffer *fb;
+-    struct fb_info *info;
+ 
+     if (!fbdev)
+     {
+@@ -378,16 +393,17 @@ int zx_fbdev_deinit(zx_card_t *zx)
+ 
+     fb = fbdev->fb;
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+-    info = fbdev->helper.fbdev;
+-#else
+-    info = fbdev->helper.info;
++    struct fb_info *info = fbdev->helper.fbdev;
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
++    struct fb_info *info = fbdev->helper.info;
+ #endif
++
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 8, 0)
+     unregister_framebuffer(info);
+ #else
+ #if DRM_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
+     drm_fb_helper_unregister_fbi(&fbdev->helper);
+-#else
++#elif DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     drm_fb_helper_unregister_info(&fbdev->helper);
+ #endif
+ #endif
+@@ -415,11 +431,13 @@ int zx_fbdev_deinit(zx_card_t *zx)
+         fb->obj = NULL;
+     }
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     drm_fb_helper_fini(&fbdev->helper);
+     if(fbdev->fb)
+     {
+         drm_framebuffer_remove(&fbdev->fb->base);
+     }
++#endif
+ 
+     zx_debugfs_remove_device_node(zx->debugfs_dev, fbdev->debug);
+     zx_core_interface->destroy_device(zx->adapter, fbdev->gpu_device);
+@@ -460,6 +478,7 @@ void zx_fbdev_set_suspend(zx_card_t *zx, int state)
+ #endif
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ void zx_fbdev_poll_changed(struct drm_device *dev)
+ {
+     zx_card_t*  zx = dev->dev_private;
+@@ -474,3 +493,4 @@ void zx_fbdev_poll_changed(struct drm_device *dev)
+         drm_fb_helper_hotplug_event(&fbdev->helper);
+     }
+ }
++#endif
+diff --git a/src/zx_fbdev.h b/src/zx_fbdev.h
+index 997dc99..1915013 100644
+--- a/src/zx_fbdev.h
++++ b/src/zx_fbdev.h
+@@ -6,7 +6,9 @@
+ struct zx_fbdev
+ {
+     unsigned int gpu_device;
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 15, 0)
+     struct drm_fb_helper helper;
++#endif
+     struct drm_zx_framebuffer *fb;
+     zx_device_debug_info_t *debug;
+ };
+-- 
+2.54.0
+

--- a/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
+++ b/runtime-display/zhaoxin-linux-graphics-driver-dri/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=21.00.86
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
+REL=1
 SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=2509&tag=0&ref=qdxz&pre=0&t=eecb7eac5d344b6d&__for_acbs_hash_url=$UPSTREAM_VER"
 CHKSUMS="sha256::0c0ce66b412dd0f6be6c3a9ed6da168e4ab6fbf64ff127d6bec774f393379cb4"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

zhaoxin-linux-graphics-driver-dri: patches for Linux 7.0 build and runtime issues

- Fix build failure on Linux 7.0 due to API changes.
- Fix "fb_helper is already set" warning, which indicates an unsupported use of DRM client that will break the entire functionality with Linux 7.0.
- I think there are still many "bad tastes" remaining in the code but I'm too tired to take care of them.
- Tracking AOSC patches for the kernel module at AOSC-Tracking/zx-kernel-dkms @ aosc/v21.00.86 (HEAD: 4726c473b2a82ad238e6f5466712d22bd557ef3b).

<!-- Please input topic description here. -->

Package(s) Affected
-------------------

<!-- Please list all package(s) affected by this topic here. -->

- zhaoxin-linux-graphics-driver-dri: `21.00.86-1`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit zhaoxin-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
