### PR TITLE
containerd: update to 2.3.2

### DIFF
--- a/app-containers/containerd/autobuild/patches/0001-FROMLIST-Export-compatibility-config.sandboxImage-in.patch
+++ b/app-containers/containerd/autobuild/patches/0001-FROMLIST-Export-compatibility-config.sandboxImage-in.patch
@@ -1,9 +1,37 @@
-# From https://github.com/containerd/containerd/pull/11114
+From 813647124ba1bc652ddbd7cdd20d34af2d3e74f6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Anders=20F=20Bj=C3=B6rklund?= <anders.f.bjorklund@gmail.com>
+Date: Sun, 8 Dec 2024 11:35:58 +0100
+Subject: [PATCH] FROMLIST: Export compatibility config.sandboxImage in CRI
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The kubeadm preflight checks for config.sandboxImage in CRI,
+make sure that this value is present in the exported "config".
+
+Signed-off-by: Anders F Björklund <anders.f.bjorklund@gmail.com>
+
+Link: https://github.com/containerd/containerd/pull/11114
+Signed-off-by: SignKirigami <prcups@krgm.moe>
+
+[ stydxm: Rebased patch against 2.3.x due to
+  https://github.com/containerd/containerd/commit/7ef50acccf917a7d006a6069dced7d9de2e26a07#diff-a77058e343f8e7b9b18296a30d053f6fdc05d217666491238ee6eda4cbf41a90 ]
+
+Signed-off-by: stydxm <stydxm@aosc.io>
+---
+ internal/cri/server/container_status_test.go |  5 +-
+ internal/cri/server/images/service.go        |  4 ++
+ internal/cri/server/service.go               |  2 +
+ internal/cri/server/service_test.go          |  8 +++
+ internal/cri/server/status.go                | 13 ++++-
+ internal/cri/server/status_test.go           | 54 ++++++++++++++++++++
+ 6 files changed, 84 insertions(+), 2 deletions(-)
+
 diff --git a/internal/cri/server/container_status_test.go b/internal/cri/server/container_status_test.go
-index f53fb1aa6..635803207 100644
+index a35dda2ce..25dde6f2e 100644
 --- a/internal/cri/server/container_status_test.go
 +++ b/internal/cri/server/container_status_test.go
-@@ -277,7 +277,8 @@ func TestContainerStatus(t *testing.T) {
+@@ -361,7 +361,8 @@ func TestToCRISignal(t *testing.T) {
  }
  
  type fakeImageService struct {
@@ -13,7 +41,7 @@ index f53fb1aa6..635803207 100644
  }
  
  func (s *fakeImageService) RuntimeSnapshotter(ctx context.Context, ociRuntime criconfig.Runtime) string {
-@@ -294,6 +295,8 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
+@@ -378,6 +379,8 @@ func (s *fakeImageService) GetSnapshot(key, snapshotter string) (snapshotstore.S
  	return snapshotstore.Snapshot{}, errors.New("not implemented")
  }
  
@@ -22,11 +50,26 @@ index f53fb1aa6..635803207 100644
  func (s *fakeImageService) LocalResolve(refOrID string) (imagestore.Image, error) {
  	return imagestore.Image{}, errors.New("not implemented")
  }
+diff --git a/internal/cri/server/images/service.go b/internal/cri/server/images/service.go
+index 9654d206a..1e912c872 100644
+--- a/internal/cri/server/images/service.go
++++ b/internal/cri/server/images/service.go
+@@ -220,6 +220,10 @@ func (c *CRIImageService) Config() criconfig.ImageConfig {
+ 	return c.config
+ }
+ 
++func (c *CRIImageService) PinnedImage(name string) string {
++	return c.config.PinnedImages[name]
++}
++
+ // GRPCService returns a new CRI Image Service grpc server.
+ func (c *CRIImageService) GRPCService() runtime.ImageServiceServer {
+ 	return &GRPCCRIImageService{c}
 diff --git a/internal/cri/server/service.go b/internal/cri/server/service.go
-index 8b65b1465..66f30a24a 100644
+index 43d36bde9..dcf66d713 100644
 --- a/internal/cri/server/service.go
 +++ b/internal/cri/server/service.go
-@@ -105,6 +105,8 @@ type ImageService interface {
+@@ -107,6 +107,8 @@ type ImageService interface {
  	GetImage(id string) (imagestore.Image, error)
  	GetSnapshot(key, snapshotter string) (snapshotstore.Snapshot, error)
  
@@ -36,7 +79,7 @@ index 8b65b1465..66f30a24a 100644
  
  	ImageFSPaths() map[string]string
 diff --git a/internal/cri/server/service_test.go b/internal/cri/server/service_test.go
-index b6d9ecfb3..b8a6bdcd3 100644
+index 21efe3c7a..001b46a53 100644
 --- a/internal/cri/server/service_test.go
 +++ b/internal/cri/server/service_test.go
 @@ -26,6 +26,7 @@ import (
@@ -47,7 +90,7 @@ index b6d9ecfb3..b8a6bdcd3 100644
  	"github.com/containerd/containerd/v2/core/sandbox"
  	criconfig "github.com/containerd/containerd/v2/internal/cri/config"
  	containerstore "github.com/containerd/containerd/v2/internal/cri/store/container"
-@@ -137,6 +138,13 @@ func withRuntimeService(rs RuntimeService) testOpt {
+@@ -141,6 +142,13 @@ func withRuntimeService(rs RuntimeService) testOpt {
  	}
  }
  
@@ -164,3 +207,6 @@ index 6ab9ffc77..d33ee0a26 100644
  func TestRuntimeConditionContainerdHasNoDeprecationWarnings(t *testing.T) {
  	deprecations := []*introspection.DeprecationWarning{
  		{
+-- 
+2.52.0
+

--- a/app-containers/containerd/spec
+++ b/app-containers/containerd/spec
@@ -1,5 +1,4 @@
-VER=2.2.0
-REL=4
+VER=2.3.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/containerd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16460"

--- a/topics/containerd-2.3.2.toml
+++ b/topics/containerd-2.3.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "containerd 2.3.2"
+
+[caution]
+default = "Fixes 5 security vulnerabilities (including 3 of Critical, 1 of High, and 1 of Medium severity)"
+zh_CN = "修复 5 个安全漏洞（含 3 个严重、1 个高危和 1 个中危漏洞）"
+
+[packages-v2]
+"containerd" = "< 2.3.2"


### PR DESCRIPTION
Topic Description
-----------------

- containerd: update to 2.3.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- containerd: 2.3.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit containerd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
