### PR TITLE
telegram-desktop: update to 6.9.3

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,4 @@
-VER=4.17.8
+VER=4.17.9
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=telegram-desktop
 PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
-        openal-soft openssl lz4 qt-6 xxhash hunspell libdispatch \
-        libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons \
-        glibmm-2.68 fmt ada crc32c"
+    openal-soft openssl lz4 qt-6 xxhash hunspell crc32c glibmm-2.68 fmt \
+    libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons ada"
+PKGDEP__MAINLINE_TIER2="${PKGDEP} libdispatch"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm gperf \
           extra-cmake-modules wayland-protocols plasma-wayland-protocols"
 PKGSUG="webkit2gtk"

--- a/app-web/telegram-desktop/autobuild/patches/0001-AOSCOS-fix-window.style-set-default-window-width-to-.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0001-AOSCOS-fix-window.style-set-default-window-width-to-.patch
@@ -1,7 +1,8 @@
-From aedbf1761efcbf0954dad1f5c6af05e52b36c19d Mon Sep 17 00:00:00 2001
+From b06244d5d0a6a15cfa3c6cf3944fa4ced30e5ca0 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 16:36:00 +0800
-Subject: [PATCH 1/5] fix(window.style): set default window width to 360px
+Subject: [PATCH 1/7] AOSCOS: fix(window.style): set default window width to
+ 360px
 
 This allows the Telegram window to scale properly on the PinePhone.
 ---
@@ -9,7 +10,7 @@ This allows the Telegram window to scale properly on the PinePhone.
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
-index dce9e2ce..71748b8e 100644
+index c4806e1b..1d8d0640 100644
 --- a/Telegram/SourceFiles/window/window.style
 +++ b/Telegram/SourceFiles/window/window.style
 @@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";

--- a/app-web/telegram-desktop/autobuild/patches/0002-AOSCOS-fix-core_settings.h-use-system-window-decorat.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0002-AOSCOS-fix-core_settings.h-use-system-window-decorat.patch
@@ -1,8 +1,8 @@
-From bf4c463267c9d27370ac379e04cd4e38bc5d82c7 Mon Sep 17 00:00:00 2001
+From 4a359b64b3615d53131b438aa3ae180b2a0dc88a Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 9 Apr 2024 17:43:49 +0800
-Subject: [PATCH 2/5] fix(core_settings.h): use system window decoration by
- default
+Subject: [PATCH 2/7] AOSCOS: fix(core_settings.h): use system window
+ decoration by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 2 +-

--- a/app-web/telegram-desktop/autobuild/patches/0003-AOSCOS-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0003-AOSCOS-fix-settings-use-system-fonts-by-default.patch
@@ -1,7 +1,7 @@
-From baf97afa9cdacc23047c371b17ff41d8742b6490 Mon Sep 17 00:00:00 2001
+From 288c66c19235a6a968b1be53c01e8fb5350b370e Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 00:06:32 -0700
-Subject: [PATCH 3/5] fix(settings): use system fonts by default
+Subject: [PATCH 3/7] AOSCOS: fix(settings): use system fonts by default
 
 ---
  Telegram/SourceFiles/core/core_settings.h | 3 ++-

--- a/app-web/telegram-desktop/autobuild/patches/0004-AOSCOS-Remove-the-confusing-Default-option-from-sele.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0004-AOSCOS-Remove-the-confusing-Default-option-from-sele.patch
@@ -1,15 +1,15 @@
-From badec8675e2d93ed1c052f94d8cf802167c843ed Mon Sep 17 00:00:00 2001
+From 0f91ac3a2a08d5aa84959a28dd5e6863f64d16ca Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 6 May 2024 17:15:17 -0700
-Subject: [PATCH 4/5] Remove the confusing "Default" option from selectable
- fonts
+Subject: [PATCH 4/7] AOSCOS: Remove the confusing "Default" option from
+ selectable fonts
 
 ---
  Telegram/SourceFiles/ui/boxes/choose_font_box.cpp | 7 +++----
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
-index c298caea..dbd64761 100644
+index bc1cbb69..6fe6280e 100644
 --- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 +++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
 @@ -530,7 +530,7 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {

--- a/app-web/telegram-desktop/autobuild/patches/0005-AOSCOS-fix-core_settings.h-enable-video-hardware-acc.patch
+++ b/app-web/telegram-desktop/autobuild/patches/0005-AOSCOS-fix-core_settings.h-enable-video-hardware-acc.patch
@@ -1,10 +1,10 @@
-From aee5157a5033f020fe612f64b0928502790a2f1e Mon Sep 17 00:00:00 2001
-From: Kaiyang Wu <self@origincode.me>
-Date: Wed, 19 Mar 2025 21:30:27 -0700
-Subject: [PATCH 5/5] fix(core_settings.h): enable video hardware acceleration
- by default
+From dc5ec4f14a23c04c1877bf4904ebf64e67bdfbb0 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 15 Jun 2026 17:12:22 +0800
+Subject: [PATCH 5/7] AOSCOS: fix(core_settings.h): enable video hardware
+ acceleration by default
 
-Signed-off-by: Kaiyang Wu <self@origincode.me>
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  Telegram/SourceFiles/core/core_settings.h | 4 ----
  1 file changed, 4 deletions(-)

--- a/app-web/telegram-desktop/autobuild/patches/0006-AOSCOS-Revert-Replace-dispatch-with-TooManyCooks.patch.mainline_tier2
+++ b/app-web/telegram-desktop/autobuild/patches/0006-AOSCOS-Revert-Replace-dispatch-with-TooManyCooks.patch.mainline_tier2
@@ -1,0 +1,25 @@
+From 618b11471e2afe5b9246dfa4bcbb977dbfee9342 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 15 Jun 2026 18:28:04 +0800
+Subject: [PATCH 6/7] AOSCOS: Revert "Replace dispatch with TooManyCooks"
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ CMakeLists.txt | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4d35335b..43153b11 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -67,7 +67,6 @@ include(cmake/options.cmake)
+ include(cmake/external/qt/package.cmake)
+ 
+ set(desktop_app_skip_libs
+-    dispatch
+     glibmm
+     variant
+ )
+-- 
+2.52.0
+

--- a/app-web/telegram-desktop/autobuild/patches/0007-FROMLIST-TooManyCooks-add-64-bit-LoongArch-support.patch.loongarch64
+++ b/app-web/telegram-desktop/autobuild/patches/0007-FROMLIST-TooManyCooks-add-64-bit-LoongArch-support.patch.loongarch64
@@ -1,0 +1,60 @@
+From a0d2ba7821b158588d7f0ca083c3c26b22772b85 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Mon, 15 Jun 2026 16:31:10 +0800
+Subject: [PATCH 7/7] FROMLIST: TooManyCooks: add 64-bit LoongArch support
+
+- LoongArch has no instruction to tell the uarch that we want to yield
+  the CPU, so TMC_CPU_PAUSE() is a nop.  I think this may affect the
+  efficiency but not the correctness.
+- 64-bit LoongArch has a stable counter like x86 TSC or ARM virtual
+  counter, but the frequency needs to be calculated from the crystal
+  oscillator frequency and the PLL factor (exposed by the cpucfg
+  instruction) by the software itself.
+
+It survived tests in tmc-examples on a Loongson 3C6000.
+
+Link: https://github.com/tzcnt/TooManyCooks/pull/250
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ .../include/tmc/detail/compat.hpp             | 25 +++++++++++++++++++
+ 1 file changed, 25 insertions(+)
+
+diff --git a/Telegram/ThirdParty/TooManyCooks/include/tmc/detail/compat.hpp b/Telegram/ThirdParty/TooManyCooks/include/tmc/detail/compat.hpp
+index 39bab94f..9ef110fd 100644
+--- a/Telegram/ThirdParty/TooManyCooks/include/tmc/detail/compat.hpp
++++ b/Telegram/ThirdParty/TooManyCooks/include/tmc/detail/compat.hpp
+@@ -105,6 +105,31 @@ static inline size_t TMC_ARM_CPU_FREQ() noexcept {
+   return freq;
+ }
+ static inline const size_t TMC_CPU_FREQ = TMC_ARM_CPU_FREQ();
++#elif defined(__loongarch__) && defined(__LP64__)
++// Oops, LoongArch has no instruction to tell the uarch we should be
++// de-prioritized.
++static inline void TMC_CPU_PAUSE() noexcept {}
++// Read the LoongArch stable counter
++static inline size_t TMC_CPU_TIMESTAMP() noexcept {
++  size_t count;
++  asm volatile("rdtime.d %0, $zero" : "=r"(count));
++  return count;
++}
++// Calculate the LoongArch stable counter frequency
++static inline size_t TMC_LOONGARCH_CPU_FREQ() noexcept {
++  size_t cc_freq;
++  asm ("cpucfg %0, %1" : "=r"(cc_freq) : "r"(0x4));
++
++  size_t cc_mul_div;
++  asm ("cpucfg %0, %1" : "=r"(cc_mul_div) : "r"(0x5));
++
++  size_t cc_mul = cc_mul_div & 0xffff;
++  size_t cc_div = (cc_mul_div >> 16) & 0xffff;
++
++  return cc_freq * cc_mul / cc_div;
++}
++
++static inline const size_t TMC_CPU_FREQ = TMC_LOONGARCH_CPU_FREQ();
+ #endif
+ 
+ // clang-format tries to collapse the pragmas into one line...
+-- 
+2.52.0
+

--- a/app-web/telegram-desktop/autobuild/patches/0007-FROMLIST-TooManyCooks-add-64-bit-LoongArch-support.patch.loongarch64_nosimd
+++ b/app-web/telegram-desktop/autobuild/patches/0007-FROMLIST-TooManyCooks-add-64-bit-LoongArch-support.patch.loongarch64_nosimd
@@ -1,0 +1,1 @@
+0007-FROMLIST-TooManyCooks-add-64-bit-LoongArch-support.patch.loongarch64

--- a/app-web/telegram-desktop/autobuild/prepare
+++ b/app-web/telegram-desktop/autobuild/prepare
@@ -29,8 +29,15 @@ ninja -C build install
 cd "$SRCDIR"
 
 if ab_match_arch riscv64; then
-	abinfo "Injecting -pthread and -latomic for RISCV64..."
-	export LDFLAGS="${LDFLAGS} -pthread -latomic"
+    abinfo "Injecting -pthread and -latomic for RISCV64..."
+    export LDFLAGS="${LDFLAGS} -pthread -latomic"
+fi
+
+if ab_match_archgroup mainline_tier2; then
+    abinfo "Patching for tier 2 architectures ..."
+    ab_apply_patches "$SRCDIR"/autobuild/patches/*.mainline_tier2
+    abinfo "Copying dispatch lib to ThirdParty ..."
+    cp -av "$SRCDIR"/../dispatch "$SRCDIR"/Telegram/ThirdParty/
 fi
 
 abinfo "Applying API ID from snapcraft.yml ..."

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,19 @@
-VER=6.9.1
+VER=6.9.3
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=e0943d068ce90b5010f1aea946e6901e25b43bf6
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::ff694e702ca1412b1c13fc8debd8cda981ff19284d7a61eb7c31e21444a4a716 \
+# Reverting commit:
+# https://github.com/telegramdesktop/tdesktop/commit/30fe208b64c851e125318a7159b44ffef9bf6262#diff-c203d12f433252dc40201d70c606df40d24b6e7cd00be423f4c306170836d6b0
+SRCS__MAINLINE_TIER2="${SRCS} \
+    git::rename=dispatch;commit=6cdb083f7f380368e402eee504fb84d9ea0bcd59::https://github.com/swiftlang/swift-corelibs-libdispatch.git"
+CHKSUMS="sha256::5e9233d4c07f717e38f414c5aca16782a3326e428ded388513c79f950acb1610 \
+         SKIP \
+         SKIP"
+CHKSUMS__MAINLINE_TIER2="sha256::5e9233d4c07f717e38f414c5aca16782a3326e428ded388513c79f950acb1610 \
+         SKIP \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 6.9.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- telegram-desktop: 6.9.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
