### PR TITLE
ROS Eigen Survey

### DIFF
--- a/runtime-ros/ros-jazzy-pcl-conversions/autobuild/defines
+++ b/runtime-ros/ros-jazzy-pcl-conversions/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-pcl-conversions
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace eigen-3 ros-jazzy-message-filters ros-jazzy-pcl-msgs ros-jazzy-rclcpp ros-jazzy-sensor-msgs ros-jazzy-std-msgs pcl"
+PKGDEP="ros-jazzy-ros-workspace eigen ros-jazzy-message-filters ros-jazzy-pcl-msgs ros-jazzy-rclcpp ros-jazzy-sensor-msgs ros-jazzy-std-msgs pcl"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest"
 PKGDES="ROS 2 module to convert between PCL data types and ROS 2 message types"
 

--- a/runtime-ros/ros-jazzy-pcl-conversions/spec
+++ b/runtime-ros/ros-jazzy-pcl-conversions/spec
@@ -1,4 +1,5 @@
 VER=2.6.4+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/pcl_conversions/${VER/+/-}::https://github.com/ros2-gbp/perception_pcl-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/perception_pcl-release;pattern=release/jazzy/pcl_conversions/.*"

--- a/runtime-ros/ros-jazzy-tf2-eigen-kdl/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tf2-eigen-kdl/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-tf2-eigen-kdl
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-orocos-kdl-vendor ros-jazzy-tf2 eigen-3"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-orocos-kdl-vendor ros-jazzy-tf2 eigen"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
 PKGDES="ROS 2 module to convert between Eigen and KDL"
 

--- a/runtime-ros/ros-jazzy-tf2-eigen-kdl/spec
+++ b/runtime-ros/ros-jazzy-tf2-eigen-kdl/spec
@@ -1,4 +1,5 @@
 VER=0.36.20+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/tf2_eigen_kdl/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_eigen_kdl/.*"

--- a/runtime-ros/ros-jazzy-tf2-eigen/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tf2-eigen/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-tf2-eigen
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-geometry-msgs ros-jazzy-tf2 ros-jazzy-tf2-ros eigen-3"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-geometry-msgs ros-jazzy-tf2 ros-jazzy-tf2-ros eigen"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-ament-cmake-gtest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common"
 PKGDES="ROS 2 module to convert between Eigen math types and tf2 message types"
 

--- a/runtime-ros/ros-jazzy-tf2-eigen/spec
+++ b/runtime-ros/ros-jazzy-tf2-eigen/spec
@@ -1,4 +1,5 @@
 VER=0.36.20+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/tf2_eigen/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_eigen/.*"

--- a/runtime-ros/ros-jazzy-tf2-sensor-msgs/autobuild/defines
+++ b/runtime-ros/ros-jazzy-tf2-sensor-msgs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=ros-jazzy-tf2-sensor-msgs
 PKGSEC=ros
-PKGDEP="ros-jazzy-ros-workspace ros-jazzy-geometry-msgs ros-jazzy-sensor-msgs ros-jazzy-tf2 ros-jazzy-tf2-ros numpy ros-jazzy-sensor-msgs-py ros-jazzy-std-msgs ros-jazzy-tf2-ros-py eigen-3 ros-jazzy-eigen3-cmake-module"
+PKGDEP="ros-jazzy-ros-workspace ros-jazzy-geometry-msgs ros-jazzy-sensor-msgs ros-jazzy-tf2 ros-jazzy-tf2-ros numpy ros-jazzy-sensor-msgs-py ros-jazzy-std-msgs ros-jazzy-tf2-ros-py eigen ros-jazzy-eigen3-cmake-module"
 BUILDDEP="ros-jazzy-ament-cmake ros-jazzy-eigen3-cmake-module ros-jazzy-python-cmake-module ros-jazzy-ament-cmake-gtest ros-jazzy-ament-cmake-pytest ros-jazzy-ament-lint-auto ros-jazzy-ament-lint-common ros-jazzy-rclcpp"
 PKGDES="ROS 2 module to transform sensor_msgs with tf2 (mainly used with PointCloud2)"
 

--- a/runtime-ros/ros-jazzy-tf2-sensor-msgs/spec
+++ b/runtime-ros/ros-jazzy-tf2-sensor-msgs/spec
@@ -1,4 +1,5 @@
 VER=0.36.20+1
+REL=1
 SRCS="git::commit=tags/release/jazzy/tf2_sensor_msgs/${VER/+/-}::https://github.com/ros2-gbp/geometry2-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/geometry2-release;pattern=release/jazzy/tf2_sensor_msgs/.*"


### PR DESCRIPTION
Topic Description
-----------------

- ros-jazzy-tf2-eigen-kdl: use eigen 5.x
    Signed-off-by: stydxm <stydxm@outlook.com>
- ros-jazzy-tf2-eigen:use eigen 5.x
    Signed-off-by: stydxm <stydxm@outlook.com>
- ros-jazzy-tf2-sensor-msgs: use eigen 5.x
    Signed-off-by: stydxm <stydxm@outlook.com>
- ros-jazzy-pcl-conversions: use eigen 5.x
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit ros-jazzy-pcl-conversions ros-jazzy-tf2-sensor-msgs ros-jazzy-tf2-eigen ros-jazzy-tf2-eigen-kdl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
