### PR TITLE
telegram-desktop: update to 6.9.2

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=6.9.1
+VER=6.9.2
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=e0943d068ce90b5010f1aea946e6901e25b43bf6
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::ff694e702ca1412b1c13fc8debd8cda981ff19284d7a61eb7c31e21444a4a716 \
+CHKSUMS="sha256::c3aef3cbb8438b63e25d7992a1f27b7fad899cc4be58f87170007b68e3159d38 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.9.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- telegram-desktop: 6.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
