### PR TITLE
danksearch: update to 0.3.1

### DIFF
--- a/app-utils/danksearch/autobuild/patches/0001-edit-executable-path.patch
+++ b/app-utils/danksearch/autobuild/patches/0001-edit-executable-path.patch
@@ -1,0 +1,13 @@
+diff --git a/assets/dsearch.service b/assets/dsearch.service
+index ff06758..879f078 100644
+--- a/assets/dsearch.service
++++ b/assets/dsearch.service
+@@ -5,7 +5,7 @@ After=network.target
+ 
+ [Service]
+ Type=simple
+-ExecStart=/usr/local/bin/dsearch serve
++ExecStart=/usr/bin/dsearch serve
+ Restart=on-failure
+ RestartSec=5s
+ 

--- a/app-utils/danksearch/autobuild/prepare
+++ b/app-utils/danksearch/autobuild/prepare
@@ -1,0 +1,6 @@
+abinfo "Setting build variables ..."
+export GO_LDFLAGS=(
+    "-X \"main.commit=$(git rev-parse HEAD~1)\""
+    "-X \"main.Version=$PKGVER\""
+    "-X \"main.buildTime=$(date)\""
+)

--- a/app-utils/danksearch/spec
+++ b/app-utils/danksearch/spec
@@ -1,5 +1,4 @@
-VER=0.2.1
-REL=1
-SRCS="git::commit=tags/v$VER::https://github.com/AvengeMedia/danksearch.git"
+VER=0.3.1
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AvengeMedia/danksearch.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=106455"


### PR DESCRIPTION
Topic Description
-----------------

- danksearch: update to 0.3.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- danksearch: 0.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit danksearch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
