### PR TITLE
loonggpu-kernel-dkms: fix a brown paper bag issue in KCD patch

### DIFF
--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-Suspend-and-resume-clients-with-client-help.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0046-loonggpu-Suspend-and-resume-clients-with-client-help.patch
@@ -1,10 +1,10 @@
-From 6570ffc7c06e1a68609b9204a69b364d74937a52 Mon Sep 17 00:00:00 2001
+From 3c5536f63076665f77482f5450471e322ddebe22 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 11 Jun 2026 17:54:03 +0800
 Subject: [PATCH 46/49] loonggpu: Suspend and resume clients with client
  helpers
 
-Replace calls to loonggpu_fbdev_set_suspend() with calls to the client
+Replace calls to radeon_fbdev_set_suspend() with calls to the client
 functions drm_client_dev_suspend() and drm_client_dev_resume(). Any
 registered in-kernel client will now receive suspend and resume events.
 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-fix-double-free-on-Linux-6.19.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0047-loonggpu-fix-double-free-on-Linux-6.19.patch
@@ -1,4 +1,4 @@
-From 1dea544667e3434ac3716e7676feaf6406b59f22 Mon Sep 17 00:00:00 2001
+From a3e6cf78f2657b4f8c4fe4526daf1106512b93fc Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Thu, 11 Jun 2026 18:07:34 +0800
 Subject: [PATCH 47/49] loonggpu: fix double free on Linux >= 6.19

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-lgkcd-only-build-kcd_debugfs.c-if-CONFIG_DEBUG_FS-is.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0048-lgkcd-only-build-kcd_debugfs.c-if-CONFIG_DEBUG_FS-is.patch
@@ -1,4 +1,4 @@
-From dad3494e87f5c7000713464c6c3dffee815546af Mon Sep 17 00:00:00 2001
+From 65dbc94a1b54a95afbac38af1fc693ebbac0a97d Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 12 Jun 2026 20:25:29 +0800
 Subject: [PATCH 48/49] lgkcd: only build kcd_debugfs.c if CONFIG_DEBUG_FS is
@@ -10,7 +10,7 @@ Signed-off-by: Xi Ruoyao <xry111@xry111.site>
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/lgkcd/lgkcd.Kbuild b/lgkcd/lgkcd.Kbuild
-index 8cbb8d6..59302be 100644
+index 8cbb8d6..02ecd80 100644
 --- a/lgkcd/lgkcd.Kbuild
 +++ b/lgkcd/lgkcd.Kbuild
 @@ -4,7 +4,6 @@ LGKCD_SOURCES += lgkcd/kcd_ipc.c
@@ -26,7 +26,7 @@ index 8cbb8d6..59302be 100644
  LGKCD_SOURCES += lgkcd/kcd_migrate.c
  endif
 +
-+ifeq ($(CONFIG_DEBUG_FS),1)
++ifeq ($(CONFIG_DEBUG_FS),y)
 +LGKCD_SOURCES += lgkcd/kcd_debugfs.c
 +endif
 -- 

--- a/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-adapt-for-the-massive-drm_buddy-gpu_buddy-r.patch
+++ b/runtime-kernel/loonggpu-kernel-dkms/autobuild/patches.deferred/0049-loonggpu-adapt-for-the-massive-drm_buddy-gpu_buddy-r.patch
@@ -1,4 +1,4 @@
-From b3ee297b7f1f79877a3c134a16390cb36320066d Mon Sep 17 00:00:00 2001
+From ac27080959f34c64d4c45d90baeeab4f944c0633 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Sat, 13 Jun 2026 22:38:06 +0800
 Subject: [PATCH 49/49] loonggpu: adapt for the massive drm_buddy => gpu_buddy

--- a/runtime-kernel/loonggpu-kernel-dkms/spec
+++ b/runtime-kernel/loonggpu-kernel-dkms/spec
@@ -2,7 +2,7 @@ UPSTREAM_VER=1.0.2-ud25.1~rc1.10.1
 # Note: For use in scripting.
 __UPSTREAM_VER=${UPSTREAM_VER}
 VER=${UPSTREAM_VER//\-/+}
-REL=1
+REL=2
 EPOCH=1
 SRCS="file::use-url-name=true::https://repo.aosc.io/aosc-repacks/loonggpu/loonggpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
 CHKSUMS="sha256::28b413f64a02246aea8f4a4f62ae3a2548506f185bdc7afd62cef3da37a07ad0"


### PR DESCRIPTION
Topic Description
-----------------

- loonggpu-kernel-dkms: fix a brown paper bag issue in KCD patch

Package(s) Affected
-------------------

- loonggpu-kernel-dkms: 1.0.2+ud25.1~rc1.10.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit loonggpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
