### PR TITLE
zen-browser: update to 1.21.3~beta

### DIFF
--- a/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
+++ b/app-web/zen-browser/autobuild/patches/0001-AOSCOS-Disable-LASX-by-default-for-libyuv.patch
@@ -1,7 +1,7 @@
-From 2a5e63173159df2da87ea90013f1eea416e74471 Mon Sep 17 00:00:00 2001
+From 076d59ffdb40456eb21533d89633e59a4f734aed Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:14:20 -0800
-Subject: [PATCH 1/7] AOSCOS: Disable LASX by default for libyuv
+Subject: [PATCH 1/8] AOSCOS: Disable LASX by default for libyuv
 
 We are starting to have powerful mobile and embedded chips that
 lack LASX capabilities, namely 3B6000M and 2K3000.
@@ -14,12 +14,12 @@ Co-Authored-By: Xuan Chen <henry.chen@oss.cipunited.com>
 
 diff --git a/src/media/libyuv/libyuv/libyuv-gyp.patch b/src/media/libyuv/libyuv/libyuv-gyp.patch
 new file mode 100644
-index 000000000..83d8e7688
+index 000000000..53a8a4f09
 --- /dev/null
 +++ b/src/media/libyuv/libyuv/libyuv-gyp.patch
 @@ -0,0 +1,16 @@
 +diff --git a/media/libyuv/libyuv/libyuv.gyp b/media/libyuv/libyuv/libyuv.gyp
-+index 57c9880f9b89c686b45f5f54ac2342926b9e18c1..09a5978c1b365e776840ccc2bb435b169101bb22 100644
++index 2ae75fefd8a0..41aaf319abfe 100644
 +--- a/media/libyuv/libyuv/libyuv.gyp
 ++++ b/media/libyuv/libyuv/libyuv.gyp
 +@@ -26,6 +26,11 @@
@@ -27,13 +27,13 @@ index 000000000..83d8e7688
 +     # Link-Time Optimizations.
 +     'use_lto%': 0,
 ++    # Disable LASX on LoongArch by default (for 2K3000/3B6000M).
-++    "loong_lasx%": 0,
+++    'loong_lasx%': 0,
 ++    # Enable LSX on LoongArch by default. Has no effect if loong_lasx is
 ++    # enabled because LASX implies LSX according to the architecture specs.
-++    "loong_lsx%": 1,
-+     'mips_msa%': 0,  # Default to msa off.
+++    'loong_lsx%': 1,
 +     'build_neon': 0,
-+     'build_msa': 0,
++     'conditions': [
++        ['(target_arch == "armv7" or target_arch == "armv7s" or \
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
+++ b/app-web/zen-browser/autobuild/patches/0002-Enable-GLES-on-riscv64.patch
@@ -1,7 +1,7 @@
-From e68372bf27b8307ded950b989c07fa59282c3eef Mon Sep 17 00:00:00 2001
+From 7181943ed838cf4c23e09b0a0fb58a15b79d74a1 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:17:48 -0800
-Subject: [PATCH 2/7] Enable GLES on riscv64
+Subject: [PATCH 2/8] Enable GLES on riscv64
 
 Co-Authored-By: Han Gao <rabenda.cn@gmail.com>
 ---

--- a/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
+++ b/app-web/zen-browser/autobuild/patches/0003-Disable-BROTLI_MODEL-macro-for-some-targets.patch
@@ -1,7 +1,7 @@
-From 17cb7230711047b8f177db00608593fea1abc92c Mon Sep 17 00:00:00 2001
+From 438c76b6e1cd56ffacb8b5091c610766949036a7 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:20:35 -0800
-Subject: [PATCH 3/7] Disable BROTLI_MODEL macro for some targets
+Subject: [PATCH 3/8] Disable BROTLI_MODEL macro for some targets
 
 PiperOrigin-RevId: 827486322
 Link: https://github.com/google/brotli/commit/e230f474b87134e8c6c85b630084c612057f253e

--- a/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
+++ b/app-web/zen-browser/autobuild/patches/0004-AOSCOS-Fix-unistd.h-header-inclusion-in-libwebrtc.patch
@@ -1,7 +1,7 @@
-From a429b8ec7b2c8f1d5ee9c8e6ae9a600c68bbd2d4 Mon Sep 17 00:00:00 2001
+From a71f8e6878ab92e959f5564c4c70073655842873 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 22:23:13 -0800
-Subject: [PATCH 4/7] AOSCOS: Fix unistd.h header inclusion in libwebrtc
+Subject: [PATCH 4/8] AOSCOS: Fix unistd.h header inclusion in libwebrtc
 
 The correct header name should be automatically-selected by asm/unistd.h
 instead of hard-coded.

--- a/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
+++ b/app-web/zen-browser/autobuild/patches/0005-AOSCOS-Update-Google-API-keyfile-path.patch
@@ -1,20 +1,20 @@
-From 8d38f4e2077bf2baf733a129c6a5fd92b13d47ee Mon Sep 17 00:00:00 2001
+From 379a1f436244debd100d7d79739e505f29b502f0 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Mon, 2 Feb 2026 23:32:26 -0800
-Subject: [PATCH 5/7] AOSCOS: Update Google API keyfile path
+Subject: [PATCH 5/8] AOSCOS: Update Google API keyfile path
 
 ---
- configs/common/mozconfig | 5 +++--
- 1 file changed, 3 insertions(+), 2 deletions(-)
+ configs/common/mozconfig | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/configs/common/mozconfig b/configs/common/mozconfig
-index 3d41bc83a..297b559a1 100644
+index 22b8e95c5..673f54d70 100644
 --- a/configs/common/mozconfig
 +++ b/configs/common/mozconfig
-@@ -36,8 +36,9 @@ if ! test "$SCCACHE_GHA_ENABLED" = "false"; then
+@@ -38,8 +38,9 @@ if test "$SCCACHE_GHA_ENABLED" = "true"; then
  fi
  
- # add safe browsing key if it exists on a file
+ # add API keys if it exists on a file
 -if test -f "$HOME/.zen-keys/safebrowsing.dat"; then
 -  ac_add_options --with-google-safebrowsing-api-keyfile="$HOME/.zen-keys/safebrowsing.dat"
 +if test -f "$SRCDIR/autobuild/google-api-key"; then
@@ -22,7 +22,16 @@ index 3d41bc83a..297b559a1 100644
 +  ac_add_options --with-google-safebrowsing-api-keyfile="$SRCDIR/autobuild/google-api-key"
  fi
  
- if test "$ZEN_RELEASE"; then
+ if test -f "$HOME/.zen-keys/mozilla.dat"; then
+@@ -93,7 +94,7 @@ if test "$ZEN_RELEASE"; then
+   ac_add_options --disable-crashreporter
+ 
+   # Experimental flag, enabled only on nightly for Firefox.
+-  # Should bring in some nice performance improvements, 
++  # Should bring in some nice performance improvements,
+   # but may cause stability issues.
+   ac_add_options --enable-replace-malloc
+ fi
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
+++ b/app-web/zen-browser/autobuild/patches/0006-AOSCOS-Rename-binary-to-zen-browser.patch
@@ -1,14 +1,14 @@
-From 7df0851541200d96169142abdb0a5ed829cc562f Mon Sep 17 00:00:00 2001
+From eeb4f39cbae7e0149fb881b9689007e168c11eaf Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <the@salted.fish>
 Date: Sat, 21 Feb 2026 20:28:31 -0500
-Subject: [PATCH 6/7] AOSCOS: Rename binary to zen-browser
+Subject: [PATCH 6/8] AOSCOS: Rename binary to zen-browser
 
 ---
  surfer.json | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/surfer.json b/surfer.json
-index 0d514c975..3b8a98daf 100644
+index b1104a111..29a364366 100644
 --- a/surfer.json
 +++ b/surfer.json
 @@ -2,7 +2,7 @@
@@ -19,7 +19,7 @@ index 0d514c975..3b8a98daf 100644
 +  "binaryName": "zen-browser",
    "version": {
      "product": "firefox",
-     "version": "149.0.2",
+     "version": "152.0.1",
 -- 
 2.52.0
 

--- a/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
+++ b/app-web/zen-browser/autobuild/patches/0007-AOSCOS-Adjust-mozconfig.patch
@@ -1,7 +1,7 @@
-From 783d781278830682aa8678e78e7e02652d58efcb Mon Sep 17 00:00:00 2001
+From 9ff99fa4ef2439562ca5b9826846ed009149974b Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Tue, 3 Feb 2026 05:56:14 -0500
-Subject: [PATCH 7/7] AOSCOS: Adjust mozconfig
+Subject: [PATCH 7/8] AOSCOS: Adjust mozconfig
 
 - Set prefix to /usr.
 - Disable updater.
@@ -10,12 +10,12 @@ Subject: [PATCH 7/7] AOSCOS: Adjust mozconfig
 
 Ref: aosc-os-abbs/app-web/firefox.
 ---
- configs/common/mozconfig | 11 +------
- configs/linux/mozconfig  | 64 +++++++++++++++++++++++-----------------
- 2 files changed, 38 insertions(+), 37 deletions(-)
+ configs/common/mozconfig | 13 ++-------
+ configs/linux/mozconfig  | 61 +++++++++++++++++++++-------------------
+ 2 files changed, 34 insertions(+), 40 deletions(-)
 
 diff --git a/configs/common/mozconfig b/configs/common/mozconfig
-index 297b559a1..947f1593e 100644
+index 673f54d70..6648bd1c6 100644
 --- a/configs/common/mozconfig
 +++ b/configs/common/mozconfig
 @@ -6,9 +6,6 @@
@@ -28,16 +28,18 @@ index 297b559a1..947f1593e 100644
  export MOZ_APP_BASENAME=Zen
  export MOZ_BRANDING_DIRECTORY=${brandingDir}
  export MOZ_OFFICIAL_BRANDING_DIRECTORY=${brandingDir}
-@@ -45,7 +42,7 @@ if test "$ZEN_RELEASE"; then
+@@ -53,8 +50,8 @@ fi
  
-   # TODO: Make this successful in builds
-   # ac_add_options --enable-clang-plugin
+ if test "$ZEN_RELEASE"; then
+ 
+-  ac_add_options --enable-clang-plugin
 -  ac_add_options --enable-bootstrap=-sccache
++  # ac_add_options --enable-clang-plugin
 +  # ac_add_options --enable-bootstrap=-sccache
  
    ac_add_options --enable-optimize
  
-@@ -56,7 +53,6 @@ if test "$ZEN_RELEASE"; then
+@@ -65,7 +62,6 @@ if test "$ZEN_RELEASE"; then
    ac_add_options --disable-tests
  
    ac_add_options --enable-rust-simd
@@ -45,70 +47,72 @@ index 297b559a1..947f1593e 100644
  
    ac_add_options --disable-geckodriver
    ac_add_options --disable-rust-tests
-@@ -83,11 +79,6 @@ if test "$ZEN_RELEASE"; then
+@@ -92,11 +88,6 @@ if test "$ZEN_RELEASE"; then
    export MOZ_PACKAGE_JSSHELL=1
  
    ac_add_options --disable-crashreporter
 -
 -  # Experimental flag, enabled only on nightly for Firefox.
--  # Should bring in some nice performance improvements, 
+-  # Should bring in some nice performance improvements,
 -  # but may cause stability issues.
 -  ac_add_options --enable-replace-malloc
  fi
  
- ac_add_options --enable-unverified-updates
+ ac_add_options --enable-jxl
 diff --git a/configs/linux/mozconfig b/configs/linux/mozconfig
-index b15dcd399..ec024ff4b 100644
+index c959a8eec..19d93fb5d 100644
 --- a/configs/linux/mozconfig
 +++ b/configs/linux/mozconfig
-@@ -11,30 +11,40 @@ else
-     export CXX=clang++
- fi
+@@ -2,36 +2,39 @@
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
  
 -if test "$ZEN_RELEASE"; then
 -    if test "$SURFER_COMPAT" = "x86_64"; then
 -        ac_add_options --target=x86_64-pc-linux
 -        ac_add_options --enable-eme=widevine
--
++# Disable DMD and necko-wifi
++ac_add_options --disable-dmd
++ac_add_options --disable-necko-wifi
+ 
 -        # Enable Profile Guided Optimization
 -        if ! test "$ZEN_GA_DISABLE_PGO"; then
--            export MOZ_PGO=1
--            ac_add_options MOZ_PGO=1
+-            if test "$ZEN_GA_GENERATE_PROFILE"; then
+-                mk_add_options "export MOZ_AUTOMATION_PACKAGE_GENERATED_SOURCES=0"
+-                ac_add_options --enable-profile-generate=cross
+-            else
+-                ac_add_options --enable-profile-use=cross
+-                ac_add_options --with-pgo-profile-path="$(echo ~)/artifact/merged.profdata"
+-                ac_add_options --with-pgo-jarlog="$(echo ~)/artifact/en-US.log"
+-            fi
 -        fi
 -    elif test "$SURFER_COMPAT" = "aarch64"; then
 -        ac_add_options --target=aarch64-linux-gnu
--
++# Common options
++ac_add_options --enable-alsa
++ac_add_options --enable-pulseaudio
+ 
 -        # override LTO settings
 -        export MOZ_LTO=cross,thin
 -        ac_add_options --enable-lto=cross,thin
 -    fi
--
++# Basic path definitions.
++ac_add_options --prefix=/usr
++ac_add_options --libdir=/usr/lib
+ 
 -    # Disable DMD and ELF hacks, enable linker lld
 -    ac_add_options --enable-linker=lld
 -    ac_add_options --disable-elf-hack
--
++# Toolchain settings.
++ac_add_options --disable-strip
++ac_add_options --disable-install-strip
++ac_add_options --enable-hardening
+ 
 -    # Stripping options for release builds
 -    ac_add_options --enable-install-strip
 -    ac_add_options --enable-strip
 -    export STRIP_FLAGS="--strip-debug --strip-unneeded"
 -fi
-+# Disable DMD and necko-wifi
-+ac_add_options --disable-dmd
-+ac_add_options --disable-necko-wifi
-+
-+# Common options
-+ac_add_options --enable-alsa
-+ac_add_options --enable-pulseaudio
-+
-+# Basic path definitions.
-+ac_add_options --prefix=/usr
-+ac_add_options --libdir=/usr/lib
-+
-+# Toolchain settings.
-+ac_add_options --disable-strip
-+ac_add_options --disable-install-strip
-+ac_add_options --enable-hardening
-+
 +# Optimize
 +ac_add_options --enable-optimize="-O2"
 +
@@ -126,7 +130,6 @@ index b15dcd399..ec024ff4b 100644
 +# Features.
 +ac_add_options --enable-chrome-format=omni
 +ac_add_options --enable-js-shell
-+ac_add_options --enable-av1
 +ac_add_options --disable-tests
 +ac_add_options --disable-updater
 -- 

--- a/app-web/zen-browser/autobuild/patches/0008-AOSCOS-Guard-stray-inclusion-of-Simulator-riscv64.h-.patch
+++ b/app-web/zen-browser/autobuild/patches/0008-AOSCOS-Guard-stray-inclusion-of-Simulator-riscv64.h-.patch
@@ -1,0 +1,47 @@
+From 4ab87c2ff7f4d0bfad7762f9643bf5449dfa0e52 Mon Sep 17 00:00:00 2001
+From: miwu04 <me@alanlin.icu>
+Date: Sun, 21 Jun 2026 03:21:25 +0800
+Subject: [PATCH 8/8] AOSCOS: Guard stray inclusion of Simulator-riscv64.h This
+ is a leftover by Bug 2038968 D300034, but it should be fixed in Bug 2039343
+ D300387 which happens to miss the Fx152 train.
+
+Should be dropped by the release of Fx153.
+
+Link: https://phabricator.services.mozilla.com/D300034 ("Bug 2038968 -
+ Part 4: Make it an error to include simulator headers when simulator is
+ disabled. r=jandem!")
+Link: https://phabricator.services.mozilla.com/D300387 ("Bug 2039343 -
+ Part 6: Remove InstructionGetters. r=jandem!")
+
+Co-authored-by: CSharperMantle <rong.bao@csmantle.top>
+---
+ .../constant/Base-constant-riscv-cpp.patch      | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+ create mode 100644 src/js/src/jit/riscv64/constant/Base-constant-riscv-cpp.patch
+
+diff --git a/src/js/src/jit/riscv64/constant/Base-constant-riscv-cpp.patch b/src/js/src/jit/riscv64/constant/Base-constant-riscv-cpp.patch
+new file mode 100644
+index 000000000..359cd343d
+--- /dev/null
++++ b/src/js/src/jit/riscv64/constant/Base-constant-riscv-cpp.patch
+@@ -0,0 +1,17 @@
++diff --git a/js/src/jit/riscv64/constant/Base-constant-riscv.cpp b/js/src/jit/riscv64/constant/Base-constant-riscv.cpp
++index b25ce174bc5b..40b7472ccec1 100644
++--- a/js/src/jit/riscv64/constant/Base-constant-riscv.cpp
+++++ b/js/src/jit/riscv64/constant/Base-constant-riscv.cpp
++@@ -13,7 +13,11 @@
++ #include "jit/riscv64/constant/Constant-riscv-v.h"
++ #include "jit/riscv64/constant/Constant-riscv-zicsr.h"
++ #include "jit/riscv64/constant/Constant-riscv-zifencei.h"
++-#include "jit/riscv64/Simulator-riscv64.h"
+++
+++#ifdef JS_SIMULATOR_RISCV64
+++#  include "jit/riscv64/Simulator-riscv64.h"
+++#endif
+++
++ namespace js {
++ namespace jit {
++ 
+-- 
+2.52.0
+

--- a/app-web/zen-browser/spec
+++ b/app-web/zen-browser/spec
@@ -1,8 +1,10 @@
-__VER="1.19.8"
+__VER="1.21.3"
 VER="${__VER}~beta"
 SRCS="git::commit=tags/${__VER}b;copy-repo=true::https://github.com/zen-browser/desktop"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=387659"
 
+# Note: zen-browser currently requires extremely large memory to build
 ENVREQ="total_mem=60"
 ENVREQ__ARM64="total_mem=120"
+ENVREQ__RISCV64="total_mem=120"

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,5 +1,5 @@
 VER=8.18.0
-REL=3
+REL=4
 SRCS="tbl::https://github.com/libvips/libvips/releases/download/v$VER/vips-$VER.tar.xz"
 CHKSUMS="sha256::b85ab92280c30d22f5c8fe2f68b809cddb7eaac437d8c33474475dac84ddc574"
 CHKUPDATE="anitya::id=5097"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: rebuild for openexr 3.14
- zen-browser: adjust memory requirement for riscv64
- zen-browser: update to 1.21.3\~beta

Package(s) Affected
-------------------

- libvips: 8.18.0-4
- zen-browser: 1.21.3~beta

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvips zen-browser
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
