### PR TITLE
caddy: update to 2.11.4

### DIFF
--- a/app-web/caddy/spec
+++ b/app-web/caddy/spec
@@ -1,8 +1,7 @@
-VER=2.11.3
-REL=1
+VER=2.11.4
 SRCS="tbl::https://github.com/caddyserver/caddy/releases/download/v${VER}/caddy_${VER}_buildable-artifact.tar.gz \
       git::commit=tags/v$VER;rename=dist::https://github.com/caddyserver/dist.git"
-CHKSUMS="sha256::13e921d1a4db2740fe80df7c47a3dd9bf6cde7ea302684d836c6352706ce3f6a \
+CHKSUMS="sha256::33777097f666d60d78bfb74df06978c933f32aa5a0d4ce0b0c5d028489984187 \
          SKIP"
 CHKUPDATE="anitya::id=15601"
 SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- caddy: update to 2.11.4
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- caddy: 2.11.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit caddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
