### PR TITLE
hmcl: remove update settings

### DIFF
--- a/app-games/hmcl/autobuild/patches/remove-update-settings.patch
+++ b/app-games/hmcl/autobuild/patches/remove-update-settings.patch
@@ -1,0 +1,28 @@
+diff --git a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsPage.java b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsPage.java
+index ceff5dc8f..aede651dd 100644
+--- a/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsPage.java
++++ b/HMCL/src/main/java/org/jackhuang/hmcl/ui/main/SettingsPage.java
+@@ -71,7 +71,6 @@ import static org.jackhuang.hmcl.util.logging.Logger.LOG;
+ 
+ public final class SettingsPage extends ScrollPane {
+     @SuppressWarnings("FieldCanBeLocal")
+-    private final InvalidationListener updateListener;
+ 
+     public SettingsPage() {
+         this.setFitToWidth(true);
+@@ -82,6 +81,7 @@ public final class SettingsPage extends ScrollPane {
+         FXUtils.smoothScrolling(this);
+ 
+         {
++            /*
+             ComponentList updatePaneList = new ComponentList();
+             {
+                 ObjectProperty<UpdateChannel> updateChannel;
+@@ -164,6 +164,7 @@ public final class SettingsPage extends ScrollPane {
+ 
+                 rootPane.getChildren().addAll(ComponentList.createComponentListTitle(i18n("update")), updatePaneList);
+             }
++            */
+ 
+             {
+                 ComponentList languagePaneList = new ComponentList();

--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -2,3 +2,4 @@ VER=3.14.1
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKUPDATE="anitya::id=371893"
 CHKSUMS="SKIP"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: remove update settings
- gh: update to 2.95.0
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- hmcl: 3.14.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
