### PR TITLE
clash-verge-rev: update to 2.5.1+git20260612

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From 557408db15367ff51656c3d0dbc33da5afa97811 Mon Sep 17 00:00:00 2001
+From 00be40affb8da4df0abc55a38ed2585361392f1c Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
@@ -9,11 +9,11 @@ Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
  2 files changed, 2 insertions(+), 32 deletions(-)
 
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index 497f41b4..fcdc0790 100755
+index 2f4e1c12..f92d4b6f 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -2,7 +2,7 @@
-   "version": "2.5.0",
+   "version": "2.5.2",
    "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
    "bundle": {
 -    "active": true,

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
@@ -1,4 +1,4 @@
-From 0e95a48a49ef06bf0c240939754c0d61d7784c9e Mon Sep 17 00:00:00 2001
+From ab15613322cd450a37ce37de24ac4fb007bd4b48 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 02/13] feat: drop mihomo-alpha support
@@ -8,7 +8,7 @@ Subject: [PATCH 02/13] feat: drop mihomo-alpha support
  1 file changed, 1 insertion(+), 6 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 1fc4a528..a605ae3c 100644
+index 1f0fd8e2..cab6fc20 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
 @@ -29,12 +29,7 @@ const VALID_CORE = [

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
@@ -1,4 +1,4 @@
-From 43b40d5f495937b0fb6e9dc9ee92fab39a8329f9 Mon Sep 17 00:00:00 2001
+From 1ea6f548cce741f8b0b034b7fae47cf716c96dda Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
@@ -9,10 +9,10 @@ Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
  2 files changed, 14 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index d08700e4..05341de5 100644
+index 3aa2daf7..f561f673 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -752,20 +752,7 @@ const resolveUnSetDnsScript = () =>
+@@ -751,20 +751,7 @@ const resolveUnSetDnsScript = () =>
  // Tasks
  // =======================
  const tasks = [
@@ -34,7 +34,7 @@ index d08700e4..05341de5 100644
    { name: 'geosite', func: resolveGeosite, retry: 5 },
    { name: 'geoip', func: resolveGeoIP, retry: 5 },
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index fcdc0790..2daea4f9 100755
+index f92d4b6f..30e04830 100755
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
 @@ -13,7 +13,6 @@

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
@@ -1,4 +1,4 @@
-From 4ab6c252cea78cf5add90a2c3bc7782fb578eb79 Mon Sep 17 00:00:00 2001
+From 458eef5e55d7b455259eaf1ee526e5f9d429a976 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 04/13] Drop check update feature and update checker component
@@ -50,10 +50,10 @@ index 81da3cc8..fdb0a907 100644
  }
  
 diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
-index 8edf3200..c6c617ba 100644
+index 4198ea88..6b8842dc 100644
 --- a/src/components/home/system-info-card.tsx
 +++ b/src/components/home/system-info-card.tsx
-@@ -96,25 +96,7 @@ export const SystemInfoCard = () => {
+@@ -93,25 +93,7 @@ export const SystemInfoCard = () => {
      if (isSidecarMode || (isAdminMode && isSidecarMode)) {
        installServiceAndRestartCore()
      }
@@ -80,7 +80,7 @@ index 8edf3200..c6c617ba 100644
  
    // 是否启用自启动
    const autoLaunchEnabled = useMemo(
-@@ -264,24 +246,6 @@ export const SystemInfoCard = () => {
+@@ -261,24 +243,6 @@ export const SystemInfoCard = () => {
            </Typography>
          </Stack>
          <Divider />
@@ -676,10 +676,10 @@ index 4d451246..099cce8d 100644
  
        <SettingItem label={t('settings.components.verge.basic.fields.language')}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index 763e8dc8..31189787 100644
+index ecdce94b..e3b9e4c3 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -310,32 +310,31 @@ const Layout = () => {
+@@ -308,32 +308,31 @@ const Layout = () => {
          {/* Custom titlebar - rendered only when decorated is false, memoized for performance */}
          {customTitlebar}
  

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From f147dbe300879a020c70962c635d244824b48013 Mon Sep 17 00:00:00 2001
+From 1683a89c85dcc51ef5175a7231e365c3926dd7d2 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 05/13] Set core binary name as mihomo
@@ -47,10 +47,10 @@ index b306b2fe..571aefdc 100644
    zip.addLocalFolder(configDir, '.config')
  
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 05341de5..1477d7b9 100644
+index f561f673..8568802a 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -295,8 +295,8 @@ function clashMetaAlpha() {
+@@ -294,8 +294,8 @@ function clashMetaAlpha() {
    const isWin = platform === 'win32'
    const urlExt = isWin ? 'zip' : 'gz'
    return {
@@ -61,7 +61,7 @@ index 05341de5..1477d7b9 100644
      exeFile: `${name}${isWin ? '.exe' : ''}`,
      zipFile: `${name}-${META_ALPHA_VERSION}.${urlExt}`,
      downloadURL: `${META_ALPHA_URL_PREFIX}/${name}-${META_ALPHA_VERSION}.${urlExt}`,
-@@ -308,8 +308,8 @@ function clashMeta() {
+@@ -307,8 +307,8 @@ function clashMeta() {
    const isWin = platform === 'win32'
    const urlExt = isWin ? 'zip' : 'gz'
    return {
@@ -184,7 +184,7 @@ index c2132e84..454842b6 100644
              None => true,
          }
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index a605ae3c..46ba11a4 100644
+index cab6fc20..28a76790 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
 @@ -26,7 +26,7 @@ import { showNotice } from '@/services/notice-service'

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From 4e140e4a368e8d4fb8ba892a5cf58975fea74354 Mon Sep 17 00:00:00 2001
+From 423d6ee1234f5855c027eea47429cc7a50d2c31e Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 06/13] feat: always not portable

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,4 +1,4 @@
-From 1d92999979b6dee9ffe2eaa91896795b0bcebe78 Mon Sep 17 00:00:00 2001
+From 88b431349501eed11839f39798d825294e852764 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 07/13] Set service install/uninstall script path to
@@ -9,10 +9,10 @@ Subject: [PATCH 07/13] Set service install/uninstall script path to
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index 5ef7dd3c..2af22a86 100644
+index d32b1b2d..056ceceb 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -114,8 +114,10 @@ fn install_service() -> Result<()> {
+@@ -121,8 +121,10 @@ fn install_service() -> Result<()> {
  #[cfg(target_os = "linux")]
  fn uninstall_service() -> Result<()> {
      logging!(info, Type::Service, "uninstall service");
@@ -24,7 +24,7 @@ index 5ef7dd3c..2af22a86 100644
  
      if !uninstall_path.exists() {
          bail!(format!("uninstaller not found: {uninstall_path:?}"));
-@@ -170,8 +172,10 @@ fn uninstall_service() -> Result<()> {
+@@ -177,8 +179,10 @@ fn uninstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
  fn install_service() -> Result<()> {
      logging!(info, Type::Service, "install service");

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From 16ba123af87c45182d216b209f23f5516421a6d1 Mon Sep 17 00:00:00 2001
+From 37589fa0b1bd3366ed5e53378df2e4a33fee41ff Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 08/13] Do not use gcc

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
@@ -1,4 +1,4 @@
-From e460c9b59087ad82f0a4e5eee561003ef7ac9906 Mon Sep 17 00:00:00 2001
+From 157cff13410174be2478d8a801a9961d526e1800 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 09/13] Drop "Upgrade core" button
@@ -9,7 +9,7 @@ Subject: [PATCH 09/13] Drop "Upgrade core" button
  2 files changed, 1 insertion(+), 33 deletions(-)
 
 diff --git a/src/components/setting/mods/clash-core-viewer.tsx b/src/components/setting/mods/clash-core-viewer.tsx
-index 46ba11a4..dadbbed3 100644
+index 28a76790..4c64cdae 100644
 --- a/src/components/setting/mods/clash-core-viewer.tsx
 +++ b/src/components/setting/mods/clash-core-viewer.tsx
 @@ -87,26 +87,7 @@ export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
@@ -44,7 +44,7 @@ index 46ba11a4..dadbbed3 100644
          <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
            {t('settings.sections.clash.form.fields.clashCore')}
            <Box>
--            <LoadingButton
+-            <Button
 -              variant="contained"
 -              size="small"
 -              startIcon={<SwitchAccessShortcutRounded />}
@@ -55,12 +55,12 @@ index 46ba11a4..dadbbed3 100644
 -              onClick={onUpgrade}
 -            >
 -              {t('shared.actions.upgrade')}
--            </LoadingButton>
-             <LoadingButton
+-            </Button>
+             <Button
                variant="contained"
                size="small"
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index 31189787..efc51814 100644
+index e3b9e4c3..8f486129 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
 @@ -35,7 +35,6 @@ import { BaseErrorBoundary } from '@/components/base'

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
@@ -1,4 +1,4 @@
-From b655feb0ded2e1fc1f33925aae8a57d4939c459e Mon Sep 17 00:00:00 2001
+From c47f5c7e91f13e2300409c381a0f0e95fca68140 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 10/13] fix: drop Open Core Dir function
@@ -14,7 +14,7 @@ This is useless for our users as it would just open /usr/bin.
  6 files changed, 1 insertion(+), 26 deletions(-)
 
 diff --git a/src-tauri/src/cmd/app.rs b/src-tauri/src/cmd/app.rs
-index fce5bdf2..f9cfd2aa 100644
+index 75ad8d62..7e1bd12d 100644
 --- a/src-tauri/src/cmd/app.rs
 +++ b/src-tauri/src/cmd/app.rs
 @@ -11,14 +11,6 @@ pub async fn open_app_dir() -> CmdResult<()> {
@@ -45,10 +45,10 @@ index 7012ce21..2fd3de09 100644
      open_dir => OPEN_DIR, "tray_open_dir", "tray.openDir",
      app_log => APP_LOG, "tray_app_log", "tray.appLog",
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index 3ab9761f..09b2d55f 100644
+index f6d9a355..1b8cb8b8 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
-@@ -763,8 +763,6 @@ async fn create_tray_menu(
+@@ -770,8 +770,6 @@ async fn create_tray_menu(
  
      let open_app_dir = &MenuItem::with_id(app_handle, MenuIds::CONF_DIR, &texts.conf_dir, true, None::<&str>)?;
  
@@ -57,7 +57,7 @@ index 3ab9761f..09b2d55f 100644
      let open_logs_dir = &MenuItem::with_id(app_handle, MenuIds::LOGS_DIR, &texts.logs_dir, true, None::<&str>)?;
  
      let open_app_log = &MenuItem::with_id(app_handle, MenuIds::APP_LOG, &texts.app_log, true, None::<&str>)?;
-@@ -776,7 +774,7 @@ async fn create_tray_menu(
+@@ -783,7 +781,7 @@ async fn create_tray_menu(
          MenuIds::OPEN_DIR,
          &texts.open_dir,
          true,
@@ -66,7 +66,7 @@ index 3ab9761f..09b2d55f 100644
      )?;
  
      let restart_clash = &MenuItem::with_id(
-@@ -946,9 +944,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+@@ -953,9 +951,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
              MenuIds::CONF_DIR => {
                  let _ = cmd::open_app_dir().await;
              }
@@ -77,17 +77,17 @@ index 3ab9761f..09b2d55f 100644
                  let _ = cmd::open_logs_dir().await;
              }
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index e38a6ed2..eca4be87 100644
+index 55156df3..20f11c09 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
-@@ -130,7 +130,6 @@ mod app_init {
+@@ -140,7 +140,6 @@ mod app_init {
              cmd::open_app_dir,
              cmd::open_logs_dir,
              cmd::open_web_url,
 -            cmd::open_core_dir,
-             cmd::open_app_log,
-             cmd::open_core_log,
              cmd::get_portable_flag,
+             cmd::get_network_interfaces,
+             cmd::get_system_hostname,
 diff --git a/src/components/setting/setting-verge-advanced.tsx b/src/components/setting/setting-verge-advanced.tsx
 index 51231e2a..752003c2 100644
 --- a/src/components/setting/setting-verge-advanced.tsx
@@ -113,7 +113,7 @@ index 51231e2a..752003c2 100644
          onClick={openLogsDir}
          label={t('settings.components.verge.advanced.fields.openLogsDir')}
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index dc18fb9f..5588658b 100644
+index 960aacdf..0538e34a 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
 @@ -330,10 +330,6 @@ export async function openAppDir() {

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
@@ -1,4 +1,4 @@
-From 5ab05cddd2c7ff734fc35f6883a183140416ebe7 Mon Sep 17 00:00:00 2001
+From 3bc1e5bc02d00cf010912389a81baa740548d80b Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 11/13] fix: disable GeoData update
@@ -10,10 +10,10 @@ We handle this via mihomo-rules-dat.
  2 files changed, 3 insertions(+), 25 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 1477d7b9..eb6e8b8e 100644
+index 8568802a..59df0894 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -720,17 +720,7 @@ const resolveMmdb = () =>
+@@ -719,17 +719,7 @@ const resolveMmdb = () =>
    resolveResource({
      file: 'Country.mmdb',
      downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb`,
@@ -32,7 +32,7 @@ index 1477d7b9..eb6e8b8e 100644
  const resolveEnableLoopback = () =>
    resolveResource({
      file: 'enableLoopback.exe',
-@@ -754,8 +744,6 @@ const resolveUnSetDnsScript = () =>
+@@ -753,8 +743,6 @@ const resolveUnSetDnsScript = () =>
  const tasks = [
    { name: 'plugin', func: resolvePlugin, retry: 5, winOnly: true },
    { name: 'mmdb', func: resolveMmdb, retry: 5 },

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From 6bf736d32ae6b1274b10b54e7672bfb21867fae4 Mon Sep 17 00:00:00 2001
+From f1160313c5607c6700c2d76968e9dc9b718ede25 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 12/13] Do not sidecar mihomo program

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
@@ -1,4 +1,4 @@
-From 370f525c3b0ebfcd6fe687bcd57d9c49806e9989 Mon Sep 17 00:00:00 2001
+From e089ed0ae0c4fb9d99114f7ef5e8a2cf8c33ac21 Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Sun, 9 Nov 2025 19:15:18 +0800
 Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
@@ -6,24 +6,24 @@ Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
 Signed-off-by: stydxm <stydxm@outlook.com>
 ---
  Cargo.lock           | 11 -----------
- package.json         |  9 ++++++++-
+ pnpm-workspace.yaml  |  7 +++++++
  scripts/prebuild.mjs |  6 ++++--
  src-tauri/Cargo.toml |  2 +-
- 4 files changed, 13 insertions(+), 15 deletions(-)
+ 4 files changed, 12 insertions(+), 14 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 6dac0365..2350a9dc 100644
+index b13885be..c61edd72 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -726,7 +726,6 @@ dependencies = [
-  "dashmap 6.1.0",
+@@ -658,7 +658,6 @@ dependencies = [
+  "dashmap",
   "dynify",
   "fast-float2",
 - "float16",
   "futures-channel",
   "futures-concurrency",
-  "futures-lite 2.6.1",
-@@ -2558,16 +2557,6 @@ dependencies = [
+  "futures-lite",
+@@ -2448,16 +2447,6 @@ dependencies = [
   "thiserror 2.0.18",
  ]
  
@@ -40,30 +40,30 @@ index 6dac0365..2350a9dc 100644
  [[package]]
  name = "fnv"
  version = "1.0.7"
-diff --git a/package.json b/package.json
-index 7846d0ee..ccab8b09 100644
---- a/package.json
-+++ b/package.json
-@@ -139,6 +139,13 @@
-       "es5-ext",
-       "meta-json-schema",
-       "unrs-resolver"
--    ]
-+    ],
-+    "overrides": {
-+      "rollup": "npm:@rollup/wasm-node",
-+      "lightningcss": "npm:lightningcss-wasm",
-+      "vite": "^7.0.0",
-+      "@vitejs/plugin-legacy": "^7.0.0",
-+      "@vitejs/plugin-react": "^5.0.0"
-+    }
-   }
- }
+diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
+index 0f304e31..3842c949 100644
+--- a/pnpm-workspace.yaml
++++ b/pnpm-workspace.yaml
+@@ -2,7 +2,14 @@ allowBuilds:
+   "@parcel/watcher": true
+   core-js: true
+   es5-ext: true
++  esbuild: true
+   meta-json-schema: true
+   unrs-resolver: true
+ minimumReleaseAgeExclude:
+   - dayjs@1.11.21
++overrides:
++  "rollup": "npm:@rollup/wasm-node"
++  "lightningcss": "npm:lightningcss-wasm"
++  "vite": "^7.0.0"
++  "@vitejs/plugin-legacy": "^7.0.0"
++  "@vitejs/plugin-react": "^5.0.0"
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index eb6e8b8e..6acd0b25 100644
+index 59df0894..32380beb 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -191,7 +191,8 @@ const META_ALPHA_MAP = {
+@@ -190,7 +190,8 @@ const META_ALPHA_MAP = {
    'linux-arm64': 'mihomo-linux-arm64',
    'linux-arm': 'mihomo-linux-armv7',
    'linux-riscv64': 'mihomo-linux-riscv64',
@@ -73,7 +73,7 @@ index eb6e8b8e..6acd0b25 100644
  }
  
  const META_MAP = {
-@@ -205,7 +206,8 @@ const META_MAP = {
+@@ -204,7 +205,8 @@ const META_MAP = {
    'linux-arm64': 'mihomo-linux-arm64',
    'linux-arm': 'mihomo-linux-armv7',
    'linux-riscv64': 'mihomo-linux-riscv64',
@@ -84,18 +84,18 @@ index eb6e8b8e..6acd0b25 100644
  
  // =======================
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 6ba634af..4c995757 100755
+index 95bd1924..bc4918ff 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -60,7 +60,7 @@ open = "5.3.3"
+@@ -60,7 +60,7 @@ open = "5.3.5"
  dunce = "1.0.5"
  nanoid = "0.5"
- chrono = "0.4.44"
--boa_engine = "0.21.0"
-+boa_engine = { version = "0.21.0", features = ["xsum"], default-features = false }
+ chrono = "0.4.45"
+-boa_engine = "0.21.1"
++boa_engine = { version = "0.21.1", features = ["xsum"], default-features = false }
  once_cell = { version = "1.21.4", features = ["parking_lot"] }
- delay_timer = "0.11.6"
  percent-encoding = "2.3.2"
+ reqwest = { version = "0.13.4", features = [
 -- 
 2.52.0
 

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,5 +1,5 @@
-VER=2.5.0
-SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
+VER=2.5.1+git20260613
+SRCS="git::commit=f763fcb244caab8476a79d44f8f40f049ad256bb;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"
 ENVREQ="total_mem=30"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: update to 2.5.1+git20260612
- clash-verge-service-ipc: auto install service

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
