### PR TITLE
gping: update to 1.20.2

### DIFF
--- a/app-web/gping/spec
+++ b/app-web/gping/spec
@@ -1,4 +1,4 @@
-VER=1.20.1
+VER=1.20.2
 SRCS="git::commit=tags/gping-v${VER}::https://github.com/orf/gping"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242646"


### PR DESCRIPTION
Topic Description
-----------------

- gping: update to 1.20.2
    Co-authored-by: Lumiere \(@atlarator\) <vzstless@qq.com>

Package(s) Affected
-------------------

- gping: 1.20.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit gping
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
