### PR TITLE
gputils: update to 1.5.2

### DIFF
--- a/app-devel/gputils/autobuild/defines
+++ b/app-devel/gputils/autobuild/defines
@@ -3,4 +3,4 @@ PKGSEC=devel
 PKGDEP="glibc"
 PKGDES="Utilities for programming on the PIC microcontrollers"
 
-AUTOTOOLS_AFTER="--enable-gdb-debuginfo"
+AUTOTOOLS_AFTER=("--enable-gdb-debuginfo")

--- a/app-devel/gputils/autobuild/patch
+++ b/app-devel/gputils/autobuild/patch
@@ -1,1 +1,0 @@
-sed -i '/warn-once/d' configure.ac

--- a/app-devel/gputils/autobuild/patches/0001-FEDORA-libgputils-1.5.2.patch
+++ b/app-devel/gputils/autobuild/patches/0001-FEDORA-libgputils-1.5.2.patch
@@ -1,0 +1,36 @@
+diff --git a/libgputils/gpcoffgen.h b/libgputils/gpcoffgen.h
+index 41d3f89..8ee08b9 100644
+--- a/libgputils/gpcoffgen.h
++++ b/libgputils/gpcoffgen.h
+@@ -88,7 +88,7 @@ extern gp_reloc_t *gp_coffgen_add_reloc(gp_section_t *Section);
+ #define RELOC_DISABLE_WARN              (1 << 0)
+ #define RELOC_ENABLE_CINIT_WARN         (1 << 1)
+ 
+-extern void gp_coffgen_check_relocations(const gp_object_t *Object, unsigned int Behavior);
++extern void gp_coffgen_check_relocations(const gp_object_t *Object, gp_boolean Behavior);
+ 
+ extern gp_boolean gp_coffgen_del_reloc(gp_section_t *Section, gp_reloc_t *Relocation);
+ extern const char *gp_coffgen_reloc_type_to_str(uint16_t Type);
+diff --git a/libgputils/gptypes.h b/libgputils/gptypes.h
+index 95eb609..8356d8f 100644
+--- a/libgputils/gptypes.h
++++ b/libgputils/gptypes.h
+@@ -26,10 +26,14 @@ Boston, MA 02111-1307, USA.  */
+ 
+ #include "stdhdr.h"
+ 
+-typedef enum {
+-  false = (0 == 1),
+-  true  = (0 == 0)
+-} gp_boolean;
++#if defined __STDC_VERSION__ && __STDC_VERSION__ > 201710L
++// ISO C standard >= C23
++#define gp_boolean bool
++#else
++#define gp_boolean _Bool
++#define true    1
++#define false   0
++#endif
+ 
+ typedef long    gp_symvalue_t;
+ 

--- a/app-devel/gputils/spec
+++ b/app-devel/gputils/spec
@@ -1,5 +1,4 @@
-VER=1.5.0.1
-REL=2
-SRCS="tbl::https://sourceforge.net/projects/gputils/files/gputils/1.5.0/gputils-1.5.0-1.tar.bz2"
-CHKSUMS="sha256::6f88a018e85717b57a22f27a0ca41b2157633a82351f7755be92e2d7dc40bb14"
+VER=1.5.2
+SRCS="tbl::https://sourceforge.net/projects/gputils/files/gputils/${VER%.*}.0/gputils-${VER}.tar.gz"
+CHKSUMS="sha256::62a215e7d5575cd488a5ada66e5708ff402634abe86a9b39e4dbdb19c986ab7e"
 CHKUPDATE="anitya::id=14558"


### PR DESCRIPTION
Topic Description
-----------------

- gputils: update to 1.5.2

Package(s) Affected
-------------------

- gputils: 1.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gputils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
