### PR TITLE
apostrophe: Fix compatibility with Python 3.14 by upstream

### DIFF
--- a/app-editors/apostrophe/autobuild/defines
+++ b/app-editors/apostrophe/autobuild/defines
@@ -6,8 +6,8 @@ PKGDEP="chardet dconf glib graphene gtk-4 gtksourceview-5 hicolor-icon-theme \
 PKGRECOM="texlive appstream fira-font"
 PKGDES="Markdown editor with distraction-free mode and support for multi-format export"
 
-# FIXME: ghc is only available on these archs
-FAIL_ARCH="!(amd64|arm64)"
+# FIXME: Sync with pandoc's list of supported architectures.
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
 
 # Note: Inheriting FAIL_ARCH requires removal of noarch flag, treating as
 # architecture-specific.

--- a/app-editors/apostrophe/autobuild/patches/0001-Fix-compatibility-with-Python-3.14.patch
+++ b/app-editors/apostrophe/autobuild/patches/0001-Fix-compatibility-with-Python-3.14.patch
@@ -1,0 +1,36 @@
+From 7a7b1bc46e72cd8c4cd0ca3123919405d20fe2b4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Ball=C3=B3=20Gy=C3=B6rgy?= <ballogyor@gmail.com>
+Date: Wed, 28 Jan 2026 14:30:27 +0100
+Subject: [PATCH] Fix compatibility with Python 3.14
+
+Python 3.14 changing multiprocessing's start method on Linux from fork to
+forkserver which requires parameters to be pickable.
+
+Closes: https://gitlab.gnome.org/World/apostrophe/-/issues/659
+---
+ apostrophe.in | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/apostrophe.in b/apostrophe.in
+index b71bcb1..5c5f683 100755
+--- a/apostrophe.in
++++ b/apostrophe.in
+@@ -19,6 +19,7 @@
+ 
+ import sys
+ import os
++import multiprocessing
+ 
+ import gettext
+ import locale
+@@ -45,6 +46,7 @@ locale.bindtextdomain('apostrophe', localedir)
+ gettext.textdomain('apostrophe')
+ gettext.bindtextdomain('apostrophe', localedir)
+ 
++multiprocessing.set_start_method('fork')
+ 
+ def run_application():
+     from apostrophe.application import Application
+-- 
+2.52.0
+

--- a/app-editors/apostrophe/spec
+++ b/app-editors/apostrophe/spec
@@ -1,7 +1,7 @@
 VER=3.4
 
 # The latest Reveal.js is provided in master branch
-REVEAL_JS_VER=5.2.1
+REVEAL_JS_VER=6.0.1
 
 SRCS="git::commit=tags/v$VER;rename=apostrophe::https://gitlab.gnome.org/World/apostrophe.git \
       git::commit=tags/$REVEAL_JS_VER;rename=reveal.js::https://github.com/hakimel/reveal.js.git"
@@ -9,4 +9,4 @@ SUBDIR="apostrophe"
 CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=222624"
-REL="1"
+REL="2"


### PR DESCRIPTION
Topic Description
-----------------

- Fix compatibility with Python 3.14 by upstream
- Sync with pandoc's list of supported architectures.
- Reveal.js: update to 6.0.1

Package(s) Affected
-------------------

- apostrophe: 3.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit apostrophe
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
