### PR TITLE
noctalia-qs: rebuild for Qt 6.11.1

### DIFF
--- a/groups/qt6-rebuilds
+++ b/groups/qt6-rebuilds
@@ -64,3 +64,4 @@ wireshark
 obs-studio
 quickshell
 telegram-desktop
+noctalia-qs

--- a/runtime-desktop/noctalia-qs/autobuild/defines
+++ b/runtime-desktop/noctalia-qs/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=noctalia-qs
 PKGSEC=libs
 PKGDES="Fork of Quickshell for Noctalia Shell"
-PKGDEP="gcc-runtime glibc jemalloc libdrm libxcb linux-pam mesa pipewire qt-6 wayland"
+PKGDEP="gcc-runtime glib glibc jemalloc libdrm libxcb linux-pam mesa pipewire qt-6 wayland polkit"
 BUILDDEP="cli11 cmake ninja pkgconf spirv-tools wayland-protocols"
 PKGCONFL="quickshell"
 

--- a/runtime-desktop/noctalia-qs/spec
+++ b/runtime-desktop/noctalia-qs/spec
@@ -2,3 +2,4 @@ VER=0.0.12
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/noctalia-dev/noctalia-qs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388550"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- noctalia-qs: rebuild for Qt 6.11.1

Package(s) Affected
-------------------

- noctalia-qs: 0.0.12-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit noctalia-qs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
