### PR TITLE
linux+kernel+vanillarc: rework, remove ABHOST=noarch

### DIFF
--- a/runtime-kernel/linux+kernel+vanillarc/autobuild/defines
+++ b/runtime-kernel/linux+kernel+vanillarc/autobuild/defines
@@ -3,6 +3,5 @@ PKGSEC=kernel
 PKGDEP="linux-kernel-vanillarc-7.1.0"
 PKGDES="Generic Linux Kernel for AOSC OS (Prepatch, without AOSC patches)"
 ABTYPE=dummy
-ABHOST=noarch
 
 FAIL_ARCH="!(amd64|arm64|loongarch64|loongson3|ppc64el|riscv64)"

--- a/runtime-kernel/linux+kernel+vanillarc/spec
+++ b/runtime-kernel/linux+kernel+vanillarc/spec
@@ -1,3 +1,4 @@
 VER=7.1.0
 DUMMYSRC=1
 CHKUPDATE="anitya::id=6501"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

linux+kernel+vanillarc: rework, remove ABHOST=noarch

Package(s) Affected
-------------------

- linux+kernel+vanillarc: `7.1.0-1`

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit linux-kernel-vanillarc linux+kernel+vanillarc
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
