### PR TITLE
bluez: update to 5.86

### DIFF
--- a/app-devices/bluez/autobuild/defines
+++ b/app-devices/bluez/autobuild/defines
@@ -9,48 +9,47 @@ PKGDES="The Bluetooth protocol stack for Linux"
 #
 # Note: --with-phonebook=dummy, as the "ebook" backend requires
 # evolution-data-server, we don't want that this low on our dependency tree.
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
-                 --with-dbusconfdir=/usr/share \
-                 --enable-optimization \
-                 --disable-asan \
-                 --disable-lsan \
-                 --disable-ubsan \
-                 --disable-debug \
-                 --enable-pie \
-                 --enable-threads \
-                 --enable-backtrace \
-                 --enable-library \
-                 --disable-test \
-                 --enable-nfc \
-                 --enable-sap \
-                 --enable-a2dp \
-                 --enable-avrcp \
-                 --enable-network \
-                 --enable-hid \
-                 --enable-hog \
-                 --enable-health \
-                 --enable-bap \
-                 --enable-mcp \
-                 --enable-vcp \
-                 --enable-tools \
-                 --enable-monitor \
-                 --enable-udev \
-                 --enable-cups \
-                 --enable-mesh \
-                 --enable-midi \
-                 --enable-obex \
-                 --enable-btpclient \
-                 --disable-external-ell \
-                 --enable-client \
-                 --enable-systemd \
-                 --enable-datafiles \
-                 --enable-manpages \
-                 --disable-testing \
-                 --enable-experimental \
-                 --enable-deprecated \
-                 --enable-sixaxis \
-                 --enable-hid2hci \
-                 --enable-logger \
-                 --enable-admin \
-                 --disable-android \
-                 --with-phonebook=dummy"
+AUTOTOOLS_AFTER=(
+	"--libexecdir=/usr/lib"
+	"--with-dbusconfdir=/usr/share"
+	"--enable-optimization"
+	"--disable-asan"
+	"--disable-lsan"
+	"--disable-ubsan"
+	"--disable-debug"
+	"--enable-pie"
+	"--enable-threads"
+	"--enable-backtrace"
+	"--enable-library"
+	"--disable-test"
+	"--enable-nfc"
+	"--enable-a2dp"
+	"--enable-avrcp"
+	"--enable-network"
+	"--enable-hid"
+	"--enable-hog"
+	"--enable-bap"
+	"--enable-mcp"
+	"--enable-vcp"
+	"--enable-tools"
+	"--enable-monitor"
+	"--enable-udev"
+	"--enable-cups"
+	"--enable-mesh"
+	"--enable-midi"
+	"--enable-obex"
+	"--enable-btpclient"
+	"--disable-external-ell"
+	"--enable-client"
+	"--enable-systemd"
+	"--enable-datafiles"
+	"--enable-manpages"
+	"--disable-testing"
+	"--enable-experimental"
+	"--enable-deprecated"
+	"--enable-sixaxis"
+	"--enable-hid2hci"
+	"--enable-logger"
+	"--enable-admin"
+	"--with-phonebook=dummy"
+)

--- a/app-devices/bluez/autobuild/defines.stage2
+++ b/app-devices/bluez/autobuild/defines.stage2
@@ -5,14 +5,16 @@ PKGSUG="cups"
 BUILDDEP=""
 PKGDES="The Bluetooth protocol stack for Linux"
 
-AUTOTOOLS_AFTER="--libexecdir=/usr/lib \
-                 --with-dbusconfdir=/usr/share \
-                 --enable-sixaxis \
-                 --enable-experimental \
-                 --enable-library \
-                 --enable-tools \
-                 --enable-deprecated \
-                 --enable-hid2hci \
-                 --disable-manpages"
+AUTOTOOLS_AFTER=(
+	"--libexecdir=/usr/lib"
+	"--with-dbusconfdir=/usr/share"
+	"--enable-sixaxis"
+	"--enable-experimental"
+	"--enable-library"
+	"--enable-tools"
+	"--enable-deprecated"
+	"--enable-hid2hci"
+	"--disable-manpages"
+)
 ABSHADOW=no
 RECONF=0

--- a/app-devices/bluez/spec
+++ b/app-devices/bluez/spec
@@ -1,4 +1,4 @@
-VER=5.79
+VER=5.86
 SRCS="tbl::https://www.kernel.org/pub/linux/bluetooth/bluez-$VER.tar.xz"
-CHKSUMS="sha256::4164a5303a9f71c70f48c03ff60be34231b568d93a9ad5e79928d34e6aa0ea8a"
+CHKSUMS="sha256::99f144540c6070591e4c53bcb977eb42664c62b7b36cb35a29cf72ded339621d"
 CHKUPDATE="anitya::id=10029"


### PR DESCRIPTION
Topic Description
-----------------

- bluez: update to 5.86
    Co-authored-by: xtex \(@xtexx\) <xtex@astrafall.org>

Package(s) Affected
-------------------

- bluez: 5.86

Security Update?
----------------

No

Build Order
-----------

```
#buildit bluez
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
