### PR TITLE
libadwaita: update to 1.9.1

### DIFF
--- a/desktop-gnome/libadwaita/spec
+++ b/desktop-gnome/libadwaita/spec
@@ -1,5 +1,4 @@
-VER=1.8.4
-REL=1
+VER=1.9.1
 SRCS="tbl::https://download.gnome.org/sources/libadwaita/${VER%.*}/libadwaita-$VER.tar.xz"
-CHKSUMS="sha256::d02bb77b6f0ff1055002d299898c487cb2d83dbf940d9edf59f6fdf2572a921c"
+CHKSUMS="sha256::2ae34dbb3ea56d270925707cefa36050482ec88a741f1810b7619a5377c41a66"
 CHKUPDATE="anitya::id=234898"


### PR DESCRIPTION
Topic Description
-----------------

- libadwaita: update to 1.9.1
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- libadwaita: 1.9.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libadwaita
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
