### PR TITLE
viddy: update to 1.3.1

### DIFF
--- a/app-utils/viddy/spec
+++ b/app-utils/viddy/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.3.1
 # Note: `copy-repo=true` is required to get git tags information for in-app version display
 SRCS="git::copy-repo=true;commit=tags/v$VER::https://github.com/sachaos/viddy"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- viddy: update to 1.3.1
    Co-authored-by: Chi_Tang \(@chitang233\) <me@chitang.dev>

Package(s) Affected
-------------------

- viddy: 1.3.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit viddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
