### PR TITLE
nginx: update to 1.30.3

### DIFF
--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,11 +1,11 @@
-NGINX_VER=1.30.2
+NGINX_VER=1.30.3
 BROTLI_VER=1.0.0~rc1+git20231009
 VER="${NGINX_VER}+brotli${BROTLI_VER}"
 # Note: After v1.0.0rc, there are still some necessary updates (including upstream submodules), 
 # so the following commit refers to the latest one in master branch.
 SRCS="tbl::https://nginx.org/download/nginx-$NGINX_VER.tar.gz \
       git::commit=a71f9312c2deb28875acc7bacfdd5695a111aa53;rename=ngx_brotli::https://github.com/google/ngx_brotli.git"
-CHKSUMS="sha256::7df3090907fca3cc0e456d6dc00ceb230da74ea88026ceff0affc29dbbd9ac4c \
+CHKSUMS="sha256::e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f \
          SKIP"
 CHKUPDATE="anitya::id=5413"
 SUBDIR="nginx-$NGINX_VER"


### PR DESCRIPTION
Topic Description
-----------------

- nginx: update to 1.30.3
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- nginx: 1.30.3+brotli1.0.0~rc1+git20231009

Security Update?
----------------

No

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
