### PR TITLE
docker-buildx: update to 0.35.0

### DIFF
--- a/app-containers/docker-buildx/spec
+++ b/app-containers/docker-buildx/spec
@@ -1,5 +1,4 @@
-VER=0.22.0
-REL=7
+VER=0.35.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/docker/buildx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=325723"


### PR DESCRIPTION
Topic Description
-----------------

- docker-buildx: update to 0.35.0
    Co-authored-by: nyovelt \(@Nyovelt\) <fqin2@ncsu.edu>

Package(s) Affected
-------------------

- docker-buildx: 0.35.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker-buildx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
