### PR TITLE
glycin: strip out glycin-gtk4 to shrink dependency tree

### DIFF
--- a/desktop-gnome/fractal/autobuild/defines
+++ b/desktop-gnome/fractal/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=fractal
 PKGSEC=gnome
 PKGDEP="glib gtk-4 libadwaita gstreamer gtksourceview-5 openssl libshumate \
         sqlite pango graphene libseccomp lcms2 libwebp glycin gstreamer \
-        gst-plugins-rs gtk-update-icon-cache"
+        gst-plugins-rs gtk-update-icon-cache glycin-gtk4"
 BUILDDEP="meson ninja rustc llvm xdg-desktop-portal desktop-file-utils grass \
           blueprint-compiler"
 PKGDES="Matrix messaging client for GNOME"

--- a/desktop-gnome/fractal/spec
+++ b/desktop-gnome/fractal/spec
@@ -1,4 +1,5 @@
 VER=14
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/World/fractal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=197366"

--- a/desktop-gnome/glycin/01-glycin/beyond
+++ b/desktop-gnome/glycin/01-glycin/beyond
@@ -1,0 +1,23 @@
+abinfo "Stripping out libglycin-gtk4 files for 02-gtk4 ..."
+mkdir -pv "$SRCDIR"/glycin-gtk4/usr/{include,lib,share}
+
+mv -v "$PKGDIR"/usr/include/glycin-gtk4-2/ \
+    "$SRCDIR"/glycin-gtk4/usr/include/
+mv -v "$PKGDIR"/usr/lib/libglycin-gtk4-2.so{,.0} \
+    "$SRCDIR"/glycin-gtk4/usr/lib/
+
+mkdir -pv "$SRCDIR"/glycin-gtk4/usr/lib/girepository-1.0/
+mv -v "$PKGDIR"/usr/lib/girepository-1.0/GlyGtk4-2.typelib \
+    "$SRCDIR"/glycin-gtk4/usr/lib/girepository-1.0/
+
+mkdir -pv "$SRCDIR"/glycin-gtk4/usr/lib/pkgconfig/
+mv -v "$PKGDIR"/usr/lib/pkgconfig/glycin-gtk4-2.pc \
+    "$SRCDIR"/glycin-gtk4/usr/lib/pkgconfig/
+
+mkdir -pv "$SRCDIR"/glycin-gtk4/usr/share/gir-1.0/
+mv -v "$PKGDIR"/usr/share/gir-1.0/GlyGtk4-2.gir \
+    "$SRCDIR"/glycin-gtk4/usr/share/gir-1.0/
+
+mkdir -pv "$SRCDIR"/glycin-gtk4/usr/share/vala/vapi/
+mv -v "$PKGDIR"/usr/share/vala/vapi/glycin-gtk4-2.{deps,vapi} \
+    "$SRCDIR"/glycin-gtk4/usr/share/vala/vapi/

--- a/desktop-gnome/glycin/01-glycin/defines
+++ b/desktop-gnome/glycin/01-glycin/defines
@@ -1,8 +1,8 @@
 PKGNAME=glycin
 PKGSEC=gnome
 PKGDEP="lcms2 glib libseccomp fontconfig libjxl librsvg libheif cairo \
-        gdk-pixbuf pango libopenraw bubblewrap gtk-4"
-BUILDDEP="rustc llvm gobject-introspection vala gettext python-3"
+        gdk-pixbuf pango libopenraw bubblewrap"
+BUILDDEP="rustc llvm gobject-introspection vala gettext python-3 gtk-4"
 PKGDES="Image loader library with sandboxing"
 
 ABTYPE=meson

--- a/desktop-gnome/glycin/02-gtk4/build
+++ b/desktop-gnome/glycin/02-gtk4/build
@@ -1,0 +1,3 @@
+abinfo "Installing GTK 4 bindings ..."
+mv -v "$SRCDIR"/glycin-gtk4/ \
+    "$PKGDIR"

--- a/desktop-gnome/glycin/02-gtk4/defines
+++ b/desktop-gnome/glycin/02-gtk4/defines
@@ -1,0 +1,10 @@
+PKGNAME=glycin-gtk4
+PKGSEC=gnome
+PKGDEP="glib gtk-4 glycin"
+BUILDDEP="rustc llvm gobject-introspection vala gettext python-3"
+PKGDES="Image loader library with sandboxing - GTK 4 bindings"
+
+ABTYPE=self
+
+PKGBREAK="glycin<=2.1.1"
+PKGREP="glycin<=2.1.1"

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,4 +1,5 @@
 VER=2.1.1
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371932"


### PR DESCRIPTION
Topic Description
-----------------

- fractal: depend on glycin-gtk4 for GTK 4 bindings
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- glycin: strip out glycin-gtk4 to shrink dependency tree
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fractal: 14-1
- glycin: 2.1.1-1
- glycin-gtk4: 2.1.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit glycin fractal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
