### PR TITLE
noto-fonts: update to 2026.06.01+emoji2.051+cjksans2.004+cjkserif2.003

### DIFF
--- a/desktop-fonts/noto-fonts/01-noto/defines
+++ b/desktop-fonts/noto-fonts/01-noto/defines
@@ -1,5 +1,4 @@
 PKGNAME=noto-fonts
-PKGEPOCH=1
 PKGSEC=fonts
 PKGDEP="adobe-source-code-pro"
 PKGDES="A font family aiming to support all languages with a harmonious look"
@@ -8,5 +7,4 @@ PKGREP="fonts-noto"
 PKGPROV="ttf-noto"
 
 ABHOST=noarch
-
-PKGEPOCH=2
+ABTYPE=self

--- a/desktop-fonts/noto-fonts/02-cjk/defines
+++ b/desktop-fonts/noto-fonts/02-cjk/defines
@@ -1,5 +1,4 @@
 PKGNAME=noto-cjk-fonts
-PKGEPOCH=1
 PKGSEC=fonts
 PKGDEP="fontconfig"
 PKGDES="A font family aiming to support all languages with a harmonious look (Pan-CJK fonts)"
@@ -8,5 +7,4 @@ PKGREP="fonts-noto"
 PKGPROV="fonts-noto-cjk ttf-noto-cjk"
 
 ABHOST=noarch
-
-PKGEPOCH=2
+ABTYPE=self

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -1,11 +1,11 @@
-UPSTREAM_VER=2025.12.01
+UPSTREAM_VER=2026.06.01
 # Note: For the main version number, go with NotoSans- prefixed tags at
 # https://github.com/notofonts/notofonts.github.io/.
-EMOJI_VER=2.042
+EMOJI_VER=2.051
 CJKSANS_VER=2.004
 CJKSERIF_VER=2.003
 VER=${UPSTREAM_VER}+emoji${EMOJI_VER}+cjksans${CJKSANS_VER}+cjkserif${CJKSERIF_VER}
-REL=3
+EPOCH=2
 # Note: We don't use the tags any more, since it's easier to install from a
 # Git repository.
 # CJKSANSVER=${VER:24:5}
@@ -15,8 +15,8 @@ CJK_COMMIT="4efc595762d1f4b4fa504bccfe8e59de91fda063"
 SRCS="tbl::https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${UPSTREAM_VER}.tar.gz \
       tbl::https://github.com/googlefonts/noto-emoji/archive/refs/tags/v${EMOJI_VER}.tar.gz \
       git::commit=${CJK_COMMIT};rename=noto-cjk::https://github.com/googlefonts/noto-cjk"
-CHKSUMS="sha256::a06f15babc162a10768964965e95a062022622a078af4bc9d988c9ba65b4c8f7 \
-         sha256::b56bd2fa4029d0f057b66b742ac59af243dbc91067fed3eb4929dac762440fc9 \
+CHKSUMS="sha256::2f8539d08b9b6c73e86dce670eaa46e1d47d2330137ccb11ef4c69b27c865601 \
+         sha256::04f3d1e5605edebebac00a7a0becb390a4a3ead015066905b27935b30c18e745 \
          SKIP"
 CHKUPDATE="anitya::id=10671"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: update to 2026.06.01+emoji2.051+cjksans2.004+cjkserif2.003

Package(s) Affected
-------------------

- noto-cjk-fonts: 2026.06.01+emoji2.051+cjksans2.004+cjkserif2.003
- noto-fonts: 2026.06.01+emoji2.051+cjksans2.004+cjkserif2.003

Security Update?
----------------

No

Build Order
-----------

```
#buildit noto-fonts noto-cjk-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
