### PR TITLE
kitty: update to 0.47.4

### DIFF
--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,4 @@
-VER=0.46.2
-REL=1
+VER=0.47.4
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::e8ea44b13a1c70032a35128a8c4c8c29c90a7cfbe0ad4f6aa2927a057d10f83e"
+CHKSUMS="sha256::7dede3743ab614409903a839ba1f264f772f4271ddf251e7d60b333cb4e51278"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.47.4
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- kitty: 0.47.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
