### PR TITLE
erlang: security update to 29.0.2

### DIFF
--- a/lang-erlang/erlang/spec
+++ b/lang-erlang/erlang/spec
@@ -1,4 +1,4 @@
-VER=28.5
+VER=29.0.2
 SRCS="tbl::https://github.com/erlang/otp/releases/download/OTP-$VER/otp_src_$VER.tar.gz"
-CHKSUMS="sha256::2c7e8ca23e6864eb20eff5d44738bfa123aed8cd21ed6d98e533d751eee28d9c"
+CHKSUMS="sha256::b9a7714fdd282c4a7113651b1e2728a58799e60ffe20e545f5cc94c621527b15"
 CHKUPDATE="anitya::id=707"

--- a/topics/erlang-29.0.2.toml
+++ b/topics/erlang-29.0.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Erlang 29.0.2"
+
+[caution]
+default = "Fixes 9 security vulnerabilities (including 5 of High and 4 of Medium severity)"
+zh_CN = "修复 9 个安全漏洞（含 5 个高危漏洞和 4 个中危漏洞）"
+
+[packages-v2]
+"erlang" = "< 29.0.2"


### PR DESCRIPTION
Topic Description
-----------------

- erlang: security update to 29.0.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- erlang: 29.0.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit erlang
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
