### PR TITLE
pandoc: update to 3.10

### DIFF
--- a/app-doc/pandoc/autobuild/defines
+++ b/app-doc/pandoc/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=doc
 PKGDES="Universal markup converter"
 PKGDEP="cmark texlive"
 BUILDDEP="cabal-install ghc zlib-static numactl libffi"
+PKGRECOM="typst"
 
 # Note: Sync with GHC.
 FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"

--- a/app-doc/pandoc/spec
+++ b/app-doc/pandoc/spec
@@ -1,4 +1,4 @@
-VER=3.9.0.2
+VER=3.10
 SRCS="git::commit=tags/$VER::https://github.com/jgm/pandoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2589"


### PR DESCRIPTION
Topic Description
-----------------

- pandoc: update to 3.10
    Add Typst as an optional dependency

Package(s) Affected
-------------------

- pandoc: 3.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit pandoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
