### PR TITLE
sdcc: update to 4.5.0

### DIFF
--- a/app-devel/sdcc/autobuild/defines
+++ b/app-devel/sdcc/autobuild/defines
@@ -3,13 +3,5 @@ PKGDEP="gputils boost"
 PKGSEC=devel
 PKGDES="Small Device C Compiler, a C compiler suite that targets several microcontrollers"
 
-ABSHADOW=0
-AB_FLAGS_FTF=0
-AUTOTOOLS_STRICT=0
-#FIXME: Parallelism breaks build.
-NOPARALLEL=1
-# Should we split the non-free part into another package?
-AUTOTOOLS_AFTER="--disable-shared \
-                 --disable-non-free"
-
+# FIXME: configure.ac:34: error: Please use exactly Autoconf 2.69 instead of 2.72.
 RECONF=0

--- a/app-devel/sdcc/autobuild/patches/0003-FEDORA-add-missing-func-def-in-aslink.patch
+++ b/app-devel/sdcc/autobuild/patches/0003-FEDORA-add-missing-func-def-in-aslink.patch
@@ -1,0 +1,12 @@
+index 4033cfa..780a52b 100644
+--- a/sdas/linksrc/aslink.h
++++ b/sdas/linksrc/aslink.h
+@@ -1312,7 +1312,7 @@ extern  VOID            s19(int i);
+ extern  VOID            sflush(void);
+ 
+ /* EEP: lkelf.c */
+-extern  VOID            elf();
++extern  VOID            elf(int i);
+ 
+ /* JCF: lkmem.c */
+ extern int summary(struct area * xp);

--- a/app-devel/sdcc/spec
+++ b/app-devel/sdcc/spec
@@ -1,12 +1,4 @@
-VER=4.3.6
-# FIXME: upstream tags patch versions without publishing the corresponding
-# tarball. Using SVN source directly instead.
-# Here's the original SRCS.
-# SRCS="https://sourceforge.net/projects/sdcc/files/sdcc/$VER/sdcc-src-$VER.tar.bz2"
-# FIXME: Maintainer beware - checking out a tag MUST have its corresponding revision
-# specified using `commit=N', without the `r' prefix. Without the commit specified,
-# ACBS will refuse to checkout.
-SRCS="svn::commit=14418::svn://svn.code.sf.net/p/sdcc/code/tags/sdcc-4.3.6"
-CHKSUMS="SKIP"
+VER=4.5.0
+SRCS="tbl::https://sourceforge.net/projects/sdcc/files/sdcc/$VER/sdcc-src-$VER.tar.bz2"
+CHKSUMS="sha256::d5030437fb436bb1d93a8dbdbfb46baaa60613318f4fb3f5871d72815d1eed80"
 CHKUPDATE="anitya::id=227271"
-SUBDIR="sdcc/sdcc"


### PR DESCRIPTION
Topic Description
-----------------

- sdcc: update to 4.5.0

Package(s) Affected
-------------------

- sdcc: 4.5.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sdcc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
