### PR TITLE
vscode: update to 1.126.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.125.1
+VER=1.126.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::f61d0a519d0cf1a29dc75dd0bef540982aa631363f40525bee7396737a079aa1"
-CHKSUMS__ARM64="sha256::cf7174565c67cadd9427c836f29a9dc628df5e6658b96869c1b7aec59bc92e07"
+CHKSUMS__AMD64="sha256::230ccba54f577e2a560b6710405f15cd6deaa78364cd0e3a426ef202a27c65f9"
+CHKSUMS__ARM64="sha256::91a808b16ca326eac1b87f1c21963f01233548df72828b9a8bddc9604c589bfb"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.126.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.126.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
