### PR TITLE
squid: security update to 7.6

### DIFF
--- a/app-web/squid/spec
+++ b/app-web/squid/spec
@@ -1,4 +1,4 @@
-VER=7.5
+VER=7.6
 SRCS="tbl::https://github.com/squid-cache/squid/releases/download/SQUID_${VER//./_}/squid-$VER.tar.xz"
-CHKSUMS="sha256::f6058907db0150d2f5d228482b5a9e5678920cf368ae0ccbcecceb2ff4c35106"
+CHKSUMS="sha256::852178fdc37c5b0786a934fc990c7d2fffc82acf19b2284be209b96431d25992"
 CHKUPDATE="anitya::id=4880"

--- a/topics/squid-7.6.toml
+++ b/topics/squid-7.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Squid Web Proxy Cache 7.6"
+
+[caution]
+default = "Fixes an Out-of-bounds Read vulnerability (CVE-2026-47729) and a Heap-based Buffer Overflow Traversal vulnerability (CVE-2026-50012) "
+zh_CN = "修复一个越界读取漏洞（漏洞编号 CVE-2026-47729）和一个堆缓冲区溢出路径穿越漏洞（漏洞编号 CVE-2026-50012）"
+
+[packages-v2]
+"squid" = "< 7.6"


### PR DESCRIPTION
Topic Description
-----------------

- squid: security update to 7.6
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- squid: 7.6

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit squid
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
