### PR TITLE
curl: use ngtcp2 and nghttp3 for HTTP/3

### DIFF
--- a/app-web/curl/autobuild/build
+++ b/app-web/curl/autobuild/build
@@ -2,7 +2,6 @@ abinfo "Configuring cURL (OpenSSL, with versioned symbols) ..."
 "$SRCDIR"/configure \
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
-     --with-openssl-quic \
      --without-gnutls \
      --without-nss \
      --enable-versioned-symbols
@@ -19,7 +18,6 @@ abinfo "Configuring cURL (OpenSSL, without versioned symbols) ..."
 "$SRCDIR"/configure \
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
-     --with-openssl-quic \
      --without-gnutls \
      --without-nss \
      --disable-versioned-symbols
@@ -53,8 +51,6 @@ abinfo "Configuring cURL (GnuTLS, without versioned symbols) ..."
      --without-openssl \
      --with-gnutls \
      --without-nss \
-     --with-nghttp3 \
-     --with-ngtcp2 \
      --disable-versioned-symbols
 abinfo "Building cURL (GnuTLS, without versioned symbols) ..."
 make -C "$SRCDIR"/lib

--- a/app-web/curl/autobuild/build.stage2
+++ b/app-web/curl/autobuild/build.stage2
@@ -2,7 +2,6 @@ abinfo "Configuring cURL (OpenSSL, with versioned symbols) ..."
 "$SRCDIR"/configure \
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
-     --with-openssl-quic \
      --without-gnutls \
      --without-nss \
      --enable-versioned-symbols

--- a/app-web/curl/autobuild/defines
+++ b/app-web/curl/autobuild/defines
@@ -23,6 +23,8 @@ AUTOTOOLS_AFTER=(
     "--with-brotli"
     "--with-librtmp"
     "--with-libpsl"
+    "--with-ngtcp2"
+    "--with-nghttp3"
     "--with-random=/dev/urandom"
     "--with-ca-bundle=/etc/ssl/ca-bundle.crt"
 )
@@ -33,6 +35,8 @@ AUTOTOOLS_AFTER__RETRO=(
     "--enable-ipv6"
     "--enable-manual"
     "--enable-threaded-resolver"
+    "--with-ngtcp2"
+    "--with-nghttp3"
     "--without-gssapi"
     "--without-libidn2"
     "--without-libssh2"

--- a/app-web/curl/autobuild/defines.stage2
+++ b/app-web/curl/autobuild/defines.stage2
@@ -11,6 +11,7 @@ AUTOTOOLS_AFTER=(
     "--enable-ipv6"
     "--enable-manual"
     "--enable-threaded-resolver"
+    "--with-ngtcp2"
     "--without-gssapi"
     "--without-libidn2"
     "--without-libssh2"

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,5 +1,5 @@
 VER=8.20.0
-REL=1
+REL=2
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
 CHKSUMS="sha256::63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896"
 CHKUPDATE="anitya::id=381"

--- a/runtime-web/nghttp3/autobuild/defines
+++ b/runtime-web/nghttp3/autobuild/defines
@@ -1,4 +1,6 @@
 PKGNAME=nghttp3
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="Next-generation HTTP/3 library"
+PKGDES="C library for HTTP/3"
+
+ABTYPE=autotools

--- a/runtime-web/nghttp3/spec
+++ b/runtime-web/nghttp3/spec
@@ -1,4 +1,4 @@
-VER=1.14.0
+VER=1.16.0
 SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/nghttp3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243323"

--- a/runtime-web/ngtcp2/autobuild/defines
+++ b/runtime-web/ngtcp2/autobuild/defines
@@ -1,9 +1,12 @@
 PKGNAME=ngtcp2
 PKGSEC=libs
-PKGDEP="glibc gnutls wolfssl brotli"
-PKGDES="QUIC library in C"
+PKGDEP="glibc gnutls wolfssl brotli openssl"
+PKGDES="C library for QUIC"
 
-AUTOTOOLS_AFTER="--with-gnutls \
-                 --with-wolfssl \
-                 --with-libbrotlienc \
-                 --with-libbrotlidec"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    "--with-gnutls"
+    "--with-wolfssl"
+    "--with-libbrotlienc"
+    "--with-libbrotlidec"
+)

--- a/runtime-web/ngtcp2/spec
+++ b/runtime-web/ngtcp2/spec
@@ -1,4 +1,4 @@
-VER=1.5.0
+VER=1.23.0
 SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/ngtcp2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370247"


### PR DESCRIPTION
Topic Description
-----------------

- ngtcp2: update to 1.23.0
- nghttp3: update to 1.16.0
- curl: use ngtcp2 and nghttp3 for HTTP/3
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- curl: 8.20.0-2
- nghttp3: 1.16.0
- ngtcp2: 1.23.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nghttp3 ngtcp2 curl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
