### PR TITLE
motrix-next: update to 3.9.6

### DIFF
--- a/app-web/aria2-next/autobuild/defines
+++ b/app-web/aria2-next/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=aria2-next
+PKGDES="Download utility that supports HTTP(S), FTP, BitTorrent, and Metalink"
+PKGDEP="c-ares gcc-runtime glibc libssh2 libxml2 openssl sqlite zlib"
+PKGSEC=net
+
+ABTYPE=cmakeninja

--- a/app-web/aria2-next/spec
+++ b/app-web/aria2-next/spec
@@ -1,0 +1,4 @@
+VER=2.4.9
+SRCS="git::commit=tags/v$VER::https://github.com/AnInsomniacy/aria2-next.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390797"

--- a/app-web/motrix-next/autobuild/build
+++ b/app-web/motrix-next/autobuild/build
@@ -7,12 +7,19 @@ abinfo "Installing Motrix Next ..."
 install -Dvm755 "$SRCDIR"/src-tauri/target/release/motrix-next \
     "$PKGDIR"/usr/bin/motrix-next
 
-abinfo "Installing aria2 config..."
+abinfo "Installing aria2 config and data..."
 install -Dvm644 "$SRCDIR"/src-tauri/binaries/aria2.conf \
-    "$PKGDIR"/usr/lib/motrix-next/binaries/aria2.conf
+    "$PKGDIR"/usr/lib/MotrixNext/binaries/aria2.conf
+install -Dvm644 "$SRCDIR"/src-tauri/data/ed2k-bootstrap/server.met \
+    "$PKGDIR"/usr/lib/MotrixNext/data/ed2k-bootstrap/server.met
+install -Dvm644 "$SRCDIR"/src-tauri/data/ed2k-bootstrap/nodes.dat \
+    "$PKGDIR"/usr/lib/MotrixNext/data/ed2k-bootstrap/nodes.dat
+install -Dvm644 "$SRCDIR"/src-tauri/data/dbip-country-lite.mmdb \
+    "$PKGDIR"/usr/lib/MotrixNext/data/dbip-country-lite.mmdb
 
 abinfo "Installing application icon ..."
 for i in 32 64 128; do
     install -Dvm644 "$SRCDIR"/src-tauri/icons/${i}x${i}.png \
                     "$PKGDIR"/usr/share/icons/hicolor/${i}x${i}/apps/motrix-next.png
 done
+

--- a/app-web/motrix-next/autobuild/defines
+++ b/app-web/motrix-next/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=motrix-next
 PKGSEC=web
 PKGDEP="cairo gcc-runtime glib glibc gdk-pixbuf\
         gtk-3 libsoup-3 pango webkit2gtk \
-        libayatana-appindicator aria2"
+        libayatana-appindicator aria2-next"
 BUILDDEP="nodejs rustc llvm tauri-cli"
 PKGDES="Full-featured download manager rebuilt with Tauri 2"
 PKGPROV="motrixnext"

--- a/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
+++ b/app-web/motrix-next/autobuild/patches/0001-feat-disable-auto-update-check.patch
@@ -1,42 +1,48 @@
-From 61cbb8890e9739f922c9a94c9748141fa38d6e2f Mon Sep 17 00:00:00 2001
+From 75ee6084a7a2ac1d69cf37ae9e9187d98e85c83e Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
-Date: Fri, 8 May 2026 18:29:51 +0800
+Date: Mon, 22 Jun 2026 22:38:57 +0800
 Subject: [PATCH 1/4] feat: disable auto-update check
 
 ---
- src/components/preference/General.vue | 67 +--------------------------
- src/layouts/MainLayout.vue            | 16 +------
- src/main.ts                           | 33 +------------
- 3 files changed, 4 insertions(+), 112 deletions(-)
+ src/components/preference/General.vue | 84 +--------------------------
+ src/layouts/MainLayout.vue            | 16 +----
+ src/main.ts                           | 32 +---------
+ 3 files changed, 5 insertions(+), 127 deletions(-)
 
 diff --git a/src/components/preference/General.vue b/src/components/preference/General.vue
-index 8be982ac..8c15aece 100644
+index a7798f94..13ddcd21 100644
 --- a/src/components/preference/General.vue
 +++ b/src/components/preference/General.vue
-@@ -27,22 +27,15 @@ import {
-   NFormItem,
-   NSelect,
-   NSwitch,
+@@ -23,27 +23,9 @@ import {
+ } from '@/composables/useGeneralPreference'
+ import { COLOR_SCHEMES, ENGINE_RPC_PORT } from '@shared/constants'
+ import { useAppMessage } from '@/composables/useAppMessage'
+-import {
+-  NForm,
+-  NFormItem,
+-  NSelect,
+-  NSwitch,
 -  NButton,
-   NDivider,
-   NText,
-   NCollapseTransition,
-   NSpace,
-   NTag,
+-  NDivider,
+-  NText,
+-  NCollapseTransition,
+-  NSpace,
+-  NTag,
 -  NRadioGroup,
 -  NRadioButton,
 -  NIcon,
-   useDialog,
- } from 'naive-ui'
+-  useDialog,
+-} from 'naive-ui'
++import { NForm, NFormItem, NSelect, NSwitch, NDivider, NCollapseTransition, NSpace, NTag, useDialog } from 'naive-ui'
  import PreferenceActionBar from './PreferenceActionBar.vue'
  import MTooltip from '@/components/common/MTooltip.vue'
 -import { CloudDownloadOutline } from '@vicons/ionicons5'
 -import UpdateDialog from '@/components/preference/UpdateDialog.vue'
 -import type { UpdateChannel } from '@shared/types'
+ import PreferenceHintLabel from './PreferenceHintLabel.vue'
  
  const { t, locale } = useI18n()
- const preferenceStore = usePreferenceStore()
-@@ -66,16 +59,6 @@ async function copyVersionToClipboard(text: string, label: string) {
+@@ -68,16 +50,6 @@ async function copyVersionToClipboard(text: string, label: string) {
      logger.debug('General.clipboard', `writeText failed: ${e}`)
    }
  }
@@ -53,8 +59,8 @@ index 8be982ac..8c15aece 100644
  
  function buildForm() {
    return buildGeneralForm(preferenceStore.config)
-@@ -226,10 +209,6 @@ const themeOptions = computed(() => [
-   { label: t('preferences.theme-dark'), value: 'dark' },
+@@ -234,10 +206,6 @@ const taskCardModeOptions = computed(() => [
+   { label: t('preferences.task-card-mode-compact'), value: 'compact' },
  ])
  
 -function handleCheckUpdate() {
@@ -64,8 +70,8 @@ index 8be982ac..8c15aece 100644
  const { restartEngine } = useEngineRestart()
  
  function handleManualRestart() {
-@@ -344,51 +323,7 @@ onMounted(async () => {
-         <NSelect v-model:value="form.locale" :options="fullLocaleOptions" style="width: 280px" />
+@@ -359,55 +327,7 @@ onMounted(async () => {
+         />
        </NFormItem>
  
 -      <!-- ③ Auto Update -->
@@ -75,7 +81,11 @@ index 8be982ac..8c15aece 100644
 -      </NFormItem>
 -      <NCollapseTransition :show="form.autoCheckUpdate" class="collapse-indent">
 -        <NFormItem :label="t('preferences.check-frequency')">
--          <NSelect v-model:value="form.autoCheckUpdateInterval" :options="checkIntervalOptions" style="width: 180px" />
+-          <NSelect
+-            v-model:value="form.autoCheckUpdateInterval"
+-            :options="checkIntervalOptions"
+-            class="pref-control-auto"
+-          />
 -        </NFormItem>
 -      </NCollapseTransition>
 -      <NFormItem :label="t('preferences.update-channel')">
@@ -97,17 +107,17 @@ index 8be982ac..8c15aece 100644
 -        </NRadioGroup>
 -      </NFormItem>
 -      <NFormItem :label="t('preferences.last-check-update-time')">
--        <div style="display: flex; align-items: center; gap: 16px">
+-        <div class="pref-inline-row">
 -          <NButton size="small" @click="handleCheckUpdate">
 -            <template #icon>
 -              <NIcon :size="14"><CloudDownloadOutline /></NIcon>
 -            </template>
 -            {{ t('app.check-updates-now') }}
 -          </NButton>
--          <NText v-if="preferenceStore.config.lastCheckUpdateTime" depth="3" style="font-size: 13px">
+-          <NText v-if="preferenceStore.config.lastCheckUpdateTime" depth="3" class="pref-inline-row__meta">
 -            {{ new Date(preferenceStore.config.lastCheckUpdateTime).toLocaleString() }}
 -          </NText>
--          <NText v-else depth="3" style="font-size: 13px">—</NText>
+-          <NText v-else depth="3" class="pref-inline-row__meta">—</NText>
 -        </div>
 -      </NFormItem>
 -      <UpdateDialog ref="updateDialogRef" />
@@ -116,20 +126,20 @@ index 8be982ac..8c15aece 100644
 +      <!-- ③ Appearance -->
        <NDivider title-placement="left">{{ t('preferences.appearance-section') }}</NDivider>
        <NFormItem :label="t('preferences.appearance')">
-         <NSelect v-model:value="form.theme" :options="themeOptions" style="width: 200px" />
+         <NSelect v-model:value="form.theme" :options="themeOptions" class="pref-control-auto" />
 diff --git a/src/layouts/MainLayout.vue b/src/layouts/MainLayout.vue
-index 92274587..a12c696e 100644
+index 957fbe8b..ce8a4d3b 100644
 --- a/src/layouts/MainLayout.vue
 +++ b/src/layouts/MainLayout.vue
 @@ -1,6 +1,6 @@
  <script setup lang="ts">
  /** @fileoverview Main application layout with sidebar, subnav, and IPC event handling. */
--import { computed, h, ref, nextTick, watch } from 'vue'
-+import { computed, h, ref, watch } from 'vue'
- import { useRoute, useRouter } from 'vue-router'
+-import { computed, ref, nextTick, watch } from 'vue'
++import { computed, ref, watch } from 'vue'
+ import { useRoute } from 'vue-router'
  import { onMounted, onUnmounted } from 'vue'
  import { useI18n } from 'vue-i18n'
-@@ -41,7 +41,6 @@ import WindowControls from '@/components/layout/WindowControls.vue'
+@@ -48,7 +48,6 @@ import WindowControls from '@/components/layout/WindowControls.vue'
  import EngineOverlay from '@/components/layout/EngineOverlay.vue'
  import AboutPanel from '@/components/about/AboutPanel.vue'
  import AddTask from '@/components/task/AddTask.vue'
@@ -137,7 +147,7 @@ index 92274587..a12c696e 100644
  import MagnetFileSelect from '@/components/task/MagnetFileSelect.vue'
  import { useTaskStore } from '@/stores/task'
  import { usePreferenceStore } from '@/stores/preference'
-@@ -83,8 +82,6 @@ const shutdownCountdown = ref(60)
+@@ -120,8 +119,6 @@ const shutdownCountdown = ref(60)
  let shutdownTimer: ReturnType<typeof setInterval> | null = null
  let unlistenPowerCountdown: (() => void) | null = null
  
@@ -146,7 +156,7 @@ index 92274587..a12c696e 100644
  let unlistenDragDrop: (() => void) | null = null
  let unlistenMenuEvent: (() => void) | null = null
  let unlistenCloseRequested: (() => void) | null = null
-@@ -410,16 +407,6 @@ async function onMaximizeToggled() {
+@@ -445,16 +442,6 @@ async function onMaximizeToggled() {
    }, 300)
  }
  
@@ -163,8 +173,8 @@ index 92274587..a12c696e 100644
  async function handleExitConfirm() {
    // Checkbox means "always minimize to tray from now on" —
    // save the setting even when quitting this time.
-@@ -972,7 +959,6 @@ onUnmounted(() => {
-     <Speedometer />
+@@ -1000,7 +987,6 @@ onUnmounted(() => {
+     </Transition>
      <AboutPanel :show="showAbout" @close="showAbout = false" />
      <AddTask :show="appStore.addTaskVisible" @close="appStore.hideAddTaskDialog()" />
 -    <UpdateDialog ref="updateDialogRef" />
@@ -172,19 +182,22 @@ index 92274587..a12c696e 100644
        :show="showEngineOverlay"
        @recovered="showEngineOverlay = false"
 diff --git a/src/main.ts b/src/main.ts
-index 466b330b..e1aa1694 100644
+index 7e37d419..fdff1e4a 100644
 --- a/src/main.ts
 +++ b/src/main.ts
-@@ -12,7 +12,7 @@ import aria2Api from './api/aria2'
- import { ENGINE_RPC_PORT, AUTO_SYNC_TRACKER_INTERVAL, DEFAULT_TRACKER_SOURCE } from '@shared/constants'
- import { convertTrackerDataToLine, convertTrackerDataToComma, reduceTrackerString } from '@shared/utils/tracker'
+@@ -20,10 +20,9 @@ import { convertTrackerDataToLine, convertTrackerDataToComma, reduceTrackerStrin
  import { logger } from '@shared/logger'
+ import { getErrorMessage } from '@shared/utils/errorMessage'
+ import { resolveUserVisibleDownloadDir, shouldPersistResolvedDownloadDir } from '@shared/utils/userVisibleDirectory'
+-import { getUpdateProxy } from '@/composables/useUpdateFlow'
+ import { resolveAppProxyUrl } from '@shared/utils/appProxyPolicy'
+ import { checkSyncDue } from '@shared/utils/syncSchedule'
 -import type { AppConfig, TauriUpdate } from '@shared/types'
 +import type { AppConfig } from '@shared/types'
  import App from './App.vue'
  import 'virtual:uno.css'
- import './styles/variables.css'
-@@ -66,33 +66,6 @@ window.addEventListener('unhandledrejection', (e) => {
+ import './styles/tokens.css'
+@@ -82,31 +81,6 @@ if (import.meta.env.PROD) {
      }
    }
  
@@ -202,9 +215,7 @@ index 466b330b..e1aa1694 100644
 -    try {
 -      const { invoke } = await import('@tauri-apps/api/core')
 -      const channel = config.updateChannel || 'stable'
--      const proxy = config.proxy
--      const proxyServer =
--        proxy?.enable && proxy.server && (proxy.scope || []).includes('update-app') ? proxy.server : null
+-      const proxyServer = getUpdateProxy(config.proxy)
 -      const update = await invoke<TauriUpdate | null>('check_for_update', { channel, proxy: proxyServer })
 -      if (update) {
 -        appStore.pendingUpdate = update
@@ -215,10 +226,10 @@ index 466b330b..e1aa1694 100644
 -    }
 -  }
 -
-   async function autoSyncTrackerOnStartup() {
-     const config = preferenceStore.config
-     if (!config.autoSyncTracker) return
-@@ -131,8 +104,7 @@ window.addEventListener('unhandledrejection', (e) => {
+   function emitAppToast(payload: { type: 'success' | 'info' | 'warning' | 'error'; key: string }): void {
+     window.dispatchEvent(new CustomEvent('app:toast', { detail: payload }))
+   }
+@@ -197,8 +171,7 @@ if (import.meta.env.PROD) {
    //  Phase 2 (engine, async)   – rpcSecret → save config → start engine
    //                              → on_engine_ready (Rust) → wait_for_engine
    //  Phase 3 (non-critical)    – autostart, protocol sync (parallel)
@@ -228,14 +239,14 @@ index 466b330b..e1aa1694 100644
    // ---------------------------------------------------------------------------
  
    /** Start the aria2 engine, wait for readiness, and connect the RPC client.
-@@ -413,7 +385,6 @@ window.addEventListener('unhandledrejection', (e) => {
+@@ -412,7 +385,6 @@ if (import.meta.env.PROD) {
      }
  
      // ── Phase 4: deferred non-critical tasks ───────────────────────────────
 -    autoCheckForUpdate()
-     autoSyncTrackerOnStartup()
+     syncNetworkSourcesIfDue(true)
  
-     // Initialize download history database, then schedule stale record cleanup
+     // Initialize download history database, then schedule lightweight cleanup.
 -- 
 2.52.0
 

--- a/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
+++ b/app-web/motrix-next/autobuild/patches/0002-feat-add-more-architectures-support.patch
@@ -1,4 +1,4 @@
-From fa5e2271098f785875adaaf142c0bb9af06a97bc Mon Sep 17 00:00:00 2001
+From 68e03ea650ecd7b5597c908078efa812c07879cb Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Tue, 14 Apr 2026 12:42:31 +0800
 Subject: [PATCH 2/4] feat: add more architectures support
@@ -64,7 +64,7 @@ index 1e978e2c..6f57ce16 100644
  
  /**
 diff --git a/src/shared/__tests__/sidecarBinaries.test.ts b/src/shared/__tests__/sidecarBinaries.test.ts
-index c51b965a..908b4e9e 100644
+index 236d0130..cd5369d8 100644
 --- a/src/shared/__tests__/sidecarBinaries.test.ts
 +++ b/src/shared/__tests__/sidecarBinaries.test.ts
 @@ -33,6 +33,10 @@ const EXPECTED_TARGETS = [

--- a/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
+++ b/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c.patch
@@ -1,65 +1,100 @@
-From ba0b790bf3a27aad3776ef82832e7ce9d66ef70a Mon Sep 17 00:00:00 2001
+From 5a4939a8c1179428fa94d3df3781245e1e0db6c8 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
-Date: Tue, 14 Apr 2026 13:47:55 +0800
+Date: Mon, 22 Jun 2026 23:18:30 +0800
 Subject: [PATCH 3/4] feat: use system aria2c
 
 ---
- src-tauri/src/engine/lifecycle.rs | 18 ++++++------------
- src-tauri/tauri.conf.json         |  3 ---
- 2 files changed, 6 insertions(+), 15 deletions(-)
+ src-tauri/src/engine/cleanup.rs   | 15 ++++++---------
+ src-tauri/src/engine/lifecycle.rs |  8 +++-----
+ src-tauri/tauri.conf.json         |  1 -
+ 3 files changed, 9 insertions(+), 15 deletions(-)
 
+diff --git a/src-tauri/src/engine/cleanup.rs b/src-tauri/src/engine/cleanup.rs
+index d6d92875..738ca370 100644
+--- a/src-tauri/src/engine/cleanup.rs
++++ b/src-tauri/src/engine/cleanup.rs
+@@ -4,10 +4,10 @@
+ /// killed when reclaiming the RPC port — never arbitrary processes that
+ /// happen to occupy the same port.
+ ///
+-/// Matches only the current `motrix-next-engine` sidecar process.
++/// Matches only the system `aria2-next` process.
+ ///
+ fn is_supported_engine_process(comm: &str) -> bool {
+-    comm.contains("motrix-next-engine")
++    comm.contains("aria2-next")
+ }
+ 
+ #[cfg(unix)]
+@@ -163,19 +163,16 @@ mod tests {
+     use super::*;
+ 
+     #[test]
+-    fn is_supported_engine_process_matches_motrix_next_engine() {
+-        assert!(is_supported_engine_process("motrix-next-engine"));
++    fn is_supported_engine_process_matches_aria2_next() {
++        assert!(is_supported_engine_process("aria2-next"));
+         assert!(is_supported_engine_process(
+-            "/Applications/MotrixNext.app/Contents/Resources/motrix-next-engine"
+-        ));
+-        assert!(is_supported_engine_process(
+-            "/usr/bin/motrix-next-engine --conf-path=/usr/lib/MotrixNext/binaries/aria2.conf"
++            "/usr/bin/aria2-next --conf-path=/usr/lib/MotrixNext/binaries/aria2.conf"
+         ));
+     }
+ 
+     #[test]
+     fn is_supported_engine_process_does_not_trust_truncated_comm_names() {
+-        assert!(!is_supported_engine_process("motrix-next-eng"));
++        assert!(!is_supported_engine_process("aria2-nex"));
+     }
+ 
+     #[test]
 diff --git a/src-tauri/src/engine/lifecycle.rs b/src-tauri/src/engine/lifecycle.rs
-index ed5b0d16..2df0b0e3 100644
+index 1eed68a4..c5ff5cbb 100644
 --- a/src-tauri/src/engine/lifecycle.rs
 +++ b/src-tauri/src/engine/lifecycle.rs
-@@ -99,13 +99,10 @@ pub fn start_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Resul
-         session_path.exists(),
-     );
+@@ -13,7 +13,7 @@ use tauri_plugin_store::StoreExt;
+ static BT_PORT_RECOVERY_IN_FLIGHT: std::sync::atomic::AtomicBool =
+     std::sync::atomic::AtomicBool::new(false);
  
--    let sidecar = app
-+    let (mut rx, child) = app
+-const ENGINE_SIDECAR_NAME: &str = "motrix-next-engine";
++const ENGINE_BINARY_NAME: &str = "aria2-next";
+ const DEFAULT_RPC_PORT_STR: &str = "29100";
+ const ENGINE_PORT_RELEASE_TIMEOUT_MS: u64 = 2600;
+ const ENGINE_PORT_RELEASE_POLL_MS: u64 = 100;
+@@ -238,8 +238,7 @@ pub fn start_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Resul
+ 
+     let sidecar = app
          .shell()
--        .sidecar("motrixnext-aria2c")
+-        .sidecar(ENGINE_SIDECAR_NAME)
 -        .map_err(|e| format!("Failed to create sidecar: {}", e))?
--        .args(&args);
--
--    let (mut rx, child) = sidecar
-+        .command("aria2c")
-+        .args(&args)
-         .spawn()
-         .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
++        .command(ENGINE_BINARY_NAME)
+         .envs(sanitized_engine_proxy_env())
+         .args(&args);
  
-@@ -310,13 +307,10 @@ pub fn restart_engine(app: &tauri::AppHandle, config: &serde_json::Value) -> Res
-         session_path.exists(),
-     );
+@@ -465,8 +464,7 @@ pub fn restart_engine(app: &tauri::AppHandle, _config: &serde_json::Value) -> Re
  
--    let sidecar = app
-+    let (mut rx, child) = app
+     let sidecar = app
          .shell()
--        .sidecar("motrixnext-aria2c")
+-        .sidecar(ENGINE_SIDECAR_NAME)
 -        .map_err(|e| format!("Failed to create sidecar: {}", e))?
--        .args(&args);
--
--    let (mut rx, child) = sidecar
-+        .command("aria2c")
-+        .args(&args)
-         .spawn()
-         .map_err(|e| format!("Failed to spawn aria2c: {}", e))?;
++        .command(ENGINE_BINARY_NAME)
+         .envs(sanitized_engine_proxy_env())
+         .args(&args);
  
 diff --git a/src-tauri/tauri.conf.json b/src-tauri/tauri.conf.json
-index c2e83b04..bfb0a6ba 100644
+index a485cab4..b357f92b 100644
 --- a/src-tauri/tauri.conf.json
 +++ b/src-tauri/tauri.conf.json
-@@ -35,9 +35,6 @@
+@@ -35,7 +35,6 @@
      "publisher": "AnInsomniacy",
      "copyright": "Copyright © 2025 AnInsomniacy. All rights reserved.",
      "createUpdaterArtifacts": true,
--    "externalBin": [
--      "binaries/motrixnext-aria2c"
--    ],
+-    "externalBin": ["binaries/motrix-next-engine"],
      "resources": [
        "binaries/aria2.conf",
-       "data/dbip-country-lite.mmdb"
+       "data/ed2k-bootstrap/server.met",
 -- 
 2.52.0
 

--- a/app-web/motrix-next/autobuild/patches/0004-Revert-chore-restrict-supported-architectures-to-cur.patch
+++ b/app-web/motrix-next/autobuild/patches/0004-Revert-chore-restrict-supported-architectures-to-cur.patch
@@ -1,4 +1,4 @@
-From d2756dcea62728c6712afdbdf8e99b326839dfcb Mon Sep 17 00:00:00 2001
+From 5c21196950e7cd4fc3a59cfc66b619f3e037bba3 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Thu, 16 Apr 2026 21:47:51 +0800
 Subject: [PATCH 4/4] Revert "chore: restrict supported architectures to
@@ -10,10 +10,10 @@ This reverts commit 3359b2a3e3561529c356e2b7d5ddcea51fa21ea1.
  1 file changed, 4 insertions(+)
 
 diff --git a/pnpm-workspace.yaml b/pnpm-workspace.yaml
-index 47281cff..550c7241 100644
+index 9eff6408..0c1884ab 100644
 --- a/pnpm-workspace.yaml
 +++ b/pnpm-workspace.yaml
-@@ -4,6 +4,10 @@ ignoredBuiltDependencies:
+@@ -16,6 +16,10 @@ minimumReleaseAgeExclude:
  supportedArchitectures:
    os:
      - current

--- a/app-web/motrix-next/spec
+++ b/app-web/motrix-next/spec
@@ -1,6 +1,5 @@
-VER=3.8.8
+VER=3.9.6
 SRCS="git::commit=tags/v$VER::https://github.com/AnInsomniacy/motrix-next.git"
 CHKSUMS="SKIP"
-SUBDIR="motrix-next"
 CHKUPDATE="anitya::id=389590"
 ENVREQ="total_mem=16"


### PR DESCRIPTION
Topic Description
-----------------

- motrix-next: update to 3.9.6
- aria2-next: new, 2.4.9

Package(s) Affected
-------------------

- aria2-next: 2.4.9
- motrix-next: 3.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit aria2-next motrix-next
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
