### PR TITLE
pypandoc: update to 1.17

### DIFF
--- a/lang-python/pypandoc/autobuild/defines
+++ b/lang-python/pypandoc/autobuild/defines
@@ -1,11 +1,11 @@
 PKGNAME=pypandoc
 PKGSEC=python
 PKGDEP="pandoc"
-BUILDDEP="python-build python-installer poetry wheel"
+BUILDDEP="python-build python-installer poetry wheel hatchling"
 PKGDES="Python bindings for Pandoc"
 
-# FIXME: ghc is only available on these archs
-FAIL_ARCH="!(amd64|arm64)"
+# FIXME: Sync with pandoc's list of supported architectures.
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
 
 # Note: Inheriting FAIL_ARCH requires removal of noarch flag, treating as
 # architecture-specific.

--- a/lang-python/pypandoc/spec
+++ b/lang-python/pypandoc/spec
@@ -1,5 +1,4 @@
-VER=1.15
+VER=1.17
 SRCS="git::commit=tags/v$VER::https://github.com/JessicaTegner/pypandoc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10570"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pypandoc: update to 1.17
- Sync with pandoc's list of supported architectures.
- Build dependency: hatchling \(fixes "Backend 'hatchling.build' not available"\).

Package(s) Affected
-------------------

- pypandoc: 1.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit pypandoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
