### PR TITLE
openexr-3.1: new, 3.1.13

### DIFF
--- a/runtime-imaging/openexr-3.1/autobuild/beyond
+++ b/runtime-imaging/openexr-3.1/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing non-runtime components ..."
+rm -rv "$PKGDIR"/usr/{bin,include,lib/legacy/$PKGNAME/{pkgconfig,cmake},share}

--- a/runtime-imaging/openexr-3.1/autobuild/defines
+++ b/runtime-imaging/openexr-3.1/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=openexr-3.1
+PKGSEC=libs
+PKGDES="Library to handle High Dynamic Range (HDR) images (legacy 3.1 branch)"
+PKGDEP="zlib imath"
+
+AB_FLAGS_O3=1
+
+# Note: We do not encourage building Doxygen documentation.
+CMAKE_AFTER=(
+    "-DCMAKE_INSTALL_LIBDIR=/usr/lib/legacy/$PKGNAME"
+    '-DBUILD_DOCS=OFF'
+)

--- a/runtime-imaging/openexr-3.1/autobuild/overrides/etc/ld.so.conf.d/openexr-3.1.conf
+++ b/runtime-imaging/openexr-3.1/autobuild/overrides/etc/ld.so.conf.d/openexr-3.1.conf
@@ -1,0 +1,2 @@
+# openexr-3.1
+/usr/lib/legacy/openexr-3.1

--- a/runtime-imaging/openexr-3.1/spec
+++ b/runtime-imaging/openexr-3.1/spec
@@ -1,0 +1,5 @@
+VER=3.1.13
+SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/openexr"
+CHKSUMS="SKIP"
+# Note: Legacy runtime.
+#CHKUPDATE="anitya::id=13289"


### PR DESCRIPTION
Topic Description
-----------------

- openexr-3.1: new, 3.1.13

Package(s) Affected
-------------------

- openexr-3.1: 3.1.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit openexr-3.1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
