### PR TITLE
ffmpeg: update to 8.1.2

### DIFF
--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,4 @@
-VER=8.1.1
-REL=3
+VER=8.1.2
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
-CHKSUMS="sha256::b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"
+CHKSUMS="sha256::464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"
 CHKUPDATE="anitya::id=5405"

--- a/runtime-optenv32/ffmpeg+32/spec
+++ b/runtime-optenv32/ffmpeg+32/spec
@@ -1,5 +1,4 @@
-VER=8.1.1
-REL=1
+VER=8.1.2
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
-CHKSUMS="sha256::b6863adde98898f42602017462871b5f6333e65aec803fdd7a6308639c52edf3"
+CHKSUMS="sha256::464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"
 CHKUPDATE="anitya::id=5405"

--- a/topics/ffmpeg-8.1.2.toml
+++ b/topics/ffmpeg-8.1.2.toml
@@ -1,0 +1,14 @@
+security = true
+must_match_all = false
+
+[name]
+default = "FFmpeg 8.1.2"
+
+[caution]
+default = "Fixes a Remote Code Escalation vulnerability (\"PixelSmash\") - CVE-2026-8461 (severity: High)"
+zh_CN = "修复一个远程代码执行漏洞 (\"PixelSmash\") ，漏洞编号 CVE-2026-8461（严重性：高）"
+
+[packages-v2]
+"ffmpeg" = "< 8.1.2"
+"ffmpeg-static-libs-for-sunshine" = "< 8.1.2"
+"ffmpeg+32" = "< 8.1.2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add ffmpeg-8.1.2.toml
- ffmpeg+32: update to 8.1.2
- ffmpeg: update to 8.1.2

Package(s) Affected
-------------------

- ffmpeg: 8.1.2
- ffmpeg-static-libs-for-sunshine: 8.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
