### PR TITLE
OpenSSL 1.1.1zh

### DIFF
--- a/runtime-cryptography/openssl-1.1/spec
+++ b/runtime-cryptography/openssl-1.1/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.1.1zg
+UPSTREAM_VER=1.1.1zh
 VER=${UPSTREAM_VER/_/+}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/kzalewski/openssl-1.1.1.git"
 CHKSUMS="SKIP"

--- a/runtime-optenv32/openssl-1.1+32/spec
+++ b/runtime-optenv32/openssl-1.1+32/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.1.1zg
+UPSTREAM_VER=1.1.1zh
 VER=${UPSTREAM_VER/_/+}
 SRCS="git::commit=tags/$UPSTREAM_VER::https://github.com/kzalewski/openssl-1.1.1.git"
 CHKSUMS="SKIP"

--- a/topics/openssl-1.1.1zh.toml
+++ b/topics/openssl-1.1.1zh.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 1.1.1zh"
+
+[caution]
+default = "Fixes 5 security vulnerabilities disclosed in OpenSSL Security Advisory on June 9, 2026 (including 1 of Critical and 3 of High severity)"
+zh_CN = "修复 OpenSSL 在 2026 年 6 月 9 日发布的安全公告中披露的 5 个安全漏洞（含 1 个严重漏洞和 3 个高危漏洞）"
+
+[packages-v2]
+"openssl-1.1" = "< 1.1.1zh"
+"openssl-1.1+32" = "< 1.1.1zh"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add openssl-1.1.1zh.toml
- openssl-1.1+32: update to 1.1.1zh
- openssl-1.1: update to 1.1.1zh

Package(s) Affected
-------------------

- openssl-1.1: 1.1.1zh

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl-1.1
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
