### PR TITLE
June Distro Survey (20260618)

### DIFF
--- a/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
@@ -1,7 +1,7 @@
 From ee19b825a3371e0ab503c0cbaf2152879e6edbea Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 23 Jan 2025 11:45:36 +0800
-Subject: [PATCH 1/6] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
+Subject: [PATCH 1/7] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
  to amdgpu, loongson, and radeon
 
 If we are using mips64el (assumed to be MIPS-based Loongson), only install

--- a/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-11systemd-crypsetup-remove-TPM2-dep.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-11systemd-crypsetup-remove-TPM2-dep.patch
@@ -1,7 +1,7 @@
 From 8154fbd46377a3496e9b180a1921174c5fd59394 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:55:49 +0800
-Subject: [PATCH 2/6] AOSCOS: LOONGSON3: 11systemd-crypsetup: remove TPM2
+Subject: [PATCH 2/7] AOSCOS: LOONGSON3: 11systemd-crypsetup: remove TPM2
  dependency
 
 There is just no way that we will get TPM2 on MIPS-based Loongson 3

--- a/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-70kernel-modules-minimise-default-k.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-70kernel-modules-minimise-default-k.patch
@@ -1,7 +1,7 @@
 From d077763d2e7d1cc3c787a3fb085a6c18e8f9b723 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:56:34 +0800
-Subject: [PATCH 3/6] AOSCOS: LOONGSON3: 70kernel-modules: minimise default
+Subject: [PATCH 3/7] AOSCOS: LOONGSON3: 70kernel-modules: minimise default
  kernel drivers
 
 Make sure that only drivers that were likely needed at early-boot were

--- a/app-admin/dracut-ng/autobuild/patches/0004-fix-70kernel-modules-Explicitly-include-xhci-pci-ren.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0004-fix-70kernel-modules-Explicitly-include-xhci-pci-ren.patch
@@ -1,7 +1,7 @@
 From 66ec58fcfcf26f45375a64c282c3d92c9933aa9b Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 1 Mar 2025 00:54:31 +0800
-Subject: [PATCH 4/6] fix(70kernel-modules): Explicitly include
+Subject: [PATCH 4/7] fix(70kernel-modules): Explicitly include
  xhci-pci-renesas
 
 Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer depends

--- a/app-admin/dracut-ng/autobuild/patches/0005-dracut_functions.sh-confirm-if-the-UUID-matches-befo.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0005-dracut_functions.sh-confirm-if-the-UUID-matches-befo.patch
@@ -1,7 +1,7 @@
 From 29e19edbffc51067293d00edbad6dde660d17219 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Dec 2025 19:10:43 +0800
-Subject: [PATCH 5/6] dracut_functions.sh: confirm if the UUID matches before
+Subject: [PATCH 5/7] dracut_functions.sh: confirm if the UUID matches before
  returning
 
 Sometimes the information read from udev may be outdated, for example a

--- a/app-admin/dracut-ng/autobuild/patches/0006-BACKPORT-FROMLIST-feat-decompress-kernel-modules-and.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0006-BACKPORT-FROMLIST-feat-decompress-kernel-modules-and.patch
@@ -1,7 +1,7 @@
 From 04823ea17d98d6bb1bcdca61a76d85761de7d243 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:58:49 +0800
-Subject: [PATCH 6/6] BACKPORT: FROMLIST: feat: decompress kernel modules and
+Subject: [PATCH 6/7] BACKPORT: FROMLIST: feat: decompress kernel modules and
  firmware before final compression
 
 Decompress all kernel modules and firmware (if compressed), this allows

--- a/app-admin/dracut-ng/autobuild/patches/0007-AOSCOS-70kernel-modules-add-megaraid-_sas-and-mpt3sa.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0007-AOSCOS-70kernel-modules-add-megaraid-_sas-and-mpt3sa.patch
@@ -1,0 +1,38 @@
+From 305affdc97f5c70986e1318468fdef46f2c0ca84 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 18 Jun 2026 23:01:12 +0800
+Subject: [PATCH 7/7] AOSCOS: 70kernel-modules: add megaraid{,_sas} and mpt3sas
+ for block modules
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ modules.d/70kernel-modules/module-setup.sh | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/modules.d/70kernel-modules/module-setup.sh b/modules.d/70kernel-modules/module-setup.sh
+index b30aa197..d8545062 100755
+--- a/modules.d/70kernel-modules/module-setup.sh
++++ b/modules.d/70kernel-modules/module-setup.sh
+@@ -31,7 +31,8 @@ installkernel() {
+                 =drivers/usb/storage \
+                 =ide nvme vmd \
+                 virtio_blk virtio_scsi \
+-                =drivers/ufs
++                =drivers/ufs \
++                megaraid megaraid_sas mpt3sas
+         else
+             # MIPS64: Minimise kernel modules to save initramfs size,
+             # taking into account USB mass storage, IDE/ATA, NVMe, and
+@@ -39,7 +40,8 @@ installkernel() {
+             hostonly=$(optional_hostonly) instmods \
+                 =drivers/usb/storage \
+                 =ide nvme \
+-                virtio_blk virtio_scsi
++                virtio_blk virtio_scsi \
++                megaraid megaraid_sas mpt3sas
+         fi
+ 
+         dracut_instmods -o -s "${_blockfuncs}" "=drivers"
+-- 
+2.52.0
+

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,4 +1,5 @@
 VER=110
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"

--- a/app-multimedia/alsa-utils/spec
+++ b/app-multimedia/alsa-utils/spec
@@ -1,4 +1,4 @@
-VER=1.2.15.1
+VER=1.2.16
 SRCS="tbl::https://www.alsa-project.org/files/pub/utils/alsa-utils-${VER}.tar.bz2"
-CHKSUMS="sha256::5ad79f349e59c30c9a4929ad4995ebee33267473e0e632d7c1a30e2b093d3327"
+CHKSUMS="sha256::092399d5e8749a1d5e188e393157521cec4b75693b60ebb79bbce728cff2232c"
 CHKUPDATE="anitya::id=37"

--- a/app-multimedia/sof-tools/spec
+++ b/app-multimedia/sof-tools/spec
@@ -1,5 +1,4 @@
-VER=2.13.1
-REL=1
+VER=2.14.3
 SRCS="git::commit=tags/v$VER::https://github.com/thesofproject/sof"
 CHKSUMS="SKIP"
 SUBDIR="sof-tools/tools"

--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2026.06.0
+VER=2026.06.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2026.06.1
+VER=2026.06.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/desktop-themes/aosc-community-wallpapers/spec
+++ b/desktop-themes/aosc-community-wallpapers/spec
@@ -1,4 +1,4 @@
-VER=2025.12.3
+VER=2026.06.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/community-wallpapers"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=283163"

--- a/runtime-data/plasma-default-settings/spec
+++ b/runtime-data/plasma-default-settings/spec
@@ -1,4 +1,4 @@
-VER=2025.12.1
+VER=2026.06.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-default-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=362934"

--- a/runtime-kernel/linux-firmware/01-nonfree/build
+++ b/runtime-kernel/linux-firmware/01-nonfree/build
@@ -15,7 +15,7 @@ mv -v "$PKGDIR"/usr/lib/firmware/amd-ucode/README.xz \
     "$PKGDIR"/usr/lib/firmware/README.amd-ucode.xz
 
 abinfo "Installing extra firmware from Debian ..."
-cp -rv "$SRCDIR"/../debian/config/* \
+cp -rv "$SRCDIR"/../debian/added-firmware/* \
     "$PKGDIR"/usr/lib/firmware/
 mkdir -pv "$PKGDIR"/usr/share/doc/firmware-nonfree/
 
@@ -32,10 +32,6 @@ for i in "$SRCDIR"/../debian/config/*; do
             "$PKGDIR"/usr/share/doc/firmware-nonfree/COPYING.$(basename $i)
     fi
 done
-
-abinfo "Correcting ipw2x00 firmware location ..."
-mv -v "$PKGDIR"/usr/lib/firmware/ipw2x00/* \
-    "$PKGDIR"/usr/lib/firmware/
 
 abinfo "Copying license details ..."
 cp -v "$SRCDIR"/{WHENCE,LICENSE.*,LICENCE.*,GPL-2,GPL-3} "${PKGDIR}"/usr/lib/firmware/
@@ -81,3 +77,11 @@ ln -sv brcmfmac43430-sdio.raspberrypi,3-model-b.txt \
     "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-2-w.txt
 ln -sv brcmfmac43430-sdio.raspberrypi,3-model-b.txt \
     "$PKGDIR"/usr/lib/firmware/brcm/brcmfmac43430-sdio.raspberrypi,model-zero-w.txt 
+
+abinfo "Installing supplemental firmware for Radxa Dragon series ..."
+cp -av "$SRCDIR"/../radxa/radxa-firmware-sc8280xp/lib \
+    "$PKGDIR"/usr/
+cp -av "$SRCDIR"/../radxa/radxa-firmware-sc8280xp/usr \
+    "$PKGDIR"/
+cp -av "$SRCDIR"/../radxa/radxa-firmware-qcs6490/usr \
+    "$PKGDIR"/

--- a/runtime-kernel/linux-firmware/spec
+++ b/runtime-kernel/linux-firmware/spec
@@ -1,17 +1,20 @@
-UPSTREAM_VER=20260221
-DEBIANVER=20260110-1
-VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}
+UPSTREAM_VER=20260519
+DEBIANVER=20260519-1
+RADXAVER=0.2.35
+VER=${UPSTREAM_VER}+debian${DEBIANVER/-/+}+radxa${RADXAVER}
 SRCS="git::commit=tags/${UPSTREAM_VER}::https://gitlab.com/kernel-firmware/linux-firmware.git \
       file::rename=brcmfmac43456-sdio.bin::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.bin \
       file::rename=brcmfmac43456-sdio.clm_blob::https://github.com/RPi-Distro/firmware-nonfree/raw/7cf2f1bca39a5efea023e834d3b4c6b00af3c5ec/debian/config/brcm80211/brcm/brcmfmac43456-sdio.clm_blob \
       file::rename=brcmfmac43456-sdio.AP6256.txt::https://github.com/armbian/firmware/raw/8e7c8a855f0a91d3a34c1e37086d5aa894b2011e/brcm/nvram_ap6256.txt \
       file::rename=BCM4345C5.hcd::https://github.com/armbian/firmware/raw/6b6f053f6089e08dd2a675cda1ec813de2e842e2/brcm/BCM4345C5.hcd \
-      tbl::rename=firmware-nonfree.debian.tar.xz::https://deb.debian.org/debian/pool/non-free-firmware/f/firmware-nonfree/firmware-nonfree_${DEBIANVER}.debian.tar.xz"
+      tbl::rename=firmware-nonfree.debian.tar.xz::https://deb.debian.org/debian/pool/non-free-firmware/f/firmware-nonfree/firmware-nonfree_${DEBIANVER}.debian.tar.xz \
+      git::rename=radxa;commit=tags/$RADXAVER::https://github.com/radxa-pkg/radxa-firmware"
 CHKSUMS="SKIP \
          sha256::ddf83f2100885b166be52d21c8966db164fdd4e1d816aca2acc67ee9cc28d726 \
          sha256::2dbd7d22fc9af0eb560ceab45b19646d211bc7b34a1dd00c6bfac5dd6ba25e8a \
          sha256::588430b4c2c167ca035f17da7478bec3d4922487152610d385d5ccb8f7c0a75f \
          sha256::f67164f0eda8d4ca96305e177a61542bf8b470f2f1c456b66fe8c660650f1c7a \
-         sha256::2deee6a63255e3a8e8ab1530e36064fd85c77b3e1db7ede89dc1484b4e0bf63c"
+         sha256::451b654e873ebb9b4b9da90cb5c4a1d8938a8def761a2143534862f06ae01c0e \
+         SKIP"
 CHKUPDATE="anitya::id=141464"
 SUBDIR="linux-firmware"

--- a/runtime-multimedia/alsa-lib/spec
+++ b/runtime-multimedia/alsa-lib/spec
@@ -1,4 +1,4 @@
-VER=1.2.15.3
+VER=1.2.16.1
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-lib-$VER.tar.bz2"
-CHKSUMS="sha256::7b079d614d582cade7ab8db2364e65271d0877a37df8757ac4ac0c8970be861e"
+CHKSUMS="sha256::f740db7f488255944ffd4428416ee3390a96742856916433df468c281436480e"
 CHKUPDATE="anitya::id=38"

--- a/runtime-multimedia/alsa-ucm-conf/spec
+++ b/runtime-multimedia/alsa-ucm-conf/spec
@@ -1,4 +1,4 @@
-VER=1.2.15.3
+VER=1.2.16.1
 SRCS="tbl::https://www.alsa-project.org/files/pub/lib/alsa-ucm-conf-$VER.tar.bz2"
-CHKSUMS="sha256::9f79e813c08fc86cfa46dd75c4fcda1a4a51b482db2607e1fcfaafb92f588a31"
+CHKSUMS="sha256::cf3d1c07e089a83c4ece2c20f05dd6a8aab7fcd108768c38811386880575492b"
 CHKUPDATE="anitya::id=141467"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: include megaraid{,_sas} and mpt3sas to block modules
    - Our users reported that the initrd lacked these modules, causing mount
    failures during boot-up.
    - Track patches at AOSC-Tracking/dracut @ aosc/110
    \(HEAD: 305affdc97f5c70986e1318468fdef46f2c0ca84\).
- plasma-default-settings: update to 2026.06.0
- aosc-community-wallpapers: update to 2026.06.0
- alsa-utils: update to 1.2.16
- alsa-ucm-conf: update to 1.2.16.1
- alsa-lib: update to 1.2.16.1
- sof-tools: update to 2.14.3
- linux-firmware: update to 20260519+debian20260519+1+radxa0.2.35
    Add supplemental firmware from Radxa for their Qualcomm-based solutions.

Package(s) Affected
-------------------

- alsa-lib: 1.2.16.1
- alsa-ucm-conf: 1.2.16.1
- alsa-utils: 1.2.16
- aosc-community-wallpapers: 1:2026.06.0
- dracut-ng: 110-1
- firmware-free: 20260519+debian20260519+1+radxa0.2.35
- firmware-nonfree: 20260519+debian20260519+1+radxa0.2.35
- plasma-default-settings: 1:2026.06.0
- sof-tools: 2.14.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-firmware sof-tools alsa-lib alsa-ucm-conf alsa-utils dracut-ng aosc-community-wallpapers plasma-default-settings
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
