### PR TITLE
osu-lazer: update to 2026.605.0

### DIFF
--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,6 +1,6 @@
 # Note: Only -lazer-suffixed tags are considered stable.
-UPSTREAM_VER=2026.305.0-lazer
-FRAMEWORK_VER=2026.303.0
+UPSTREAM_VER=2026.605.0
+FRAMEWORK_VER=2026.527.0
 VER="${UPSTREAM_VER/\-/+}"
 # Note: For components below, use latest versions.
 SRCS="git::commit=tags/${UPSTREAM_VER};rename=osu::https://github.com/ppy/osu \


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2026.605.0
    Co-authored-by: Xinmudotmoe \(@Xinmudotmoe\) <xinmu@loongfans.cn>

Package(s) Affected
-------------------

- osu-lazer: 2026.605.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
