### PR TITLE
direnv: update to 2.37.1

### DIFF
--- a/app-utils/direnv/spec
+++ b/app-utils/direnv/spec
@@ -1,5 +1,4 @@
-VER=2.35.0
+VER=2.37.1
 SRCS="git::commit=tags/v$VER::https://github.com/direnv/direnv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11598"
-REL=7


### PR DESCRIPTION
Topic Description
-----------------

- direnv: update to 2.37.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- direnv: 2.37.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit direnv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
