### PR TITLE
xdg-desktop-portal: update to 1.22.1

### DIFF
--- a/app-admin/xdg-desktop-portal/spec
+++ b/app-admin/xdg-desktop-portal/spec
@@ -1,4 +1,4 @@
-VER=1.22.0
+VER=1.22.1
 SRCS="tbl::https://github.com/flatpak/xdg-desktop-portal/releases/download/$VER/xdg-desktop-portal-$VER.tar.xz"
-CHKSUMS="sha256::a610393a123f9dbd0aed662e716f6f98362850283d2cc750399f12c8313e6564"
+CHKSUMS="sha256::d4879ddb3d65ff1a8f19187497e6f13dc5d267bcac404a5d501218be355753d3"
 CHKUPDATE="anitya::id=11089"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-desktop-portal: update to 1.22.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- xdg-desktop-portal: 1.22.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-desktop-portal
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
