### PR TITLE
libgbinder: update to 1.1.48

### DIFF
--- a/runtime-common/libgbinder/spec
+++ b/runtime-common/libgbinder/spec
@@ -1,4 +1,4 @@
-VER=1.1.47
+VER=1.1.48
 SRCS="git::commit=tags/$VER::https://github.com/mer-hybris/libgbinder"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=307121"


### PR DESCRIPTION
Topic Description
-----------------

- libgbinder: update to 1.1.48
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libgbinder: 1.1.48

Security Update?
----------------

No

Build Order
-----------

```
#buildit libgbinder
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
