### PR TITLE
deno: update to 2.8.3

### DIFF
--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,7 +1,7 @@
-From 8ecf71079aaef11bb4f4dcb5908eb9cbf74fc380 Mon Sep 17 00:00:00 2001
+From c5e9ecb54082aee68aa3b0827017c0a9e8aaf03b Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Sat, 23 May 2026 00:33:21 +0800
-Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
+Date: Fri, 12 Jun 2026 11:50:47 +0800
+Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
 
 ---
  Cargo.lock | 2 --
@@ -9,23 +9,23 @@ Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 4651851f3..c28575193 100644
+index 36d43bd869..f79d11f9bd 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -11336,8 +11336,6 @@ dependencies = [
+@@ -10713,8 +10713,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "149.0.0"
+ version = "149.3.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "55897294cf631f99d5ff57c6a0611648861645ed7c8f251579161e0768812840"
+-checksum = "65a9ff61a9b12e7b2559a7b1e5e1515e379a999c97a65b9356b936307b7f687a"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index 2be6c83cc..982a10cdd 100644
+index 086ad0e064..f6b90ce217 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -612,3 +612,6 @@ opt-level = 3
+@@ -606,3 +606,6 @@ opt-level = 3
  opt-level = 3
  [profile.release.package.twox-hash]
  opt-level = 3

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loong64
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-add-more-architectures-support.patch.loong64
@@ -1,7 +1,7 @@
 From 6b2400bee4b37d701027904926f1bcafc3115204 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 23 May 2026 00:37:00 +0800
-Subject: [PATCH 2/2] AOSCOS: add more architectures support
+Subject: [PATCH 2/3] AOSCOS: add more architectures support
 
 After cranelift 0.117.1, it can support more unknown architectures.
 

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-build-windows-sys-only-on-Windows.patch
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-build-windows-sys-only-on-Windows.patch
@@ -1,0 +1,22 @@
+From 50bb7bff7a2829489f204d6eaa189a287e5d9e32 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Fri, 12 Jun 2026 13:55:09 +0800
+Subject: [PATCH 3/3] AOSCOS: build windows-sys only on Windows
+
+---
+ ext/signals/Cargo.toml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/ext/signals/Cargo.toml b/ext/signals/Cargo.toml
+index 193f4bd505..bae3bd1578 100644
+--- a/ext/signals/Cargo.toml
++++ b/ext/signals/Cargo.toml
+@@ -18,4 +18,5 @@ libc.workspace = true
+ signal-hook.workspace = true
+ thiserror.workspace = true
+ tokio.workspace = true
++[target.'cfg(windows)'.dependencies]
+ windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Threading"] }
+-- 
+2.54.0
+

--- a/lang-js/deno/autobuild/patches/0004-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0004-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,7 +1,7 @@
-From 9b468c951884ad6c559e247baa7c76950808baa2 Mon Sep 17 00:00:00 2001
+From dc0eb5812b4ead1256265f29987aa151bf98185b Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 29 Apr 2026 19:29:06 +0800
-Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup on arm64
+Subject: [PATCH 4/6] AOSCOS: Disable cross-compilation setup on arm64
 
 Because we have native linux arm64 CI :)
 ---
@@ -9,7 +9,7 @@ Because we have native linux arm64 CI :)
  1 file changed, 16 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index a2a2e4596..8a0d0e16d 100644
+index a2a2e459..8a0d0e16 100644
 --- a/build.rs
 +++ b/build.rs
 @@ -381,22 +381,6 @@ fn build_v8(is_asan: bool) {

--- a/lang-js/deno/autobuild/patches/0005-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0005-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,7 +1,7 @@
-From c361eee641e489088d96badb55601bfbaccc5b82 Mon Sep 17 00:00:00 2001
+From af0a8ce369d5f9d48dd1aa22a7146ac95e13af43 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
-Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
+Subject: [PATCH 5/6] AOSCOS: build: correct Clang builtins path
 
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 
@@ -11,7 +11,7 @@ Correct the builtins path accordingly.
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index f429120f4..d75fbc007 100644
+index f429120f..d75fbc00 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
 @@ -188,22 +188,23 @@ template("clang_lib") {

--- a/lang-js/deno/autobuild/patches/0006-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0006-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,7 +1,7 @@
-From 39a105d73e2a1f2f886349ef4d95d25fcfa35809 Mon Sep 17 00:00:00 2001
+From 4a527a7bdac9fdef0c0e205b08bac00428038a07 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 23 May 2026 00:26:17 +0800
-Subject: [PATCH 5/5] AOSCOS: drop unknown argument
+Subject: [PATCH 6/6] AOSCOS: drop unknown argument
 
 Ref: https://github.com/cions/termux-deno/blob/7068f1fc4d8817045cbe4c65934df9646cd78368/rusty_v8-fix-unknown-options.patch
 ---
@@ -10,7 +10,7 @@ Ref: https://github.com/cions/termux-deno/blob/7068f1fc4d8817045cbe4c65934df9646
  2 files changed, 20 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index 1b53cb1d4..53b6092b7 100644
+index 1b53cb1d..53b6092b 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
 @@ -600,12 +600,6 @@ config("compiler") {
@@ -41,7 +41,7 @@ index 1b53cb1d4..53b6092b7 100644
      # by default. https://crbug.com/765793
      cflags += [
 diff --git a/build/config/sanitizers/sanitizers.gni b/build/config/sanitizers/sanitizers.gni
-index 329a2fc8b..903b87c7b 100644
+index 329a2fc8..903b87c7 100644
 --- a/build/config/sanitizers/sanitizers.gni
 +++ b/build/config/sanitizers/sanitizers.gni
 @@ -534,13 +534,6 @@ template("ubsan_hardening") {

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.8.0
+VER=2.8.3
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=149.0.0
+RUSTY_V8_VER=149.3.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::63873c643e516f10f20d5708e271ed55186a02cef04f5df632c987a91fbd25ac \
+CHKSUMS="sha256::f5aad48de4230de51a3c4125e325c798d49bc1543a7cd1ad9662eff39dc510e5 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.8.3

Package(s) Affected
-------------------

- deno: 2.8.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
