### PR TITLE
loonggpu-kernel-dkms: tie some loose ends and adapt for Linux 7.1

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-loonggpu-fix-build-without-CONFIG_MMU_NOTIFIER.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0001-loonggpu-fix-build-without-CONFIG_MMU_NOTIFIER.patch
@@ -1,7 +1,7 @@
 From 294755c077b5a208a3c145c2826ddd9fde6c266d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 3 Dec 2025 21:49:13 +0800
-Subject: [PATCH 01/45] loonggpu: fix build without CONFIG_MMU_NOTIFIER
+Subject: [PATCH 01/49] loonggpu: fix build without CONFIG_MMU_NOTIFIER
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -58,5 +58,5 @@ index 14045e0..9a60906 100644
  
 +#endif
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0002-loonggpu-Remove-unused-fbdev_list-field-in-gsgpu_fra.patch
@@ -1,7 +1,7 @@
 From ed55f5b8b5330dafcfcbfaa43677cdf94f07fba2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:03:46 +0800
-Subject: [PATCH 02/45] loonggpu: Remove unused fbdev_list field in
+Subject: [PATCH 02/49] loonggpu: Remove unused fbdev_list field in
  gsgpu_framebuffer
 
 This field is referred nowhere.
@@ -25,5 +25,5 @@ index 5585033..9d8f31d 100644
  };
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-Remove-the-unused-loonggpu_fbdev_total_size.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0003-loonggpu-Remove-the-unused-loonggpu_fbdev_total_size.patch
@@ -1,7 +1,7 @@
 From a76603b19f2d78c0486961f4ae5d9a008387d091 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:21:48 +0800
-Subject: [PATCH 03/45] loonggpu: Remove the unused loonggpu_fbdev_total_size
+Subject: [PATCH 03/49] loonggpu: Remove the unused loonggpu_fbdev_total_size
  function
 
 It's referred nowhere.
@@ -50,5 +50,5 @@ index 8a96f69..3abad83 100644
  {
  	if (!adev->mode_info.rfbdev)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-Improve-fbdev-object-test-helper.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0004-loonggpu-Improve-fbdev-object-test-helper.patch
@@ -1,7 +1,7 @@
 From 7e2e7f2039bb8972b376de98de1408cd6d46c540 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:27:04 +0800
-Subject: [PATCH 04/45] loonggpu: Improve fbdev object-test helper
+Subject: [PATCH 04/49] loonggpu: Improve fbdev object-test helper
 
 Follow the change of our reference implementation, allowing us to
 remove struct gsgpu_fbdev later.
@@ -49,5 +49,5 @@ index 3abad83..0f3e9a2 100644
 +	return true;
  }
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0005-loonggpu-Remove-struct-gsgpu_fbdev-and-add-some-clea.patch
@@ -1,7 +1,7 @@
 From 3dc148d54a632966d5d9d0614498b64cc804a656 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 16:34:42 +0800
-Subject: [PATCH 05/45] loonggpu: Remove struct gsgpu_fbdev and add some clean
+Subject: [PATCH 05/49] loonggpu: Remove struct gsgpu_fbdev and add some clean
  up code
 
 Both data fields in struct gsgpu_fbdev, the framebuffer and the
@@ -237,5 +237,5 @@ index 0f3e9a2..85c9d81 100644
  
  bool loonggpu_fbdev_robj_is_fb(struct loonggpu_device *adev, struct loonggpu_bo *robj)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-Move-fbdev-cleanup-code-into-fb_destroy-cal.patch
@@ -1,7 +1,7 @@
 From 1b8c4a574de216f5480e6295e4fa09e77f40db33 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:50:01 +0800
-Subject: [PATCH 06/45] loonggpu: Move fbdev cleanup code into fb_destroy
+Subject: [PATCH 06/49] loonggpu: Move fbdev cleanup code into fb_destroy
  callback
 
 Fbdev calls struct fb_ops.fb_destroy after cleaning up the final
@@ -125,5 +125,5 @@ index 85c9d81..467c2b2 100644
  	kfree(adev->ddev->fb_helper);
  	adev->ddev->fb_helper = NULL;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-Remove-load-callback-from-kms_driver.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0007-loonggpu-Remove-load-callback-from-kms_driver.patch
@@ -1,7 +1,7 @@
 From 5ec181b08ee1e6727032865e5ee8930830c17e31 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:10:14 +0800
-Subject: [PATCH 07/45] loonggpu: Remove load callback from kms_driver
+Subject: [PATCH 07/49] loonggpu: Remove load callback from kms_driver
 
 The ".load" callback in "struct drm_driver" is deprecated. In order to
 remove the callback, we have to manually call "gsgpu_driver_load_kms"
@@ -38,5 +38,5 @@ index 22e69ba..46a84a8 100644
  	.postclose = loonggpu_driver_postclose_kms,
  	lg_drm_driver_set_lastclose
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-Remove-redundant-info-par-assignment.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-Remove-redundant-info-par-assignment.patch
@@ -1,7 +1,7 @@
 From 94ff211a0463aab12115ba342a2f46e8b64d865d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 18:59:39 +0800
-Subject: [PATCH 08/45] loonggpu: Remove redundant info->par assignment
+Subject: [PATCH 08/49] loonggpu: Remove redundant info->par assignment
 
 It's already assigned by lg_drm_fb_helper_fill_info (no matter what the
 kernel version is).
@@ -25,5 +25,5 @@ index 467c2b2..6814e88 100644
  
  	fb = kzalloc(sizeof(struct loonggpu_framebuffer), GFP_KERNEL);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0009-loonggpu-Remove-test-for-screen_base-in-fbdev-probin.patch
@@ -1,7 +1,7 @@
 From 390a0a8453ade0e9b134a99a9d65e7eaeff7dcd6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:19:37 +0800
-Subject: [PATCH 09/45] loonggpu: Remove test for !screen_base in fbdev probing
+Subject: [PATCH 09/49] loonggpu: Remove test for !screen_base in fbdev probing
 
 The screen_base field comes from the fbdev BO and contains the fbdev
 framebuffer base address. We get the BO memory via gsgpu_bo_kmap(),
@@ -35,5 +35,5 @@ index 6814e88..9601b19 100644
  	DRM_INFO("vram apper at 0x%lX\n",  (unsigned long)adev->gmc.aper_base);
  	DRM_INFO("size %lu\n", (unsigned long)loonggpu_bo_size(abo));
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Correctly-clean-up-failed-display-probing.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0010-loonggpu-Correctly-clean-up-failed-display-probing.patch
@@ -1,7 +1,7 @@
 From fba62f1814013fcab0d60fd2f1e6cef676a2ddde Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 19:21:28 +0800
-Subject: [PATCH 10/45] loonggpu: Correctly clean up failed display probing
+Subject: [PATCH 10/49] loonggpu: Correctly clean up failed display probing
 
 Improve the fbdev probing function to fully clean up if it failed.
 Allows to remove special cases from fb_destroy as well.
@@ -148,5 +148,5 @@ index 9601b19..932541c 100644
  }
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Implement-client-based-fbdev-emulation.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0011-loonggpu-Implement-client-based-fbdev-emulation.patch
@@ -1,7 +1,7 @@
 From 0e42226f6c490509e0bf4ae84892ccb9665a4869 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:21:11 +0800
-Subject: [PATCH 11/45] loonggpu: Implement client-based fbdev emulation
+Subject: [PATCH 11/49] loonggpu: Implement client-based fbdev emulation
 
 Implement fbdev emulation on top of struct drm_client and its helpers.
 Replaces ad-hoc interfaces for restoring and closing fbdev emulation with
@@ -268,5 +268,5 @@ index 932541c..46d139b 100644
  
  void loonggpu_fbdev_set_suspend(struct loonggpu_device *adev, int state)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0012-loonggpu-Remove-a-redundant-gsgpu_fbdev_client_hotpl.patch
@@ -1,7 +1,7 @@
 From 8a2c19fde281704e197315a7826642b79db7038f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:31:20 +0800
-Subject: [PATCH 12/45] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
+Subject: [PATCH 12/49] loonggpu: Remove a redundant gsgpu_fbdev_client_hotplug
  call
 
 It's not needed anymore as now the generic drm_client_register() calls
@@ -30,5 +30,5 @@ index 46d139b..3eb7694 100644
  
  	return;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0013-loonggpu-Disable-outputs-when-releasing-fbdev-client.patch
@@ -1,7 +1,7 @@
 From 28cb216d40fdeb35a9b7d710761881eb6e4c2cf9 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:35:32 +0800
-Subject: [PATCH 13/45] loonggpu: Disable outputs when releasing fbdev client
+Subject: [PATCH 13/49] loonggpu: Disable outputs when releasing fbdev client
 
 Following up the reference implementation change to avoid potential
 errors.
@@ -26,5 +26,5 @@ index 3eb7694..48fcbba 100644
  	} else {
  		drm_client_release(&fb_helper->client);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Run-DRM-default-client-setup.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0014-loonggpu-Run-DRM-default-client-setup.patch
@@ -1,7 +1,7 @@
 From fe7b5637f0a06f85c372f2e10966632e7859dd7e Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Mon, 23 Jun 2025 20:58:47 +0800
-Subject: [PATCH 14/45] loonggpu: Run DRM default client setup
+Subject: [PATCH 14/49] loonggpu: Run DRM default client setup
 
 Rework fbdev probing to support fbdev_probe in struct drm_driver
 and remove the old fb_probe callback. Provide an initializer macro
@@ -218,5 +218,5 @@ index 48fcbba..0704b8a 100644
  {
  	if (adev->ddev->fb_helper)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-bridge-make-is_resolution_valid-static.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0015-loonggpu-bridge-make-is_resolution_valid-static.patch
@@ -1,7 +1,7 @@
 From f3ee614224a0bed047853834e168eed390268e84 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:15:00 +0800
-Subject: [PATCH 15/45] loonggpu-bridge: make is_resolution_valid static
+Subject: [PATCH 15/49] loonggpu-bridge: make is_resolution_valid static
 
 Now it's only used in the TU where we define it.
 
@@ -25,5 +25,5 @@ index 082d513..34b1f3b 100644
  	u32 vrefresh = 0;
  	u32 index;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-bridge-constify-struct-drm_display_mode-poi.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0016-loonggpu-bridge-constify-struct-drm_display_mode-poi.patch
@@ -1,7 +1,7 @@
 From c5d74b83b73a1ccde98eb8e0bf46bdefad64f797 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 4 Dec 2025 18:31:07 +0800
-Subject: [PATCH 16/45] loonggpu-bridge: constify struct drm_display_mode
+Subject: [PATCH 16/49] loonggpu-bridge: constify struct drm_display_mode
  pointers
 
 Prepare for 6.15 kernel API change.
@@ -146,5 +146,5 @@ index f958554..677e782 100644
          if (mode->hdisplay == 1680 && mode->vdisplay == 1050)
              return MODE_BAD;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0017-loonggpu-Remove-the-check-against-moving-pinned-BOs.patch
@@ -1,7 +1,7 @@
 From d9729fc7c3eb8a6a71971ab307f1491f259c07d8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 10:49:40 +0800
-Subject: [PATCH 17/45] loonggpu: Remove the check against moving pinned BOs
+Subject: [PATCH 17/49] loonggpu: Remove the check against moving pinned BOs
 
 The check is already in the generic code.
 
@@ -30,5 +30,5 @@ index 4f79a06..274cf79 100644
  
  	if (!old_mem || (old_mem->mem_type == TTM_PL_SYSTEM && bo->ttm == NULL)) {
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Remove-dead-code.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0018-loonggpu-Remove-dead-code.patch
@@ -1,7 +1,7 @@
 From 96c75343037dae92a3cc3a5ef59e0ac8ac571814 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 11:18:49 +0800
-Subject: [PATCH 18/45] loonggpu: Remove dead code
+Subject: [PATCH 18/49] loonggpu: Remove dead code
 
 The body of this if statement is obviously unreachable.
 
@@ -28,5 +28,5 @@ index 274cf79..fbc8630 100644
  	     new_mem->mem_type == TTM_PL_SYSTEM) ||
  	    (old_mem->mem_type == TTM_PL_SYSTEM &&
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0019-loonggpu-NFC-Clean-up-gsgpu_bo_move.patch
@@ -1,7 +1,7 @@
 From 53d9a195fc37b5f507147cfd1f8305ae04bd3158 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 12:11:28 +0800
-Subject: [PATCH 19/45] loonggpu: NFC: Clean up gsgpu_bo_move
+Subject: [PATCH 19/49] loonggpu: NFC: Clean up gsgpu_bo_move
 
 Just use goto to deduplicate some identical code, and wrap a long line
 to make the flow more similar to the reference implementation.
@@ -51,5 +51,5 @@ index fbc8630..d68099f 100644
  	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
  	loonggpu_bo_move_notify(bo, evict, new_mem);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Handle-tt-moves-properly.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0020-loonggpu-Handle-tt-moves-properly.patch
@@ -1,7 +1,7 @@
 From 48f631b7098c15c18db7594c221356f371c5b5d2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:08:07 +0800
-Subject: [PATCH 20/45] loonggpu: Handle tt moves properly
+Subject: [PATCH 20/49] loonggpu: Handle tt moves properly
 
 It seems required since a TTM move refactoring in 2020.  Following up the
 reference implementation change (and several changes after that).
@@ -60,5 +60,5 @@ index d68099f..52646b8 100644
  	    new_mem->mem_type == LOONGGPU_PL_DOORBELL) {
  		/* Nothing to save here */
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Use-multihop.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0021-loonggpu-Use-multihop.patch
@@ -1,7 +1,7 @@
 From b4f53b796c0f374ca14ca64bd2df2bbd82430ddb Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:35:15 +0800
-Subject: [PATCH 21/45] loonggpu: Use multihop
+Subject: [PATCH 21/49] loonggpu: Use multihop
 
 Remove the code to move resources directly between
 SYSTEM and VRAM in favour of using the core ttm mulithop code.
@@ -232,5 +232,5 @@ index 52646b8..3f40892 100644
  	/* update statistics */
  	atomic64_add(lg_gbo_to_gem_obj(abo).size, &adev->num_bytes_moved);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0022-loonggpu-Drop-the-unused-no_wait_gpu-parameter-of-gs.patch
@@ -1,7 +1,7 @@
 From aec46aa2076ac77ced96b093d111fb4b7e1df281 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:42:37 +0800
-Subject: [PATCH 22/45] loonggpu: Drop the unused no_wait_gpu parameter of
+Subject: [PATCH 22/49] loonggpu: Drop the unused no_wait_gpu parameter of
  gsgpu_move_blit
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -34,5 +34,5 @@ index 3f40892..a423a68 100644
  		r = -ENODEV;
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-loonggpu-Drop-lg_ttm_tt_bind.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0023-loonggpu-Drop-lg_ttm_tt_bind.patch
@@ -1,7 +1,7 @@
 From d03e9aed4335aca4a2239030eb8cbaf91d148bc0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 13:49:20 +0800
-Subject: [PATCH 23/45] loonggpu: Drop lg_ttm_tt_bind
+Subject: [PATCH 23/49] loonggpu: Drop lg_ttm_tt_bind
 
 Get rid of the ttm_tt_populate usage: this symbol is only exported if
 DRM_TTM_KUNIT_TEST which requires COMPILE_TEST on LoongArch.
@@ -88,5 +88,5 @@ index e9863a2..714fc94 100644
  LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_tt_set_populated
  LG_CONFTEST_FUNCTION_COMPILE_TESTS += ttm_resource_manager_evict_all
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-loonggpu-Remove-an-invalid-const-qualifier.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0024-loonggpu-Remove-an-invalid-const-qualifier.patch
@@ -1,7 +1,7 @@
 From 5490b0a0bdd294052530aa12817aad9dba0b11e7 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:24:23 +0800
-Subject: [PATCH 24/45] loonggpu: Remove an invalid "const" qualifier
+Subject: [PATCH 24/49] loonggpu: Remove an invalid "const" qualifier
 
 You obviously cannot sprintf things into a const char array!
 
@@ -25,5 +25,5 @@ index ad2f2cd..a55a591 100644
  	sprintf(pwm_name, "pwm%d", ls_bl->pwm_id);
  	ls_bl->pwm = lg_pwm_request(adev->ddev->dev, pwm_name, ls_bl->pwm_id, "Loongson_bl");
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0025-loonggpu-Fix-the-parameter-order-of-a-kmalloc_array-.patch
@@ -1,7 +1,7 @@
 From 5f290e3cbc0bc4b0a6e71e429a8e148bbb377783 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 14:26:21 +0800
-Subject: [PATCH 25/45] loonggpu: Fix the parameter order of a kmalloc_array
+Subject: [PATCH 25/49] loonggpu: Fix the parameter order of a kmalloc_array
  call
 
 The element size should be the second parameter.
@@ -26,5 +26,5 @@ index 18443d4..e394205 100644
  		return -ENOMEM;
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0026-loonggpu-Handle-the-different-drm_client_setup.h-loc.patch
@@ -1,7 +1,7 @@
 From 2630af17d64389332f56209ce9846094ed6a4c8f Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 24 Jun 2025 16:10:04 +0800
-Subject: [PATCH 26/45] loonggpu: Handle the different drm_client_setup.h
+Subject: [PATCH 26/49] loonggpu: Handle the different drm_client_setup.h
  location in 6.12
 
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -29,5 +29,5 @@ index 91416a3..230e654 100644
  #include <drm/drm_drv.h>
  #include <drm/drm_device.h>
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0027-loonggpu-Handle-the-error-from-gsgpu_driver_load_kms.patch
@@ -1,7 +1,7 @@
 From a27877ae135c7ec9cfd923c2f45c760451437b3b Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sun, 28 Dec 2025 18:18:19 +0800
-Subject: [PATCH 27/45] loonggpu: Handle the error from gsgpu_driver_load_kms
+Subject: [PATCH 27/49] loonggpu: Handle the error from gsgpu_driver_load_kms
  correctly
 
 With a 4KiB-page kernel, gsgpu_gart_init will fail because it requires
@@ -35,5 +35,5 @@ index 230e654..04632c0 100644
  retry_init:
  	ret = drm_dev_register(dev, pci_gpu_flags);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0028-loonggpu-fix-typo-mistake-in-include-gsgpu_ttm_resou.patch
@@ -1,7 +1,7 @@
 From 9e426e51e0a6adc7f74e8c1d833ab4fe111fcfc7 Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:28:47 +0800
-Subject: [PATCH 28/45] loonggpu: fix typo mistake in
+Subject: [PATCH 28/49] loonggpu: fix typo mistake in
  include/gsgpu_ttm_resource_helper.h
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -20,5 +20,5 @@ index 1b51af1..7b1fe87 100644
  
  #if !defined (LG_DRM_TTM_TTM_BO_H_PRESENT)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0029-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,7 +1,7 @@
 From 2edd092fd434867a43937163510889a686fde0f5 Mon Sep 17 00:00:00 2001
 From: tsingkong <tsingkong@163.com>
 Date: Wed, 10 Sep 2025 17:33:29 +0800
-Subject: [PATCH 29/45] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
+Subject: [PATCH 29/49] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
  switched to c23
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -26,5 +26,5 @@ index 6a792ac..e2fe2b8
      if [ "$OUTPUT" != "$SOURCES" ]; then
          OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Drop-CLEAN-from-dkms.conf.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0030-loonggpu-Drop-CLEAN-from-dkms.conf.patch
@@ -1,7 +1,7 @@
 From ac14d66905769d5f18db981d9595a97e23968ab8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 4 Nov 2025 11:26:37 +0800
-Subject: [PATCH 30/45] loonggpu: Drop CLEAN= from dkms.conf
+Subject: [PATCH 30/49] loonggpu: Drop CLEAN= from dkms.conf
 
 It's unneeded and deprecated in the recent dkms release.
 
@@ -21,5 +21,5 @@ index 044472a..ee69c4e 100644
      make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
 -CLEAN="make KERNEL_UNAME=${kernelver} clean"
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-don-t-return-an-error-if-backlight-initiali.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0031-loonggpu-don-t-return-an-error-if-backlight-initiali.patch
@@ -1,7 +1,7 @@
 From 972127f8a062bcc77226895a723227e123a4e370 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 22:06:18 +0800
-Subject: [PATCH 31/45] loonggpu: don't return an error if backlight
+Subject: [PATCH 31/49] loonggpu: don't return an error if backlight
  initialization fails
 
 If this returns an error, the load of loonggpu will fail.  But in fact
@@ -49,5 +49,5 @@ index a55a591..dc97460 100644
 +	return 0;
  }
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-backlight-get-PWM-correctly-and-skip-GPIO-f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0032-loonggpu-backlight-get-PWM-correctly-and-skip-GPIO-f.patch
@@ -1,7 +1,7 @@
 From 90d0d6864bd69397f481626359298d06712f6623 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Tue, 30 Dec 2025 22:22:22 +0800
-Subject: [PATCH 32/45] loonggpu: backlight: get PWM correctly and skip GPIO
+Subject: [PATCH 32/49] loonggpu: backlight: get PWM correctly and skip GPIO
  for now
 
 This should make backlight control at least usable with AOSC 6.16.1-rc1
@@ -121,5 +121,5 @@ index dc97460..abe1b3f 100644
  		lcd_ctrl->gpio_detect_open_polarity = lcd_ctrl_res->gpio_detect_open_polarity;
  		lcd_ctrl->gpio_ctrl_vdd = lcd_ctrl_res->gpio_ctrl_vdd;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0033-loonggpu-Only-build-a-dummy-if-page-size-is-4-KiB.patch
@@ -1,7 +1,7 @@
 From 76656c20de2b931768813287da81c672d904edaa Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 30 Oct 2025 10:12:33 +0800
-Subject: [PATCH 33/45] loonggpu: Only build a dummy if page size is 4 KiB
+Subject: [PATCH 33/49] loonggpu: Only build a dummy if page size is 4 KiB
 
 The hack [1] is not enough as when we install a kernel package (like
 linux-kernel-6.17.1), the postinstall script of the kernel package still
@@ -65,5 +65,5 @@ index 714fc94..4e2e1a3 100644
  obj-m += loonggpu.o
  loonggpu-y := $(LOONGGPU_OBJECTS)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-bridge-remove-redundant-bridge-func-vptr-as.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0034-loonggpu-bridge-remove-redundant-bridge-func-vptr-as.patch
@@ -1,7 +1,7 @@
 From d0c774bb9eb733346db64ab386dd523640def592 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 14:12:17 +0800
-Subject: [PATCH 34/45] loonggpu-bridge: remove redundant bridge func vptr
+Subject: [PATCH 34/49] loonggpu-bridge: remove redundant bridge func vptr
  assignment
 
 On Linux >= 6.16, devm_drm_bridge_alloc() already assigns it.
@@ -27,5 +27,5 @@ index b7ba368..30b041c 100644
  	ret = lg_drm_bridge_attach(phy->encoder, &phy->bridge, NULL, 0);
  	if (ret) {
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-bridge-make-some-functions-static.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0035-loonggpu-bridge-make-some-functions-static.patch
@@ -1,7 +1,7 @@
 From 923837e73d4b481a65c6bde2ba5c63da77914ba0 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 14:29:47 +0800
-Subject: [PATCH 35/45] loonggpu-bridge: make some functions static
+Subject: [PATCH 35/49] loonggpu-bridge: make some functions static
 
 They are only used in the TU where the function is defined.  Thus we
 can make them static to fix some missing prototype warnings.
@@ -40,5 +40,5 @@ index 60121cf..87e086f 100644
  	struct loonggpu_device *adev = crtc->dc->adev;
  	struct connector_resource *connector_res;
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-adapt-for-ttm_device_init-API-change.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0036-loonggpu-adapt-for-ttm_device_init-API-change.patch
@@ -1,7 +1,7 @@
 From 5651144ffd2c0eeb999b68a091c64774394456f6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 10 Dec 2025 14:58:46 +0800
-Subject: [PATCH 36/45] loonggpu: adapt for ttm_device_init API change
+Subject: [PATCH 36/49] loonggpu: adapt for ttm_device_init API change
 
 Link: https://git.kernel.org/torvalds/c/77e19f8d3297
 Signed-off-by: Xi Ruoyao <xry111@xry111.site>
@@ -33,5 +33,5 @@ index 072764f..fb8ebd1 100644
  				driver, adev->dev,
  				adev->ddev->anon_inode->i_mapping,
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-conftest-add-fms-extensions-to-CFLAGS.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0037-loonggpu-conftest-add-fms-extensions-to-CFLAGS.patch
@@ -1,7 +1,7 @@
 From f321a4f62c87b24b6ecf862f87b2985eaa7cf45a Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 15:14:56 +0800
-Subject: [PATCH 37/45] loonggpu: conftest: add -fms-extensions to CFLAGS
+Subject: [PATCH 37/49] loonggpu: conftest: add -fms-extensions to CFLAGS
 
 Since Linux 6.19, some constructs in the (non-UAPI) headers uses the
 Go-like unnamed member, that -fms-extensions enables.
@@ -28,5 +28,5 @@ index e2fe2b8..2f5cec9 100755
      if [ "$OUTPUT" != "$SOURCES" ]; then
          OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Drop-the-call-to-drm_fb_helper_alloc_info.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0038-loonggpu-Drop-the-call-to-drm_fb_helper_alloc_info.patch
@@ -1,7 +1,7 @@
 From b650e9dbacaa8968d359ff28c0a3d769466c3ea3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 10 Dec 2025 15:34:32 +0800
-Subject: [PATCH 38/45] loonggpu: Drop the call to drm_fb_helper_alloc_info
+Subject: [PATCH 38/49] loonggpu: Drop the call to drm_fb_helper_alloc_info
 
 On Linux >= 6.19 it's called by the DRM generic code and no longer
 exported for the drivers.
@@ -29,5 +29,5 @@ index fb8ebd1..615e139 100644
  #else
  	return drm_fb_helper_alloc_fbi(helper);
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0039-loonggpu-use-ttm_resource_manager_cleanup-instead-of.patch
@@ -1,7 +1,7 @@
 From 447d6558f7381e1d720c0f34b4d0a1c47e7dfbf8 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 11 Dec 2025 09:49:49 +0800
-Subject: [PATCH 39/45] loonggpu: use ttm_resource_manager_cleanup instead of
+Subject: [PATCH 39/49] loonggpu: use ttm_resource_manager_cleanup instead of
  manually inlining it
 
 It should work since Linux 5.9.  And inlining an outdated copy causes a
@@ -28,5 +28,5 @@ index a423a68..7bb3408 100644
  
  	/* this just adjusts TTM size idea, which sets lpfn to the correct value */
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0040-loonggpu-remove-gsgpu_driver_lastclose_kms-on-Linux-.patch
@@ -1,7 +1,7 @@
 From 56ef039d374c28b5b4422577041e9155034e67ba Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Wed, 10 Dec 2025 17:12:38 +0800
-Subject: [PATCH 40/45] loonggpu: remove gsgpu_driver_lastclose_kms on Linux >=
+Subject: [PATCH 40/49] loonggpu: remove gsgpu_driver_lastclose_kms on Linux >=
  6.12
 
 This is not used on Linux >= 6.12, and it fails to build on Linux 6.19.
@@ -41,5 +41,5 @@ index 9b19708..fcb31b5 100644
  /**
   * loonggpu_driver_open_kms - drm callback for open
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-handle-the-pci_resize_resource-API-change-i.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0041-loonggpu-handle-the-pci_resize_resource-API-change-i.patch
@@ -1,7 +1,7 @@
 From b6029518fc927804ec125592a1f0742eeb5f4659 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 3 Jan 2026 15:55:57 +0800
-Subject: [PATCH 41/45] loonggpu: handle the pci_resize_resource API change in
+Subject: [PATCH 41/49] loonggpu: handle the pci_resize_resource API change in
  Linux 6.19
 
 The loonggpu_device_resize_fb_bar() function seems not used as at now so
@@ -37,5 +37,5 @@ index a520de5..cb6eba4 100644
  		DRM_INFO("Not enough PCI address space for a large BAR.");
  	else if (r && r != -ENOTSUPP)
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-don-t-check-the-return-value-of-dma_fence_s.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0042-loonggpu-don-t-check-the-return-value-of-dma_fence_s.patch
@@ -1,7 +1,7 @@
 From 92bf122b8599f03b0252e9de0f247775f3172ab2 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 28 Feb 2026 23:43:21 +0800
-Subject: [PATCH 42/45] loonggpu: don't check the return value of
+Subject: [PATCH 42/49] loonggpu: don't check the return value of
  dma_fence_signal
 
 Linux 7.0-rc1 has changed the function to return void.  If we really
@@ -45,5 +45,5 @@ index ba33884..c063a42 100644
  	} while (last_seq != seq);
  }
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-include-linux-version.h-in-loonggpu_helper..patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0043-loonggpu-include-linux-version.h-in-loonggpu_helper..patch
@@ -1,7 +1,7 @@
 From 65dc57cc13e44bdc37583a54c50817e8eb9c49b3 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 5 Mar 2026 11:11:10 +0800
-Subject: [PATCH 43/45] loonggpu: include linux/version.h in loonggpu_helper.h
+Subject: [PATCH 43/49] loonggpu: include linux/version.h in loonggpu_helper.h
 
 Some helpers in this header uses LINUX_VERSION_CODE in #if directives,
 include linux/version.h here instead of relying on the translation
@@ -25,5 +25,5 @@ index 615e139..5978135 100644
  /*
   * drm_sched_hw_job_reset() was replaced with drm_seched_stop.
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-handle-the-rename-of-ttm_bo_put-to-ttm_bo_f.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0044-loonggpu-handle-the-rename-of-ttm_bo_put-to-ttm_bo_f.patch
@@ -1,7 +1,7 @@
 From cafc224f80e53b409422577e3f28d23fd7175489 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 5 Mar 2026 11:58:08 +0800
-Subject: [PATCH 44/45] loonggpu: handle the rename of ttm_bo_put to
+Subject: [PATCH 44/49] loonggpu: handle the rename of ttm_bo_put to
  ttm_bo_fini
 
 Link: https://git.kernel.org/torvalds/c/ed7a4397f55b
@@ -27,5 +27,5 @@ index bd76d63..08740b2 100644
  }
  
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-AOSCOS-trim-unused-loose-patches.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0045-AOSCOS-trim-unused-loose-patches.patch
@@ -1,7 +1,7 @@
 From 428a0f1a35448cd152a38beb93f3a9761f3750aa Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 8 May 2026 10:38:38 +0800
-Subject: [PATCH 45/45] AOSCOS: trim unused, loose patches
+Subject: [PATCH 45/49] AOSCOS: trim unused, loose patches
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
@@ -209,5 +209,5 @@ index 6b1bdf7..0000000
 -2.51.0
 -
 -- 
-2.52.0
+2.54.0
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-Suspend-and-resume-clients-with-client-help.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-Suspend-and-resume-clients-with-client-help.patch
@@ -1,0 +1,108 @@
+From 6570ffc7c06e1a68609b9204a69b364d74937a52 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Jun 2026 17:54:03 +0800
+Subject: [PATCH 46/49] loonggpu: Suspend and resume clients with client
+ helpers
+
+Replace calls to loonggpu_fbdev_set_suspend() with calls to the client
+functions drm_client_dev_suspend() and drm_client_dev_resume(). Any
+registered in-kernel client will now receive suspend and resume events.
+
+Following the reference implementation changes.
+
+Link: https://git.kernel.org/torvalds/c/88c79de8575c
+Link: https://git.kernel.org/torvalds/c/612ec7c69d04
+Link: https://git.kernel.org/torvalds/c/fff8e0504499
+Link: https://git.kernel.org/torvalds/c/7910d69376cd
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/loonggpu.h         |  4 ++--
+ loonggpu/loonggpu_device.c | 19 ++++++++++++-------
+ 2 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/include/loonggpu.h b/include/loonggpu.h
+index 1d95ac3..512f596 100644
+--- a/include/loonggpu.h
++++ b/include/loonggpu.h
+@@ -1716,8 +1716,8 @@ int loonggpu_driver_open_kms(struct drm_device *dev, struct drm_file *file_priv)
+ void loonggpu_driver_postclose_kms(struct drm_device *dev,
+ 				 struct drm_file *file_priv);
+ int loonggpu_device_ip_suspend(struct loonggpu_device *adev);
+-int loonggpu_device_suspend(struct drm_device *dev, bool suspend, bool fbcon);
+-int loonggpu_device_resume(struct drm_device *dev, bool resume, bool fbcon);
++int loonggpu_device_suspend(struct drm_device *dev, bool suspend, bool notify_clients);
++int loonggpu_device_resume(struct drm_device *dev, bool resume, bool notify_clients);
+ u32 loonggpu_get_vblank_counter_kms(struct drm_device *dev, unsigned int pipe);
+ long loonggpu_kms_compat_ioctl(struct file *filp, unsigned int cmd,
+ 			     unsigned long arg);
+diff --git a/loonggpu/loonggpu_device.c b/loonggpu/loonggpu_device.c
+index cb6eba4..a070545 100644
+--- a/loonggpu/loonggpu_device.c
++++ b/loonggpu/loonggpu_device.c
+@@ -1,10 +1,10 @@
+ #include <linux/power_supply.h>
+ #include <linux/kthread.h>
+-#include <linux/console.h>
+ #include <linux/slab.h>
+ #include "loonggpu.h"
+ #include <drm/drm_crtc_helper.h>
+ #include <drm/drm_atomic_helper.h>
++#include <drm/drm_client_event.h>
+ #include "loonggpu_drm.h"
+ #include <linux/vgaarb.h>
+ #include <linux/vga_switcheroo.h>
+@@ -1701,6 +1701,11 @@ static int loonggpu_zip_gem_bo_evict(int id, void *ptr, void *data)
+ 	return 0;
+ }
+ 
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
++#define drm_client_dev_suspend(x) (drm_client_dev_suspend)((x), false)
++#define drm_client_dev_resume(x) (drm_client_dev_resume)((x), false)
++#endif
++
+ /*
+  * Suspend & resume.
+  */
+@@ -1715,7 +1720,7 @@ static int loonggpu_zip_gem_bo_evict(int id, void *ptr, void *data)
+  * Returns 0 for success or an error on failure.
+  * Called at driver suspend.
+  */
+-int loonggpu_device_suspend(struct drm_device *dev, bool suspend, bool fbcon)
++int loonggpu_device_suspend(struct drm_device *dev, bool suspend, bool notify_clients)
+ {
+ 	struct loonggpu_device *adev;
+ 	int r;
+@@ -1732,8 +1737,8 @@ int loonggpu_device_suspend(struct drm_device *dev, bool suspend, bool fbcon)
+ 
+ 	drm_kms_helper_poll_disable(dev);
+ 
+-	if (fbcon)
+-		loonggpu_fbdev_set_suspend(adev, 1);
++	if (notify_clients)
++		drm_client_dev_suspend(dev);
+ 
+ 	loonggpu_lgkcd_suspend(adev, false);
+ 
+@@ -1789,7 +1794,7 @@ int loonggpu_device_suspend(struct drm_device *dev, bool suspend, bool fbcon)
+  * Returns 0 for success or an error on failure.
+  * Called at driver resume.
+  */
+-int loonggpu_device_resume(struct drm_device *dev, bool resume, bool fbcon)
++int loonggpu_device_resume(struct drm_device *dev, bool resume, bool notify_clients)
+ {
+ 	struct loonggpu_device *adev = dev->dev_private;
+ 	struct loonggpu_dc *dc = adev->dc;
+@@ -1870,8 +1875,8 @@ int loonggpu_device_resume(struct drm_device *dev, bool resume, bool fbcon)
+ 	flush_delayed_work(&adev->late_init_work);
+ 
+ 	/* blat the mode back in */
+-	if (fbcon)
+-		loonggpu_fbdev_set_suspend(adev, 0);
++	if (notify_clients)
++		drm_client_dev_resume(dev);
+ 
+ 	drm_kms_helper_poll_enable(dev);
+ 
+-- 
+2.54.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-fix-double-free-on-Linux-6.19.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-fix-double-free-on-Linux-6.19.patch
@@ -1,0 +1,44 @@
+From 1dea544667e3434ac3716e7676feaf6406b59f22 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 11 Jun 2026 18:07:34 +0800
+Subject: [PATCH 47/49] loonggpu: fix double free on Linux >= 6.19
+
+Following the reference implementation change.
+
+Link: https://git.kernel.org/torvalds/c/a16f6ba43d9d
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ loonggpu/loonggpu_fb.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/loonggpu/loonggpu_fb.c b/loonggpu/loonggpu_fb.c
+index 0704b8a..1fe9a36 100644
+--- a/loonggpu/loonggpu_fb.c
++++ b/loonggpu/loonggpu_fb.c
+@@ -1,6 +1,7 @@
+ #include <linux/module.h>
+ #include <linux/slab.h>
+ #include <linux/pm_runtime.h>
++#include <linux/version.h>
+ #include <linux/vga_switcheroo.h>
+ 
+ #include "loonggpu.h"
+@@ -76,8 +77,15 @@ static void loonggpu_fbdev_fb_destroy(struct fb_info *info)
+ 
+ 	loonggpufb_destroy_pinned_object(gobj);
+ 	drm_client_release(&fb_helper->client);
++
++	/*
++	 * In 6.19 and later drm_client_release() has already done this, so
++	 * we need to avoid a double free.  Sigh.
++	 */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+ 	drm_fb_helper_unprepare(fb_helper);
+ 	kfree(fb_helper);
++#endif
+ }
+ 
+ static struct fb_ops loonggpufb_ops = {
+-- 
+2.54.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-lgkcd-only-build-kcd_debugfs.c-if-CONFIG_DEBUG_FS-is.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-lgkcd-only-build-kcd_debugfs.c-if-CONFIG_DEBUG_FS-is.patch
@@ -1,0 +1,34 @@
+From dad3494e87f5c7000713464c6c3dffee815546af Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Fri, 12 Jun 2026 20:25:29 +0800
+Subject: [PATCH 48/49] lgkcd: only build kcd_debugfs.c if CONFIG_DEBUG_FS is
+ enabled
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ lgkcd/lgkcd.Kbuild | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/lgkcd/lgkcd.Kbuild b/lgkcd/lgkcd.Kbuild
+index 8cbb8d6..59302be 100644
+--- a/lgkcd/lgkcd.Kbuild
++++ b/lgkcd/lgkcd.Kbuild
+@@ -4,7 +4,6 @@ LGKCD_SOURCES += lgkcd/kcd_ipc.c
+ LGKCD_SOURCES += lgkcd/kcd_chardev.c
+ LGKCD_SOURCES += lgkcd/kcd_crat.c
+ LGKCD_SOURCES += lgkcd/kcd_debug.c
+-LGKCD_SOURCES += lgkcd/kcd_debugfs.c
+ LGKCD_SOURCES += lgkcd/kcd_device.c
+ LGKCD_SOURCES += lgkcd/kcd_device_queue_manager.c
+ LGKCD_SOURCES += lgkcd/kcd_device_queue_manager_lg2xx.c
+@@ -30,3 +29,7 @@ ifeq ($(CONFIG_VDD_LOONGSON_SVM),1)
+ LGKCD_SOURCES += lgkcd/kcd_svm.c
+ LGKCD_SOURCES += lgkcd/kcd_migrate.c
+ endif
++
++ifeq ($(CONFIG_DEBUG_FS),1)
++LGKCD_SOURCES += lgkcd/kcd_debugfs.c
++endif
+-- 
+2.54.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-adapt-for-the-massive-drm_buddy-gpu_buddy-r.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-adapt-for-the-massive-drm_buddy-gpu_buddy-r.patch
@@ -1,0 +1,377 @@
+From b3ee297b7f1f79877a3c134a16390cb36320066d Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sat, 13 Jun 2026 22:38:06 +0800
+Subject: [PATCH 49/49] loonggpu: adapt for the massive drm_buddy => gpu_buddy
+ renaming in Linux 7.1
+
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+---
+ include/loonggpu_ttm.h             | 22 +++++++++++-
+ include/loonggpu_ttm_helper.h      | 14 ++++++++
+ include/loonggpu_vram_mgr_helper.h | 18 ++++++----
+ loonggpu/loonggpu_ttm_buddy.c      | 11 +++---
+ loonggpu/loonggpu_vram_mgr.c       |  2 +-
+ loonggpu/loonggpu_vram_mgr_buddy.c | 58 +++++++++++++++---------------
+ 6 files changed, 81 insertions(+), 44 deletions(-)
+
+diff --git a/include/loonggpu_ttm.h b/include/loonggpu_ttm.h
+index cdecced..a1c6056 100644
+--- a/include/loonggpu_ttm.h
++++ b/include/loonggpu_ttm.h
+@@ -17,10 +17,30 @@
+ #define LOONGGPU_VRAM_NUM_TRANSFER_WINDOWS     2
+ uint64_t loonggpu_ttm_domain_start(struct loonggpu_device *adev, uint32_t type);
+ 
++#if __has_include(<linux/gpu_buddy.h>)
++typedef struct gpu_buddy lg_buddy_t;
++typedef struct gpu_buddy_block lg_buddy_block_t;
++#define lg_buddy_init gpu_buddy_init
++#define lg_buddy_fini gpu_buddy_fini
++#define lg_buddy_print gpu_buddy_print
++#define lg_buddy_alloc_blocks gpu_buddy_alloc_blocks
++#define LG_BUDDY_TOPDOWN_ALLOCATION GPU_BUDDY_TOPDOWN_ALLOCATION
++#define LG_BUDDY_RANGE_ALLOCATION GPU_BUDDY_RANGE_ALLOCATION
++#else
++typedef struct drm_buddy lg_buddy_t;
++typedef struct drm_buddy_block lg_buddy_block_t;
++#define lg_buddy_init drm_buddy_init
++#define lg_buddy_fini drm_buddy_fini
++#define lg_buddy_print drm_buddy_print
++#define lg_buddy_alloc_blocks drm_buddy_alloc_blocks
++#define LG_BUDDY_TOPDOWN_ALLOCATION DRM_BUDDY_TOPDOWN_ALLOCATION
++#define LG_BUDDY_RANGE_ALLOCATION DRM_BUDDY_RANGE_ALLOCATION
++#endif
++
+ struct loonggpu_vram_mgr {
+         lg_loonggpu_vram_mgr_man
+ 	#if defined(LG_DRM_DRM_BUDDY_H_PRESENT)
+-	struct drm_buddy b_mm;
++	lg_buddy_t b_mm;
+ 	#endif
+ 	struct mutex m_lock;
+         struct drm_mm mm;
+diff --git a/include/loonggpu_ttm_helper.h b/include/loonggpu_ttm_helper.h
+index c1767f9..6576f96 100644
+--- a/include/loonggpu_ttm_helper.h
++++ b/include/loonggpu_ttm_helper.h
+@@ -244,6 +244,19 @@ void loonggpu_res_first(struct ttm_resource *res,
+ 		     struct loonggpu_res_cursor *cur);
+ void loonggpu_res_next(struct loonggpu_res_cursor *cur, uint64_t size);
+ 
++#if __has_include(<linux/gpu_buddy.h>)
++static inline u64
++loonggpu_vram_mgr_block_start(struct gpu_buddy_block *block)
++{
++	return gpu_buddy_block_offset(block);
++}
++
++static inline u64
++loonggpu_vram_mgr_block_size(struct gpu_buddy_block *block)
++{
++	return (u64)PAGE_SIZE << gpu_buddy_block_order(block);
++}
++#else
+ static inline u64
+ loonggpu_vram_mgr_block_start(struct drm_buddy_block *block)
+ {
+@@ -255,6 +268,7 @@ loonggpu_vram_mgr_block_size(struct drm_buddy_block *block)
+ {
+ 	return (u64)PAGE_SIZE << drm_buddy_block_order(block);
+ }
++#endif
+ 
+ static inline struct loonggpu_vram_mgr_resource *
+ to_loonggpu_vram_mgr_resource(struct ttm_resource *res)
+diff --git a/include/loonggpu_vram_mgr_helper.h b/include/loonggpu_vram_mgr_helper.h
+index 7638909..fc6725f 100644
+--- a/include/loonggpu_vram_mgr_helper.h
++++ b/include/loonggpu_vram_mgr_helper.h
+@@ -2,22 +2,26 @@
+ #define __LOONGGPU_VRAM_MGR_HELPER_H__
+ 
+ #if defined(LG_DRM_DRM_BUDDY_H_PRESENT)
+-static inline void lg_drm_buddy_free_list(struct drm_buddy *mm,
++static inline void lg_drm_buddy_free_list(lg_buddy_t *mm,
+ 					struct list_head *objects,
+ 					unsigned int flags)
+ {
+-#if defined(LG_DRM_BUDDY_FREE_LIST_HAS_FLAGS)
++#if __has_include(<linux/gpu_buddy.h>)
++	gpu_buddy_free_list(mm, objects, flags);
++#elif defined(LG_DRM_BUDDY_FREE_LIST_HAS_FLAGS)
+ 	drm_buddy_free_list(mm, objects, flags);
+ #else
+ 	drm_buddy_free_list(mm, objects);
+ #endif
+ }
+-static inline void lg_drm_buddy_block_trim(struct drm_buddy *mm,
++static inline void lg_drm_buddy_block_trim(lg_buddy_t *mm,
+ 					   u64 *start,
+ 					   u64 new_size,
+ 					   struct list_head *blocks)
+ {
+-#if defined(LG_DRM_BUDDY_BLOCK_TRIM_HAS_START)
++#if __has_include(<linux/gpu_buddy.h>)
++	gpu_buddy_block_trim(mm, start, new_size, blocks);
++#elif defined(LG_DRM_BUDDY_BLOCK_TRIM_HAS_START)
+ 	drm_buddy_block_trim(mm, start, new_size, blocks);
+ #else
+ 	drm_buddy_block_trim(mm, new_size, blocks);
+@@ -182,7 +186,7 @@ static inline void lg_vram_init_mgr(struct loonggpu_vram_mgr *mgr)
+ static inline int lg_vram_init_mgr_mm(struct loonggpu_vram_mgr *mgr, u64 start, u64 size)
+ {
+ #if defined(LG_DRM_DRM_BUDDY_H_PRESENT)
+-	return drm_buddy_init(&mgr->b_mm, size, PAGE_SIZE);
++	return lg_buddy_init(&mgr->b_mm, size, PAGE_SIZE);
+ #else
+ 	drm_mm_init(&mgr->mm, start, size);
+ 	return 0;
+@@ -193,7 +197,7 @@ static inline void lg_vram_mm_fini(struct loonggpu_vram_mgr *mgr)
+ {
+ #if defined(LG_DRM_DRM_BUDDY_H_PRESENT)
+ 	mutex_lock(&mgr->m_lock);
+-	drm_buddy_fini(&mgr->b_mm);
++	lg_buddy_fini(&mgr->b_mm);
+ 	mutex_unlock(&mgr->m_lock);
+ #else
+ 	spin_lock(&mgr->lock);
+@@ -203,7 +207,7 @@ static inline void lg_vram_mm_fini(struct loonggpu_vram_mgr *mgr)
+ }
+ 
+ #if defined(LG_DRM_DRM_BUDDY_H_PRESENT)
+-#define lg_vram_mgr_vis_size_arg struct drm_buddy_block *block
++#define lg_vram_mgr_vis_size_arg lg_buddy_block_t *block
+ #define lg_vram_mgr_vis_size_start loonggpu_vram_mgr_block_start(block)
+ #define lg_vram_mgr_vis_size_end start + loonggpu_vram_mgr_block_size(block)
+ #else
+diff --git a/loonggpu/loonggpu_ttm_buddy.c b/loonggpu/loonggpu_ttm_buddy.c
+index 050fbbb..f8d235b 100644
+--- a/loonggpu/loonggpu_ttm_buddy.c
++++ b/loonggpu/loonggpu_ttm_buddy.c
+@@ -10,7 +10,7 @@ void loonggpu_res_first(struct ttm_resource *res,
+ 		     u64 start, u64 size,
+ 		     struct loonggpu_res_cursor *cur)
+ {
+-	struct drm_buddy_block *block;
++	lg_buddy_block_t *block;
+ 	struct list_head *head, *next;
+ 	struct drm_mm_node *node;
+ 
+@@ -25,8 +25,7 @@ void loonggpu_res_first(struct ttm_resource *res,
+ 	case TTM_PL_VRAM:
+ 		head = &to_loonggpu_vram_mgr_resource(res)->blocks;
+ 
+-		block = list_first_entry_or_null(head,
+-						 struct drm_buddy_block,
++		block = list_first_entry_or_null(head, lg_buddy_block_t,
+ 						 link);
+ 		if (!block)
+ 			goto fallback;
+@@ -36,7 +35,7 @@ void loonggpu_res_first(struct ttm_resource *res,
+ 
+ 			next = block->link.next;
+ 			if (next != head)
+-				block = list_entry(next, struct drm_buddy_block, link);
++				block = list_entry(next, lg_buddy_block_t, link);
+ 		}
+ 
+ 		cur->start = loonggpu_vram_mgr_block_start(block) + start;
+@@ -72,7 +71,7 @@ fallback:
+ 
+ void loonggpu_res_next(struct loonggpu_res_cursor *cur, u64 size)
+ {
+-	struct drm_buddy_block *block;
++	lg_buddy_block_t *block;
+ 	struct drm_mm_node *node;
+ 	struct list_head *next;
+ 
+@@ -93,7 +92,7 @@ void loonggpu_res_next(struct loonggpu_res_cursor *cur, u64 size)
+ 		block = cur->node;
+ 
+ 		next = block->link.next;
+-		block = list_entry(next, struct drm_buddy_block, link);
++		block = list_entry(next, lg_buddy_block_t, link);
+ 
+ 		cur->node = block;
+ 		cur->start = loonggpu_vram_mgr_block_start(block);
+diff --git a/loonggpu/loonggpu_vram_mgr.c b/loonggpu/loonggpu_vram_mgr.c
+index 3d207cf..b3f659f 100644
+--- a/loonggpu/loonggpu_vram_mgr.c
++++ b/loonggpu/loonggpu_vram_mgr.c
+@@ -85,7 +85,7 @@ u64 loonggpu_vram_mgr_bo_visible_size(struct loonggpu_bo *bo)
+ 	lg_ttm_mem_t *mem = lg_bo_to_mem;
+ #if defined(LG_DRM_DRM_BUDDY_H_PRESENT)
+ 	struct loonggpu_vram_mgr_resource *vres = to_loonggpu_vram_mgr_resource(mem);
+-	struct drm_buddy_block *block;
++	lg_buddy_block_t *block;
+ #else
+ 	struct drm_mm_node *nodes = mem->mm_node;
+ 	unsigned pages = mem->num_pages;
+diff --git a/loonggpu/loonggpu_vram_mgr_buddy.c b/loonggpu/loonggpu_vram_mgr_buddy.c
+index 9199f92..7d1bbe4 100644
+--- a/loonggpu/loonggpu_vram_mgr_buddy.c
++++ b/loonggpu/loonggpu_vram_mgr_buddy.c
+@@ -32,7 +32,7 @@ int loonggpu_vram_mgr_init_buddy(struct loonggpu_device *adev)
+ 	mgr->default_page_size = PAGE_SIZE;
+ 
+ 	man->func = &loonggpu_vram_mgr_func;
+-	err = drm_buddy_init(&mgr->b_mm, man->size, PAGE_SIZE);
++	err = lg_buddy_init(&mgr->b_mm, man->size, PAGE_SIZE);
+ 	if (err)
+ 		return err;
+ 	ttm_set_driver_manager(&adev->mman.bdev, TTM_PL_VRAM, &mgr->manager);
+@@ -70,23 +70,23 @@ void loonggpu_vram_mgr_fini_buddy(struct loonggpu_device *adev)
+ 		lg_drm_buddy_free_list(&mgr->b_mm, &rsv->allocated, 0);
+ 		kfree(rsv);
+ 	}
+-	drm_buddy_fini(&mgr->b_mm);
++	lg_buddy_fini(&mgr->b_mm);
+ 	mutex_unlock(&mgr->m_lock);
+ 
+ 	ttm_resource_manager_cleanup(man);
+ 	ttm_set_driver_manager(&adev->mman.bdev, TTM_PL_VRAM, NULL);
+ }
+ 
+-static inline struct drm_buddy_block *
++static inline lg_buddy_block_t *
+ loonggpu_vram_mgr_first_block(struct list_head *list)
+ {
+-	return list_first_entry_or_null(list, struct drm_buddy_block, link);
++	return list_first_entry_or_null(list, lg_buddy_block_t, link);
+ }
+ 
+ static inline bool
+ loonggpu_is_vram_mgr_blocks_contiguous(struct list_head *head)
+ {
+-	struct drm_buddy_block *block;
++	lg_buddy_block_t *block;
+ 	u64 start, size;
+ 
+ 	block = loonggpu_vram_mgr_first_block(head);
+@@ -97,7 +97,7 @@ loonggpu_is_vram_mgr_blocks_contiguous(struct list_head *head)
+ 		start = loonggpu_vram_mgr_block_start(block);
+ 		size = loonggpu_vram_mgr_block_size(block);
+ 
+-		block = list_entry(block->link.next, struct drm_buddy_block, link);
++		block = list_entry(block->link.next, lg_buddy_block_t, link);
+ 		if (start + size != loonggpu_vram_mgr_block_start(block))
+ 			return false;
+ 	}
+@@ -125,8 +125,8 @@ int loonggpu_vram_mgr_new_buddy(struct ttm_resource_manager *man,
+ 	struct loonggpu_device *adev = vram_mgr_to_loonggpu_device(mgr);
+ 	struct loonggpu_vram_mgr_resource *vres;
+ 	u64 size, remaining_size, lpfn, fpfn;
+-	struct drm_buddy *mm = &mgr->b_mm;
+-	struct drm_buddy_block *block;
++	lg_buddy_t *mm = &mgr->b_mm;
++	lg_buddy_block_t *block;
+ 	unsigned long pages_per_block;
+ 	int r;
+ 
+@@ -164,10 +164,10 @@ int loonggpu_vram_mgr_new_buddy(struct ttm_resource_manager *man,
+ 	INIT_LIST_HEAD(&vres->blocks);
+ 
+ 	if (place->flags & TTM_PL_FLAG_TOPDOWN)
+-		vres->flags = DRM_BUDDY_TOPDOWN_ALLOCATION;
++		vres->flags = LG_BUDDY_TOPDOWN_ALLOCATION;
+ 
+ 	if (fpfn || lpfn != mgr->b_mm.size)
+-		vres->flags |= DRM_BUDDY_RANGE_ALLOCATION;
++		vres->flags |= LG_BUDDY_RANGE_ALLOCATION;
+ 
+ 	remaining_size = (u64)vres->base.size;
+ 
+@@ -205,12 +205,12 @@ int loonggpu_vram_mgr_new_buddy(struct ttm_resource_manager *man,
+ 			}
+ 		}
+ 
+-		r = drm_buddy_alloc_blocks(mm, fpfn,
+-					   lpfn,
+-					   size,
+-					   min_block_size,
+-					   &vres->blocks,
+-					   vres->flags);
++		r = lg_buddy_alloc_blocks(mm, fpfn,
++					  lpfn,
++					  size,
++					  min_block_size,
++					  &vres->blocks,
++					  vres->flags);
+ 		if (unlikely(r))
+ 			goto error_free_blocks;
+ 
+@@ -222,7 +222,7 @@ int loonggpu_vram_mgr_new_buddy(struct ttm_resource_manager *man,
+ 	mutex_unlock(&mgr->m_lock);
+ 
+ 	if (cur_size != size) {
+-		struct drm_buddy_block *block;
++		lg_buddy_block_t *block;
+ 		struct list_head *trim_list;
+ 		u64 original_size;
+ 		LIST_HEAD(temp);
+@@ -293,17 +293,17 @@ static void loonggpu_vram_mgr_do_reserve(struct ttm_resource_manager *man)
+ 	struct loonggpu_vram_mgr *mgr = lg_man_to_vram_mgr(man);
+ 	struct loonggpu_device *adev = vram_mgr_to_loonggpu_device(mgr);
+ 	struct loonggpu_vram_reservation *rsv, *tmp;
+-	struct drm_buddy *mm = &mgr->b_mm;
+-	struct drm_buddy_block *block;
++	lg_buddy_t *mm = &mgr->b_mm;
++	lg_buddy_block_t *block;
+ 	uint64_t vis_usage;
+ 	int ret;
+ 
+ 	list_for_each_entry_safe(rsv, tmp, &mgr->reservations_pending, blocks) {
+-		ret = drm_buddy_alloc_blocks(mm, rsv->start,
+-					     rsv->start + rsv->size,
+-					     rsv->size, mm->chunk_size,
+-					     &rsv->allocated,
+-					     DRM_BUDDY_RANGE_ALLOCATION);
++		ret = lg_buddy_alloc_blocks(mm, rsv->start,
++					    rsv->start + rsv->size,
++					    rsv->size, mm->chunk_size,
++					    &rsv->allocated,
++					    LG_BUDDY_RANGE_ALLOCATION);
+ 		if (ret)
+ 			continue;
+ 
+@@ -341,8 +341,8 @@ void loonggpu_vram_mgr_del_buddy(struct ttm_resource_manager *man,
+ 	struct loonggpu_vram_mgr_resource *vres = to_loonggpu_vram_mgr_resource(res);
+ 	struct loonggpu_vram_mgr *mgr = lg_man_to_vram_mgr(man);
+ 	struct loonggpu_device *adev = vram_mgr_to_loonggpu_device(mgr);
+-	struct drm_buddy *mm = &mgr->b_mm;
+-	struct drm_buddy_block *block;
++	lg_buddy_t *mm = &mgr->b_mm;
++	lg_buddy_block_t *block;
+ 	uint64_t vis_usage = 0;
+ 
+ 	mutex_lock(&mgr->m_lock);
+@@ -372,7 +372,7 @@ void loonggpu_vram_mgr_debug_buddy(struct ttm_resource_manager *man,
+ 			  	struct drm_printer *printer)
+ {
+ 	struct loonggpu_vram_mgr *mgr = lg_man_to_vram_mgr(man);
+-	struct drm_buddy *mm = &mgr->b_mm;
++	lg_buddy_t *mm = &mgr->b_mm;
+ 
+ 	mutex_lock(&mgr->m_lock);
+ 	drm_buddy_print(mm, printer);
+@@ -399,7 +399,7 @@ bool loonggpu_vram_mgr_intersects(struct ttm_resource_manager *man,
+ 				size_t size)
+ {
+ 	struct loonggpu_vram_mgr_resource *mgr = to_loonggpu_vram_mgr_resource(res);
+-	struct drm_buddy_block *block;
++	lg_buddy_block_t *block;
+ 
+ 	/* Check each drm buddy block individually */
+ 	list_for_each_entry(block, &mgr->blocks, link) {
+@@ -432,7 +432,7 @@ bool loonggpu_vram_mgr_compatible(struct ttm_resource_manager *man,
+ 				size_t size)
+ {
+ 	struct loonggpu_vram_mgr_resource *mgr = to_loonggpu_vram_mgr_resource(res);
+-	struct drm_buddy_block *block;
++	lg_buddy_block_t *block;
+ 
+ 	/* Check each drm buddy block individually */
+ 	list_for_each_entry(block, &mgr->blocks, link) {
+-- 
+2.54.0
+

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,6 +2,7 @@ UPSTREAM_VER=1.0.2-ud25.1~rc1.10.1
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}
+REL=1
 EPOCH=1
 SRCS="file::use-url-name=true::https://repo.aosc.io/aosc-repacks/loonggpu/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::28b413f64a02246aea8f4a4f62ae3a2548506f185bdc7afd62cef3da37a07ad0"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

<!-- Please input topic description here. -->

loonggpu-kernel-dkms: tie some loose ends and adapt for Linux 7.1
- Fix build with CONFIG_DEBUG_FS=n, to make things easier when testing this module with customly built kernel.
- Switch suspend and resume logic for framebuffer to DRM client.  This had been a loose end when we switched the FB to DRM client.
- Fix a potential double free with Linux >= 6.19.
- Adapt for the massive drm_buddy => gpu_buddy rename in Linux 7.1 development cycle.
- Tracking AOSC patches at AOSC-Tracking/loonggpu-kernel-dkms @ aosc/1.0.2-ud25.1-rc1.10.1 (HEAD: 00f8fd79b6e29a302585253b84add48972e9dc6e).

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: `1:1.0.2+ud25.1~rc1.10.1-1`

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
