### PR TITLE
fan2go: update to 0.14.0

### DIFF
--- a/app-utils/fan2go/spec
+++ b/app-utils/fan2go/spec
@@ -1,5 +1,4 @@
-VER=0.11.1
-REL=4
+VER=0.14.0
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/markusressel/fan2go.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376893"


### PR DESCRIPTION
Topic Description
-----------------

- fan2go: update to 0.14.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- fan2go: 0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fan2go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
