### PR TITLE
manboster: new, 0.2.1

### DIFF
--- a/app-utils/manboster/autobuild/defines
+++ b/app-utils/manboster/autobuild/defines
@@ -1,0 +1,15 @@
+PKGNAME=manboster
+PKGSEC=utils
+PKGDEP="glibc"
+BUILDDEP="go git"
+PKGDES="Personal AI Agent"
+
+ABTYPE="gomod"
+GO_LDFLAGS=(
+    "-X 'github.com/manboster/manboster/internal/config.CurrentChannel=stable'"
+)
+GO_PACKAGES=("cmd/manboster")
+
+# FIXME: github.com/jupyterrider/ffi only supports these architectures
+# github.com/jupyterrider/ffi: build constraints exclude all Go files in /build/go/pkg/mod/github.com/jupyterrider/ffi@0.7.0
+FAIL_ARCH="!(amd64|arm64|riscv64)"

--- a/app-utils/manboster/spec
+++ b/app-utils/manboster/spec
@@ -1,0 +1,4 @@
+VER=0.2.1
+# Note: Git metadata for version detection, copy metadata here.
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/manboster/manboster.git"
+CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- manboster: new, 0.2.1

Package(s) Affected
-------------------

- manboster: 0.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit manboster
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**
- [x] RISC-V 64-bit `riscv64`
