### PR TITLE
bazel: update to 9.1.0

### DIFF
--- a/app-devel/bazel/autobuild/build
+++ b/app-devel/bazel/autobuild/build
@@ -33,8 +33,12 @@ bazel_build "src:bazel_nojdk" \
   --override_module=rules_java=$SRCDIR/override_module/rules_java
 
 abinfo "Task complete. Install bazel ..."
-install -Dvm0755 "$SRCDIR"/bazel-bin/src/bazel_nojdk \
+
+install -Dvm0755 "$SRCDIR"/scripts/packages/bazel.sh \
     "$PKGDIR"/usr/bin/bazel
+
+install -Dvm0755 "$SRCDIR"/bazel-bin/src/bazel_nojdk \
+    "$PKGDIR"/usr/bin/bazel-real
 
 mkdir -pv "$PKGDIR"/usr/lib/bazel/
 for i in third_party tools; do

--- a/app-devel/bazel/autobuild/build
+++ b/app-devel/bazel/autobuild/build
@@ -33,8 +33,12 @@ bazel_build "src:bazel_nojdk" \
   --override_module=rules_java=$SRCDIR/override_module/rules_java
 
 abinfo "Task complete. Install bazel ..."
-install -Dvm0755 "$SRCDIR"/bazel-bin/src/bazel_nojdk \
+
+install -Dm755 "$SRCDIR"/scripts/packages/bazel.sh \
     "$PKGDIR"/usr/bin/bazel
+
+install -Dvm0755 "$SRCDIR"/bazel-bin/src/bazel_nojdk \
+    "$PKGDIR"/usr/bin/bazel-real
 
 mkdir -pv "$PKGDIR"/usr/lib/bazel/
 for i in third_party tools; do

--- a/app-devel/bazel/autobuild/patches/0000-bazel-support-loongarch64.patch
+++ b/app-devel/bazel/autobuild/patches/0000-bazel-support-loongarch64.patch
@@ -62,33 +62,3 @@ index 88ae4a3..15759cb 100755
    UNKNOWN("unknown", ImmutableSet.<String>of());
 
    private final String canonicalName;
-diff --git a/third_party/BUILD b/third_party/BUILD
-index 023a760..21151e4 100755
---- a/third_party/BUILD
-+++ b/third_party/BUILD
-@@ -525,6 +525,7 @@ UNNECESSARY_DYNAMIC_LIBRARIES = select({
-     # The .so file is an x86/s390x one, so we can just remove it if the CPU is not x86/s390x
-     "//src/conditions:arm": "*.so *.jnilib *.dll",
-     "//src/conditions:linux_aarch64": "*.so *.jnilib *.dll",
-+    "//src/conditions:linux_loongarch64": "*.so *.jnilib *.dll",
-     "//src/conditions:linux_ppc": "*.so *.jnilib *.dll",
-     "//src/conditions:freebsd": "*.so *.jnilib *.dll",
-     "//src/conditions:openbsd": "*.so *.jnilib *.dll",
-@@ -761,10 +762,15 @@ config_setting(
-     values = {"host_cpu": "ppc"},
- )
-
-+config_setting(
-+    name = "loongarch64",
-+    values = {"host_cpu": "loongarch64"},
-+)
-+
- test_suite(
-     name = "all_windows_tests",
-     tests = [
-         "//third_party/def_parser:windows_tests",
-     ],
-     visibility = ["//src:__pkg__"],
--)
-\ No newline at end of file
-+)

--- a/app-devel/bazel/autobuild/patches/0002-bazel-rules_go-support.patch
+++ b/app-devel/bazel/autobuild/patches/0002-bazel-rules_go-support.patch
@@ -1,27 +1,29 @@
---- a/go/private/platforms.bzl  2024-05-21 17:54:21.000000000 +0000
-+++ b/go/private/platforms.bzl  2025-12-22 05:53:04.511106240 +0000
-@@ -33,6 +33,8 @@
-     "ppc64": "@platforms//cpu:ppc",
-     "ppc64le": "@platforms//cpu:ppc",
+diff --git a/go/private/platforms.bzl b/go/private/platforms.bzl
+index c3009b2..62bb4fd 100644
+--- a/go/private/platforms.bzl
++++ b/go/private/platforms.bzl
+@@ -35,6 +35,8 @@ BAZEL_GOARCH_CONSTRAINTS = {
+     "ppc64le": "@platforms//cpu:ppc64le",
      "s390x": "@platforms//cpu:s390x",
+     "riscv64": "@platforms//cpu:riscv64",
 +    "loong64": "@platforms//cpu:loongarch64",
 +    "mips64": "@platforms//cpu:mips64",
  }
-
+ 
  GOOS_GOARCH = (
-@@ -66,6 +68,7 @@
-     ("linux", "ppc64le"),
-     ("linux", "riscv64"),
-     ("linux", "s390x"),
+@@ -96,6 +98,7 @@ GOOS_GOARCH = (
+     ("windows", "amd64"),
+     ("windows", "arm"),
+     ("windows", "arm64"),
 +    ("linux", "loongarch64"),
-     ("nacl", "386"),
-     ("nacl", "amd64p32"),
-     ("nacl", "arm"),
-@@ -124,6 +127,7 @@
-     ("linux", "mipsle"): None,
-     ("linux", "ppc64le"): None,
-     ("linux", "riscv64"): None,
+ )
+ 
+ RACE_GOOS_GOARCH = {
+@@ -149,6 +152,7 @@ CGO_GOOS_GOARCH = {
+     ("windows", "386"): None,
+     ("windows", "amd64"): None,
+     ("windows", "arm64"): None,
 +    ("linux", "loong64"): None,
-     ("linux", "s390x"): None,
-     ("linux", "sparc64"): None,
-     ("netbsd", "386"): None,
+ }
+ 
+ def _generate_constraints(names, bazel_constraints):

--- a/app-devel/bazel/autobuild/patches/0003-bazel-rules_java-support.patch
+++ b/app-devel/bazel/autobuild/patches/0003-bazel-rules_java-support.patch
@@ -1,6 +1,8 @@
---- a/MODULE.bazel  2000-01-01 00:00:00.000000000 +0000
-+++ b/MODULE.bazel  2025-12-22 08:05:08.827353020 +0000
-@@ -42,6 +42,7 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 24653fe..1b16f58 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -59,6 +59,7 @@ JDKS = {
          "linux",
          "linux_aarch64",
          "linux_s390x",
@@ -8,7 +10,7 @@
          "macos",
          "macos_aarch64",
          "windows",
-@@ -52,6 +53,7 @@
+@@ -69,6 +70,7 @@ JDKS = {
          "linux_aarch64",
          "linux_ppc64le",
          "linux_s390x",
@@ -16,46 +18,40 @@
          "macos",
          "macos_aarch64",
          "win",
-@@ -63,6 +65,7 @@
+@@ -79,6 +81,7 @@ JDKS = {
+         "linux",
          "linux_aarch64",
          "linux_ppc64le",
-         "linux_s390x",
 +        "linux_loongarch64",
+         "linux_s390x",
          "macos",
          "macos_aarch64",
-         "win",
-@@ -74,6 +77,7 @@
-         "linux_aarch64",
+@@ -92,6 +95,7 @@ JDKS = {
          "linux_ppc64le",
          "linux_riscv64",
-+        "linux_loongarch64",
          "linux_s390x",
++        "linux_loongarch64",
          "macos",
          "macos_aarch64",
---- a/toolchains/BUILD      2000-01-01 00:00:00.000000000 +0000
-+++ b/toolchains/BUILD      2025-12-22 08:00:32.054103470 +0000
-@@ -141,6 +141,7 @@
-         "@bazel_tools//src/conditions:darwin": [":jni_md_header-darwin"],
-         "@bazel_tools//src/conditions:freebsd": [":jni_md_header-freebsd"],
-         "@bazel_tools//src/conditions:linux_aarch64": [":jni_md_header-linux"],
-+        "@bazel_tools//src/conditions:linux_loongarch64": [":jni_md_header-linux"],
-         "@bazel_tools//src/conditions:linux_mips64": [":jni_md_header-linux"],
-         "@bazel_tools//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
-         "@bazel_tools//src/conditions:linux_riscv64": [":jni_md_header-linux"],
-@@ -154,6 +155,7 @@
-         "@bazel_tools//src/conditions:darwin": ["include/darwin"],
-         "@bazel_tools//src/conditions:freebsd": ["include/freebsd"],
-         "@bazel_tools//src/conditions:linux_aarch64": ["include/linux"],
-+        "@bazel_tools//src/conditions:linux_loongarch64": ["include/linux"],
-         "@bazel_tools//src/conditions:linux_mips64": ["include/linux"],
-         "@bazel_tools//src/conditions:linux_ppc64le": ["include/linux"],
-         "@bazel_tools//src/conditions:linux_riscv64": ["include/linux"],
---- a/java/repositories.bzl 2000-01-01 00:00:00.000000000 +0000
-+++ b/java/repositories.bzl 2025-12-22 08:15:31.377449520 +0000
-@@ -94,6 +94,14 @@
+         "win",
+@@ -100,6 +104,8 @@ JDKS = {
+     "25": [
+         "linux",
+         "linux_aarch64",
++        "linux_ppc64le",
++        "linux_loongarch64",
+         "macos",
+         "macos_aarch64",
+         "win",
+diff --git a/java/repositories.bzl b/java/repositories.bzl
+index 8209375..95ce96a 100644
+--- a/java/repositories.bzl
++++ b/java/repositories.bzl
+@@ -106,6 +106,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-macosx_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-macosx_aarch64.tar.gz"],
          version = "8",
      ),
-     struct(
++    struct(
 +        name = "remote_jdk8_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "dad733f3cbb0614ac093a33429dafe9e54c2a62f836359a7eb7753ad3e87bcf6",
@@ -63,14 +59,14 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk8/loongson8.1.25-fx-jdk8u472b08-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "8",
 +    ),
-+    struct(
-         name = "remote_jdk8_macos_aarch64",
-         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-         sha256 = "effa6d1bd4b6bce68328df66e063a97c2c4afeb0aa36fda4f85c434dd8246572",
-@@ -142,6 +150,14 @@
+     struct(
+         name = "remote_jdk8_macos",
+         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+@@ -154,6 +162,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-macosx_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-macosx_aarch64.tar.gz"],
          version = "11",
      ),
-     struct(
++    struct(
 +        name = "remotejdk11_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "8e13b683beae81eeb2eb2ffa085d25e4caf4760ad9a3359da90536d2caa9a373",
@@ -78,14 +74,14 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk11/loongson11.16.22-fx-jdk11.0.29_7-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "11",
 +    ),
-+    struct(
-         name = "remotejdk11_macos_aarch64",
-         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-         sha256 = "3708badcc0c79fc1791e74b62478188a1f43c4f9a1e7d3e1bd4173da995479a3",
-@@ -198,6 +214,14 @@
+     struct(
+         name = "remotejdk11_macos",
+         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+@@ -202,6 +218,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-linux_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-linux_aarch64.tar.gz"],
          version = "17",
      ),
-     struct(
++    struct(
 +        name = "remotejdk17_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "340b751662256287d43cc292585b5dbeaac7571b2446d4c85f02a9a7ac3aff62",
@@ -93,14 +89,14 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk17/loongson17.16.27-fx-jdk17.0.17_10-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "17",
 +    ),
-+    struct(
+     struct(
          name = "remotejdk17_linux",
          target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-         sha256 = "37ab75b2f5da0ff0db973b31e9d9f14f729137a0a110abd6472ac8c6f2feabb6",
-@@ -270,6 +294,15 @@
+@@ -266,6 +290,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-linux_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-linux_aarch64.tar.gz"],
          version = "21",
      ),
-     struct(
++    struct(
 +        name = "remotejdk21_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "165e1b329739d8dd2364ceca6af0873c019fa65891c2345d2a8d68decc8fc0e3",
@@ -108,8 +104,68 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk21/loongson21.9.21-fx-jdk21.0.9_10-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "21",
 +    ),
-+
+     struct(
+         name = "remotejdk21_linux",
+         target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+@@ -346,6 +378,22 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-linux_x64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-linux_x64.tar.gz"],
+         version = "25",
+     ),
 +    struct(
-         name = "remotejdk21_macos_aarch64",
++        name = "remotejdk25_linux_loongarch64",
++        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
++        sha256 = "165e1b329739d8dd2364ceca6af0873c019fa65891c2345d2a8d68decc8fc0e3",
++        strip_prefix = "zulu25.30.17-ca-jdk25.0.1-linux_x64",
++        urls = ["https://ftp.loongnix.cn/Java/openjdk25/loongson25.4.28-fx-jdk25.0.3_9-linux-loongarch64-glibc2.34.tar.gz"],
++        version = "25",
++    ),
++    struct(
++        name = "remotejdk25_linux_ppc64le",
++        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:ppc64le"],
++        sha256 = "b508ca140557322c73da4278d21004b22480b894ffdc67a8795d7814afd8775c",
++        strip_prefix = "jdk-25.0.44+1",
++        urls = ["https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.4.1%2B1/OpenJDK25U-jdk_ppc64le_linux_hotspot_25.0.4.1_1.tar.gz"],
++        version = "25",
++    ),
+     struct(
+         name = "remotejdk25_macos_aarch64",
          target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-         sha256 = "1d6385f17ae2dc3b57a6d1b6fd6aeadafe1c7138bc744f62a767851eececd092",
+diff --git a/toolchains/BUILD b/toolchains/BUILD
+index 0f3ef2b..30b78e5 100644
+--- a/toolchains/BUILD
++++ b/toolchains/BUILD
+@@ -133,19 +133,12 @@ java_runtime_files(
+ #
+ # See test_jni in third_party/bazel/src/test/shell/bazel/bazel_java_test.sh for
+ # an example of using Bazel to build a Java program that calls a C function.
+-#
+-# TODO(ilist): use //src:condition:linux when released in Bazel
+ cc_library(
+     name = "jni",
+     hdrs = [":jni_header"] + select({
+         "@bazel_tools//src/conditions:darwin": [":jni_md_header-darwin"],
+         "@bazel_tools//src/conditions:freebsd": [":jni_md_header-freebsd"],
+-        "@bazel_tools//src/conditions:linux_aarch64": [":jni_md_header-linux"],
+-        "@bazel_tools//src/conditions:linux_mips64": [":jni_md_header-linux"],
+-        "@bazel_tools//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
+-        "@bazel_tools//src/conditions:linux_riscv64": [":jni_md_header-linux"],
+-        "@bazel_tools//src/conditions:linux_s390x": [":jni_md_header-linux"],
+-        "@bazel_tools//src/conditions:linux_x86_64": [":jni_md_header-linux"],
++        "@bazel_tools//src/conditions:linux": [":jni_md_header-linux"],
+         "@bazel_tools//src/conditions:openbsd": [":jni_md_header-openbsd"],
+         "@bazel_tools//src/conditions:windows": [":jni_md_header-windows"],
+         "//conditions:default": [],
+@@ -153,12 +146,7 @@ cc_library(
+     includes = ["include"] + select({
+         "@bazel_tools//src/conditions:darwin": ["include/darwin"],
+         "@bazel_tools//src/conditions:freebsd": ["include/freebsd"],
+-        "@bazel_tools//src/conditions:linux_aarch64": ["include/linux"],
+-        "@bazel_tools//src/conditions:linux_mips64": ["include/linux"],
+-        "@bazel_tools//src/conditions:linux_ppc64le": ["include/linux"],
+-        "@bazel_tools//src/conditions:linux_riscv64": ["include/linux"],
+-        "@bazel_tools//src/conditions:linux_s390x": ["include/linux"],
+-        "@bazel_tools//src/conditions:linux_x86_64": ["include/linux"],
++        "@bazel_tools//src/conditions:linux": ["include/linux"],
+         "@bazel_tools//src/conditions:openbsd": ["include/openbsd"],
+         "@bazel_tools//src/conditions:windows": ["include/win32"],
+         "//conditions:default": [],

--- a/app-devel/bazel/autobuild/patches/0003-bazel-rules_java-support.patch
+++ b/app-devel/bazel/autobuild/patches/0003-bazel-rules_java-support.patch
@@ -1,6 +1,8 @@
---- a/MODULE.bazel  2000-01-01 00:00:00.000000000 +0000
-+++ b/MODULE.bazel  2025-12-22 08:05:08.827353020 +0000
-@@ -42,6 +42,7 @@
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 24653fe..544d7df 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -59,6 +59,7 @@ JDKS = {
          "linux",
          "linux_aarch64",
          "linux_s390x",
@@ -8,7 +10,7 @@
          "macos",
          "macos_aarch64",
          "windows",
-@@ -52,6 +53,7 @@
+@@ -69,6 +70,7 @@ JDKS = {
          "linux_aarch64",
          "linux_ppc64le",
          "linux_s390x",
@@ -16,46 +18,39 @@
          "macos",
          "macos_aarch64",
          "win",
-@@ -63,6 +65,7 @@
+@@ -79,6 +81,7 @@ JDKS = {
+         "linux",
          "linux_aarch64",
          "linux_ppc64le",
-         "linux_s390x",
 +        "linux_loongarch64",
+         "linux_s390x",
          "macos",
          "macos_aarch64",
-         "win",
-@@ -74,6 +77,7 @@
-         "linux_aarch64",
+@@ -92,6 +95,7 @@ JDKS = {
          "linux_ppc64le",
          "linux_riscv64",
-+        "linux_loongarch64",
          "linux_s390x",
++        "linux_loongarch64",
          "macos",
          "macos_aarch64",
---- a/toolchains/BUILD      2000-01-01 00:00:00.000000000 +0000
-+++ b/toolchains/BUILD      2025-12-22 08:00:32.054103470 +0000
-@@ -141,6 +141,7 @@
-         "@bazel_tools//src/conditions:darwin": [":jni_md_header-darwin"],
-         "@bazel_tools//src/conditions:freebsd": [":jni_md_header-freebsd"],
-         "@bazel_tools//src/conditions:linux_aarch64": [":jni_md_header-linux"],
-+        "@bazel_tools//src/conditions:linux_loongarch64": [":jni_md_header-linux"],
-         "@bazel_tools//src/conditions:linux_mips64": [":jni_md_header-linux"],
-         "@bazel_tools//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
-         "@bazel_tools//src/conditions:linux_riscv64": [":jni_md_header-linux"],
-@@ -154,6 +155,7 @@
-         "@bazel_tools//src/conditions:darwin": ["include/darwin"],
-         "@bazel_tools//src/conditions:freebsd": ["include/freebsd"],
-         "@bazel_tools//src/conditions:linux_aarch64": ["include/linux"],
-+        "@bazel_tools//src/conditions:linux_loongarch64": ["include/linux"],
-         "@bazel_tools//src/conditions:linux_mips64": ["include/linux"],
-         "@bazel_tools//src/conditions:linux_ppc64le": ["include/linux"],
-         "@bazel_tools//src/conditions:linux_riscv64": ["include/linux"],
---- a/java/repositories.bzl 2000-01-01 00:00:00.000000000 +0000
-+++ b/java/repositories.bzl 2025-12-22 08:15:31.377449520 +0000
-@@ -94,6 +94,14 @@
+         "win",
+@@ -100,6 +104,7 @@ JDKS = {
+     "25": [
+         "linux",
+         "linux_aarch64",
++        "linux_loongarch64",
+         "macos",
+         "macos_aarch64",
+         "win",
+diff --git a/java/repositories.bzl b/java/repositories.bzl
+index 8209375..d2e105f 100644
+--- a/java/repositories.bzl
++++ b/java/repositories.bzl
+@@ -106,6 +106,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-macosx_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-macosx_aarch64.tar.gz"],
          version = "8",
      ),
-     struct(
++    struct(
 +        name = "remote_jdk8_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "dad733f3cbb0614ac093a33429dafe9e54c2a62f836359a7eb7753ad3e87bcf6",
@@ -63,14 +58,14 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk8/loongson8.1.25-fx-jdk8u472b08-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "8",
 +    ),
-+    struct(
-         name = "remote_jdk8_macos_aarch64",
-         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-         sha256 = "effa6d1bd4b6bce68328df66e063a97c2c4afeb0aa36fda4f85c434dd8246572",
-@@ -142,6 +150,14 @@
+     struct(
+         name = "remote_jdk8_macos",
+         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+@@ -154,6 +162,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-macosx_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-macosx_aarch64.tar.gz"],
          version = "11",
      ),
-     struct(
++    struct(
 +        name = "remotejdk11_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "8e13b683beae81eeb2eb2ffa085d25e4caf4760ad9a3359da90536d2caa9a373",
@@ -78,14 +73,14 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk11/loongson11.16.22-fx-jdk11.0.29_7-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "11",
 +    ),
-+    struct(
-         name = "remotejdk11_macos_aarch64",
-         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-         sha256 = "3708badcc0c79fc1791e74b62478188a1f43c4f9a1e7d3e1bd4173da995479a3",
-@@ -198,6 +214,14 @@
+     struct(
+         name = "remotejdk11_macos",
+         target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:x86_64"],
+@@ -202,6 +218,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-linux_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-linux_aarch64.tar.gz"],
          version = "17",
      ),
-     struct(
++    struct(
 +        name = "remotejdk17_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "340b751662256287d43cc292585b5dbeaac7571b2446d4c85f02a9a7ac3aff62",
@@ -93,14 +88,14 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk17/loongson17.16.27-fx-jdk17.0.17_10-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "17",
 +    ),
-+    struct(
+     struct(
          name = "remotejdk17_linux",
          target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
-         sha256 = "37ab75b2f5da0ff0db973b31e9d9f14f729137a0a110abd6472ac8c6f2feabb6",
-@@ -270,6 +294,15 @@
+@@ -266,6 +290,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-linux_aarch64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-linux_aarch64.tar.gz"],
          version = "21",
      ),
-     struct(
++    struct(
 +        name = "remotejdk21_linux_loongarch64",
 +        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
 +        sha256 = "165e1b329739d8dd2364ceca6af0873c019fa65891c2345d2a8d68decc8fc0e3",
@@ -108,8 +103,41 @@
 +        urls = ["https://ftp.loongnix.cn/Java/openjdk21/loongson21.9.21-fx-jdk21.0.9_10-linux-loongarch64-glibc2.34.tar.gz"],
 +        version = "21",
 +    ),
-+
+     struct(
+         name = "remotejdk21_linux",
+         target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+@@ -346,6 +378,14 @@ _REMOTE_JDK_CONFIGS_LIST = [
+         urls = ["https://cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-linux_x64.tar.gz", "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-linux_x64.tar.gz"],
+         version = "25",
+     ),
 +    struct(
-         name = "remotejdk21_macos_aarch64",
++        name = "remotejdk25_linux_loongarch64",
++        target_compatible_with = ["@platforms//os:linux", "@platforms//cpu:loongarch64"],
++        sha256 = "165e1b329739d8dd2364ceca6af0873c019fa65891c2345d2a8d68decc8fc0e3",
++        strip_prefix = "zulu25.30.17-ca-jdk25.0.1-linux_x64",
++        urls = ["https://ftp.loongnix.cn/Java/openjdk25/loongson25.4.28-fx-jdk25.0.3_9-linux-loongarch64-glibc2.34.tar.gz"],
++        version = "25",
++    ),
+     struct(
+         name = "remotejdk25_macos_aarch64",
          target_compatible_with = ["@platforms//os:macos", "@platforms//cpu:aarch64"],
-         sha256 = "1d6385f17ae2dc3b57a6d1b6fd6aeadafe1c7138bc744f62a767851eececd092",
+diff --git a/toolchains/BUILD b/toolchains/BUILD
+index 0f3ef2b..6ae5ad9 100644
+--- a/toolchains/BUILD
++++ b/toolchains/BUILD
+@@ -141,6 +141,7 @@ cc_library(
+         "@bazel_tools//src/conditions:darwin": [":jni_md_header-darwin"],
+         "@bazel_tools//src/conditions:freebsd": [":jni_md_header-freebsd"],
+         "@bazel_tools//src/conditions:linux_aarch64": [":jni_md_header-linux"],
++        "@bazel_tools//src/conditions:linux_loongarch64": [":jni_md_header-linux"],
+         "@bazel_tools//src/conditions:linux_mips64": [":jni_md_header-linux"],
+         "@bazel_tools//src/conditions:linux_ppc64le": [":jni_md_header-linux"],
+         "@bazel_tools//src/conditions:linux_riscv64": [":jni_md_header-linux"],
+@@ -154,6 +155,7 @@ cc_library(
+         "@bazel_tools//src/conditions:darwin": ["include/darwin"],
+         "@bazel_tools//src/conditions:freebsd": ["include/freebsd"],
+         "@bazel_tools//src/conditions:linux_aarch64": ["include/linux"],
++        "@bazel_tools//src/conditions:linux_loongarch64": ["include/linux"],
+         "@bazel_tools//src/conditions:linux_mips64": ["include/linux"],
+         "@bazel_tools//src/conditions:linux_ppc64le": ["include/linux"],
+         "@bazel_tools//src/conditions:linux_riscv64": ["include/linux"],

--- a/app-devel/bazel/spec
+++ b/app-devel/bazel/spec
@@ -1,12 +1,13 @@
-VER=8.5.0
+VER=9.1.0
 # Note: See Bazel module dependencies "$SRCDIR/MODULE.bazel".
 SRCS="tbl::rename=bazel.zip::https://github.com/bazelbuild/bazel/releases/download/$VER/bazel-$VER-dist.zip \
-      file::rename=rules_go.zip::https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip \
-      file::rename=rules_java.tar.gz::https://github.com/bazelbuild/rules_java/releases/download/8.14.0/rules_java-8.14.0.tar.gz \
+      file::rename=rules_go.zip::https://github.com/bazelbuild/rules_go/releases/download/v0.59.0/rules_go-v0.59.0.zip \
+      file::rename=rules_java.tar.gz::https://github.com/bazelbuild/rules_java/releases/download/9.1.0/rules_java-9.1.0.tar.gz \
       file::rename=platforms.tar.gz::https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz"
-CHKSUMS="sha256::b476d96141f9bd803562aee0448376b61494112918bce441898585493db33ed1 \
-         sha256::33acc4ae0f70502db4b893c9fc1dd7a9bf998c23e7ff2c4517741d4049a976f8 \
-         sha256::bbe7d94360cc9ed4607ec5fd94995fd1ec41e84257020b6f09e64055281ecb12 \
+CHKSUMS="sha256::229e999cec4f408946d368af6c33c5137fe999e9966538562f8c90b0de7aa0ad \
+         sha256::68af54cb97fbdee5e5e8fe8d210d15a518f9d62abfd71620c3eaff3b26a5ff86 \
+         sha256::4e1a28a25c2efa53500c928d22ceffbc505dd95b335a2d025836a293b592212f \
          sha256::3384eb1c30762704fbe38e440204e114154086c8fc8a8c2e3e28441028c019a8 "
 CHKUPDATE="anitya::id=15227"
 SUBDIR="."
+


### PR DESCRIPTION
Topic Description
-----------------

- bazel: update to 9.1.0

Package(s) Affected
-------------------

- bazel: 9.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bazel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
