### PR TITLE
Spiral mark fixes for appindicator series libraries

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.17.7
+VER=4.17.8
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/runtime-desktop/libappindicator/spec
+++ b/runtime-desktop/libappindicator/spec
@@ -1,5 +1,5 @@
 VER=12.10.0
-REL=8
+REL=9
 SRCS="https://launchpad.net/libappindicator/${VER%.*}/$VER/+download/libappindicator-$VER.tar.gz"
 CHKSUMS="sha256::d5907c1f98084acf28fd19593cb70672caa0ca1cf82d747ba6f4830d4cc3b49f"
 CHKUPDATE="anitya::id=229549"

--- a/runtime-desktop/libayatana-appindicator/spec
+++ b/runtime-desktop/libayatana-appindicator/spec
@@ -1,4 +1,5 @@
 VER=0.5.93
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/AyatanaIndicators/libayatana-appindicator"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18446"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: update to 4.17.8
- libappindicator: rebuild for spiral fix, add gir1.2-appindicator3-0.1 sprial PKGPROV
- libayatana-appindicator: rebuild for spiral fix, add gir1.2-ayatanaappindicator3-0.1 sprial PKGPROV

Package(s) Affected
-------------------

- autobuild4: 4.17.8
- libappindicator: 1:12.10.0-9
- libayatana-appindicator: 0.5.93-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 libayatana-appindicator libappindicator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
