### PR TITLE
[FLIGHT] linux-kernel-vanillarc: systemio test

### DIFF
--- a/runtime-kernel/linux-kernel-vanillarc/autobuild/patches/9999-FLIGHT-SYSTEMIO.patch
+++ b/runtime-kernel/linux-kernel-vanillarc/autobuild/patches/9999-FLIGHT-SYSTEMIO.patch
@@ -1,0 +1,85 @@
+diff --git a/arch/loongarch/include/asm/acpi.h b/arch/loongarch/include/asm/acpi.h
+index 7376840fa9f7..32999f281d5b 100644
+--- a/arch/loongarch/include/asm/acpi.h
++++ b/arch/loongarch/include/asm/acpi.h
+@@ -38,6 +38,8 @@ static inline bool acpi_has_cpu_in_madt(void)
+ extern struct list_head acpi_wakeup_device_list;
+ extern struct acpi_madt_core_pic acpi_core_pic[MAX_CORE_PIC];
+ 
++extern void acpi_add_early_pio(void);
++extern void acpi_remove_early_pio(void);
+ extern int __init parse_acpi_topology(void);
+ 
+ static inline u32 get_acpi_id_for_cpu(unsigned int cpu)
+diff --git a/arch/loongarch/kernel/acpi.c b/arch/loongarch/kernel/acpi.c
+index 1367ca759468..88ad24d1e729 100644
+--- a/arch/loongarch/kernel/acpi.c
++++ b/arch/loongarch/kernel/acpi.c
+@@ -16,6 +16,7 @@
+ #include <linux/memblock.h>
+ #include <linux/of_fdt.h>
+ #include <linux/serial_core.h>
++#include <linux/vmalloc.h>
+ #include <asm/io.h>
+ #include <asm/numa.h>
+ #include <asm/loongson.h>
+@@ -59,6 +60,33 @@ void __iomem *acpi_os_ioremap(acpi_physical_address phys, acpi_size size)
+ 		return ioremap_cache(phys, size);
+ }
+ 
++#define PIO_BASE (unsigned long)PCI_IOBASE
++#define PIO_SIZE ALIGN(ISA_IOSIZE, PAGE_SIZE)
++
++static bool acpi_pio;
++
++/* Add PIO for early access */
++void acpi_add_early_pio(void)
++{
++	if (!acpi_disabled) {
++		acpi_pio = true;
++		vmap_page_range(PIO_BASE, PIO_BASE + PIO_SIZE,
++				LOONGSON_LIO_BASE, pgprot_device(PAGE_KERNEL));
++	}
++}
++
++/* Remove PIO for PCI register */
++void acpi_remove_early_pio(void)
++{
++	if (!acpi_pio)
++		return;
++
++	if (!acpi_disabled) {
++		acpi_pio = false;
++		vunmap_range(PIO_BASE, PIO_BASE + PIO_SIZE);
++	}
++}
++
+ #ifdef CONFIG_SMP
+ static int set_processor_mask(u32 id, u32 pass)
+ {
+diff --git a/arch/loongarch/kernel/setup.c b/arch/loongarch/kernel/setup.c
+index 2b260d15b2e2..9db041976c7c 100644
+--- a/arch/loongarch/kernel/setup.c
++++ b/arch/loongarch/kernel/setup.c
+@@ -542,6 +542,8 @@ static __init int arch_reserve_pio_range(void)
+ 		}
+ 	}
+ 
++	acpi_add_early_pio();
++
+ 	return 0;
+ }
+ arch_initcall(arch_reserve_pio_range);
+diff --git a/arch/loongarch/pci/acpi.c b/arch/loongarch/pci/acpi.c
+index a6d869e103c1..1a28fe847d47 100644
+--- a/arch/loongarch/pci/acpi.c
++++ b/arch/loongarch/pci/acpi.c
+@@ -65,6 +65,8 @@ static int acpi_prepare_root_resources(struct acpi_pci_root_info *ci)
+ 	struct resource_entry *entry, *tmp;
+ 	struct acpi_device *device = ci->bridge;
+ 
++	acpi_remove_early_pio();
++
+ 	status = acpi_pci_probe_root_resources(ci);
+ 	if (status > 0) {
+ 		acpi_evaluate_integer(device->handle, "PCIH", NULL, &pci_h);

--- a/runtime-kernel/linux-kernel-vanillarc/spec
+++ b/runtime-kernel/linux-kernel-vanillarc/spec
@@ -18,7 +18,7 @@ __VER="${VER}"
 # Use this for mainline RC releases.
 RC=7
 # To RFC: Increment by 0.1 per RC release, i.e., RC3 = 0.3.
-REL=0.${RC}-1
+REL=0.${RC}-1.1
 SRCS="tbl::https://git.kernel.org/torvalds/t/linux-${VER%%.0}-rc${RC}.tar.gz"
 CHKSUMS="sha256::f9ef2aba50622b36cd4decdd677c9c8cfe37c9caedabaf38db750959906ea17b"
 


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] linux-kernel-vanillarc: systemio test

Package(s) Affected
-------------------

- linux-kernel-vanillarc-${__VER}: 7.1.0-0.7-1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel-vanillarc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
