### PR TITLE
exim: security update to 4.99.4

### DIFF
--- a/app-web/exim/autobuild/defines
+++ b/app-web/exim/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=exim
 PKGSEC=mail
-PKGDEP="gdbm pcre2 linux-pam openssl openldap libnsl2"
-BUILDDEP="mariadb perl-file-fcntllock postgresql xfpt"
-PKGDES="A general purpose e-mail message transfer agent (MTA)"
+PKGDEP="gdbm pcre2 linux-pam openssl openldap libnsl2 mariadb"
+BUILDDEP="perl-file-fcntllock postgresql xfpt"
+PKGDES="General purpose e-mail message transfer agent (MTA)"
 
 ABTYPE=self
 

--- a/app-web/exim/autobuild/overrides/usr/lib/tmpfiles.d/exim.conf
+++ b/app-web/exim/autobuild/overrides/usr/lib/tmpfiles.d/exim.conf
@@ -1,3 +1,4 @@
 d /var/spool/exim 0770 root exim - -
 d /var/spool/exim/db 0770 exim exim - -
 d /var/log/exim 0770 root exim - -
+f /var/log/exim_mainlog 0640 exim exim - -

--- a/app-web/exim/autobuild/postinst
+++ b/app-web/exim/autobuild/postinst
@@ -1,2 +1,5 @@
+echo "Creating system users ..."
 systemd-sysusers exim.conf
+
+echo "Creating daemon directories ..."
 systemd-tmpfiles --create exim.conf

--- a/app-web/exim/spec
+++ b/app-web/exim/spec
@@ -1,4 +1,4 @@
-VER=4.99.3
+VER=4.99.4
 SRCS="git::commit=tags/exim-$VER;copy-repo=true::https://code.exim.org/exim/exim"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=768"

--- a/topics/exim-4.99.4.toml
+++ b/topics/exim-4.99.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Exim 4.99.4"
+
+[caution]
+default = "Fixes a Numeric Range Comparison Without Minimum Check vulnerability (CVE-2026-48840, Severity: Medium)"
+zh_CN = "修复一处比较数值数值未检查最小值的漏洞（CVE-2026-48840，严重性：中）"
+
+[packages-v2]
+"exim" = "< 4.99.4"


### PR DESCRIPTION
Topic Description
-----------------

- exim: security update to 4.99.4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- exim: 4.99.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit exim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
