### PR TITLE
pennstander-fonts: new, 0.4.1


### DIFF
--- a/desktop-fonts/pennstander-fonts/autobuild/build
+++ b/desktop-fonts/pennstander-fonts/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Installing Pennstander font files ..."
+install -Dvm644 "$SRCDIR"/fonts/otf/*.otf \
+    -t "$PKGDIR"/usr/share/fonts/OTF/
+install -Dvm644 "$SRCDIR"/fonts/otf/*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF/
+
+abinfo "Installing LICENSE ..."
+install -Dvm644 "$SRCDIR"/OFL.txt \
+    -t "$PKGDIR"/usr/share/doc/pennstander-fonts/

--- a/desktop-fonts/pennstander-fonts/autobuild/defines
+++ b/desktop-fonts/pennstander-fonts/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=pennstander-fonts
+PKGSEC=fonts
+PKGDEP="fontconfig"
+PKGDES="Text and mathematics typeface based on Grandstander"
+
+PKGPROV="ttf-pennstander"
+ABHOST=noarch

--- a/desktop-fonts/pennstander-fonts/spec
+++ b/desktop-fonts/pennstander-fonts/spec
@@ -1,0 +1,4 @@
+VER=0.4.1
+SRCS="git::commit=tags/v$VER::https://github.com/juliusross1/Pennstander"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390635"


### PR DESCRIPTION
Topic Description
-----------------

- pennstander-fonts: new, 0.4.1

Package(s) Affected
-------------------

- pennstander-fonts: 0.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pennstander-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
