### PR TITLE
goreleaser: update to 2.16.0

### DIFF
--- a/lang-golang/goreleaser/autobuild/beyond
+++ b/lang-golang/goreleaser/autobuild/beyond
@@ -1,20 +1,14 @@
-abinfo "Building shell completions ..."
-"$SRCDIR"/scripts/completions.sh
-
-abinfo "Building manpages ..."
-"$SRCDIR"/scripts/manpages.sh
-
 abinfo "Installing shell completions ..."
-install -Dvm644 "$SRCDIR"/completions/goreleaser.bash \
-    "$PKGDIR"/usr/share/bash-completion/completions/goreleaser
-install -Dvm644 "$SRCDIR"/completions/goreleaser.fish \
-    "$PKGDIR"/usr/share/fish/vendor_completions.d/goreleaser.fish
-install -Dvm644 "$SRCDIR"/completions/goreleaser.zsh \
-    "$PKGDIR"/usr/share/zsh/vendor-completions/_goreleaser
+mkdir -pv "$PKGDIR"/usr/share/bash-completion/completions/
+mkdir -pv "$PKGDIR"/usr/share/zsh/vendor-completions/
+mkdir -pv "$PKGDIR"/usr/share/fish/vendor_completions.d/
+"$PKGDIR"/usr/bin/goreleaser completion bash > "$PKGDIR"/usr/share/bash-completion/completions/goreleaser
+"$PKGDIR"/usr/bin/goreleaser completion fish > "$PKGDIR"/usr/share/fish/vendor_completions.d/goreleaser.fish
+"$PKGDIR"/usr/bin/goreleaser completion zsh > "$PKGDIR"/usr/share/zsh/vendor-completions/_goreleaser
 
 abinfo "Installing manpages ..."
-install -Dvm644 "$SRCDIR"/manpages/goreleaser.1.gz \
-    "$PKGDIR"/usr/share/man/man1/goreleaser.1.gz
+mkdir -pv "$PKGDIR"/usr/share/man/man1/
+"$PKGDIR"/usr/bin/goreleaser man | gzip -c -9 > "$PKGDIR"/usr/share/man/man1/goreleaser.1.gz
 
 abinfo "Installing license file ..."
 install -Dvm644 "$SRCDIR"/LICENSE.md \

--- a/lang-golang/goreleaser/autobuild/defines
+++ b/lang-golang/goreleaser/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=goreleaser
 PKGSEC=devel
 PKGDEP="glibc"
 BUILDDEP="go"
-PKGDES="A tool for building and releasing Go projects"
+PKGDES="Tool for building and releasing Go projects"
 
 ABTYPE=gomod
 GO_LDFLAGS=("-X main.version=$PKGVER -X main.builtBy=AOSC")

--- a/lang-golang/goreleaser/spec
+++ b/lang-golang/goreleaser/spec
@@ -1,5 +1,4 @@
-VER=2.13.1
-REL=4
+VER=2.16.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/goreleaser/goreleaser.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374129"


### PR DESCRIPTION
Topic Description
-----------------

- goreleaser: update to 2.16.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- goreleaser: 2.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit goreleaser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
