### PR TITLE
cx4-linux-graphics-driver-dri: downgrade to 26.00.46

### DIFF
--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0001-AOSCOS-fix-dkms.conf-drop-check_gcc_version.patch
@@ -1,7 +1,7 @@
-From 3a60dba763547ac1910a2268a34380c84a94a63e Mon Sep 17 00:00:00 2001
+From 30f60b2563c2214d9f45dbf33ed89fd3db66d6a1 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 7 Nov 2025 23:50:09 +0800
-Subject: [PATCH 1/7] AOSCOS: fix(dkms.conf): drop check_gcc_version()
+Subject: [PATCH 1/9] AOSCOS: fix(dkms.conf): drop check_gcc_version()
 
 Not even sure why it's here. Drop it.
 
@@ -11,7 +11,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 1 insertion(+), 46 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 1326747..71476e6 100644
+index 0a239dc..8b97cbc 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -19,50 +19,5 @@ num_cpu_cores()

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0002-AOSCOS-fix-dkms.conf-drop-unused-options.patch
@@ -1,7 +1,7 @@
-From 2aa72971bba47acf152cea3e0098acb539fc2ff9 Mon Sep 17 00:00:00 2001
+From dd0046d224145aaf3a60e7b777a1981ef1533745 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Fri, 7 Nov 2025 23:50:49 +0800
-Subject: [PATCH 2/7] AOSCOS: fix(dkms.conf): drop unused options
+Subject: [PATCH 2/9] AOSCOS: fix(dkms.conf): drop unused options
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
@@ -9,12 +9,12 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 2 deletions(-)
 
 diff --git a/dkms.conf b/dkms.conf
-index 71476e6..3653f35 100644
+index 8b97cbc..a1d8982 100644
 --- a/dkms.conf
 +++ b/dkms.conf
 @@ -1,8 +1,6 @@
  PACKAGE_NAME="cx4"
- PACKAGE_VERSION=26.00.49
+ PACKAGE_VERSION=26.00.46
  AUTOINSTALL="yes"
 -#REMAKE_INITRD="yes"
 -SKIP_IMMD_MODPROBE=1

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0003-AOSCOS-fix-do-not-include-linux-pfn_t.h-on-Linux-6.1.patch
@@ -1,7 +1,7 @@
-From 4837de46af264dd095f069d73fc17c94b9c1127c Mon Sep 17 00:00:00 2001
+From 9faec9235268b84293639296bb13bb215f8d52af Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 8 Nov 2025 22:45:52 +0800
-Subject: [PATCH 3/7] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
+Subject: [PATCH 3/9] AOSCOS: fix: do not include <linux/pfn_t.h> on Linux >=
  6.17
 
 Follow commit 21aa65bf82a7 ("mm: remove callers of pfn_t functionality")

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0004-AOSCOS-fix-adapt-to-drm-atomic-changes-in-6.19.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0004-AOSCOS-fix-adapt-to-drm-atomic-changes-in-6.19.patch
@@ -1,7 +1,7 @@
-From 1b336deb88e1834d8c6f08b75841a4f3c3ec0e7c Mon Sep 17 00:00:00 2001
+From 3c1497a4aa5549a5f75f479f277cd1de9f01782c Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Wed, 10 Jun 2026 21:59:15 +0800
-Subject: [PATCH 4/7] AOSCOS: fix: adapt to drm/atomic changes in 6.19
+Subject: [PATCH 4/9] AOSCOS: fix: adapt to drm/atomic changes in 6.19
 
 With commit 1226cd7 ("drm/atomic: Change state pointers to a more meaningful name"),
 the 'state' field in struct drm_plane_state, drm_crtc_state, and drm_connector_state
@@ -14,10 +14,10 @@ Follow suit to fix build with kernels >= 6.19.
  2 files changed, 35 insertions(+)
 
 diff --git a/linux/zx_crtc.c b/linux/zx_crtc.c
-index 95f5425..85cdedb 100644
+index a1f4f44..9631f15 100644
 --- a/linux/zx_crtc.c
 +++ b/linux/zx_crtc.c
-@@ -378,7 +378,11 @@ static bool zx_need_wait_vblank(struct drm_crtc *crtc, struct drm_crtc_state *ol
+@@ -369,7 +369,11 @@ static bool zx_need_wait_vblank(struct drm_crtc *crtc, struct drm_crtc_state *ol
          if(old_crtc_state->state->planes[i].ptr)
          {
              plane = old_crtc_state->state->planes[i].ptr;

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0005-AOSCOS-fix-adapt-to-shmem_file_setup-changes-in-7.0.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0005-AOSCOS-fix-adapt-to-shmem_file_setup-changes-in-7.0.patch
@@ -1,7 +1,7 @@
-From 35cf0cda5687d370d7a8c8cf43c3b2ccf5f4a8ad Mon Sep 17 00:00:00 2001
+From 022b813f67c4ffc21dad1472468ceaa906849b0e Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Wed, 10 Jun 2026 22:01:25 +0800
-Subject: [PATCH 5/7] AOSCOS: fix: adapt to shmem_file_setup changes in 7.0
+Subject: [PATCH 5/9] AOSCOS: fix: adapt to shmem_file_setup changes in 7.0
 
 With commit 590d356 ("mm: update shmem_[kernel]_file_*() functions to use vma_flags_t"),
 the flags parameter of shmem_file_setup() was changed from unsigned long to vma_flags_t.

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0006-AOSCOS-fix-adapt-to-screen_info-changes-in-7.0.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0006-AOSCOS-fix-adapt-to-screen_info-changes-in-7.0.patch
@@ -1,7 +1,7 @@
-From a7bda6badbb58af9bd3f4c1d7f2bfbb9b6863d5e Mon Sep 17 00:00:00 2001
+From e73498021a66db4010a9eceebb1e80b2ed68453f Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Wed, 10 Jun 2026 22:08:34 +0800
-Subject: [PATCH 6/7] AOSCOS: fix: adapt to screen_info changes in 7.0
+Subject: [PATCH 6/9] AOSCOS: fix: adapt to screen_info changes in 7.0
 
 With commit a41e0ab ("sysfb: Replace screen_info with sysfb_primary_display"),
 the global screen_info variable was replaced by sysfb_primary_display.screen
@@ -43,7 +43,7 @@ index 199b3a4..1acf821 100644
  
      zx_info("Screen info base = 0x%lx.\n", scrn_base);
 diff --git a/linux/zx_kms.h b/linux/zx_kms.h
-index 5ece6ab..7e0a5b3 100644
+index a24d7af..fead326 100644
 --- a/linux/zx_kms.h
 +++ b/linux/zx_kms.h
 @@ -60,7 +60,11 @@

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0007-AOSCOS-fix-set-framebuffer-gem-objects.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0007-AOSCOS-fix-set-framebuffer-gem-objects.patch
@@ -1,7 +1,7 @@
-From d85884b84584b484dcf26974154229f446d723c7 Mon Sep 17 00:00:00 2001
+From 59810e07ea4807e23a1a1a25891d5848788bfc60 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Thu, 11 Jun 2026 02:54:00 +0800
-Subject: [PATCH 7/7] AOSCOS: fix: set framebuffer gem objects
+Subject: [PATCH 7/9] AOSCOS: fix: set framebuffer gem objects
 
 Fix:
 

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0008-AOSCOS-fix-adapt-to-drm_fb_helper_lastclose-drop-6.1.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0008-AOSCOS-fix-adapt-to-drm_fb_helper_lastclose-drop-6.1.patch
@@ -1,0 +1,33 @@
+From 21d4d2c98bb24d06eb559c4c4aeaa9991969d025 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Tue, 16 Jun 2026 21:34:02 +0800
+Subject: [PATCH 8/9] AOSCOS: fix: adapt to drm_fb_helper_lastclose drop <=
+ 6.12
+
+---
+ linux/zx_pcie.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/linux/zx_pcie.c b/linux/zx_pcie.c
+index 8e47a77..a63e5d6 100644
+--- a/linux/zx_pcie.c
++++ b/linux/zx_pcie.c
+@@ -512,6 +512,7 @@ static void zx_drm_postclose(struct drm_device *dev, struct drm_file *file)
+ #endif
+ }
+ 
++#if DRM_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+ void  zx_drm_last_close(struct drm_device* dev)
+ {
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4, 19, 0)
+@@ -521,6 +522,7 @@ void  zx_drm_last_close(struct drm_device* dev)
+     drm_fb_helper_lastclose(dev);
+ #endif
+ }
++#endif
+ 
+ #if DRM_VERSION_CODE < KERNEL_VERSION(4,11,0)
+ static int zx_drm_device_is_agp(struct drm_device * dev)
+-- 
+2.52.0
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0009-AOSCOS-fix-adapt-to-Werror-empty-body.patch
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/module-patches/0009-AOSCOS-fix-adapt-to-Werror-empty-body.patch
@@ -1,0 +1,30 @@
+From 9a22cfa065a11f663594de8815e9bb596370e360 Mon Sep 17 00:00:00 2001
+From: Qing Yun <kf@aosc.io>
+Date: Tue, 16 Jun 2026 21:36:11 +0800
+Subject: [PATCH 9/9] AOSCOS: fix: adapt to -Werror=empty-body
+
+---
+ core/vidsch/vidsch_vm_update.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/core/vidsch/vidsch_vm_update.c b/core/vidsch/vidsch_vm_update.c
+index d399858..988b348 100644
+--- a/core/vidsch/vidsch_vm_update.c
++++ b/core/vidsch/vidsch_vm_update.c
+@@ -200,9 +200,13 @@ int vidsch_wait_prepare_event(vidsch_mgr_t *sch_mgr, task_desc_t *task_desc, uns
+ 
+             /* use wait_task_type to distinguish between vm_prepare_task and page_table_set_task */
+             if (wait_task_type == task_type_vm_prepare)
++            {
+                 zx_debug("sch_mgr->engine_index %d is waitting for vm_prepare_task more than %d x 100 ms\n", sch_mgr->engine_index, timeout_cnt);
++            }
+             else if (wait_task_type == task_type_page_table_set)
++            {
+                 zx_debug("sch_mgr->engine_index %d is waitting for page_table_set_task more than %d x 100 ms\n", sch_mgr->engine_index, timeout_cnt);
++            }
+         }
+ 
+     }while(force_wait && e_status != ZX_EVENT_BACK);
+-- 
+2.52.0
+

--- a/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
+++ b/runtime-display/cx4-linux-graphics-driver-dri/autobuild/prepare
@@ -8,7 +8,7 @@ done
 
 abinfo "Unpacking upstream deb package ..."
 dpkg-deb -X \
-    "$SRCDIR"/cx4-linux-graphics-driver-dri-glvnd_"$__UPSTREAM_VER"_amd64.deb \
+    "$SRCDIR"/cx4-linux-graphics-driver-dri-"$__UPSTREAM_VER".deb \
     "$SRCDIR"
 
 abinfo "Entering kernel module sources directory"

--- a/runtime-display/cx4-linux-graphics-driver-dri/spec
+++ b/runtime-display/cx4-linux-graphics-driver-dri/spec
@@ -1,6 +1,7 @@
-UPSTREAM_VER=26.00.49
+UPSTREAM_VER=26.00.46
 __UPSTREAM_VER="$UPSTREAM_VER"
 VER="$UPSTREAM_VER"
-SRCS="tbl::https://www.zhaoxin.com/Admin/Others/DownloadsPage.aspx?nid=31&id=3419&tag=0&ref=qdxz&pre=0&t=20ce3b68fe29466a&__for_acbs_hash_url=$UPSTREAM_VER"
-CHKSUMS="sha256::8f0884b4f9d16d416c060c135030e44930492e5a4662d60516b6f4b1f27e4740"
+EPOCH=1
+SRCS="tbl::https://cdn-community-packages.deepin.com/deepin/beige/pool/commercial/c/cx4-linux-graphics-driver-dri/cx4-linux-graphics-driver-dri_${UPSTREAM_VER}_amd64.deb"
+CHKSUMS="sha256::4dd471f140e74f82dd89498d79921d93a88561b161876851cf49c505df38564e"
 # FIXME: Impossible to generate CHKUPDATE from non-static pages.


### PR DESCRIPTION
Topic Description
-----------------

- cx4-linux-graphics-driver-dri: downgrade to 26.00.46
    Downgrade as xrdp doesn’t work:
    0x00007fd2a784d5e6 n/a \(libxcb.so.1 + 0x175e6\)
    0x00007fd2a784d74d xcb_prefetch_extension_data \(libxcb.so.1 + 0x1774d\)
    0x00007fd290a29715 n/a \(libEGL_cx4.so.0 + 0x29715\)
    0x00007fd290a20a28 n/a \(libEGL_cx4.so.0 + 0x20a28\)
    0x00007fd290a0e3c4 n/a \(libEGL_cx4.so.0 + 0xe3c4\)
    Track patches at AOSC-Tracking/cx4-kernel-dkms @ aosc/v26.00.46
    \(HEAD: 59810e07ea4807e23a1a1a25891d5848788bfc60\).

Package(s) Affected
-------------------

- cx4-linux-graphics-driver-dri: 26.00.46

Security Update?
----------------

No

Build Order
-----------

```
#buildit cx4-linux-graphics-driver-dri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
