### PR TITLE
curl: update to 8.21.0

### DIFF
--- a/app-web/curl/autobuild/build
+++ b/app-web/curl/autobuild/build
@@ -3,7 +3,6 @@ abinfo "Configuring cURL (OpenSSL, with versioned symbols) ..."
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
      --without-gnutls \
-     --without-nss \
      --enable-versioned-symbols
 abinfo "Building cURL (OpenSSL, with versioned symbols) ..."
 make
@@ -19,7 +18,6 @@ abinfo "Configuring cURL (OpenSSL, without versioned symbols) ..."
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
      --without-gnutls \
-     --without-nss \
      --disable-versioned-symbols
 abinfo "Building cURL (OpenSSL, without versioned symbols) ..."
 make -C "$SRCDIR"/lib
@@ -50,7 +48,6 @@ abinfo "Configuring cURL (GnuTLS, without versioned symbols) ..."
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --without-openssl \
      --with-gnutls \
-     --without-nss \
      --disable-versioned-symbols
 abinfo "Building cURL (GnuTLS, without versioned symbols) ..."
 make -C "$SRCDIR"/lib

--- a/app-web/curl/autobuild/build.stage2
+++ b/app-web/curl/autobuild/build.stage2
@@ -3,7 +3,6 @@ abinfo "Configuring cURL (OpenSSL, with versioned symbols) ..."
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
      --without-gnutls \
-     --without-nss \
      --enable-versioned-symbols
 abinfo "Building cURL (OpenSSL, with versioned symbols) ..."
 make

--- a/app-web/curl/autobuild/defines
+++ b/app-web/curl/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=curl
 PKGSEC=utils
 PKGDEP="ca-certs openssl krb5 libidn2 libssh2 nghttp2 gnutls zlib \
-        rtmpdump brotli libpsl zstd e2fsprogs nss nghttp3 ngtcp2"
+        brotli libpsl zstd e2fsprogs nghttp3 ngtcp2"
 BUILDDEP="patchelf"
 PKGDES="URL retrieval utility and library"
 PKGRECOM="ca-certs"
@@ -21,11 +21,9 @@ AUTOTOOLS_AFTER=(
     "--with-libidn2"
     "--with-libssh2"
     "--with-brotli"
-    "--with-librtmp"
     "--with-libpsl"
     "--with-ngtcp2"
     "--with-nghttp3"
-    "--with-random=/dev/urandom"
     "--with-ca-bundle=/etc/ssl/ca-bundle.crt"
 )
 AUTOTOOLS_AFTER__RETRO=(
@@ -41,9 +39,7 @@ AUTOTOOLS_AFTER__RETRO=(
     "--without-libidn2"
     "--without-libssh2"
     "--without-brotli"
-    "--without-librtmp"
     "--without-libpsl"
-    "--with-random=/dev/urandom"
     "--with-ca-bundle=/etc/ssl/ca-bundle.crt"
 )
 

--- a/app-web/curl/autobuild/defines.stage2
+++ b/app-web/curl/autobuild/defines.stage2
@@ -16,8 +16,6 @@ AUTOTOOLS_AFTER=(
     "--without-libidn2"
     "--without-libssh2"
     "--without-brotli"
-    "--without-librtmp"
     "--without-libpsl"
-    "--with-random=/dev/urandom"
     "--with-ca-bundle=/etc/ssl/ca-bundle.crt"
 )

--- a/app-web/curl/spec
+++ b/app-web/curl/spec
@@ -1,5 +1,4 @@
-VER=8.20.0
-REL=2
+VER=8.21.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896"
+CHKSUMS="sha256::aa1b66a70eace83dc624508745646c08ae561de512ab403adffb93ac87fc72e6"
 CHKUPDATE="anitya::id=381"

--- a/runtime-optenv32/curl+32/autobuild/build
+++ b/runtime-optenv32/curl+32/autobuild/build
@@ -2,9 +2,7 @@ abinfo "Configuring cURL (OpenSSL, with versioned symbols) ..."
 "$SRCDIR"/configure \
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
-     --with-openssl-quic \
      --without-gnutls \
-     --without-nss \
      --enable-versioned-symbols
 abinfo "Building cURL (OpenSSL, with versioned symbols) ..."
 make
@@ -19,9 +17,7 @@ abinfo "Configuring cURL (OpenSSL, without versioned symbols) ..."
 "$SRCDIR"/configure \
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --with-openssl \
-     --with-openssl-quic \
      --without-gnutls \
-     --without-nss \
      --disable-versioned-symbols
 abinfo "Building cURL (OpenSSL, without versioned symbols) ..."
 make -C "$SRCDIR"/lib
@@ -52,7 +48,6 @@ abinfo "Configuring cURL (GnuTLS, without versioned symbols) ..."
      ${AUTOTOOLS_DEF[@]} ${AUTOTOOLS_AFTER[@]} ${AUTOTOOLS_TARGET[@]} \
      --without-openssl \
      --with-gnutls \
-     --without-nss \
      --disable-versioned-symbols
 abinfo "Building cURL (GnuTLS, without versioned symbols) ..."
 make -C "$SRCDIR"/lib

--- a/runtime-optenv32/curl+32/autobuild/defines
+++ b/runtime-optenv32/curl+32/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=curl+32
 PKGSEC=utils
-PKGDEP="aosc-aaa+32 ca-certs gnutls+32 krb5+32 libssh2+32 openssl+32 rtmpdump+32 zlib+32"
+PKGDEP="aosc-aaa+32 ca-certs gnutls+32 krb5+32 libssh2+32 openssl+32 zlib+32"
 BUILDDEP="devel-base+32 patchelf"
 PKGDES="URL retrieval utility and library (32-bit x86 runtime)"
 
@@ -19,8 +19,6 @@ AUTOTOOLS_AFTER=(
     "--with-libidn2"
     "--with-libssh2"
     "--without-brotli"
-    "--with-librtmp"
     "--without-libpsl"
-    "--with-random=/dev/urandom"
     "--with-ca-bundle=/etc/ssl/ca-bundle.crt"
 )

--- a/runtime-optenv32/curl+32/spec
+++ b/runtime-optenv32/curl+32/spec
@@ -1,4 +1,4 @@
-VER=8.20.0
+VER=8.21.0
 SRCS="tbl::https://curl.se/download/curl-$VER.tar.xz"
-CHKSUMS="sha256::63fe2dc148ba0ceae89922ef838f7e5c946272c2e78b7c59fab4b79d3ce2b896"
+CHKSUMS="sha256::aa1b66a70eace83dc624508745646c08ae561de512ab403adffb93ac87fc72e6"
 CHKUPDATE="anitya::id=381"

--- a/topics/curl-8.21.0.toml
+++ b/topics/curl-8.21.0.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "curl 8.21.0"
+
+[caution]
+default = "Fixes 18 security vulnerabilities (including 4 of Medium severity)"
+zh_CN = "修复 18 个安全漏洞（含 4 个中危漏洞）"
+
+[packages-v2]
+"curl" = "< 8.21.0"
+"curl+32" = "< 8.21.0"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add curl-8.21.0.toml
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- curl+32: update to 8.21.0
    - Cleanup deprecated options and dependencies
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- curl: update to 8.21.0
    - Cleanup deprecated options and dependencies
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- curl: 8.21.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit curl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
