### PR TITLE
ps3netsrv-go: update to 0.4.1

### DIFF
--- a/app-network/ps3netsrv-go/spec
+++ b/app-network/ps3netsrv-go/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/xakep666/ps3netsrv-go"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=383793"


### PR DESCRIPTION
Topic Description
-----------------

- ps3netsrv-go: update to 0.4.1

Package(s) Affected
-------------------

- ps3netsrv-go: 0.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ps3netsrv-go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
