### PR TITLE
codex: update to 0.142.0

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,6 +1,6 @@
-From 6d5a5d409448ae1632e9b19fca5d88c24eee5a00 Mon Sep 17 00:00:00 2001
+From adae3cf15b5bfaee98013e8751e8353e87872908 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Tue, 9 Jun 2026 14:36:42 +0800
+Date: Tue, 23 Jun 2026 13:51:19 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
 
 Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
@@ -10,30 +10,30 @@ Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index d67e418..d86f8bb 100644
+index cd658f9a88..123f5915f8 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -14069,8 +14069,6 @@ dependencies = [
+@@ -14319,8 +14319,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "147.4.0"
+ version = "149.2.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
+-checksum = "46dccf61a364b61bbaac70a8ba64a1a1006e87123b7d62eaeec999a3ba31ecdb"
  dependencies = [
   "bindgen",
   "bitflags 2.10.0",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index 9522dcc..986b91c 100644
+index d469506851..a0ab8042ac 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -532,5 +532,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -552,5 +552,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  
-+v8 = { path = '../../rusty_v8' }
++v8 = { path = "../../rusty_v8" }
 +
  [patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
- tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
+ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "4fffad30fe373adbdcffab9545e9e9bf4f2fc19f" }
 -- 
 2.52.0
 

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
@@ -1,883 +1,915 @@
-From d813a26e9b717bdcf7e3c8b4dd4374aaeaaa49c1 Mon Sep 17 00:00:00 2001
+From 8c38b6827cd4445188245c056b7bd30b24892d7b Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Tue, 9 Jun 2026 14:39:06 +0800
+Date: Tue, 23 Jun 2026 13:52:20 +0800
 Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
 
 Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
 ---
- codex-rs/Cargo.lock | 244 ++++++++++++++++++++++----------------------
- 1 file changed, 122 insertions(+), 122 deletions(-)
+ codex-rs/Cargo.lock | 254 ++++++++++++++++++++++----------------------
+ 1 file changed, 127 insertions(+), 127 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index d86f8bb..87e6991 100644
+index 123f5915f8..e1123a1102 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -402,7 +402,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+@@ -394,7 +394,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
  
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1800,7 +1800,7 @@ dependencies = [
+@@ -1863,7 +1863,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-graph-store"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-protocol",
-@@ -1815,7 +1815,7 @@ dependencies = [
+  "codex-state",
+@@ -1877,7 +1877,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-identity"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1834,7 +1834,7 @@ dependencies = [
+@@ -1896,7 +1896,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1854,7 +1854,7 @@ dependencies = [
+@@ -1917,7 +1917,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1863,7 +1863,7 @@ dependencies = [
+@@ -1926,7 +1926,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1898,7 +1898,7 @@ dependencies = [
+@@ -1959,7 +1959,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -1987,7 +1987,7 @@ dependencies = [
+@@ -2051,7 +2051,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -2014,7 +2014,7 @@ dependencies = [
+@@ -2078,7 +2078,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-daemon"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2035,7 +2035,7 @@ dependencies = [
+@@ -2099,7 +2099,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2062,7 +2062,7 @@ dependencies = [
+@@ -2127,7 +2127,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2083,7 +2083,7 @@ dependencies = [
+@@ -2149,7 +2149,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-transport"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2122,7 +2122,7 @@ dependencies = [
+@@ -2188,7 +2188,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2141,7 +2141,7 @@ dependencies = [
+@@ -2208,7 +2208,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -2160,7 +2160,7 @@ dependencies = [
+@@ -2228,7 +2228,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "pretty_assertions",
-@@ -2170,7 +2170,7 @@ dependencies = [
+  "tokio",
+@@ -2237,7 +2237,7 @@ dependencies = [
  
  [[package]]
  name = "codex-aws-auth"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "aws-config",
   "aws-credential-types",
-@@ -2185,7 +2185,7 @@ dependencies = [
+@@ -2252,7 +2252,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -2202,7 +2202,7 @@ dependencies = [
+@@ -2269,7 +2269,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "serde",
   "serde_json",
-@@ -2211,7 +2211,7 @@ dependencies = [
+@@ -2278,7 +2278,7 @@ dependencies = [
  
  [[package]]
  name = "codex-bwrap"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "cc",
   "libc",
-@@ -2220,7 +2220,7 @@ dependencies = [
+@@ -2287,7 +2287,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2243,7 +2243,7 @@ dependencies = [
+@@ -2309,7 +2309,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2317,7 +2317,7 @@ dependencies = [
+@@ -2385,7 +2385,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "bytes",
-@@ -2348,7 +2348,7 @@ dependencies = [
+  "codex-utils-cargo-bin",
+@@ -2415,7 +2415,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-config"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "base64 0.22.1",
   "chrono",
-@@ -2371,7 +2371,7 @@ dependencies = [
+@@ -2439,7 +2439,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-trait",
-@@ -2403,7 +2403,7 @@ dependencies = [
+  "chrono",
+@@ -2470,7 +2470,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-trait",
-@@ -2418,7 +2418,7 @@ dependencies = [
+  "chrono",
+@@ -2484,7 +2484,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "chrono",
-@@ -2428,7 +2428,7 @@ dependencies = [
+  "codex-cloud-tasks-client",
+@@ -2493,7 +2493,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
+ dependencies = [
+  "codex-code-mode-protocol",
+  "codex-protocol",
+@@ -2508,11 +2508,11 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-code-mode-host"
+-version = "0.0.0"
++version = "0.142.0"
+ 
+ [[package]]
+ name = "codex-code-mode-protocol"
+-version = "0.0.0"
++version = "0.142.0"
  dependencies = [
   "codex-protocol",
-  "deno_core_icudata",
-@@ -2443,11 +2443,11 @@ dependencies = [
+  "pretty_assertions",
+@@ -2524,11 +2524,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-trait",
-@@ -2495,7 +2495,7 @@ dependencies = [
+  "base64 0.22.1",
+@@ -2576,7 +2576,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2511,7 +2511,7 @@ dependencies = [
+@@ -2593,7 +2593,7 @@ dependencies = [
  
  [[package]]
  name = "codex-context-fragments"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -2519,7 +2519,7 @@ dependencies = [
+@@ -2601,7 +2601,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2641,7 +2641,7 @@ dependencies = [
+@@ -2725,7 +2725,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-api"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-analytics",
   "codex-app-server-protocol",
-@@ -2660,7 +2660,7 @@ dependencies = [
+@@ -2745,7 +2745,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-plugins"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2700,7 +2700,7 @@ dependencies = [
+@@ -2790,7 +2790,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-skills"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-analytics",
-@@ -2732,7 +2732,7 @@ dependencies = [
+@@ -2825,7 +2825,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2778,7 +2778,7 @@ dependencies = [
+@@ -2871,7 +2871,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2820,7 +2820,7 @@ dependencies = [
+@@ -2916,7 +2916,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2837,7 +2837,7 @@ dependencies = [
+@@ -2933,7 +2933,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy-legacy"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "allocative",
   "anyhow",
-@@ -2857,7 +2857,7 @@ dependencies = [
+@@ -2953,7 +2953,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2866,7 +2866,7 @@ dependencies = [
+@@ -2962,7 +2962,7 @@ dependencies = [
  
  [[package]]
  name = "codex-extension-api"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
+  "codex-config",
   "codex-context-fragments",
-@@ -2876,7 +2876,7 @@ dependencies = [
+@@ -2975,7 +2975,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-migration"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-hooks",
   "pretty_assertions",
-@@ -2888,7 +2888,7 @@ dependencies = [
+@@ -2987,7 +2987,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-sessions"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "chrono",
   "codex-app-server-protocol",
-@@ -2902,7 +2902,7 @@ dependencies = [
+@@ -3001,7 +3001,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -2915,7 +2915,7 @@ dependencies = [
+@@ -3014,7 +3014,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-login",
-@@ -2928,7 +2928,7 @@ dependencies = [
+@@ -3027,7 +3027,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2944,7 +2944,7 @@ dependencies = [
+@@ -3043,7 +3043,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-system"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
+  "bytes",
   "codex-protocol",
-@@ -2954,7 +2954,7 @@ dependencies = [
+@@ -3055,7 +3055,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-watcher"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "notify",
   "pretty_assertions",
-@@ -2965,7 +2965,7 @@ dependencies = [
+@@ -3066,7 +3066,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2989,7 +2989,7 @@ dependencies = [
+@@ -3091,7 +3091,7 @@ dependencies = [
  
  [[package]]
  name = "codex-goal-extension"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-trait",
-@@ -3011,7 +3011,7 @@ dependencies = [
+  "chrono",
+@@ -3113,7 +3113,7 @@ dependencies = [
  
  [[package]]
  name = "codex-guardian"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-core",
-@@ -3021,7 +3021,7 @@ dependencies = [
+  "codex-extension-api",
+@@ -3122,7 +3122,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-home"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "codex-extension-api",
+  "codex-utils-absolute-path",
+@@ -3133,7 +3133,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3044,7 +3044,7 @@ dependencies = [
+@@ -3156,7 +3156,7 @@ dependencies = [
  
  [[package]]
  name = "codex-image-generation-extension"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-api",
-@@ -3065,7 +3065,7 @@ dependencies = [
+  "codex-core",
+@@ -3179,7 +3179,7 @@ dependencies = [
  
  [[package]]
  name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-utils-absolute-path",
   "codex-utils-home-dir",
-@@ -3075,7 +3075,7 @@ dependencies = [
+@@ -3189,7 +3189,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "keyring",
   "tracing",
-@@ -3083,7 +3083,7 @@ dependencies = [
+@@ -3197,7 +3197,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "clap",
   "codex-core",
-@@ -3107,7 +3107,7 @@ dependencies = [
+@@ -3221,7 +3221,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -3121,7 +3121,7 @@ dependencies = [
+@@ -3235,7 +3235,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-trait",
-@@ -3163,7 +3163,7 @@ dependencies = [
+  "base64 0.22.1",
+@@ -3277,7 +3277,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-channel",
-@@ -3195,7 +3195,7 @@ dependencies = [
+  "arc-swap",
+@@ -3311,7 +3311,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-mcp-extension"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "codex-config",
+  "codex-core",
+@@ -3335,7 +3335,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-arg0",
-@@ -3227,7 +3227,7 @@ dependencies = [
+@@ -3368,7 +3368,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-extension"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-core",
-@@ -3249,7 +3249,7 @@ dependencies = [
+  "codex-extension-api",
+@@ -3389,7 +3389,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-read"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -3259,7 +3259,7 @@ dependencies = [
+@@ -3399,7 +3399,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-write"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3294,7 +3294,7 @@ dependencies = [
+@@ -3436,7 +3436,7 @@ dependencies = [
  
  [[package]]
  name = "codex-message-history"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-config",
   "memchr",
-@@ -3308,7 +3308,7 @@ dependencies = [
+@@ -3450,7 +3450,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-agent-identity",
-@@ -3332,7 +3332,7 @@ dependencies = [
+  "codex-api",
+@@ -3473,7 +3473,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider-info"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-api",
   "codex-app-server-protocol",
-@@ -3349,7 +3349,7 @@ dependencies = [
+@@ -3490,7 +3490,7 @@ dependencies = [
  
  [[package]]
  name = "codex-models-manager"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "chrono",
-@@ -3370,7 +3370,7 @@ dependencies = [
+  "codex-app-server-protocol",
+@@ -3510,7 +3510,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "async-trait",
-@@ -3404,7 +3404,7 @@ dependencies = [
+  "base64 0.22.1",
+@@ -3545,7 +3545,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -3424,7 +3424,7 @@ dependencies = [
+@@ -3565,7 +3565,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -3456,7 +3456,7 @@ dependencies = [
+@@ -3597,7 +3597,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-config",
-  "codex-utils-absolute-path",
-@@ -3466,7 +3466,7 @@ dependencies = [
+  "codex-protocol",
+@@ -3609,7 +3609,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -3474,7 +3474,7 @@ dependencies = [
+@@ -3617,7 +3617,7 @@ dependencies = [
  
  [[package]]
  name = "codex-prompts"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-context-fragments",
-@@ -3488,7 +3488,7 @@ dependencies = [
+@@ -3631,7 +3631,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -3528,7 +3528,7 @@ dependencies = [
+@@ -3672,7 +3672,7 @@ dependencies = [
  
  [[package]]
  name = "codex-realtime-webrtc"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "libwebrtc",
   "thiserror 2.0.18",
-@@ -3537,7 +3537,7 @@ dependencies = [
+@@ -3681,7 +3681,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3548,7 +3548,7 @@ dependencies = [
+@@ -3692,7 +3692,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3565,7 +3565,7 @@ dependencies = [
+@@ -3709,7 +3709,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -3605,7 +3605,7 @@ dependencies = [
+@@ -3751,7 +3751,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "anyhow",
-  "async-trait",
-@@ -3631,7 +3631,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-rollout-trace"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "anyhow",
-  "codex-code-mode",
-@@ -3647,7 +3647,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-sandboxing"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "anyhow",
-  "async-trait",
-@@ -3668,7 +3668,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-secrets"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "age",
-  "anyhow",
-@@ -3689,7 +3689,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-shell-command"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "anyhow",
-  "base64 0.22.1",
-@@ -3710,7 +3710,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-shell-escalation"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "anyhow",
-  "async-trait",
-@@ -3731,7 +3731,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-skills"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "codex-utils-absolute-path",
-  "include_dir",
-@@ -3740,7 +3740,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-skills-extension"
--version = "0.0.0"
-+version = "0.138.0"
- dependencies = [
-  "async-trait",
-  "codex-core",
-@@ -3753,7 +3753,7 @@ dependencies = [
- 
- [[package]]
- name = "codex-state"
--version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "chrono",
 @@ -3776,7 +3776,7 @@ dependencies = [
  
  [[package]]
+ name = "codex-rollout-trace"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "anyhow",
+  "codex-code-mode",
+@@ -3792,7 +3792,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-sandboxing"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "anyhow",
+  "codex-network-proxy",
+@@ -3815,7 +3815,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-secrets"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "age",
+  "anyhow",
+@@ -3836,7 +3836,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-shell-command"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "anyhow",
+  "base64 0.22.1",
+@@ -3857,7 +3857,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-shell-escalation"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "anyhow",
+  "clap",
+@@ -3877,7 +3877,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-skills"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "codex-utils-absolute-path",
+  "include_dir",
+@@ -3886,7 +3886,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-skills-extension"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "codex-core-skills",
+  "codex-exec-server",
+@@ -3908,7 +3908,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-state"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "anyhow",
+  "chrono",
+@@ -3932,7 +3932,7 @@ dependencies = [
+ 
+ [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-uds",
-@@ -3788,7 +3788,7 @@ dependencies = [
+@@ -3944,7 +3944,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -3796,7 +3796,7 @@ dependencies = [
+@@ -3952,7 +3952,7 @@ dependencies = [
  
  [[package]]
  name = "codex-test-binary-support"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-arg0",
   "tempfile",
-@@ -3804,7 +3804,7 @@ dependencies = [
+@@ -3960,7 +3960,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-manager-sample"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3815,7 +3815,7 @@ dependencies = [
+@@ -3971,7 +3971,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-store"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "chrono",
-@@ -3837,7 +3837,7 @@ dependencies = [
+  "codex-git-utils",
+@@ -3992,7 +3992,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-app-server-protocol",
-@@ -3861,7 +3861,7 @@ dependencies = [
+  "codex-code-mode",
+@@ -4016,7 +4016,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
-  "arboard",
-@@ -3971,7 +3971,7 @@ dependencies = [
+  "app_test_support",
+@@ -4126,7 +4126,7 @@ dependencies = [
  
  [[package]]
  name = "codex-uds"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "async-io",
   "pretty_assertions",
-@@ -3983,7 +3983,7 @@ dependencies = [
+@@ -4138,7 +4138,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "dirs",
   "dunce",
-@@ -3997,14 +3997,14 @@ dependencies = [
+@@ -4152,14 +4152,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-protocol",
  ]
@@ -885,125 +917,134 @@ index d86f8bb..87e6991 100644
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "lru 0.16.3",
   "sha1 0.10.6",
-@@ -4013,7 +4013,7 @@ dependencies = [
+@@ -4168,7 +4168,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -4022,7 +4022,7 @@ dependencies = [
+@@ -4177,7 +4177,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -4034,15 +4034,15 @@ dependencies = [
+@@ -4189,15 +4189,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dirs",
-@@ -4052,7 +4052,7 @@ dependencies = [
+@@ -4207,7 +4207,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -4065,7 +4065,7 @@ dependencies = [
+@@ -4220,7 +4220,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -4074,7 +4074,7 @@ dependencies = [
+@@ -4229,7 +4229,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -4084,7 +4084,7 @@ dependencies = [
+@@ -4239,7 +4239,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -4093,7 +4093,7 @@ dependencies = [
+@@ -4248,7 +4248,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -4103,7 +4103,7 @@ dependencies = [
+@@ -4258,7 +4258,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-utils-path-uri"
+-version = "0.0.0"
++version = "0.142.0"
+ dependencies = [
+  "base64 0.22.1",
+  "codex-utils-absolute-path",
+@@ -4274,7 +4274,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-exec-server",
-  "codex-login",
-@@ -4116,7 +4116,7 @@ dependencies = [
+  "codex-utils-absolute-path",
+@@ -4287,7 +4287,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -4132,7 +4132,7 @@ dependencies = [
+@@ -4303,7 +4303,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "assert_matches",
-  "async-trait",
-@@ -4143,14 +4143,14 @@ dependencies = [
+  "thiserror 2.0.18",
+@@ -4313,14 +4313,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "rustls",
  ]
@@ -1011,25 +1052,25 @@ index d86f8bb..87e6991 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -4161,7 +4161,7 @@ dependencies = [
+@@ -4331,7 +4331,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -4171,14 +4171,14 @@ dependencies = [
+@@ -4341,14 +4341,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1037,16 +1078,16 @@ index d86f8bb..87e6991 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -4188,14 +4188,14 @@ dependencies = [
+@@ -4358,14 +4358,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1054,43 +1095,43 @@ index d86f8bb..87e6991 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -4203,7 +4203,7 @@ dependencies = [
+@@ -4373,7 +4373,7 @@ dependencies = [
  
  [[package]]
  name = "codex-web-search-extension"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
-  "async-trait",
   "codex-api",
-@@ -4223,7 +4223,7 @@ dependencies = [
+  "codex-core",
+@@ -4392,7 +4392,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4480,7 +4480,7 @@ dependencies = [
+@@ -4649,7 +4649,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -8834,7 +8834,7 @@ dependencies = [
+@@ -9035,7 +9035,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.138.0"
++version = "0.142.0"
  dependencies = [
   "anyhow",
   "codex-login",

--- a/app-utils/codex/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup-on-arm64.patch.deferred
@@ -1,18 +1,20 @@
-From 19b099baf17f611b7681ebda212bfa7ca471f388 Mon Sep 17 00:00:00 2001
+From 66cfcdedee58a6a55b83722466fcae382899605d Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 29 Apr 2026 19:29:06 +0800
 Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup on arm64
 
 Because we have native linux arm64 CI :)
+
+Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
 ---
  build.rs | 16 ----------------
  1 file changed, 16 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index b7a71b2698..3cf8f0231f 100644
+index a2a2e4596..8a0d0e16d 100644
 --- a/build.rs
 +++ b/build.rs
-@@ -379,22 +379,6 @@ fn build_v8(is_asan: bool) {
+@@ -381,22 +381,6 @@ fn build_v8(is_asan: bool) {
    if needs_tls_define && !tls_define_injected {
      gn_args.push(r#"extra_cflags=["-DV8_TLS_USED_IN_LIBRARY"]"#.to_string());
    }
@@ -32,6 +34,9 @@ index b7a71b2698..3cf8f0231f 100644
 -    maybe_install_sysroot("i386");
 -    maybe_install_sysroot("arm");
 -  }
-
+ 
    let target_triple = env::var("TARGET").unwrap();
    // check if the target triple describes a non-native environment
+-- 
+2.52.0
+

--- a/app-utils/codex/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,4 +1,4 @@
-From cba75642b38a0dd58a73fba1f60c8b92770f48c2 Mon Sep 17 00:00:00 2001
+From c9f49a911a855ae46c4c5bf98b063c7876f087f8 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
 Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
@@ -6,15 +6,17 @@ Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 
 Correct the builtins path accordingly.
+
+Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
 ---
  build/config/clang/BUILD.gn | 19 ++++++++++---------
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index e05032c0c6..67092527ad 100644
+index f429120f4..d75fbc007 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -185,22 +185,23 @@ template("clang_lib") {
+@@ -188,22 +188,23 @@ template("clang_lib") {
        } else if (is_apple) {
          _dir = "darwin"
        } else if (is_linux || is_chromeos) {
@@ -46,12 +48,15 @@ index e05032c0c6..67092527ad 100644
          } else {
            assert(false)  # Unhandled cpu type
          }
-@@ -231,7 +232,7 @@ template("clang_lib") {
+@@ -234,7 +235,7 @@ template("clang_lib") {
          assert(false)  # Unhandled target platform
        }
-
+ 
 -      _clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"
 +      _clang_lib_dir = "$clang_base_path/lib/llvm-$clang_version/lib/clang/$clang_version/lib"
        _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
        libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
      }
+-- 
+2.52.0
+

--- a/app-utils/codex/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,17 +1,33 @@
-From 307723a74fc208fe64c0cbfb3a0348f9885cfc50 Mon Sep 17 00:00:00 2001
+From 975957febe3eb82ad3ef55ad2c70dc902b62dbef Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Sun, 29 Mar 2026 18:50:37 +0800
+Date: Sat, 23 May 2026 00:26:17 +0800
 Subject: [PATCH 5/5] AOSCOS: drop unknown argument
 
+Ref: https://github.com/cions/termux-deno/blob/7068f1fc4d8817045cbe4c65934df9646cd78368/rusty_v8-fix-unknown-options.patch
+Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
 ---
- build/config/compiler/BUILD.gn | 19 -------------------
- 1 file changed, 19 deletions(-)
+ build/config/compiler/BUILD.gn         | 13 -------------
+ build/config/sanitizers/sanitizers.gni |  7 -------
+ 2 files changed, 20 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index ff8022f047..9721cdd99b 100644
+index 1b53cb1d4..53b6092b7 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -625,13 +625,6 @@ config("compiler") {
+@@ -600,12 +600,6 @@ config("compiler") {
+   if (is_clang) {
+     # Flags for diagnostics.
+     cflags += [ "-fcolor-diagnostics" ]
+-    if (!is_win) {
+-      cflags += [ "-fdiagnostics-show-inlining-chain" ]
+-    } else {
+-      # Combine after https://github.com/llvm/llvm-project/pull/192241
+-      cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+-    }
+     if (diagnostics_print_source_range_info && !is_win) {
+       cflags += [ "-fdiagnostics-print-source-range-info" ]
+     }
+@@ -636,13 +630,6 @@ config("compiler") {
        ]
      }
  
@@ -25,22 +41,24 @@ index ff8022f047..9721cdd99b 100644
      # TODO(hans): Remove this once Clang generates better optimized debug info
      # by default. https://crbug.com/765793
      cflags += [
-@@ -1892,18 +1885,6 @@ config("sanitize_c_array_bounds") {
-     cflags = [
-       "-fsanitize=array-bounds",
-       "-fsanitize-trap=array-bounds",
+diff --git a/build/config/sanitizers/sanitizers.gni b/build/config/sanitizers/sanitizers.gni
+index 329a2fc8b..903b87c7b 100644
+--- a/build/config/sanitizers/sanitizers.gni
++++ b/build/config/sanitizers/sanitizers.gni
+@@ -534,13 +534,6 @@ template("ubsan_hardening") {
+       cflags = [
+         "-fsanitize=${invoker.sanitizer}",
+         "-fsanitize-trap=${invoker.sanitizer}",
 -
--      # Some code users feature detection to determine if UBSAN (or any
--      # sanitizer) is enabled, they then do expensive debug like operations. We
--      # want to suppress this behaviour since we want to keep performance costs
--      # as low as possible while having these checks.
--      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
--
--      # Because we've enabled array-bounds sanitizing we also want to suppress
--      # the related warning about "unsafe-buffer-usage-in-static-sized-array",
--      # since we know that the array bounds sanitizing will catch any out-of-
--      # bounds accesses.
--      "-Wno-unsafe-buffer-usage-in-static-sized-array",
-     ]
-   }
- }
+-        # Prevents `__has_feature(undefined_behavior_sanitizer)`
+-        # from evaluating true. Configs defined here are intended to
+-        # be usable even in release builds, i.e. as widely as possible.
+-        # It's important not to have full-on UBSan workarounds activate
+-        # just because we built support for a specific sanitizer.
+-        "-fsanitize-ignore-for-ubsan-feature=${invoker.sanitizer}",
+       ]
+       if (defined(invoker.cflags)) {
+         cflags += invoker.cflags
+-- 
+2.52.0
+

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,6 +1,6 @@
-VER=0.138.0
+VER=0.142.0
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
-RUSTY_V8_VER=147.4.0
+RUSTY_V8_VER=149.2.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
 CHKSUMS="SKIP \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.142.0

Package(s) Affected
-------------------

- codex: 0.142.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
