### PR TITLE
delve: update to 1.26.3

### DIFF
--- a/lang-golang/delve/spec
+++ b/lang-golang/delve/spec
@@ -1,5 +1,4 @@
-VER=1.24.0
-REL=6
+VER=1.26.3
 SRCS="git::commit=tags/v$VER::https://github.com/go-delve/delve"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=40149"


### PR DESCRIPTION
Topic Description
-----------------

- delve: update to 1.26.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- delve: 1.26.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit delve
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
