### PR TITLE
syncthing: update to 2.1.1

### DIFF
--- a/app-network/syncthing/spec
+++ b/app-network/syncthing/spec
@@ -1,5 +1,4 @@
-VER=2.0.13
-REL=4
+VER=2.1.1
 SRCS="tbl::https://github.com/syncthing/syncthing/releases/download/v$VER/syncthing-source-v$VER.tar.gz"
-CHKSUMS="sha256::fd7c93e01a6d61faa84adda8b22479dd7fd106144fbbb2eb15d773707d8a382e"
+CHKSUMS="sha256::418a99452f484abf30e403b769d0cf914a038142cd1a7e10be85b68f45d9f42a"
 CHKUPDATE="anitya::id=11814"


### PR DESCRIPTION
Topic Description
-----------------

- syncthing: update to 2.1.1
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- syncthing: 2.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit syncthing
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
