### PR TITLE
clash-verge-service-ipc: mitigate a variant of CVE-2025-50505

### DIFF
--- a/app-proxy/clash-verge-service-ipc/autobuild/patches/0002-AOSC-fix-a-variant-of-CVE-2025-50505.patch
+++ b/app-proxy/clash-verge-service-ipc/autobuild/patches/0002-AOSC-fix-a-variant-of-CVE-2025-50505.patch
@@ -1,0 +1,27 @@
+diff --git a/src/core/server.rs b/src/core/server.rs
+index 694aa95..0e41073 100644
+--- a/src/core/server.rs
++++ b/src/core/server.rs
+@@ -381,7 +381,8 @@ fn create_ipc_router() -> Result<Router> {
+             trace!("Received StartClash command");
+             ipc_request_context_to_auth_context(&ctx)?;
+             match ctx.json::<ClashConfig>() {
+-                Ok(start_clash) => {
++                Ok(mut start_clash) => {
++                    start_clash.core_config.core_path = "/usr/bin/mihomo".to_string();
+                     match CORE_MANAGER
+                         .lock()
+                         .await
+diff --git a/src/core/structure.rs b/src/core/structure.rs
+index 3eed96b..8044a07 100644
+--- a/src/core/structure.rs
++++ b/src/core/structure.rs
+@@ -76,7 +76,7 @@ impl Default for CoreConfig {
+             "/tmp/verge/verge-mihomo.sock".to_string()
+         };
+         Self {
+-            core_path: "./clash".to_string(),
++            core_path: "/usr/bin/mihomo".to_string(),
+             core_ipc_path,
+             config_path: "./config.yaml".to_string(),
+             config_dir: "./configs".to_string(),

--- a/app-proxy/clash-verge-service-ipc/spec
+++ b/app-proxy/clash-verge-service-ipc/spec
@@ -1,3 +1,4 @@
 VER=2.3.0
+REL=1
 SRCS="git::commit=v$VER::https://github.com/clash-verge-rev/clash-verge-service-ipc"
 CHKSUMS="SKIP"

--- a/topics/clash-verge-service-ipc-2.3.0-1.toml
+++ b/topics/clash-verge-service-ipc-2.3.0-1.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Clash Verge Service (IPC) 2.3.0, Revision 1"
+zh_CN = "Clash Verge 服务 (IPC) 2.3.0，修订 1"
+
+[caution]
+default = "Mitigates an Execution with Unnecessary Privileges vulnerability, but Denial-of-Service is still possible (a vairant of CVE-2025-50505, severity: High)"
+zh_CN = "缓解一个使用不必要权限执行的漏洞，但仍可能导致拒绝服务（CVE-2025-50505 的变种，严重性：高）"
+
+[packages-v2]
+"clash-verge-service-ipc" = "< 2.3.0-1"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-service-ipc: mitigate a variant of CVE-2025-50505

Package(s) Affected
-------------------

- clash-verge-service-ipc: 2.3.0-1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit clash-verge-service-ipc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
