### PR TITLE
vlc: update to 3.0.23

### DIFF
--- a/app-multimedia/vlc/spec
+++ b/app-multimedia/vlc/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=3.0.23-2
+UPSTREAM_VER=3.0.23
 VER=${UPSTREAM_VER/-/+}
-REL=3
 SRCS="git::copy-repo=true;commit=tags/${UPSTREAM_VER}::https://github.com/videolan/vlc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6504"


### PR DESCRIPTION
Topic Description
-----------------

- vlc: update to 3.0.23
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- vlc: 3.0.23

Security Update?
----------------

No

Build Order
-----------

```
#buildit vlc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
