### PR TITLE
libidn: update to 1.44

### DIFF
--- a/runtime-network/libidn/autobuild/beyond
+++ b/runtime-network/libidn/autobuild/beyond
@@ -1,1 +1,0 @@
-ln -sv libidn.so.12 "$PKGDIR"/usr/lib/libidn.so.11

--- a/runtime-network/libidn/autobuild/defines
+++ b/runtime-network/libidn/autobuild/defines
@@ -1,12 +1,20 @@
 PKGNAME=libidn
 PKGSEC=libs
-PKGDES="Implementation of the Stringprep, Punycode and IDNA specifications"
 PKGDEP="glibc"
+# Note: gtk-doc needed for re-configuration. Documentation generation
+# disabled explicitly below.
 BUILDDEP="gtk-doc"
+PKGDES="Library to implement the Stringprep, Punycode, and IDNA specifications"
 
-AUTOTOOLS_AFTER="--disable-java \
-                 --disable-csharp"
-ABSHADOW=0
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--disable-java'
+    '--disable-csharp'
+    # Note: Per the Styling Manual.
+    '--disable-gtk-doc'
+    '--disable-gtk-doc-html'
+    '--disable-gtk-doc-pdf'
+)
 
 PKGBREAK="elinks<=0.12pre6 filezilla<=3.31.0 gloox<=1.0.20 gsasl<=1.8.0-3 \
           libpurple<=2.12.0 loudmouth<=1.4.3-3 monotone<=1.1 mutt<=1.10.0 \

--- a/runtime-network/libidn/autobuild/defines.stage2
+++ b/runtime-network/libidn/autobuild/defines.stage2
@@ -1,14 +1,17 @@
 PKGNAME=libidn
 PKGSEC=libs
-PKGDES="Implementation of the Stringprep, Punycode and IDNA specifications"
-PKGDEP=glibc
+PKGDEP="glibc"
+PKGDES="Library to implement the Stringprep, Punycode, and IDNA specifications"
 
-AUTOTOOLS_AFTER="--disable-java --disable-csharp"
-ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--disable-java'
+    '--disable-csharp'
+)
+
+# Note: gtk-doc is needed for re-configuration.
+RECONF=0
 
 PKGBREAK="elinks<=0.12pre6 filezilla<=3.31.0 gloox<=1.0.20 gsasl<=1.8.0-3 \
           libpurple<=2.12.0 loudmouth<=1.4.3-3 monotone<=1.1 mutt<=1.10.0 \
           neomutt<=20180622 podofo<=0.9.5 swift-im<=3.0-1 tdelibs<=14.0.4-4 \
           vlc<=3.0.3-2 ghostscript<=9.23-1 gmime-3<=3.0.3"
-
-RECONF=0

--- a/runtime-network/libidn/spec
+++ b/runtime-network/libidn/spec
@@ -1,4 +1,4 @@
-VER=1.43
+VER=1.44
 SRCS="tbl::https://ftp.gnu.org/gnu/libidn/libidn-$VER.tar.gz"
-CHKSUMS="sha256::bdc662c12d041b2539d0e638f3a6e741130cdb33a644ef3496963a443482d164"
+CHKSUMS="sha256::499608bab3a65650a0ea52888c13a8deebe3f71408e319acd9ec52e02eb13959"
 CHKUPDATE="anitya::id=1639"

--- a/runtime-optenv32/libidn+32/autobuild/defines
+++ b/runtime-optenv32/libidn+32/autobuild/defines
@@ -1,7 +1,19 @@
 PKGNAME=libidn+32
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 glibc+32"
+# Note: gtk-doc needed for re-configuration. Documentation generation
+# disabled explicitly below.
 BUILDDEP="devel-base+32 gtk-doc"
-PKGDES="Implementation of the Stringprep, Punycode and IDNA specifications (32-bit x86 runtime)"
+PKGDES="Library to implement the Stringprep, Punycode, and IDNA specifications (32-bit x86 runtime)"
+
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--disable-java'
+    '--disable-csharp'
+    # Note: Per the Styling Manual.
+    '--disable-gtk-doc'        
+    '--disable-gtk-doc-html'   
+    '--disable-gtk-doc-pdf'
+)
 
 ABHOST=optenv32

--- a/runtime-optenv32/libidn+32/spec
+++ b/runtime-optenv32/libidn+32/spec
@@ -1,4 +1,4 @@
-VER=1.42
+VER=1.44
 SRCS="tbl::https://ftp.gnu.org/gnu/libidn/libidn-$VER.tar.gz"
-CHKSUMS="sha256::d6c199dcd806e4fe279360cb4b08349a0d39560ed548ffd1ccadda8cdecb4723"
+CHKSUMS="sha256::499608bab3a65650a0ea52888c13a8deebe3f71408e319acd9ec52e02eb13959"
 CHKUPDATE="anitya::id=1639"


### PR DESCRIPTION
Topic Description
-----------------

- libidn+32: update to 1.44
- libidn: update to 1.44
    - Drop unused \(and unexplained\) beyond script.
    - Disable gtk-doc per the Styling Manual.

Package(s) Affected
-------------------

- libidn: 1.44

Security Update?
----------------

No

Build Order
-----------

```
#buildit libidn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
