### PR TITLE
redsocks2: update to 0.71

### DIFF
--- a/app-proxy/redsocks2/spec
+++ b/app-proxy/redsocks2/spec
@@ -1,5 +1,4 @@
-VER=0.67+git20201229
-SRCS="git::commit=1951b49b774b0aab702348d0370e26bae1c3a7df::https://github.com/semigodking/redsocks"
+VER=0.71
+SRCS="git::commit=release-${VER}::https://github.com/semigodking/redsocks"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227511"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- redsocks2: update to 0.71

Package(s) Affected
-------------------

- redsocks2: 0.71

Security Update?
----------------

No

Build Order
-----------

```
#buildit redsocks2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
