### PR TITLE
kdeconnect: add kirigami-addons dep

### DIFF
--- a/desktop-kde/kdeconnect/autobuild/defines
+++ b/desktop-kde/kdeconnect/autobuild/defines
@@ -4,14 +4,17 @@ PKGDEP="fontconfig freetype fontconfig freetype kcmutils kcodecs kconfig \
         kcoreaddons kdbusaddons kguiaddons ki18n kiconthemes kio kirigami2 \
         kjobwidgets knotifications kpackage kpeople kpeoplevcard kservice \
         kwayland kwindowsystem libfakekey pulseaudio-qt qca \
-        qqc2-desktop-style solid sshfs"
+        qqc2-desktop-style solid sshfs kirigami-addons"
 BUILDDEP="extra-cmake-modules kdoctools plasma-wayland-protocols"
 PKGDES="Applications suite for communication between KDE and other mobile devices"
 
-CMAKE_AFTER="-DBUILD_COVERAGE=OFF \
-             -DBUILD_TESTING=OFF \
-             -DBUILD_WITH_QT6=OFF \
-             -DENABLE_BSYMBOLICFUNCTIONS=OFF \
-             -DKDE_INSTALL_PREFIX_SCRIPT=OFF \
-             -DKDE_INSTALL_USE_QT_SYS_PATHS=ON \
-             -DLOOPBACK_ENABLED=ON"
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DBUILD_COVERAGE=OFF'
+    '-DBUILD_TESTING=OFF'
+    '-DBUILD_WITH_QT6=OFF'
+    '-DENABLE_BSYMBOLICFUNCTIONS=OFF'
+    '-DKDE_INSTALL_PREFIX_SCRIPT=OFF'
+    '-DKDE_INSTALL_USE_QT_SYS_PATHS=ON'
+    '-DLOOPBACK_ENABLED=ON'
+)

--- a/desktop-kde/kdeconnect/spec
+++ b/desktop-kde/kdeconnect/spec
@@ -1,5 +1,5 @@
 VER=23.08.5
-REL=1
+REL=2
 SRCS="tbl::https://download.kde.org/stable/release-service/${VER}/src/kdeconnect-kde-${VER}.tar.xz"
 CHKSUMS="sha256::4b42cd66f824b9ba2ddd09c7147b2abe6107ac866104033a78c0c46909300d64"
 CHKUPDATE="anitya::id=8763"


### PR DESCRIPTION
Topic Description
-----------------

- kdeconnect: add kirigami-addons dep

Package(s) Affected
-------------------

- kdeconnect: 23.08.5-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kdeconnect
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
