### PR TITLE
manboster: update to 0.2.2

### DIFF
--- a/app-utils/manboster/spec
+++ b/app-utils/manboster/spec
@@ -1,4 +1,4 @@
-VER=0.2.1
+VER=0.2.2
 # Note: Git metadata for version detection, copy metadata here.
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/manboster/manboster.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- manboster: update to 0.2.2
    Co-authored-by: chihuo2104 \(@chihuo2104\) <i@chihuo2104.dev>

Package(s) Affected
-------------------

- manboster: 0.2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit manboster
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
