### PR TITLE
qtcreator: update to 20.0.0

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,5 +1,4 @@
-VER=18.0.0
-REL=6
+VER=20.0.0
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
-CHKSUMS="sha256::c773b74114d1fbca66c81b8fb799892827e7e1542491ed459aaad279e0253973"
+CHKSUMS="sha256::76e094ac8ae56e8611bc2dae07e972652860b2ae9d59baff49768523a4cff289"
 CHKUPDATE="anitya::id=4136"


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: update to 20.0.0

Package(s) Affected
-------------------

- qtcreator: 20.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
