### PR TITLE
vhs: update to 0.11.0

### DIFF
--- a/app-utils/vhs/autobuild/defines
+++ b/app-utils/vhs/autobuild/defines
@@ -4,3 +4,4 @@ PKGDES="Recorder for command-line application output"
 PKGDEP="glibc ttyd"
 BUILDDEP="go"
 ABTYPE=gomod
+GO_LDFLAGS=("-X main.Version=$PKGVER")

--- a/app-utils/vhs/spec
+++ b/app-utils/vhs/spec
@@ -1,5 +1,4 @@
-VER=0.10.0
-REL=6
+VER=0.11.0
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/vhs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377764"


### PR DESCRIPTION
Topic Description
-----------------

- vhs: update to 0.11.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vhs: 0.11.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vhs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
