### PR TITLE
wine: update to 11.11+gecko2.47.4+mono11.1.0

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,13 +1,13 @@
 __GECKO_VER=2.47.4
 __MONO_VER=11.1.0
-UPSTREAM_VER=11.10
+UPSTREAM_VER=11.11
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::e4c35ebe26f4f8eef5f2143e24a1fb9fd103f1d46132ad4755479227d086b8e7 \
+CHKSUMS="sha256::57dfd96448bf195efc1b1386131c3ba15d4b2d9faf2feba314e83d743d36d38d \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 11.11+gecko2.47.4+mono11.1.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wine: 3:11.11+gecko2.47.4+mono11.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
