### PR TITLE
iosevka-fonts: update to 34.6.3

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=34.6.1
+VER=34.6.3
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::ff48478ec300081e8b17f66bcc6cf635a83ed26b8d35fbb8a2f203b7a92f54ab \
-         sha256::d85fac260053a90e3af660939ad3dcd5462418d6c8e853fddd25150fa587a5af \
-         sha256::b20a208102011169776029e621c5546f6c9946631923debf0a348dfa412a5319 \
-         sha256::3c61511fa7dd28da532aed8b2a57677517052bb4d88a284b59a2f8693850311c \
-         sha256::0b89e7ab48998d1c351d116250c2c7240c153c4746799484b83aa07b7c2dc708 \
-         sha256::bce5746934b51dcb27bdd790c81482559f827a36d0af36cce062a7e2cd04a730 \
-         sha256::be5402bec71a576aa831ab0e2ec89f6142c92ead525df12bd3fc161f4b92f986 \
-         sha256::e608aa8e117551445a48e5163bc186c9069bed106fb92a1b02205b61b895fb63 \
-         sha256::8173bdbe52fcc4a5935a733e39da857657d561d6a4c9f840029f91235f1d8643 \
-         sha256::746357a38e99421b8f6bcd44f98b4748af893e002702262989380306bc4f8f50 \
-         sha256::671a47b8adeea1d0d89595f211a081d500dfb0cce2b74e670a4da89cfc722b80 \
-         sha256::bdbc85b2dbf92d0fc94c9a38c8dfbf46f7aa16fe1f478457e7c9d54585bf7219 \
-         sha256::052da895f97861d4c0106e15f671e5382608c75c4ea8dd1a1b417f24d1e9283b \
-         sha256::5e5c127bae271872a38ac69a138b25cf7f5e9c4ae807b66eba3e8958146d55f6 \
-         sha256::408dd65d9889f0647f29a93c50cd772fef894f0877b5443e970aaae4cf986549 \
-         sha256::a5c9a319da80fc8acce80138594958f9f647eb4654b3fea5a1368b9414c8e1c7 \
-         sha256::e4b7904be7c13715057327125309fe02b3cf0d96658c2b66e5726d276a2877ae \
-         sha256::d48dca0e399c7bfa9a81d194770af8c0e2aa9e0bcac5813371971e3517080440 \
-         sha256::4cb269f069ad8b12187b3a0c49755ed9876728d8ff156aca4eef8a7d5152005f \
-         sha256::49c3b5fb76e2268b7951b0b6fc2bba8c1869dc0f0d1ad4a69365ceec194f169a \
-         sha256::e99934f8de75708ddadf4c85d257c243f1c67bab5e58844d62c2f472d42e6628 \
-         sha256::0ba75738d2fa2b57bfc558674f440dba8fd8ec68b5875c3d0ab0170826a3d620 \
-         sha256::b8556eaafe79020555542f7cb75b49b42278061ca660505d9a05d317c64e4fa0 \
-         sha256::b2f6b3572e1ab2a74ed727918f3b062b41de2166fa776b6a36cb8ef8b5c03c97 \
+CHKSUMS="sha256::ecc5a79fac4d887a130d2ed36e8edf27784277c040bb8a48e295bd4529123074 \
+         sha256::e3b3581e76113c015e95b80c4a469fc05d68385859c1a3d2f55707e2daebc8e8 \
+         sha256::46d73d1dfccd1518a9c5100239b14c688a136491c6018222844f9410ba1f97cf \
+         sha256::cfd3f7b790d093657326e3d11edeeace603b0e8d4224d4d50db0f42ebfbefeb8 \
+         sha256::671501cd1d2b50a2aa66664507d5479369474285e65c4d70efba748c17be3bc7 \
+         sha256::4016f146346992726e92efec6a7561505316eaf090c1730b2532f2c151bc59dd \
+         sha256::7285fafe1f4fca7aaf419fe0cb96ad04aae8b0a16752df3624bd5d25629f52dc \
+         sha256::9d17aa8134c7801e8a9c3fb8a098596834bc87b7834533811fae3d738990b220 \
+         sha256::38fb03eb2dc60a273eec686b01b511917297c049aff7cc399405316e320d2a20 \
+         sha256::b24021712cf9f6531899178b2a08c267958291dc0742f6e3f2c44648b30df21b \
+         sha256::958b5d9ca68460105482c9581c8e742c71d23c95546dcddc1d57f80ae45b5478 \
+         sha256::2756ddcc16db559a4f87f55edc1c93781c50c6206500bb16295b09b22c3dca18 \
+         sha256::b00f5d9c61df7a05b2a72b9e69b73c2349e80d5a07492241f12e679404dcf332 \
+         sha256::e70e08d543694d39ae5a3dc0f3c8e1b670e8ac7a68fa47f3cdf7f6285812db62 \
+         sha256::3cd6524f0a49f6206ae0ecd5379af298802eab419e1bb2408ed6f6596ef27838 \
+         sha256::cf5d31a3a00308fb0bc38bfe96d170901e1396e56505516a1886719ced74735a \
+         sha256::93f3f23469bd7732e4d5febfda33f4413a634c8d29d022a1949f30e74e0278fd \
+         sha256::5d5033e19aac47e5719594ab8baf28753dbd739a6b3db81b300dcf0914380baa \
+         sha256::2a4aaf09f8a32d96ecbcd776f72bd843a7f39fda5f5dedf35bd16110ffe91531 \
+         sha256::50ac7bf327aba3e96604f49382cc98d459d14fabe0b4e260de168dbb8d1a1d3f \
+         sha256::a71cca7b0446a2b0e8aba986080df6993577f8fd0ec2eda7431697e58872eb4c \
+         sha256::9ddb7cfeafcc325d6e94c5eeec61d4682713429e336fca3e8e6b1cccf705a55a \
+         sha256::2a144bc83bec2038c0a58388fd2b3e76d9c37ef62869751b9d4b5e636c022170 \
+         sha256::5997cbbbd22bd017063b91dcfdc9d317e11d3fe2ba69ff8d82bab16d42920c5b \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.6.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.6.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
