### PR TITLE
sourcegit: new, 2026.13

### DIFF
--- a/app-vcs/sourcegit/autobuild/build
+++ b/app-vcs/sourcegit/autobuild/build
@@ -1,0 +1,25 @@
+abinfo "Building SourceGit directly..."
+dotnet publish \
+    "$SRCDIR"/src/SourceGit.csproj \
+    -c Release \
+    -p:DisableUpdateDetection=true \
+    -o "$PKGDIR"/usr/lib/sourcegit
+
+abinfo "Move the debug symbol"
+mkdir -pv "$SYMDIR"/usr/lib/sourcegit
+mv -v "$PKGDIR"/usr/lib/sourcegit/SourceGit.dbg "$SYMDIR"/usr/lib/sourcegit/
+
+abinfo "Link the main program"
+mkdir -v "$PKGDIR"/usr/bin
+ln -sv ../lib/sourcegit/SourceGit "$PKGDIR"/usr/bin/sourcegit
+
+abinfo "Change the desktop entry"
+desktop-file-edit "$SRCDIR"/build/resources/_common/applications/sourcegit.desktop \
+    --set-key Exec \
+    --set-value /usr/bin/sourcegit
+
+abinfo "Installing desktop entry"
+install -Dvm644 "$SRCDIR"/build/resources/_common/applications/sourcegit.desktop \
+    "$PKGDIR"/usr/share/applications/sourcegit.desktop
+install -Dvm644 "$SRCDIR"/build/resources/_common/icons/sourcegit.png \
+    "$PKGDIR"/usr/share/icons/sourcegit.png

--- a/app-vcs/sourcegit/autobuild/defines
+++ b/app-vcs/sourcegit/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=sourcegit
+PKGSEC=vcs
+
+# FIXME: After compiling with NativeAOT, there is no longer a need to rely on the .NET Runtime.
+PKGDEP="x11-lib icu xdg-utils desktop-file-utils"
+BUILDDEP="dotnet-sdk-10.0 dotnet-sdk-aot-10.0"
+
+PKGDES="Graphical client for Git"
+ABTYPE=self
+
+# FIXME: Avalonia officially supports only amd64, arm64 and loongarch64.
+# FIXME: The secondary architectures are untested
+# FIXME: loongson3/mips64el doesn't have dotnet support.
+# FIXME: loongarch64_nosimd doesn't have GUI capabilities, so supporting it serves no practical purpose.
+# FIXME: ppc64el doesn't have SkiaSharp support, it compiles successfully but doesn't work.
+FAIL_ARCH="(loongson3|loongarch64_nosimd|ppc64el)"

--- a/app-vcs/sourcegit/autobuild/patches/0000-patch-remove-drag-and-drop-tip.patch
+++ b/app-vcs/sourcegit/autobuild/patches/0000-patch-remove-drag-and-drop-tip.patch
@@ -1,0 +1,35 @@
+From df8c4882c370bf961d2ad730a57f8e0ff72305ee Mon Sep 17 00:00:00 2001
+From: LiarOnce <liaronce@hotmail.com>
+Date: Fri, 26 Jun 2026 20:27:32 +0800
+Subject: [PATCH] patch: remove drag-and-drop tip on Welcome page
+
+The current version of Avalonia UI used by SourceGit does not yet support drag-and-drop operations on Linux;
+delete this tip to avoid misleading users.
+
+Signed-off-by: LiarOnce <liaronce@hotmail.com>
+---
+ src/Views/Welcome.axaml | 9 ---------
+ 1 file changed, 9 deletions(-)
+
+diff --git a/src/Views/Welcome.axaml b/src/Views/Welcome.axaml
+index 6f6950b4..66a36f12 100644
+--- a/src/Views/Welcome.axaml
++++ b/src/Views/Welcome.axaml
+@@ -211,14 +211,5 @@
+         </ListBox.ItemTemplate>
+       </v:RepositoryListBox>
+     </Grid>
+-
+-    <!-- Tips -->
+-    <TextBlock Grid.Row="1" Grid.Column="1"
+-               Classes="italic"
+-               Margin="0,0,8,0"
+-               HorizontalAlignment="Center" VerticalAlignment="Center"
+-               FontSize="{Binding Source={x:Static vm:Preferences.Instance}, Path=DefaultFontSize, Converter={x:Static c:DoubleConverters.Decrease}}"
+-               Text="{DynamicResource Text.Welcome.DragDropTip}"
+-               Foreground="{DynamicResource Brush.FG2}"/>
+   </Grid>
+ </UserControl>
+-- 
+2.52.0
+

--- a/app-vcs/sourcegit/spec
+++ b/app-vcs/sourcegit/spec
@@ -1,0 +1,4 @@
+VER=2026.13
+SRCS="git::commit=tags/v$VER::https://github.com/sourcegit-scm/sourcegit.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=374318"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

sourcegit: new package, 2026.13

Starting with this release, SourceGit has updated Avalonia to `12.0.4`, so its LoongArch support has been fully integrated with the upstream.

Package(s) Affected
-------------------

sourcegit: 1:2026.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit sourcegit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`

