### PR TITLE
jq: update to 1.8.2

### DIFF
--- a/app-devel/jq/spec
+++ b/app-devel/jq/spec
@@ -1,4 +1,4 @@
-VER=1.8.1
+VER=1.8.2
 SRCS="tbl::https://github.com/jqlang/jq/releases/download/jq-$VER/jq-$VER.tar.gz"
-CHKSUMS="sha256::2be64e7129cecb11d5906290eba10af694fb9e3e7f9fc208a311dc33ca837eb0"
+CHKSUMS="sha256::71b8d6e8f5fe81f6c6d0d110e3892251f6ce76ed095abd315e26e6e1193af3af"
 CHKUPDATE="anitya::id=13252"


### PR DESCRIPTION
Topic Description
-----------------

- jq: update to 1.8.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- jq: 1.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit jq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
