### PR TITLE
gimp: update to 3.2.4

### DIFF
--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,5 +1,4 @@
-VER=3.2.2
-REL=2
+VER=3.2.4
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:3}/gimp-${VER/~rc/-RC}.tar.xz"
-CHKSUMS="sha256::6c5f8cbabe081f405633a2d32b79a08166aeb7b43c7f548391608dc0d0de71be"
+CHKSUMS="sha256::7312bc53e9c6d2d0056ca7b93f1c6b98707946dd934f714c21b8746ecb601588"
 CHKUPDATE="anitya::id=1161"


### PR DESCRIPTION
Topic Description
-----------------

- gimp: update to 3.2.4
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- gimp: 3.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gimp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
