### PR TITLE
zfs: update to 2.4.3

### DIFF
--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,4 @@
-VER=2.4.2
+VER=2.4.3
 SRCS="git::commit=tags/zfs-$VER::https://github.com/openzfs/zfs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: update to 2.4.3
    Co-authored-by: Gray David \(@grayawa\)

Package(s) Affected
-------------------

- zfs: 2.4.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
