### PR TITLE
vim: security update to 9.2.680

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0677
+VER=9.2.0680
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0680.toml
+++ b/topics/vim-9.2.0680.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0680"
+
+[caution]
+default = "Fixes an Out-of-bounds Read vulnerability (Severity: Moderate)"
+zh_CN = "修复 1 个越界读取漏洞（严重性：中）"
+
+[packages-v2]
+"vim" = ">= 9.2.0320 && < 9.2.0680"


### PR DESCRIPTION
Topic Description
-----------------

- vim: security update to 9.2.680
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.0680
- vim: 9.2.0680

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
