### PR TITLE
vscode: update to 1.125.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,4 +1,4 @@
-VER=1.125.0
+VER=1.125.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
 CHKSUMS__AMD64="sha256::f61d0a519d0cf1a29dc75dd0bef540982aa631363f40525bee7396737a079aa1"

--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.124.0
+VER=1.125.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::544f8e6638be2b5ad00be8609ba192860733ffd5b60572755f942d2ca4d98f8b"
-CHKSUMS__ARM64="sha256::1fa99070d580849680ca3fefe00a06df36d155d03bed948cb98881d3acf0a852"
+CHKSUMS__AMD64="sha256::f61d0a519d0cf1a29dc75dd0bef540982aa631363f40525bee7396737a079aa1"
+CHKSUMS__ARM64="sha256::cf7174565c67cadd9427c836f29a9dc628df5e6658b96869c1b7aec59bc92e07"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------
vscode:update to 1.125.1

Package(s) Affected
-------------------

vscode 1.125.1

Security Update?
----------------
No

Build Order
-----------
```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
