### PR TITLE
cinny-desktop: update to 4.12.4

### DIFF
--- a/app-web/cinny-desktop/spec
+++ b/app-web/cinny-desktop/spec
@@ -1,4 +1,4 @@
-VER=4.12.2
+VER=4.12.4
 SRCS="git::commit=tags/v$VER::https://github.com/cinnyapp/cinny-desktop"
 CHKSUMS="SKIP"
 SUBDIR="cinny-desktop/src-tauri"


### PR DESCRIPTION
Topic Description
-----------------

- cinny-desktop: update to 4.12.4
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- cinny-desktop: 4.12.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinny-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
