### PR TITLE
ethtool: update to 7.0

### DIFF
--- a/app-network/ethtool/spec
+++ b/app-network/ethtool/spec
@@ -1,5 +1,4 @@
-VER=6.11
-REL=1
+VER=7.0
 SRCS="tbl::https://www.kernel.org/pub/software/network/ethtool/ethtool-$VER.tar.xz"
-CHKSUMS="sha256::8d91f5c72ae3f25b7e88d4781279dcb320f71e30058914370b1c574c96b31202"
+CHKSUMS="sha256::660bf9725a7871343a0d232068a7634fbcfb69b6c2f8eff455827faefb0cd162"
 CHKUPDATE="anitya::id=763"


### PR DESCRIPTION
Topic Description
-----------------

- ethtool: update to 7.0
    Co-authored-by: xtex \(@xtexx\) <xtex@astrafall.org>

Package(s) Affected
-------------------

- ethtool: 7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ethtool
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
