### PR TITLE
libssh2: fix CVE-2026-7598, CVE-2025-15661, CVE-2026-55199, and CVE-2026-55200

### DIFF
--- a/runtime-network/libssh2/autobuild/defines
+++ b/runtime-network/libssh2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=libssh2
 PKGSEC=libs
 PKGDEP="openssl zlib"
-PKGDES="A client-side C library implementing the SSH2 protocol"
+PKGDES="Client-side C library to implement the SSH2 protocol"
 
 ABTYPE=cmakeninja

--- a/runtime-network/libssh2/autobuild/patches/0001-UPSTREAM-userauth.c-username_len-bounds-checking-185.patch
+++ b/runtime-network/libssh2/autobuild/patches/0001-UPSTREAM-userauth.c-username_len-bounds-checking-185.patch
@@ -1,0 +1,58 @@
+From 4e95b12381dc5fc90fcbcec0c2778622a9e9c34c Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Mon, 13 Apr 2026 11:18:25 -0700
+Subject: [PATCH 1/5] UPSTREAM: userauth.c: username_len bounds checking
+ (#1858)
+
+Return errors when username_len will exceed bounds, fix existing bounds
+check.
+
+Credit:
+[dapickle](https://github.com/dapickle)
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/userauth.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/userauth.c b/src/userauth.c
+index 0040c3fa..588b83f2 100644
+--- a/src/userauth.c
++++ b/src/userauth.c
+@@ -80,6 +80,12 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
+         memset(&session->userauth_list_packet_requirev_state, 0,
+                sizeof(session->userauth_list_packet_requirev_state));
+ 
++        if(username_len > UINT32_MAX - 27) {
++            _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                           "username_len out of bounds");
++            return NULL;
++        }
++
+         session->userauth_list_data_len = username_len + 27;
+ 
+         s = session->userauth_list_data =
+@@ -307,6 +313,11 @@ userauth_password(LIBSSH2_SESSION *session,
+          * 40 = packet_type(1) + username_len(4) + service_len(4) +
+          * service(14)"ssh-connection" + method_len(4) + method(8)"password" +
+          * chgpwdbool(1) + password_len(4) */
++        if(username_len > UINT32_MAX - 40) {
++            return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                                  "username_len out of bounds");
++        }
++
+         session->userauth_pswd_data_len = username_len + 40;
+ 
+         session->userauth_pswd_data0 =
+@@ -447,7 +458,7 @@ password_response:
+                         }
+ 
+                         /* basic data_len + newpw_len(4) */
+-                        if(username_len + password_len + 44 <= UINT_MAX) {
++                        if(username_len <= UINT32_MAX - password_len - 44) {
+                             session->userauth_pswd_data_len =
+                                 username_len + password_len + 44;
+                             s = session->userauth_pswd_data =
+-- 
+2.52.0
+

--- a/runtime-network/libssh2/autobuild/patches/0002-BACKPORT-UPSTREAM-Update-sftp_symlink-to-avoid-out-o.patch
+++ b/runtime-network/libssh2/autobuild/patches/0002-BACKPORT-UPSTREAM-Update-sftp_symlink-to-avoid-out-o.patch
@@ -1,0 +1,129 @@
+From b49d2946b10ebc673688a13eff4243e9b18cab0e Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Fri, 10 Oct 2025 08:26:20 -0700
+Subject: [PATCH 2/5] BACKPORT: UPSTREAM: Update sftp_symlink to avoid out of
+ bounds read on malformed packet #1705 (#1717)
+
+Use buffer struct to guard against out of bounds reads and invalid packets.
+
+Discovery Credit:
+Joshua Rogers
+
+[ Mingcong Bai: Resolved a minor merge conflict in
+  src/sftp.c ]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/sftp.c | 66 ++++++++++++++++++++++++++++++++++++++----------------
+ 1 file changed, 47 insertions(+), 19 deletions(-)
+
+diff --git a/src/sftp.c b/src/sftp.c
+index 6ede3111..43b6ff90 100644
+--- a/src/sftp.c
++++ b/src/sftp.c
+@@ -3795,15 +3795,19 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
+ {
+     LIBSSH2_CHANNEL *channel = sftp->channel;
+     LIBSSH2_SESSION *session = channel->session;
+-    size_t data_len = 0, link_len;
++    size_t data_len = 0, lk_len;
+     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
+     ssize_t packet_len =
+         path_len + 13 +
+         ((link_type == LIBSSH2_SFTP_SYMLINK) ? (4 + target_len) : 0);
+     unsigned char *s, *data = NULL;
++    struct string_buf buf;
+     static const unsigned char link_responses[2] =
+         { SSH_FXP_NAME, SSH_FXP_STATUS };
+     int retcode;
++    unsigned char packet_type;
++    uint32_t tmp_u32;
++    unsigned char *lk_target;
+ 
+     if(sftp->symlink_state == libssh2_NB_state_idle) {
+         sftp->last_errno = LIBSSH2_FX_OK;
+@@ -3891,8 +3895,25 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
+ 
+     sftp->symlink_state = libssh2_NB_state_idle;
+ 
+-    if(data[0] == SSH_FXP_STATUS) {
+-        retcode = _libssh2_ntohu32(data + 5);
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(data);
++    buf.dataptr = buf.data;
++    buf.len = data_len;
++
++    if(_libssh2_get_byte(&buf, &packet_type)) {
++        LIBSSH2_FREE(session, data);
++        return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
++                              "SFTP Protocol Error (type)");
++    }
++
++    if(packet_type == SSH_FXP_STATUS) {
++        if(_libssh2_get_u32(&buf, &tmp_u32)) {
++            LIBSSH2_FREE(session, data);
++            return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
++                                  "SFTP Protocol Error (code)");
++        }
++
++        retcode = (int)tmp_u32;
++
+         LIBSSH2_FREE(session, data);
+         if(retcode == LIBSSH2_FX_OK)
+             return LIBSSH2_ERROR_NONE;
+@@ -3903,30 +3924,37 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
+         }
+     }
+ 
+-    if(_libssh2_ntohu32(data + 5) < 1) {
++    /* advance past id */
++    if(_libssh2_get_u32(&buf, &tmp_u32)) {
+         LIBSSH2_FREE(session, data);
+         return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
+-                              "Invalid READLINK/REALPATH response, "
+-                              "no name entries");
++                              "SFTP Protocol Error (id)");
+     }
+ 
+-    if(data_len < 13) {
+-        if(data_len > 0) {
+-            LIBSSH2_FREE(session, data);
+-        }
++    /* look for at least one link */
++    if(_libssh2_get_u32(&buf, &tmp_u32) || tmp_u32 < 1) {
++        LIBSSH2_FREE(session, data);
+         return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
+-                              "SFTP stat packet too short");
++                                     "Invalid READLINK/REALPATH response, "
++                                     "no name entries");
+     }
+ 
+-    /* this reads a u32 and stores it into a signed 32bit value */
+-    link_len = _libssh2_ntohu32(data + 9);
+-    if(link_len < target_len) {
+-        memcpy(target, data + 13, link_len);
+-        target[link_len] = 0;
+-        retcode = (int)link_len;
++    if(_libssh2_get_string(&buf, &lk_target, &lk_len) == LIBSSH2_ERROR_NONE) {
++        if(lk_len < target_len) {
++            memcpy(target, lk_target, lk_len);
++            target[lk_len] = '\0';
++            retcode = (int)lk_len;
++        }
++        else {
++            retcode = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
++        }
+     }
+-    else
+-        retcode = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
++    else {
++        LIBSSH2_FREE(session, data);
++        return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
++                              "SFTP Protocol Error (filename)");
++    }
++
+     LIBSSH2_FREE(session, data);
+ 
+     return retcode;
+-- 
+2.52.0
+

--- a/runtime-network/libssh2/autobuild/patches/0003-UPSTREAM-packet-check-_libssh2_get_string-return-in-.patch
+++ b/runtime-network/libssh2/autobuild/patches/0003-UPSTREAM-packet-check-_libssh2_get_string-return-in-.patch
@@ -1,0 +1,44 @@
+From 8fb49a709b95af64db11282778481a584bcf6ce8 Mon Sep 17 00:00:00 2001
+From: TristanInSec <tristan.mtn@gmail.com>
+Date: Wed, 15 Apr 2026 14:51:08 -0400
+Subject: [PATCH 3/5] UPSTREAM: packet: check `_libssh2_get_string()` return in
+ `EXT_INFO` handler
+
+The `SSH_MSG_EXT_INFO` handler discards the return values from
+`_libssh2_get_string()` when parsing extension name/value pairs. When
+the buffer is exhausted before all claimed extensions are parsed,
+the loop continues with no-op iterations until `nr_extensions` reaches
+zero.
+
+The `nr_extensions >= 1024` cap limits the worst case, but the loop
+should still break on parse failure for correctness and consistency
+with other parsers in this file (e.g. `SSH_MSG_CHANNEL_OPEN`,
+`SSH_MSG_KEXINIT`) that check `_libssh2_get_string()` return values.
+
+Closes #1864
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/packet.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index 6da14e9f..ebaddae5 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -868,8 +868,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+ 
+                     nr_extensions -= 1;
+ 
+-                    _libssh2_get_string(&buf, &name, &name_len);
+-                    _libssh2_get_string(&buf, &value, &value_len);
++                    if(_libssh2_get_string(&buf, &name, &name_len))
++                        break;
++                    if(_libssh2_get_string(&buf, &value, &value_len))
++                        break;
+ 
+                     if(name && value) {
+                         _libssh2_debug((session,
+-- 
+2.52.0
+

--- a/runtime-network/libssh2/autobuild/patches/0004-BACKPORT-UPSTREAM-transport.c-Additional-boundary-ch.patch
+++ b/runtime-network/libssh2/autobuild/patches/0004-BACKPORT-UPSTREAM-transport.c-Additional-boundary-ch.patch
@@ -1,0 +1,39 @@
+From 213b0608f99b5b5793d42167a1d819c4ddfa48d4 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Fri, 12 Jun 2026 15:57:44 -0700
+Subject: [PATCH 4/5] BACKPORT: UPSTREAM: transport.c: Additional boundary
+ checks for packet length (#2052)
+
+Add additional bounds checking on packet length to prevent OOB write.
+
+Credit: [TristanInSec](https://github.com/TristanInSec)
+
+[ Mingcong Bai: Resolved a minor merge conflict in
+  src/transport.c ]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/transport.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/transport.c b/src/transport.c
+index e1120656..d147505b 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -639,8 +639,12 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+                 total_num = 4;
+ 
+                 p->packet_length = _libssh2_ntohu32(block);
+-                if(p->packet_length < 1)
++                if(p->packet_length < 1) {
+                     return LIBSSH2_ERROR_DECRYPT;
++                }
++                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD) {
++                    return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
++                }
+ 
+                 /* total_num may include size field, however due to existing
+                  * logic it needs to be removed after the entire packet is read
+-- 
+2.52.0
+

--- a/runtime-network/libssh2/autobuild/patches/0005-UPSTREAM-build-enable-Wcast-qual-fix-fallouts.patch
+++ b/runtime-network/libssh2/autobuild/patches/0005-UPSTREAM-build-enable-Wcast-qual-fix-fallouts.patch
@@ -1,0 +1,1062 @@
+From a1d36ccc365d6941cd63102348966e7444365639 Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Thu, 30 Jan 2025 21:18:23 +0100
+Subject: [PATCH 5/5] UPSTREAM: build: enable `-Wcast-qual`, fix fallouts
+
+- enable compiler warning `-Wcast-qual`.
+- add `LIBSSH2_UNCONST()` macro to strip const where absolutely
+  necessary to avoid compiler warnings.
+- fix const stripping by constifying where necessary.
+- fix const stripping by using `LIBSSH2_UNCONST()`.
+- libgcrypt.h: drop unnecessary casts.
+- openssl: fix to use new `BIO_new_mem_buf()` parameter types
+  with wolfSSL.
+
+Cherry-picked from #1484
+Closes #1527
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ acinclude.m4                    |  2 ++
+ cmake/PickyWarnings.cmake       |  1 +
+ example/ssh2_agent_forwarding.c |  5 ++--
+ example/ssh2_echo.c             |  5 ++--
+ example/ssh2_exec.c             |  5 ++--
+ src/agent.c                     |  6 ++--
+ src/channel.c                   | 13 +++++----
+ src/comp.c                      | 11 ++++---
+ src/hostkey.c                   | 10 +++----
+ src/kex.c                       | 52 ++++++++++++++++-----------------
+ src/libgcrypt.h                 | 10 +++----
+ src/libssh2_priv.h              |  8 +++++
+ src/mbedtls.c                   |  4 +--
+ src/misc.c                      |  2 +-
+ src/openssl.c                   | 43 +++++++++++++++------------
+ src/packet.c                    |  4 +--
+ src/pem.c                       |  7 +++--
+ src/publickey.c                 |  4 +--
+ src/session.c                   | 25 ++++++++--------
+ src/sftp.c                      |  2 +-
+ src/userauth.c                  | 26 +++++++++--------
+ src/wincng.c                    | 17 ++++++-----
+ 22 files changed, 147 insertions(+), 115 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index e06476fd..b0bcc181 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -279,6 +279,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
+           #
+           dnl Only clang 3.0 or later
+           if test "$compiler_num" -ge "300"; then
++            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
+             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
+             tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
+           fi
+@@ -435,6 +436,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
+           #
+           dnl Only gcc 4.0 or later
+           if test "$compiler_num" -ge "400"; then
++            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
+             tmp_CFLAGS="$tmp_CFLAGS -Wstrict-aliasing=3"
+           fi
+           #
+diff --git a/cmake/PickyWarnings.cmake b/cmake/PickyWarnings.cmake
+index 94feee87..17948e3a 100644
+--- a/cmake/PickyWarnings.cmake
++++ b/cmake/PickyWarnings.cmake
+@@ -94,6 +94,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
+       -Waddress                            # clang  2.7  gcc  4.3
+       -Wattributes                         # clang  2.7  gcc  4.1
+       -Wcast-align                         # clang  1.0  gcc  4.2
++      -Wcast-qual                          # clang  3.0  gcc  3.4.6
+       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
+       -Wdiv-by-zero                        # clang  2.7  gcc  4.1
+       -Wempty-body                         # clang  2.7  gcc  4.3
+diff --git a/example/ssh2_agent_forwarding.c b/example/ssh2_agent_forwarding.c
+index 1be35216..baa7534f 100644
+--- a/example/ssh2_agent_forwarding.c
++++ b/example/ssh2_agent_forwarding.c
+@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
+     LIBSSH2_AGENT *agent = NULL;
+     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
+     int exitcode;
+-    char *exitsignal = (char *)"none";
++    char *exitsignal = NULL;
+     ssize_t bytecount = 0;
+ 
+ #ifdef _WIN32
+@@ -272,7 +272,8 @@ int main(int argc, char *argv[])
+     }
+ 
+     if(exitsignal) {
+-        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
++        fprintf(stderr, "\nGot signal: %s\n",
++                exitsignal ? exitsignal : "none");
+     }
+     else {
+         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
+diff --git a/example/ssh2_echo.c b/example/ssh2_echo.c
+index 9b45c21a..1f9e46f8 100644
+--- a/example/ssh2_echo.c
++++ b/example/ssh2_echo.c
+@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
+     LIBSSH2_SESSION *session = NULL;
+     LIBSSH2_CHANNEL *channel;
+     int exitcode = 0;
+-    char *exitsignal = (char *)"none";
++    char *exitsignal = NULL;
+     size_t len;
+     LIBSSH2_KNOWNHOSTS *nh;
+     int type;
+@@ -340,7 +340,8 @@ int main(int argc, char *argv[])
+         }
+ 
+         if(exitsignal)
+-            fprintf(stderr, "\nGot signal: %s\n", exitsignal);
++            fprintf(stderr, "\nGot signal: %s\n",
++                    exitsignal ? exitsignal : "none");
+ 
+         libssh2_channel_free(channel);
+         channel = NULL;
+diff --git a/example/ssh2_exec.c b/example/ssh2_exec.c
+index ee8d2fb9..8cf27026 100644
+--- a/example/ssh2_exec.c
++++ b/example/ssh2_exec.c
+@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
+     LIBSSH2_SESSION *session = NULL;
+     LIBSSH2_CHANNEL *channel;
+     int exitcode;
+-    char *exitsignal = (char *)"none";
++    char *exitsignal = NULL;
+     ssize_t bytecount = 0;
+     size_t len;
+     LIBSSH2_KNOWNHOSTS *nh;
+@@ -283,7 +283,8 @@ int main(int argc, char *argv[])
+     }
+ 
+     if(exitsignal)
+-        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
++        fprintf(stderr, "\nGot signal: %s\n",
++                exitsignal ? exitsignal : "none");
+     else
+         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
+                 exitcode, (long)bytecount);
+diff --git a/src/agent.c b/src/agent.c
+index dd709eb1..43edaff5 100644
+--- a/src/agent.c
++++ b/src/agent.c
+@@ -223,14 +223,16 @@ static ssize_t _send_all(LIBSSH2_SEND_FUNC(func), libssh2_socket_t socket,
+                          const void *buffer, size_t length,
+                          int flags, void **abstract)
+ {
+-    RECV_SEND_ALL(func, socket, buffer, length, flags, abstract);
++    RECV_SEND_ALL(func, socket, LIBSSH2_UNCONST(buffer), length,
++                  flags, abstract);
+ }
+ 
+ static ssize_t _recv_all(LIBSSH2_RECV_FUNC(func), libssh2_socket_t socket,
+                          void *buffer, size_t length,
+                          int flags, void **abstract)
+ {
+-    RECV_SEND_ALL(func, socket, buffer, length, flags, abstract);
++    RECV_SEND_ALL(func, socket, buffer, length,
++                  flags, abstract);
+ }
+ 
+ #undef RECV_SEND_ALL
+diff --git a/src/channel.c b/src/channel.c
+index 529c2ef8..420e6c08 100644
+--- a/src/channel.c
++++ b/src/channel.c
+@@ -368,7 +368,7 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *type,
+     BLOCK_ADJUST_ERRNO(ptr, session,
+                        _libssh2_channel_open(session, type, type_len,
+                                              window_size, packet_size,
+-                                             (unsigned char *)msg,
++                                             (const unsigned char *)msg,
+                                              msg_len));
+     return ptr;
+ }
+@@ -1043,7 +1043,7 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
+ 
+         *(s++) = SSH_MSG_CHANNEL_REQUEST;
+         _libssh2_store_u32(&s, channel->remote.id);
+-        _libssh2_store_str(&s, (char *)"pty-req", sizeof("pty-req") - 1);
++        _libssh2_store_str(&s, (const char *)"pty-req", sizeof("pty-req") - 1);
+ 
+         *(s++) = 0x01;
+ 
+@@ -1151,7 +1151,7 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
+         s = channel->req_auth_agent_packet;
+         *(s++) = SSH_MSG_CHANNEL_REQUEST;
+         _libssh2_store_u32(&s, channel->remote.id);
+-        _libssh2_store_str(&s, (char *)request_str, request_str_len);
++        _libssh2_store_str(&s, (const char *)request_str, request_str_len);
+         *(s++) = 0x01;
+ 
+         channel->req_auth_agent_state = libssh2_NB_state_created;
+@@ -1311,7 +1311,7 @@ channel_request_pty_size(LIBSSH2_CHANNEL * channel, int width,
+ 
+         *(s++) = SSH_MSG_CHANNEL_REQUEST;
+         _libssh2_store_u32(&s, channel->remote.id);
+-        _libssh2_store_str(&s, (char *)"window-change",
++        _libssh2_store_str(&s, (const char *)"window-change",
+                            sizeof("window-change") - 1);
+         *(s++) = 0x00; /* Don't reply */
+         _libssh2_store_u32(&s, width);
+@@ -1575,7 +1575,8 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
+         rc = _libssh2_transport_send(session,
+                                      channel->process_packet,
+                                      channel->process_packet_len,
+-                                     (unsigned char *)message, message_len);
++                                     (const unsigned char *)message,
++                                     message_len);
+         if(rc == LIBSSH2_ERROR_EAGAIN) {
+             _libssh2_error(session, rc,
+                            "Would block sending channel request");
+@@ -2483,7 +2484,7 @@ libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
+ 
+     BLOCK_ADJUST(rc, channel->session,
+                  _libssh2_channel_write(channel, stream_id,
+-                                        (unsigned char *)buf, buflen));
++                                        (const unsigned char *)buf, buflen));
+     return rc;
+ }
+ 
+diff --git a/src/comp.c b/src/comp.c
+index ecfb28a3..d8b8e6a4 100644
+--- a/src/comp.c
++++ b/src/comp.c
+@@ -88,10 +88,13 @@ comp_method_none_decomp(LIBSSH2_SESSION * session,
+                         size_t src_len, void **abstract)
+ {
+     (void)session;
++    (void)dest;
++    (void)dest_len;
+     (void)payload_limit;
++    (void)src;
++    (void)src_len;
+     (void)abstract;
+-    *dest = (unsigned char *) src;
+-    *dest_len = src_len;
++
+     return 0;
+ }
+ 
+@@ -195,7 +198,7 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
+     uInt out_maxlen = (uInt)*dest_len;
+     int status;
+ 
+-    strm->next_in = (unsigned char *) src;
++    strm->next_in = (unsigned char *) LIBSSH2_UNCONST(src);
+     strm->avail_in = (uInt)src_len;
+     strm->next_out = dest;
+     strm->avail_out = out_maxlen;
+@@ -249,7 +252,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
+     if(out_maxlen > payload_limit)
+         out_maxlen = payload_limit;
+ 
+-    strm->next_in = (unsigned char *) src;
++    strm->next_in = (unsigned char *) LIBSSH2_UNCONST(src);
+     strm->avail_in = (uInt)src_len;
+     strm->next_out = (unsigned char *) LIBSSH2_ALLOC(session,
+                                                      (uInt)out_maxlen);
+diff --git a/src/hostkey.c b/src/hostkey.c
+index 99eaf3e0..29642a1b 100644
+--- a/src/hostkey.c
++++ b/src/hostkey.c
+@@ -80,7 +80,7 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+@@ -563,7 +563,7 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+@@ -804,7 +804,7 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+@@ -944,7 +944,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
+ 
+     /* keyname_len(4) + keyname(19){"ecdsa-sha2-nistp256"} +
+        signature_len(4) */
+-    buf.data = (unsigned char *)sig;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(sig);
+     buf.dataptr = buf.data;
+     buf.len = sig_len;
+ 
+@@ -1156,7 +1156,7 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+diff --git a/src/kex.c b/src/kex.c
+index 4ca9c34c..ebee54f9 100644
+--- a/src/kex.c
++++ b/src/kex.c
+@@ -149,7 +149,7 @@ static int _libssh2_sha_algo_ctx_init(int sha_algo, void *ctx)
+ }
+ 
+ static int _libssh2_sha_algo_ctx_update(int sha_algo, void *ctx,
+-                                        void *data, size_t len)
++                                        const void *data, size_t len)
+ {
+     if(sha_algo == 512) {
+         libssh2_sha512_ctx *_ctx = (libssh2_sha512_ctx*)ctx;
+@@ -663,7 +663,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
+                                                 exchange_state->h_sig_comp, 4);
+             hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
+                                                 exchange_hash_ctx,
+-                                   (unsigned char *)LIBSSH2_SSH_DEFAULT_BANNER,
++                                      (const void *)LIBSSH2_SSH_DEFAULT_BANNER,
+                                        sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
+         }
+ 
+@@ -3280,7 +3280,7 @@ typedef struct _LIBSSH2_COMMON_METHOD
+  * Another sign of bad coding practices gone mad.  Pretend you don't see this.
+  */
+ static size_t
+-kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
++kex_method_strlen(const LIBSSH2_COMMON_METHOD ** method)
+ {
+     size_t len = 0;
+ 
+@@ -3303,7 +3303,7 @@ kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
+  */
+ static uint32_t
+ kex_method_list(unsigned char *buf, uint32_t list_strlen,
+-                LIBSSH2_COMMON_METHOD ** method)
++                const LIBSSH2_COMMON_METHOD ** method)
+ {
+     _libssh2_htonu32(buf, list_strlen);
+     buf += 4;
+@@ -3327,20 +3327,20 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
+ 
+ #define LIBSSH2_METHOD_PREFS_LEN(prefvar, defaultvar)           \
+     (uint32_t)((prefvar) ? strlen(prefvar) :                    \
+-        kex_method_strlen((LIBSSH2_COMMON_METHOD**)(defaultvar)))
+-
+-#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)     \
+-    do {                                                                   \
+-        if(prefvar) {                                                      \
+-            _libssh2_htonu32((buf), (prefvarlen));                         \
+-            buf += 4;                                                      \
+-            memcpy((buf), (prefvar), (prefvarlen));                        \
+-            buf += (prefvarlen);                                           \
+-        }                                                                  \
+-        else {                                                             \
+-            buf += kex_method_list((buf), (prefvarlen),                    \
+-                                   (LIBSSH2_COMMON_METHOD**)(defaultvar)); \
+-        }                                                                  \
++        kex_method_strlen((const LIBSSH2_COMMON_METHOD**)(defaultvar)))
++
++#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)        \
++    do {                                                                      \
++        if(prefvar) {                                                         \
++            _libssh2_htonu32((buf), (prefvarlen));                            \
++            buf += 4;                                                         \
++            memcpy((buf), (prefvar), (prefvarlen));                           \
++            buf += (prefvarlen);                                              \
++        }                                                                     \
++        else {                                                                \
++            buf += kex_method_list((buf), (prefvarlen),                       \
++                                (const LIBSSH2_COMMON_METHOD**)(defaultvar)); \
++        }                                                                     \
+     } while(0)
+ 
+ /* kexinit
+@@ -3542,7 +3542,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
+     left = end_haystack - s;
+ 
+     /* Needle at start of haystack */
+-    if((strncmp((char *) haystack, (char *) needle, needle_len) == 0) &&
++    if((strncmp((char *) haystack, (const char *) needle, needle_len) == 0) &&
+         (needle_len == haystack_len || haystack[needle_len] == ',')) {
+         return haystack;
+     }
+@@ -3562,7 +3562,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
+         }
+ 
+         /* Needle at X position */
+-        if((strncmp((char *) s, (char *) needle, needle_len) == 0) &&
++        if((strncmp((char *) s, (const char *) needle, needle_len) == 0) &&
+             (((s - haystack) + needle_len) == haystack_len
+              || s[needle_len] == ',')) {
+             return s;
+@@ -3643,7 +3643,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
+ 
+     while(hostkeyp && (*hostkeyp) && (*hostkeyp)->name) {
+         s = _libssh2_kex_agree_instr(hostkey, hostkey_len,
+-                                     (unsigned char *) (*hostkeyp)->name,
++                                     (const unsigned char *) (*hostkeyp)->name,
+                                      strlen((*hostkeyp)->name));
+         if(s) {
+             /* So far so good, but does it suit our purposes? (Encrypting vs
+@@ -3679,7 +3679,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
+     const LIBSSH2_KEX_METHOD **kexp = libssh2_kex_methods;
+     unsigned char *s;
+     const unsigned char *strict =
+-        (unsigned char *)"kex-strict-s-v00@openssh.com";
++        (const unsigned char *)"kex-strict-s-v00@openssh.com";
+ 
+     if(_libssh2_kex_agree_instr(kex, kex_len, strict, 28)) {
+         session->kex_strict = 1;
+@@ -3726,7 +3726,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
+ 
+     while(*kexp && (*kexp)->name) {
+         s = _libssh2_kex_agree_instr(kex, kex_len,
+-                                     (unsigned char *) (*kexp)->name,
++                                     (const unsigned char *) (*kexp)->name,
+                                      strlen((*kexp)->name));
+         if(s) {
+             /* We've agreed on a key exchange method,
+@@ -3794,7 +3794,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
+ 
+     while(*cryptp && (*cryptp)->name) {
+         s = _libssh2_kex_agree_instr(crypt, crypt_len,
+-                                     (unsigned char *) (*cryptp)->name,
++                                     (const unsigned char *) (*cryptp)->name,
+                                      strlen((*cryptp)->name));
+         if(s) {
+             endpoint->crypt = *cryptp;
+@@ -3857,7 +3857,7 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
+ 
+     while(*macp && (*macp)->name) {
+         s = _libssh2_kex_agree_instr(mac, mac_len,
+-                                     (unsigned char *) (*macp)->name,
++                                     (const unsigned char *) (*macp)->name,
+                                      strlen((*macp)->name));
+         if(s) {
+             endpoint->mac = *macp;
+@@ -3912,7 +3912,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
+ 
+     while(*compp && (*compp)->name) {
+         s = _libssh2_kex_agree_instr(comp, comp_len,
+-                                     (unsigned char *) (*compp)->name,
++                                     (const unsigned char *) (*compp)->name,
+                                      strlen((*compp)->name));
+         if(s) {
+             endpoint->comp = *compp;
+diff --git a/src/libgcrypt.h b/src/libgcrypt.h
+index e8efc4be..62d607b9 100644
+--- a/src/libgcrypt.h
++++ b/src/libgcrypt.h
+@@ -88,7 +88,7 @@
+ #define libssh2_sha1_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))
+ #define libssh2_sha1_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha1_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -99,7 +99,7 @@
+ #define libssh2_sha256_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
+ #define libssh2_sha256_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha256_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA256_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -110,7 +110,7 @@
+ #define libssh2_sha384_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
+ #define libssh2_sha384_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha384_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA384_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -121,7 +121,7 @@
+ #define libssh2_sha512_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
+ #define libssh2_sha512_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha512_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA512_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -133,7 +133,7 @@
+ #define libssh2_md5_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_MD5, 0))
+ #define libssh2_md5_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_md5_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), MD5_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+diff --git a/src/libssh2_priv.h b/src/libssh2_priv.h
+index 9b8866dc..bb1f8ad3 100644
+--- a/src/libssh2_priv.h
++++ b/src/libssh2_priv.h
+@@ -117,6 +117,14 @@
+ #define UINT32_MAX 0xffffffffU
+ #endif
+ 
++#ifdef _WIN64
++#define LIBSSH2_UNCONST(p)  ((void *)(libssh2_uint64_t)(const void *)(p))
++#elif defined(_MSC_VER)
++#define LIBSSH2_UNCONST(p)  ((void *)(unsigned int)(const void *)(p))
++#else
++#define LIBSSH2_UNCONST(p)  ((void *)(uintptr_t)(const void *)(p))
++#endif
++
+ #if (defined(__GNUC__) || defined(__clang__)) && \
+     defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+     !defined(LIBSSH2_NO_FMT_CHECKS)
+diff --git a/src/mbedtls.c b/src/mbedtls.c
+index a66e36c5..67605ff9 100644
+--- a/src/mbedtls.c
++++ b/src/mbedtls.c
+@@ -476,11 +476,11 @@ _libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
+     mbedtls_pk_init(&pkey);
+ 
+ #if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (char *)passphrase,
++    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase,
+                                    mbedtls_ctr_drbg_random,
+                                    &_libssh2_mbedtls_ctr_drbg);
+ #else
+-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (char *)passphrase);
++    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase);
+ #endif
+     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
+         mbedtls_pk_free(&pkey);
+diff --git a/src/misc.c b/src/misc.c
+index 6c28327c..cd9971a5 100644
+--- a/src/misc.c
++++ b/src/misc.c
+@@ -88,7 +88,7 @@ int _libssh2_error_flags(LIBSSH2_SESSION* session, int errcode,
+     }
+ 
+     if(session->err_flags & LIBSSH2_ERR_FLAG_DUP)
+-        LIBSSH2_FREE(session, (char *)session->err_msg);
++        LIBSSH2_FREE(session, (char *)LIBSSH2_UNCONST(session->err_msg));
+ 
+     session->err_code = errcode;
+     session->err_flags = 0;
+diff --git a/src/openssl.c b/src/openssl.c
+index eba05031..803824df 100644
+--- a/src/openssl.c
++++ b/src/openssl.c
+@@ -78,7 +78,7 @@ static int _libssh2_hmac_init(libssh2_hmac_ctx *ctx,
+     params[0] = OSSL_PARAM_construct_octet_string(
+         OSSL_MAC_PARAM_KEY, (void *)key, keylen);
+     params[1] = OSSL_PARAM_construct_utf8_string(
+-        OSSL_MAC_PARAM_DIGEST, (char *)digest_name, 0);
++        OSSL_MAC_PARAM_DIGEST, (char *)LIBSSH2_UNCONST(digest_name), 0);
+     params[2] = OSSL_PARAM_construct_end();
+ 
+     return EVP_MAC_init(*ctx, NULL, 0, params);
+@@ -487,7 +487,7 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+ #else
+ 
+     ret = RSA_verify(nid_type, hash, (unsigned int) hash_len,
+-                     (unsigned char *) sig,
++                     (const unsigned char *) sig,
+                      (unsigned int) sig_len, rsactx);
+ #endif
+ 
+@@ -1192,7 +1192,7 @@ read_private_key_from_memory(void **key_ctx,
+ 
+     *key_ctx = NULL;
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
+     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+ #else
+     bp = BIO_new_mem_buf((char *)filedata, (int)filedata_len);
+@@ -1202,7 +1202,7 @@ read_private_key_from_memory(void **key_ctx,
+     }
+ 
+     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
+-                                (void *) passphrase);
++                                (void *) LIBSSH2_UNCONST(passphrase));
+ 
+     BIO_free(bp);
+     return (*key_ctx) ? 0 : -1;
+@@ -1226,7 +1226,7 @@ read_private_key_from_file(void **key_ctx,
+     }
+ 
+     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
+-                                (void *) passphrase);
++                                (void *) LIBSSH2_UNCONST(passphrase));
+ 
+     BIO_free(bp);
+     return (*key_ctx) ? 0 : -1;
+@@ -2437,7 +2437,8 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
+             *key_handle = LIBSSH2_ALLOC(session, *handle_len);
+ 
+             if(key_handle) {
+-                memcpy((void *)*key_handle, handle, *handle_len);
++                memcpy((void *)LIBSSH2_UNCONST(*key_handle),
++                       handle, *handle_len);
+             }
+         }
+     }
+@@ -2477,9 +2478,10 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
+         _libssh2_store_str(&p, (const char *)app, app_len);
+ 
+         if(application && app_len > 0) {
+-            *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
+-            _libssh2_explicit_zero((void *)*application, app_len + 1);
+-            memcpy((void *)*application, app, app_len);
++            *application = LIBSSH2_ALLOC(session, app_len + 1);
++            _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
++                                   app_len + 1);
++            memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
+         }
+ 
+         memcpy(method_buf, key_type, strlen(key_type));
+@@ -3791,7 +3793,8 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
+             *key_handle = LIBSSH2_ALLOC(session, *handle_len);
+ 
+             if(*key_handle) {
+-                memcpy((void *)*key_handle, handle, *handle_len);
++                memcpy((void *)LIBSSH2_UNCONST(*key_handle),
++                       handle, *handle_len);
+             }
+         }
+     }
+@@ -3829,9 +3832,10 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
+         _libssh2_store_str(&p, (const char *)app, app_len);
+ 
+         if(application && app_len > 0) {
+-            *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
+-            _libssh2_explicit_zero((void *)*application, app_len + 1);
+-            memcpy((void *)*application, app, app_len);
++            *application = LIBSSH2_ALLOC(session, app_len + 1);
++            _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
++                                   app_len + 1);
++            memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
+         }
+ 
+         LIBSSH2_FREE(session, *pubkeydata);
+@@ -4663,7 +4667,8 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
+     }
+ 
+     (void)BIO_reset(bp);
+-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
++    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
++                                 (void *)LIBSSH2_UNCONST(passphrase));
+     BIO_free(bp);
+ 
+     if(!pk) {
+@@ -5003,7 +5008,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+                    LIBSSH2_TRACE_AUTH,
+                    "Computing public key from private key."));
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
+     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
+ #else
+     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
+@@ -5013,7 +5018,8 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+                               "Unable to allocate memory when"
+                               "computing public key");
+     (void)BIO_reset(bp);
+-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
++    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
++                                 (void *)LIBSSH2_UNCONST(passphrase));
+ #ifdef HAVE_SSLERROR_BAD_DECRYPT
+     sslError = ERR_get_error();
+ #endif
+@@ -5114,7 +5120,7 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                    LIBSSH2_TRACE_AUTH,
+                    "Computing public key from private key."));
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
+     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
+ #else
+     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
+@@ -5124,7 +5130,8 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                               "Unable to allocate memory when"
+                               "computing public key");
+     (void)BIO_reset(bp);
+-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
++    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
++                                 (void *)LIBSSH2_UNCONST(passphrase));
+     BIO_free(bp);
+ 
+     if(!pk) {
+diff --git a/src/packet.c b/src/packet.c
+index ebaddae5..606c449c 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -687,7 +687,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 }
+                 else {
+                     const unsigned char *strict =
+-                    (unsigned char *)"kex-strict-s-v00@openssh.com";
++                        (const unsigned char *)"kex-strict-s-v00@openssh.com";
+                     struct string_buf buf;
+                     unsigned char *algs = NULL;
+                     size_t algs_len = 0;
+@@ -1644,7 +1644,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
+             }
+         }
+ 
+-        if(strchr((char *) packet_types, ret)) {
++        if(strchr((const char *) packet_types, ret)) {
+             /* Be lazy, let packet_ask pull it out of the brigade */
+             ret = _libssh2_packet_askv(session, packet_types, data,
+                                        data_len, match_ofs, match_buf,
+diff --git a/src/pem.c b/src/pem.c
+index c9ab7746..63372862 100644
+--- a/src/pem.c
++++ b/src/pem.c
+@@ -219,7 +219,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
+         /* Perform key derivation (PBKDF1/MD5) */
+         if(!libssh2_md5_init(&fingerprint_ctx) ||
+            !libssh2_md5_update(fingerprint_ctx, passphrase,
+-                               strlen((char *)passphrase)) ||
++                               strlen((const char *)passphrase)) ||
+            !libssh2_md5_update(fingerprint_ctx, iv, 8) ||
+            !libssh2_md5_final(fingerprint_ctx, secret)) {
+             ret = -1;
+@@ -230,7 +230,8 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
+                !libssh2_md5_update(fingerprint_ctx,
+                                    secret, MD5_DIGEST_LENGTH) ||
+                !libssh2_md5_update(fingerprint_ctx,
+-                                   passphrase, strlen((char *)passphrase)) ||
++                                   passphrase,
++                                   strlen((const char *)passphrase)) ||
+                !libssh2_md5_update(fingerprint_ctx, iv, 8) ||
+                !libssh2_md5_final(fingerprint_ctx,
+                                   secret + MD5_DIGEST_LENGTH)) {
+@@ -431,7 +432,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
+         goto out;
+     }
+ 
+-    if(strncmp((char *) decoded.dataptr, AUTH_MAGIC,
++    if(strncmp((const char *) decoded.dataptr, AUTH_MAGIC,
+                strlen(AUTH_MAGIC)) != 0) {
+         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                              "key auth magic mismatch");
+diff --git a/src/publickey.c b/src/publickey.c
+index 9c9fa618..9ff2e5cf 100644
+--- a/src/publickey.c
++++ b/src/publickey.c
+@@ -597,7 +597,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
+     /*  19 = packet_len(4) + add_len(4) + "add"(3) + name_len(4) + {name}
+         blob_len(4) + {blob} */
+     unsigned long i, packet_len = 19 + name_len + blob_len;
+-    unsigned char *comment = NULL;
++    const unsigned char *comment = NULL;
+     unsigned long comment_len = 0;
+     int rc;
+ 
+@@ -619,7 +619,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
+                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
+                     strncmp(attrs[i].name, "comment",
+                             sizeof("comment") - 1) == 0) {
+-                    comment = (unsigned char *) attrs[i].value;
++                    comment = (const unsigned char *) attrs[i].value;
+                     comment_len = attrs[i].value_len;
+                     break;
+                 }
+diff --git a/src/session.c b/src/session.c
+index 2d77b05e..945aa649 100644
+--- a/src/session.c
++++ b/src/session.c
+@@ -212,7 +212,7 @@ banner_receive(LIBSSH2_SESSION * session)
+ static int
+ banner_send(LIBSSH2_SESSION * session)
+ {
+-    char *banner = (char *) LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
++    const char *banner = LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
+     size_t banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
+     ssize_t ret;
+ 
+@@ -260,7 +260,8 @@ banner_send(LIBSSH2_SESSION * session)
+         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                        "Sent %ld/%ld bytes at %p+%ld", (long)ret,
+                        (long)(banner_len - session->banner_TxRx_total_send),
+-                       (void *)banner, (long)session->banner_TxRx_total_send));
++                       (const void *)banner,
++                       (long)session->banner_TxRx_total_send));
+ 
+     if(ret != (ssize_t)(banner_len - session->banner_TxRx_total_send)) {
+         if(ret >= 0 || ret == -EAGAIN) {
+@@ -1158,7 +1159,7 @@ session_free(LIBSSH2_SESSION *session)
+     /* error string */
+     if(session->err_msg &&
+        ((session->err_flags & LIBSSH2_ERR_FLAG_DUP) != 0)) {
+-        LIBSSH2_FREE(session, (char *)session->err_msg);
++        LIBSSH2_FREE(session, (char *)LIBSSH2_UNCONST(session->err_msg));
+     }
+ 
+     LIBSSH2_FREE(session, session);
+@@ -1272,31 +1273,31 @@ libssh2_session_methods(LIBSSH2_SESSION * session, int method_type)
+         break;
+ 
+     case LIBSSH2_METHOD_HOSTKEY:
+-        method = (LIBSSH2_KEX_METHOD *) session->hostkey;
++        method = (const LIBSSH2_KEX_METHOD *) session->hostkey;
+         break;
+ 
+     case LIBSSH2_METHOD_CRYPT_CS:
+-        method = (LIBSSH2_KEX_METHOD *) session->local.crypt;
++        method = (const LIBSSH2_KEX_METHOD *) session->local.crypt;
+         break;
+ 
+     case LIBSSH2_METHOD_CRYPT_SC:
+-        method = (LIBSSH2_KEX_METHOD *) session->remote.crypt;
++        method = (const LIBSSH2_KEX_METHOD *) session->remote.crypt;
+         break;
+ 
+     case LIBSSH2_METHOD_MAC_CS:
+-        method = (LIBSSH2_KEX_METHOD *) session->local.mac;
++        method = (const LIBSSH2_KEX_METHOD *) session->local.mac;
+         break;
+ 
+     case LIBSSH2_METHOD_MAC_SC:
+-        method = (LIBSSH2_KEX_METHOD *) session->remote.mac;
++        method = (const LIBSSH2_KEX_METHOD *) session->remote.mac;
+         break;
+ 
+     case LIBSSH2_METHOD_COMP_CS:
+-        method = (LIBSSH2_KEX_METHOD *) session->local.comp;
++        method = (const LIBSSH2_KEX_METHOD *) session->local.comp;
+         break;
+ 
+     case LIBSSH2_METHOD_COMP_SC:
+-        method = (LIBSSH2_KEX_METHOD *) session->remote.comp;
++        method = (const LIBSSH2_KEX_METHOD *) session->remote.comp;
+         break;
+ 
+     case LIBSSH2_METHOD_LANG_CS:
+@@ -1351,7 +1352,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
+                 }
+             }
+             else {
+-                *errmsg = (char *) "";
++                *errmsg = (char *)LIBSSH2_UNCONST("");
+             }
+         }
+         if(errmsg_len) {
+@@ -1374,7 +1375,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
+             }
+         }
+         else
+-            *errmsg = (char *)error;
++            *errmsg = (char *)LIBSSH2_UNCONST(error);
+     }
+ 
+     if(errmsg_len) {
+diff --git a/src/sftp.c b/src/sftp.c
+index 43b6ff90..d2c391d0 100644
+--- a/src/sftp.c
++++ b/src/sftp.c
+@@ -675,7 +675,7 @@ sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs, const unsigned char *p,
+ {
+     struct string_buf buf;
+     uint32_t flags = 0;
+-    buf.data = (unsigned char *)p;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(p);
+     buf.dataptr = buf.data;
+     buf.len = data_len;
+ 
+diff --git a/src/userauth.c b/src/userauth.c
+index 588b83f2..a8e15b47 100644
+--- a/src/userauth.c
++++ b/src/userauth.c
+@@ -107,7 +107,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
+     if(session->userauth_list_state == libssh2_NB_state_created) {
+         rc = _libssh2_transport_send(session, session->userauth_list_data,
+                                      session->userauth_list_data_len,
+-                                     (unsigned char *)"none", 4);
++                                     (const unsigned char *)"none", 4);
+         if(rc == LIBSSH2_ERROR_EAGAIN) {
+             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
+                            "Would block requesting userauth list");
+@@ -487,7 +487,8 @@ password_response:
+                         _libssh2_store_str(&s, "password",
+                                            sizeof("password") - 1);
+                         *s++ = 0x01;
+-                        _libssh2_store_str(&s, (char *)password, password_len);
++                        _libssh2_store_str(&s, (const char *)password,
++                                           password_len);
+                         _libssh2_store_u32(&s,
+                                            session->userauth_pswd_newpw_len);
+                         /* send session->userauth_pswd_newpw separately */
+@@ -500,7 +501,7 @@ password_response:
+                         rc = _libssh2_transport_send(session,
+                                             session->userauth_pswd_data,
+                                             session->userauth_pswd_data_len,
+-                                            (unsigned char *)
++                                            (const unsigned char *)
+                                             session->userauth_pswd_newpw,
+                                             session->userauth_pswd_newpw_len);
+                         if(rc == LIBSSH2_ERROR_EAGAIN) {
+@@ -565,7 +566,8 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session, const char *username,
+     int rc;
+     BLOCK_ADJUST(rc, session,
+                  userauth_password(session, username, username_len,
+-                                   (unsigned char *)password, password_len,
++                                   (const unsigned char *)password,
++                                   password_len,
+                                    passwd_change_cb));
+     return rc;
+ }
+@@ -776,7 +778,7 @@ memory_read_privatekey(LIBSSH2_SESSION * session,
+ 
+     if((*hostkey_method)->
+         initPEMFromMemory(session, privkeyfiledata, privkeyfiledata_len,
+-                          (unsigned char *) passphrase,
++                          (const unsigned char *) passphrase,
+                           hostkey_abstract)) {
+         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
+                               "Unable to initialize private key from memory");
+@@ -817,7 +819,7 @@ file_read_privatekey(LIBSSH2_SESSION * session,
+     }
+ 
+     if((*hostkey_method)->
+-        initPEM(session, privkeyfile, (unsigned char *) passphrase,
++        initPEM(session, privkeyfile, (const unsigned char *) passphrase,
+                 hostkey_abstract)) {
+         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
+                               "Unable to initialize private key from file");
+@@ -857,7 +859,7 @@ sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
+         return rc;
+ 
+     libssh2_prepare_iovec(&datavec, 1);
+-    datavec.iov_base = (void *)data;
++    datavec.iov_base = (void *)LIBSSH2_UNCONST(data);
+     datavec.iov_len  = data_len;
+ 
+     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
+@@ -893,7 +895,7 @@ sign_fromfile(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
+         return rc;
+ 
+     libssh2_prepare_iovec(&datavec, 1);
+-    datavec.iov_base = (void *)data;
++    datavec.iov_base = (void *)LIBSSH2_UNCONST(data);
+     datavec.iov_len  = data_len;
+ 
+     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
+@@ -2463,7 +2465,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                 LIBSSH2_FREE(session, tmp_method);
+             }
+ 
+-            if(!strncmp((char *)publickeydata, ecdsa, strlen(ecdsa))) {
++            if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
+                 session->userauth_pblc_method_len = strlen(ecdsa);
+                 session->userauth_pblc_method =
+                     LIBSSH2_ALLOC(session, session->userauth_pblc_method_len);
+@@ -2471,7 +2473,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                 memcpy(session->userauth_pblc_method, ecdsa,
+                        session->userauth_pblc_method_len);
+             }
+-            else if(!strncmp((char *)publickeydata, ed25519,
++            else if(!strncmp((const char *)publickeydata, ed25519,
+                              strlen(ed25519))) {
+                 session->userauth_pblc_method_len = strlen(ed25519);
+                 session->userauth_pblc_method =
+@@ -2485,7 +2487,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                                        &session->userauth_pblc_method,
+                                        &session->userauth_pblc_method_len,
+                                        &pubkeydata, &pubkeydata_len,
+-                                       (char *)publickeydata,
++                                       (const char *)publickeydata,
+                                        publickeydata_len);
+         }
+     }
+@@ -2510,7 +2512,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+         LIBSSH2_FREE(session, tmp_publickeydata);
+ 
+     if(sk_info.application) {
+-        LIBSSH2_FREE(session, (void *)sk_info.application);
++        LIBSSH2_FREE(session, (void *)LIBSSH2_UNCONST(sk_info.application));
+     }
+ 
+     return rc;
+diff --git a/src/wincng.c b/src/wincng.c
+index 5d4b36b7..edad04f1 100644
+--- a/src/wincng.c
++++ b/src/wincng.c
+@@ -431,7 +431,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlgAES_CBC,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_CBC,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_CBC),
+                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgAES_CBC, 0);
+@@ -446,7 +446,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlgAES_ECB,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_ECB,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_ECB),
+                                 sizeof(BCRYPT_CHAIN_MODE_ECB), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgAES_ECB, 0);
+@@ -461,7 +461,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlgRC4_NA,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_NA,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_NA),
+                                 sizeof(BCRYPT_CHAIN_MODE_NA), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgRC4_NA, 0);
+@@ -476,7 +476,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlg3DES_CBC,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_CBC,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_CBC),
+                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlg3DES_CBC,
+@@ -676,7 +676,8 @@ _libssh2_wincng_hash_update(_libssh2_wincng_hash_ctx *ctx,
+ {
+     int ret;
+ 
+-    ret = BCryptHashData(ctx->hHash, (PUCHAR)data, datalen, 0);
++    ret = BCryptHashData(ctx->hHash,
++                         (PUCHAR)LIBSSH2_UNCONST(data), datalen, 0);
+ 
+     return BCRYPT_SUCCESS(ret) ? 0 : -1;
+ }
+@@ -2887,9 +2888,9 @@ _libssh2_wincng_ecdsa_new_private_frommemory(
+     }
+ 
+     data_buffer.len = data_len;
+-    data_buffer.data = (unsigned char *)data;
+-    data_buffer.dataptr =
+-        (unsigned char *)data + strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
++    data_buffer.data = (unsigned char *)LIBSSH2_UNCONST(data);
++    data_buffer.dataptr = data_buffer.data +
++                          strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
+ 
+     /* Read ciphername, should be 'none' as we don't support passphrases */
+     result = _libssh2_match_string(&data_buffer, "none");
+-- 
+2.52.0
+

--- a/runtime-network/libssh2/spec
+++ b/runtime-network/libssh2/spec
@@ -1,4 +1,5 @@
 VER=1.11.1
+REL=1
 SRCS="git::commit=tags/libssh2-${VER}::https://github.com/libssh2/libssh2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1730"

--- a/runtime-optenv32/libssh2+32/autobuild/defines
+++ b/runtime-optenv32/libssh2+32/autobuild/defines
@@ -2,11 +2,12 @@ PKGNAME=libssh2+32
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 openssl+32 zlib+32"
 BUILDDEP="autoconf-archive devel-base+32"
-PKGDES="A client-side C library implementing the SSH2 protocol (32-bit x86 runtime)"
+PKGDES="Client-side C library to implement the SSH2 protocol (32-bit x86 runtime)"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
-# FIXME: Found ZLIB: /usr/lib/libz.so (found version "1.3.1")
+    # FIXME: Found ZLIB: /usr/lib/libz.so (found version "1.3.1")
     '-DCMAKE_PREFIX_PATH=/opt/32'
 )
-ABTYPE=cmakeninja
+
 ABHOST=optenv32

--- a/runtime-optenv32/libssh2+32/autobuild/patches/0001-UPSTREAM-userauth.c-username_len-bounds-checking-185.patch
+++ b/runtime-optenv32/libssh2+32/autobuild/patches/0001-UPSTREAM-userauth.c-username_len-bounds-checking-185.patch
@@ -1,0 +1,58 @@
+From 4e95b12381dc5fc90fcbcec0c2778622a9e9c34c Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Mon, 13 Apr 2026 11:18:25 -0700
+Subject: [PATCH 1/5] UPSTREAM: userauth.c: username_len bounds checking
+ (#1858)
+
+Return errors when username_len will exceed bounds, fix existing bounds
+check.
+
+Credit:
+[dapickle](https://github.com/dapickle)
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/userauth.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/src/userauth.c b/src/userauth.c
+index 0040c3fa..588b83f2 100644
+--- a/src/userauth.c
++++ b/src/userauth.c
+@@ -80,6 +80,12 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
+         memset(&session->userauth_list_packet_requirev_state, 0,
+                sizeof(session->userauth_list_packet_requirev_state));
+ 
++        if(username_len > UINT32_MAX - 27) {
++            _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                           "username_len out of bounds");
++            return NULL;
++        }
++
+         session->userauth_list_data_len = username_len + 27;
+ 
+         s = session->userauth_list_data =
+@@ -307,6 +313,11 @@ userauth_password(LIBSSH2_SESSION *session,
+          * 40 = packet_type(1) + username_len(4) + service_len(4) +
+          * service(14)"ssh-connection" + method_len(4) + method(8)"password" +
+          * chgpwdbool(1) + password_len(4) */
++        if(username_len > UINT32_MAX - 40) {
++            return _libssh2_error(session, LIBSSH2_ERROR_PROTO,
++                                  "username_len out of bounds");
++        }
++
+         session->userauth_pswd_data_len = username_len + 40;
+ 
+         session->userauth_pswd_data0 =
+@@ -447,7 +458,7 @@ password_response:
+                         }
+ 
+                         /* basic data_len + newpw_len(4) */
+-                        if(username_len + password_len + 44 <= UINT_MAX) {
++                        if(username_len <= UINT32_MAX - password_len - 44) {
+                             session->userauth_pswd_data_len =
+                                 username_len + password_len + 44;
+                             s = session->userauth_pswd_data =
+-- 
+2.52.0
+

--- a/runtime-optenv32/libssh2+32/autobuild/patches/0002-BACKPORT-UPSTREAM-Update-sftp_symlink-to-avoid-out-o.patch
+++ b/runtime-optenv32/libssh2+32/autobuild/patches/0002-BACKPORT-UPSTREAM-Update-sftp_symlink-to-avoid-out-o.patch
@@ -1,0 +1,129 @@
+From b49d2946b10ebc673688a13eff4243e9b18cab0e Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Fri, 10 Oct 2025 08:26:20 -0700
+Subject: [PATCH 2/5] BACKPORT: UPSTREAM: Update sftp_symlink to avoid out of
+ bounds read on malformed packet #1705 (#1717)
+
+Use buffer struct to guard against out of bounds reads and invalid packets.
+
+Discovery Credit:
+Joshua Rogers
+
+[ Mingcong Bai: Resolved a minor merge conflict in
+  src/sftp.c ]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/sftp.c | 66 ++++++++++++++++++++++++++++++++++++++----------------
+ 1 file changed, 47 insertions(+), 19 deletions(-)
+
+diff --git a/src/sftp.c b/src/sftp.c
+index 6ede3111..43b6ff90 100644
+--- a/src/sftp.c
++++ b/src/sftp.c
+@@ -3795,15 +3795,19 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
+ {
+     LIBSSH2_CHANNEL *channel = sftp->channel;
+     LIBSSH2_SESSION *session = channel->session;
+-    size_t data_len = 0, link_len;
++    size_t data_len = 0, lk_len;
+     /* 13 = packet_len(4) + packet_type(1) + request_id(4) + path_len(4) */
+     ssize_t packet_len =
+         path_len + 13 +
+         ((link_type == LIBSSH2_SFTP_SYMLINK) ? (4 + target_len) : 0);
+     unsigned char *s, *data = NULL;
++    struct string_buf buf;
+     static const unsigned char link_responses[2] =
+         { SSH_FXP_NAME, SSH_FXP_STATUS };
+     int retcode;
++    unsigned char packet_type;
++    uint32_t tmp_u32;
++    unsigned char *lk_target;
+ 
+     if(sftp->symlink_state == libssh2_NB_state_idle) {
+         sftp->last_errno = LIBSSH2_FX_OK;
+@@ -3891,8 +3895,25 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
+ 
+     sftp->symlink_state = libssh2_NB_state_idle;
+ 
+-    if(data[0] == SSH_FXP_STATUS) {
+-        retcode = _libssh2_ntohu32(data + 5);
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(data);
++    buf.dataptr = buf.data;
++    buf.len = data_len;
++
++    if(_libssh2_get_byte(&buf, &packet_type)) {
++        LIBSSH2_FREE(session, data);
++        return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
++                              "SFTP Protocol Error (type)");
++    }
++
++    if(packet_type == SSH_FXP_STATUS) {
++        if(_libssh2_get_u32(&buf, &tmp_u32)) {
++            LIBSSH2_FREE(session, data);
++            return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
++                                  "SFTP Protocol Error (code)");
++        }
++
++        retcode = (int)tmp_u32;
++
+         LIBSSH2_FREE(session, data);
+         if(retcode == LIBSSH2_FX_OK)
+             return LIBSSH2_ERROR_NONE;
+@@ -3903,30 +3924,37 @@ static int sftp_symlink(LIBSSH2_SFTP *sftp, const char *path,
+         }
+     }
+ 
+-    if(_libssh2_ntohu32(data + 5) < 1) {
++    /* advance past id */
++    if(_libssh2_get_u32(&buf, &tmp_u32)) {
+         LIBSSH2_FREE(session, data);
+         return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
+-                              "Invalid READLINK/REALPATH response, "
+-                              "no name entries");
++                              "SFTP Protocol Error (id)");
+     }
+ 
+-    if(data_len < 13) {
+-        if(data_len > 0) {
+-            LIBSSH2_FREE(session, data);
+-        }
++    /* look for at least one link */
++    if(_libssh2_get_u32(&buf, &tmp_u32) || tmp_u32 < 1) {
++        LIBSSH2_FREE(session, data);
+         return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
+-                              "SFTP stat packet too short");
++                                     "Invalid READLINK/REALPATH response, "
++                                     "no name entries");
+     }
+ 
+-    /* this reads a u32 and stores it into a signed 32bit value */
+-    link_len = _libssh2_ntohu32(data + 9);
+-    if(link_len < target_len) {
+-        memcpy(target, data + 13, link_len);
+-        target[link_len] = 0;
+-        retcode = (int)link_len;
++    if(_libssh2_get_string(&buf, &lk_target, &lk_len) == LIBSSH2_ERROR_NONE) {
++        if(lk_len < target_len) {
++            memcpy(target, lk_target, lk_len);
++            target[lk_len] = '\0';
++            retcode = (int)lk_len;
++        }
++        else {
++            retcode = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
++        }
+     }
+-    else
+-        retcode = LIBSSH2_ERROR_BUFFER_TOO_SMALL;
++    else {
++        LIBSSH2_FREE(session, data);
++        return _libssh2_error(session, LIBSSH2_ERROR_SFTP_PROTOCOL,
++                              "SFTP Protocol Error (filename)");
++    }
++
+     LIBSSH2_FREE(session, data);
+ 
+     return retcode;
+-- 
+2.52.0
+

--- a/runtime-optenv32/libssh2+32/autobuild/patches/0003-UPSTREAM-packet-check-_libssh2_get_string-return-in-.patch
+++ b/runtime-optenv32/libssh2+32/autobuild/patches/0003-UPSTREAM-packet-check-_libssh2_get_string-return-in-.patch
@@ -1,0 +1,44 @@
+From 8fb49a709b95af64db11282778481a584bcf6ce8 Mon Sep 17 00:00:00 2001
+From: TristanInSec <tristan.mtn@gmail.com>
+Date: Wed, 15 Apr 2026 14:51:08 -0400
+Subject: [PATCH 3/5] UPSTREAM: packet: check `_libssh2_get_string()` return in
+ `EXT_INFO` handler
+
+The `SSH_MSG_EXT_INFO` handler discards the return values from
+`_libssh2_get_string()` when parsing extension name/value pairs. When
+the buffer is exhausted before all claimed extensions are parsed,
+the loop continues with no-op iterations until `nr_extensions` reaches
+zero.
+
+The `nr_extensions >= 1024` cap limits the worst case, but the loop
+should still break on parse failure for correctness and consistency
+with other parsers in this file (e.g. `SSH_MSG_CHANNEL_OPEN`,
+`SSH_MSG_KEXINIT`) that check `_libssh2_get_string()` return values.
+
+Closes #1864
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/packet.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/packet.c b/src/packet.c
+index 6da14e9f..ebaddae5 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -868,8 +868,10 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+ 
+                     nr_extensions -= 1;
+ 
+-                    _libssh2_get_string(&buf, &name, &name_len);
+-                    _libssh2_get_string(&buf, &value, &value_len);
++                    if(_libssh2_get_string(&buf, &name, &name_len))
++                        break;
++                    if(_libssh2_get_string(&buf, &value, &value_len))
++                        break;
+ 
+                     if(name && value) {
+                         _libssh2_debug((session,
+-- 
+2.52.0
+

--- a/runtime-optenv32/libssh2+32/autobuild/patches/0004-BACKPORT-UPSTREAM-transport.c-Additional-boundary-ch.patch
+++ b/runtime-optenv32/libssh2+32/autobuild/patches/0004-BACKPORT-UPSTREAM-transport.c-Additional-boundary-ch.patch
@@ -1,0 +1,39 @@
+From 213b0608f99b5b5793d42167a1d819c4ddfa48d4 Mon Sep 17 00:00:00 2001
+From: Will Cosgrove <will@panic.com>
+Date: Fri, 12 Jun 2026 15:57:44 -0700
+Subject: [PATCH 4/5] BACKPORT: UPSTREAM: transport.c: Additional boundary
+ checks for packet length (#2052)
+
+Add additional bounds checking on packet length to prevent OOB write.
+
+Credit: [TristanInSec](https://github.com/TristanInSec)
+
+[ Mingcong Bai: Resolved a minor merge conflict in
+  src/transport.c ]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/transport.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/src/transport.c b/src/transport.c
+index e1120656..d147505b 100644
+--- a/src/transport.c
++++ b/src/transport.c
+@@ -639,8 +639,12 @@ int _libssh2_transport_read(LIBSSH2_SESSION * session)
+                 total_num = 4;
+ 
+                 p->packet_length = _libssh2_ntohu32(block);
+-                if(p->packet_length < 1)
++                if(p->packet_length < 1) {
+                     return LIBSSH2_ERROR_DECRYPT;
++                }
++                else if(p->packet_length > LIBSSH2_PACKET_MAXPAYLOAD) {
++                    return LIBSSH2_ERROR_OUT_OF_BOUNDARY;
++                }
+ 
+                 /* total_num may include size field, however due to existing
+                  * logic it needs to be removed after the entire packet is read
+-- 
+2.52.0
+

--- a/runtime-optenv32/libssh2+32/autobuild/patches/0005-UPSTREAM-build-enable-Wcast-qual-fix-fallouts.patch
+++ b/runtime-optenv32/libssh2+32/autobuild/patches/0005-UPSTREAM-build-enable-Wcast-qual-fix-fallouts.patch
@@ -1,0 +1,1062 @@
+From a1d36ccc365d6941cd63102348966e7444365639 Mon Sep 17 00:00:00 2001
+From: Viktor Szakats <commit@vsz.me>
+Date: Thu, 30 Jan 2025 21:18:23 +0100
+Subject: [PATCH 5/5] UPSTREAM: build: enable `-Wcast-qual`, fix fallouts
+
+- enable compiler warning `-Wcast-qual`.
+- add `LIBSSH2_UNCONST()` macro to strip const where absolutely
+  necessary to avoid compiler warnings.
+- fix const stripping by constifying where necessary.
+- fix const stripping by using `LIBSSH2_UNCONST()`.
+- libgcrypt.h: drop unnecessary casts.
+- openssl: fix to use new `BIO_new_mem_buf()` parameter types
+  with wolfSSL.
+
+Cherry-picked from #1484
+Closes #1527
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ acinclude.m4                    |  2 ++
+ cmake/PickyWarnings.cmake       |  1 +
+ example/ssh2_agent_forwarding.c |  5 ++--
+ example/ssh2_echo.c             |  5 ++--
+ example/ssh2_exec.c             |  5 ++--
+ src/agent.c                     |  6 ++--
+ src/channel.c                   | 13 +++++----
+ src/comp.c                      | 11 ++++---
+ src/hostkey.c                   | 10 +++----
+ src/kex.c                       | 52 ++++++++++++++++-----------------
+ src/libgcrypt.h                 | 10 +++----
+ src/libssh2_priv.h              |  8 +++++
+ src/mbedtls.c                   |  4 +--
+ src/misc.c                      |  2 +-
+ src/openssl.c                   | 43 +++++++++++++++------------
+ src/packet.c                    |  4 +--
+ src/pem.c                       |  7 +++--
+ src/publickey.c                 |  4 +--
+ src/session.c                   | 25 ++++++++--------
+ src/sftp.c                      |  2 +-
+ src/userauth.c                  | 26 +++++++++--------
+ src/wincng.c                    | 17 ++++++-----
+ 22 files changed, 147 insertions(+), 115 deletions(-)
+
+diff --git a/acinclude.m4 b/acinclude.m4
+index e06476fd..b0bcc181 100644
+--- a/acinclude.m4
++++ b/acinclude.m4
+@@ -279,6 +279,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
+           #
+           dnl Only clang 3.0 or later
+           if test "$compiler_num" -ge "300"; then
++            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
+             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
+             tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
+           fi
+@@ -435,6 +436,7 @@ AC_DEFUN([CURL_CC_DEBUG_OPTS],
+           #
+           dnl Only gcc 4.0 or later
+           if test "$compiler_num" -ge "400"; then
++            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [cast-qual])
+             tmp_CFLAGS="$tmp_CFLAGS -Wstrict-aliasing=3"
+           fi
+           #
+diff --git a/cmake/PickyWarnings.cmake b/cmake/PickyWarnings.cmake
+index 94feee87..17948e3a 100644
+--- a/cmake/PickyWarnings.cmake
++++ b/cmake/PickyWarnings.cmake
+@@ -94,6 +94,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_C_COMPILER_I
+       -Waddress                            # clang  2.7  gcc  4.3
+       -Wattributes                         # clang  2.7  gcc  4.1
+       -Wcast-align                         # clang  1.0  gcc  4.2
++      -Wcast-qual                          # clang  3.0  gcc  3.4.6
+       -Wdeclaration-after-statement        # clang  1.0  gcc  3.4
+       -Wdiv-by-zero                        # clang  2.7  gcc  4.1
+       -Wempty-body                         # clang  2.7  gcc  4.3
+diff --git a/example/ssh2_agent_forwarding.c b/example/ssh2_agent_forwarding.c
+index 1be35216..baa7534f 100644
+--- a/example/ssh2_agent_forwarding.c
++++ b/example/ssh2_agent_forwarding.c
+@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
+     LIBSSH2_AGENT *agent = NULL;
+     struct libssh2_agent_publickey *identity, *prev_identity = NULL;
+     int exitcode;
+-    char *exitsignal = (char *)"none";
++    char *exitsignal = NULL;
+     ssize_t bytecount = 0;
+ 
+ #ifdef _WIN32
+@@ -272,7 +272,8 @@ int main(int argc, char *argv[])
+     }
+ 
+     if(exitsignal) {
+-        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
++        fprintf(stderr, "\nGot signal: %s\n",
++                exitsignal ? exitsignal : "none");
+     }
+     else {
+         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
+diff --git a/example/ssh2_echo.c b/example/ssh2_echo.c
+index 9b45c21a..1f9e46f8 100644
+--- a/example/ssh2_echo.c
++++ b/example/ssh2_echo.c
+@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
+     LIBSSH2_SESSION *session = NULL;
+     LIBSSH2_CHANNEL *channel;
+     int exitcode = 0;
+-    char *exitsignal = (char *)"none";
++    char *exitsignal = NULL;
+     size_t len;
+     LIBSSH2_KNOWNHOSTS *nh;
+     int type;
+@@ -340,7 +340,8 @@ int main(int argc, char *argv[])
+         }
+ 
+         if(exitsignal)
+-            fprintf(stderr, "\nGot signal: %s\n", exitsignal);
++            fprintf(stderr, "\nGot signal: %s\n",
++                    exitsignal ? exitsignal : "none");
+ 
+         libssh2_channel_free(channel);
+         channel = NULL;
+diff --git a/example/ssh2_exec.c b/example/ssh2_exec.c
+index ee8d2fb9..8cf27026 100644
+--- a/example/ssh2_exec.c
++++ b/example/ssh2_exec.c
+@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
+     LIBSSH2_SESSION *session = NULL;
+     LIBSSH2_CHANNEL *channel;
+     int exitcode;
+-    char *exitsignal = (char *)"none";
++    char *exitsignal = NULL;
+     ssize_t bytecount = 0;
+     size_t len;
+     LIBSSH2_KNOWNHOSTS *nh;
+@@ -283,7 +283,8 @@ int main(int argc, char *argv[])
+     }
+ 
+     if(exitsignal)
+-        fprintf(stderr, "\nGot signal: %s\n", exitsignal);
++        fprintf(stderr, "\nGot signal: %s\n",
++                exitsignal ? exitsignal : "none");
+     else
+         fprintf(stderr, "\nEXIT: %d bytecount: %ld\n",
+                 exitcode, (long)bytecount);
+diff --git a/src/agent.c b/src/agent.c
+index dd709eb1..43edaff5 100644
+--- a/src/agent.c
++++ b/src/agent.c
+@@ -223,14 +223,16 @@ static ssize_t _send_all(LIBSSH2_SEND_FUNC(func), libssh2_socket_t socket,
+                          const void *buffer, size_t length,
+                          int flags, void **abstract)
+ {
+-    RECV_SEND_ALL(func, socket, buffer, length, flags, abstract);
++    RECV_SEND_ALL(func, socket, LIBSSH2_UNCONST(buffer), length,
++                  flags, abstract);
+ }
+ 
+ static ssize_t _recv_all(LIBSSH2_RECV_FUNC(func), libssh2_socket_t socket,
+                          void *buffer, size_t length,
+                          int flags, void **abstract)
+ {
+-    RECV_SEND_ALL(func, socket, buffer, length, flags, abstract);
++    RECV_SEND_ALL(func, socket, buffer, length,
++                  flags, abstract);
+ }
+ 
+ #undef RECV_SEND_ALL
+diff --git a/src/channel.c b/src/channel.c
+index 529c2ef8..420e6c08 100644
+--- a/src/channel.c
++++ b/src/channel.c
+@@ -368,7 +368,7 @@ libssh2_channel_open_ex(LIBSSH2_SESSION *session, const char *type,
+     BLOCK_ADJUST_ERRNO(ptr, session,
+                        _libssh2_channel_open(session, type, type_len,
+                                              window_size, packet_size,
+-                                             (unsigned char *)msg,
++                                             (const unsigned char *)msg,
+                                              msg_len));
+     return ptr;
+ }
+@@ -1043,7 +1043,7 @@ static int channel_request_pty(LIBSSH2_CHANNEL *channel,
+ 
+         *(s++) = SSH_MSG_CHANNEL_REQUEST;
+         _libssh2_store_u32(&s, channel->remote.id);
+-        _libssh2_store_str(&s, (char *)"pty-req", sizeof("pty-req") - 1);
++        _libssh2_store_str(&s, (const char *)"pty-req", sizeof("pty-req") - 1);
+ 
+         *(s++) = 0x01;
+ 
+@@ -1151,7 +1151,7 @@ static int channel_request_auth_agent(LIBSSH2_CHANNEL *channel,
+         s = channel->req_auth_agent_packet;
+         *(s++) = SSH_MSG_CHANNEL_REQUEST;
+         _libssh2_store_u32(&s, channel->remote.id);
+-        _libssh2_store_str(&s, (char *)request_str, request_str_len);
++        _libssh2_store_str(&s, (const char *)request_str, request_str_len);
+         *(s++) = 0x01;
+ 
+         channel->req_auth_agent_state = libssh2_NB_state_created;
+@@ -1311,7 +1311,7 @@ channel_request_pty_size(LIBSSH2_CHANNEL * channel, int width,
+ 
+         *(s++) = SSH_MSG_CHANNEL_REQUEST;
+         _libssh2_store_u32(&s, channel->remote.id);
+-        _libssh2_store_str(&s, (char *)"window-change",
++        _libssh2_store_str(&s, (const char *)"window-change",
+                            sizeof("window-change") - 1);
+         *(s++) = 0x00; /* Don't reply */
+         _libssh2_store_u32(&s, width);
+@@ -1575,7 +1575,8 @@ _libssh2_channel_process_startup(LIBSSH2_CHANNEL *channel,
+         rc = _libssh2_transport_send(session,
+                                      channel->process_packet,
+                                      channel->process_packet_len,
+-                                     (unsigned char *)message, message_len);
++                                     (const unsigned char *)message,
++                                     message_len);
+         if(rc == LIBSSH2_ERROR_EAGAIN) {
+             _libssh2_error(session, rc,
+                            "Would block sending channel request");
+@@ -2483,7 +2484,7 @@ libssh2_channel_write_ex(LIBSSH2_CHANNEL *channel, int stream_id,
+ 
+     BLOCK_ADJUST(rc, channel->session,
+                  _libssh2_channel_write(channel, stream_id,
+-                                        (unsigned char *)buf, buflen));
++                                        (const unsigned char *)buf, buflen));
+     return rc;
+ }
+ 
+diff --git a/src/comp.c b/src/comp.c
+index ecfb28a3..d8b8e6a4 100644
+--- a/src/comp.c
++++ b/src/comp.c
+@@ -88,10 +88,13 @@ comp_method_none_decomp(LIBSSH2_SESSION * session,
+                         size_t src_len, void **abstract)
+ {
+     (void)session;
++    (void)dest;
++    (void)dest_len;
+     (void)payload_limit;
++    (void)src;
++    (void)src_len;
+     (void)abstract;
+-    *dest = (unsigned char *) src;
+-    *dest_len = src_len;
++
+     return 0;
+ }
+ 
+@@ -195,7 +198,7 @@ comp_method_zlib_comp(LIBSSH2_SESSION *session,
+     uInt out_maxlen = (uInt)*dest_len;
+     int status;
+ 
+-    strm->next_in = (unsigned char *) src;
++    strm->next_in = (unsigned char *) LIBSSH2_UNCONST(src);
+     strm->avail_in = (uInt)src_len;
+     strm->next_out = dest;
+     strm->avail_out = out_maxlen;
+@@ -249,7 +252,7 @@ comp_method_zlib_decomp(LIBSSH2_SESSION * session,
+     if(out_maxlen > payload_limit)
+         out_maxlen = payload_limit;
+ 
+-    strm->next_in = (unsigned char *) src;
++    strm->next_in = (unsigned char *) LIBSSH2_UNCONST(src);
+     strm->avail_in = (uInt)src_len;
+     strm->next_out = (unsigned char *) LIBSSH2_ALLOC(session,
+                                                      (uInt)out_maxlen);
+diff --git a/src/hostkey.c b/src/hostkey.c
+index 99eaf3e0..29642a1b 100644
+--- a/src/hostkey.c
++++ b/src/hostkey.c
+@@ -80,7 +80,7 @@ hostkey_method_ssh_rsa_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+@@ -563,7 +563,7 @@ hostkey_method_ssh_dss_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+@@ -804,7 +804,7 @@ hostkey_method_ssh_ecdsa_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+@@ -944,7 +944,7 @@ hostkey_method_ssh_ecdsa_sig_verify(LIBSSH2_SESSION * session,
+ 
+     /* keyname_len(4) + keyname(19){"ecdsa-sha2-nistp256"} +
+        signature_len(4) */
+-    buf.data = (unsigned char *)sig;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(sig);
+     buf.dataptr = buf.data;
+     buf.len = sig_len;
+ 
+@@ -1156,7 +1156,7 @@ hostkey_method_ssh_ed25519_init(LIBSSH2_SESSION * session,
+         return -1;
+     }
+ 
+-    buf.data = (unsigned char *)hostkey_data;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(hostkey_data);
+     buf.dataptr = buf.data;
+     buf.len = hostkey_data_len;
+ 
+diff --git a/src/kex.c b/src/kex.c
+index 4ca9c34c..ebee54f9 100644
+--- a/src/kex.c
++++ b/src/kex.c
+@@ -149,7 +149,7 @@ static int _libssh2_sha_algo_ctx_init(int sha_algo, void *ctx)
+ }
+ 
+ static int _libssh2_sha_algo_ctx_update(int sha_algo, void *ctx,
+-                                        void *data, size_t len)
++                                        const void *data, size_t len)
+ {
+     if(sha_algo == 512) {
+         libssh2_sha512_ctx *_ctx = (libssh2_sha512_ctx*)ctx;
+@@ -663,7 +663,7 @@ static int diffie_hellman_sha_algo(LIBSSH2_SESSION *session,
+                                                 exchange_state->h_sig_comp, 4);
+             hok &= _libssh2_sha_algo_ctx_update(sha_algo_value,
+                                                 exchange_hash_ctx,
+-                                   (unsigned char *)LIBSSH2_SSH_DEFAULT_BANNER,
++                                      (const void *)LIBSSH2_SSH_DEFAULT_BANNER,
+                                        sizeof(LIBSSH2_SSH_DEFAULT_BANNER) - 1);
+         }
+ 
+@@ -3280,7 +3280,7 @@ typedef struct _LIBSSH2_COMMON_METHOD
+  * Another sign of bad coding practices gone mad.  Pretend you don't see this.
+  */
+ static size_t
+-kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
++kex_method_strlen(const LIBSSH2_COMMON_METHOD ** method)
+ {
+     size_t len = 0;
+ 
+@@ -3303,7 +3303,7 @@ kex_method_strlen(LIBSSH2_COMMON_METHOD ** method)
+  */
+ static uint32_t
+ kex_method_list(unsigned char *buf, uint32_t list_strlen,
+-                LIBSSH2_COMMON_METHOD ** method)
++                const LIBSSH2_COMMON_METHOD ** method)
+ {
+     _libssh2_htonu32(buf, list_strlen);
+     buf += 4;
+@@ -3327,20 +3327,20 @@ kex_method_list(unsigned char *buf, uint32_t list_strlen,
+ 
+ #define LIBSSH2_METHOD_PREFS_LEN(prefvar, defaultvar)           \
+     (uint32_t)((prefvar) ? strlen(prefvar) :                    \
+-        kex_method_strlen((LIBSSH2_COMMON_METHOD**)(defaultvar)))
+-
+-#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)     \
+-    do {                                                                   \
+-        if(prefvar) {                                                      \
+-            _libssh2_htonu32((buf), (prefvarlen));                         \
+-            buf += 4;                                                      \
+-            memcpy((buf), (prefvar), (prefvarlen));                        \
+-            buf += (prefvarlen);                                           \
+-        }                                                                  \
+-        else {                                                             \
+-            buf += kex_method_list((buf), (prefvarlen),                    \
+-                                   (LIBSSH2_COMMON_METHOD**)(defaultvar)); \
+-        }                                                                  \
++        kex_method_strlen((const LIBSSH2_COMMON_METHOD**)(defaultvar)))
++
++#define LIBSSH2_METHOD_PREFS_STR(buf, prefvarlen, prefvar, defaultvar)        \
++    do {                                                                      \
++        if(prefvar) {                                                         \
++            _libssh2_htonu32((buf), (prefvarlen));                            \
++            buf += 4;                                                         \
++            memcpy((buf), (prefvar), (prefvarlen));                           \
++            buf += (prefvarlen);                                              \
++        }                                                                     \
++        else {                                                                \
++            buf += kex_method_list((buf), (prefvarlen),                       \
++                                (const LIBSSH2_COMMON_METHOD**)(defaultvar)); \
++        }                                                                     \
+     } while(0)
+ 
+ /* kexinit
+@@ -3542,7 +3542,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
+     left = end_haystack - s;
+ 
+     /* Needle at start of haystack */
+-    if((strncmp((char *) haystack, (char *) needle, needle_len) == 0) &&
++    if((strncmp((char *) haystack, (const char *) needle, needle_len) == 0) &&
+         (needle_len == haystack_len || haystack[needle_len] == ',')) {
+         return haystack;
+     }
+@@ -3562,7 +3562,7 @@ _libssh2_kex_agree_instr(unsigned char *haystack, size_t haystack_len,
+         }
+ 
+         /* Needle at X position */
+-        if((strncmp((char *) s, (char *) needle, needle_len) == 0) &&
++        if((strncmp((char *) s, (const char *) needle, needle_len) == 0) &&
+             (((s - haystack) + needle_len) == haystack_len
+              || s[needle_len] == ',')) {
+             return s;
+@@ -3643,7 +3643,7 @@ static int kex_agree_hostkey(LIBSSH2_SESSION * session,
+ 
+     while(hostkeyp && (*hostkeyp) && (*hostkeyp)->name) {
+         s = _libssh2_kex_agree_instr(hostkey, hostkey_len,
+-                                     (unsigned char *) (*hostkeyp)->name,
++                                     (const unsigned char *) (*hostkeyp)->name,
+                                      strlen((*hostkeyp)->name));
+         if(s) {
+             /* So far so good, but does it suit our purposes? (Encrypting vs
+@@ -3679,7 +3679,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
+     const LIBSSH2_KEX_METHOD **kexp = libssh2_kex_methods;
+     unsigned char *s;
+     const unsigned char *strict =
+-        (unsigned char *)"kex-strict-s-v00@openssh.com";
++        (const unsigned char *)"kex-strict-s-v00@openssh.com";
+ 
+     if(_libssh2_kex_agree_instr(kex, kex_len, strict, 28)) {
+         session->kex_strict = 1;
+@@ -3726,7 +3726,7 @@ static int kex_agree_kex_hostkey(LIBSSH2_SESSION * session, unsigned char *kex,
+ 
+     while(*kexp && (*kexp)->name) {
+         s = _libssh2_kex_agree_instr(kex, kex_len,
+-                                     (unsigned char *) (*kexp)->name,
++                                     (const unsigned char *) (*kexp)->name,
+                                      strlen((*kexp)->name));
+         if(s) {
+             /* We've agreed on a key exchange method,
+@@ -3794,7 +3794,7 @@ static int kex_agree_crypt(LIBSSH2_SESSION * session,
+ 
+     while(*cryptp && (*cryptp)->name) {
+         s = _libssh2_kex_agree_instr(crypt, crypt_len,
+-                                     (unsigned char *) (*cryptp)->name,
++                                     (const unsigned char *) (*cryptp)->name,
+                                      strlen((*cryptp)->name));
+         if(s) {
+             endpoint->crypt = *cryptp;
+@@ -3857,7 +3857,7 @@ static int kex_agree_mac(LIBSSH2_SESSION * session,
+ 
+     while(*macp && (*macp)->name) {
+         s = _libssh2_kex_agree_instr(mac, mac_len,
+-                                     (unsigned char *) (*macp)->name,
++                                     (const unsigned char *) (*macp)->name,
+                                      strlen((*macp)->name));
+         if(s) {
+             endpoint->mac = *macp;
+@@ -3912,7 +3912,7 @@ static int kex_agree_comp(LIBSSH2_SESSION *session,
+ 
+     while(*compp && (*compp)->name) {
+         s = _libssh2_kex_agree_instr(comp, comp_len,
+-                                     (unsigned char *) (*compp)->name,
++                                     (const unsigned char *) (*compp)->name,
+                                      strlen((*compp)->name));
+         if(s) {
+             endpoint->comp = *compp;
+diff --git a/src/libgcrypt.h b/src/libgcrypt.h
+index e8efc4be..62d607b9 100644
+--- a/src/libgcrypt.h
++++ b/src/libgcrypt.h
+@@ -88,7 +88,7 @@
+ #define libssh2_sha1_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA1, 0))
+ #define libssh2_sha1_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha1_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -99,7 +99,7 @@
+ #define libssh2_sha256_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA256, 0))
+ #define libssh2_sha256_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha256_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA256_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -110,7 +110,7 @@
+ #define libssh2_sha384_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA384, 0))
+ #define libssh2_sha384_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha384_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA384_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -121,7 +121,7 @@
+ #define libssh2_sha512_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_SHA512, 0))
+ #define libssh2_sha512_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_sha512_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), SHA512_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+@@ -133,7 +133,7 @@
+ #define libssh2_md5_init(ctx) \
+     (GPG_ERR_NO_ERROR == gcry_md_open(ctx, GCRY_MD_MD5, 0))
+ #define libssh2_md5_update(ctx, data, len) \
+-    (gcry_md_write(ctx, (unsigned char *) data, len), 1)
++    (gcry_md_write(ctx, data, len), 1)
+ #define libssh2_md5_final(ctx, out) \
+     (memcpy(out, gcry_md_read(ctx, 0), MD5_DIGEST_LENGTH), \
+     gcry_md_close(ctx), 1)
+diff --git a/src/libssh2_priv.h b/src/libssh2_priv.h
+index 9b8866dc..bb1f8ad3 100644
+--- a/src/libssh2_priv.h
++++ b/src/libssh2_priv.h
+@@ -117,6 +117,14 @@
+ #define UINT32_MAX 0xffffffffU
+ #endif
+ 
++#ifdef _WIN64
++#define LIBSSH2_UNCONST(p)  ((void *)(libssh2_uint64_t)(const void *)(p))
++#elif defined(_MSC_VER)
++#define LIBSSH2_UNCONST(p)  ((void *)(unsigned int)(const void *)(p))
++#else
++#define LIBSSH2_UNCONST(p)  ((void *)(uintptr_t)(const void *)(p))
++#endif
++
+ #if (defined(__GNUC__) || defined(__clang__)) && \
+     defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
+     !defined(LIBSSH2_NO_FMT_CHECKS)
+diff --git a/src/mbedtls.c b/src/mbedtls.c
+index a66e36c5..67605ff9 100644
+--- a/src/mbedtls.c
++++ b/src/mbedtls.c
+@@ -476,11 +476,11 @@ _libssh2_mbedtls_rsa_new_private(libssh2_rsa_ctx **rsa,
+     mbedtls_pk_init(&pkey);
+ 
+ #if MBEDTLS_VERSION_NUMBER >= 0x03000000
+-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (char *)passphrase,
++    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase,
+                                    mbedtls_ctr_drbg_random,
+                                    &_libssh2_mbedtls_ctr_drbg);
+ #else
+-    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (char *)passphrase);
++    ret = mbedtls_pk_parse_keyfile(&pkey, filename, (const char *)passphrase);
+ #endif
+     if(ret || mbedtls_pk_get_type(&pkey) != MBEDTLS_PK_RSA) {
+         mbedtls_pk_free(&pkey);
+diff --git a/src/misc.c b/src/misc.c
+index 6c28327c..cd9971a5 100644
+--- a/src/misc.c
++++ b/src/misc.c
+@@ -88,7 +88,7 @@ int _libssh2_error_flags(LIBSSH2_SESSION* session, int errcode,
+     }
+ 
+     if(session->err_flags & LIBSSH2_ERR_FLAG_DUP)
+-        LIBSSH2_FREE(session, (char *)session->err_msg);
++        LIBSSH2_FREE(session, (char *)LIBSSH2_UNCONST(session->err_msg));
+ 
+     session->err_code = errcode;
+     session->err_flags = 0;
+diff --git a/src/openssl.c b/src/openssl.c
+index eba05031..803824df 100644
+--- a/src/openssl.c
++++ b/src/openssl.c
+@@ -78,7 +78,7 @@ static int _libssh2_hmac_init(libssh2_hmac_ctx *ctx,
+     params[0] = OSSL_PARAM_construct_octet_string(
+         OSSL_MAC_PARAM_KEY, (void *)key, keylen);
+     params[1] = OSSL_PARAM_construct_utf8_string(
+-        OSSL_MAC_PARAM_DIGEST, (char *)digest_name, 0);
++        OSSL_MAC_PARAM_DIGEST, (char *)LIBSSH2_UNCONST(digest_name), 0);
+     params[2] = OSSL_PARAM_construct_end();
+ 
+     return EVP_MAC_init(*ctx, NULL, 0, params);
+@@ -487,7 +487,7 @@ _libssh2_rsa_sha2_verify(libssh2_rsa_ctx * rsactx,
+ #else
+ 
+     ret = RSA_verify(nid_type, hash, (unsigned int) hash_len,
+-                     (unsigned char *) sig,
++                     (const unsigned char *) sig,
+                      (unsigned int) sig_len, rsactx);
+ #endif
+ 
+@@ -1192,7 +1192,7 @@ read_private_key_from_memory(void **key_ctx,
+ 
+     *key_ctx = NULL;
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
+     bp = BIO_new_mem_buf(filedata, (int)filedata_len);
+ #else
+     bp = BIO_new_mem_buf((char *)filedata, (int)filedata_len);
+@@ -1202,7 +1202,7 @@ read_private_key_from_memory(void **key_ctx,
+     }
+ 
+     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
+-                                (void *) passphrase);
++                                (void *) LIBSSH2_UNCONST(passphrase));
+ 
+     BIO_free(bp);
+     return (*key_ctx) ? 0 : -1;
+@@ -1226,7 +1226,7 @@ read_private_key_from_file(void **key_ctx,
+     }
+ 
+     *key_ctx = read_private_key(bp, NULL, (pem_password_cb *) passphrase_cb,
+-                                (void *) passphrase);
++                                (void *) LIBSSH2_UNCONST(passphrase));
+ 
+     BIO_free(bp);
+     return (*key_ctx) ? 0 : -1;
+@@ -2437,7 +2437,8 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
+             *key_handle = LIBSSH2_ALLOC(session, *handle_len);
+ 
+             if(key_handle) {
+-                memcpy((void *)*key_handle, handle, *handle_len);
++                memcpy((void *)LIBSSH2_UNCONST(*key_handle),
++                       handle, *handle_len);
+             }
+         }
+     }
+@@ -2477,9 +2478,10 @@ gen_publickey_from_sk_ed25519_openssh_priv_data(LIBSSH2_SESSION *session,
+         _libssh2_store_str(&p, (const char *)app, app_len);
+ 
+         if(application && app_len > 0) {
+-            *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
+-            _libssh2_explicit_zero((void *)*application, app_len + 1);
+-            memcpy((void *)*application, app, app_len);
++            *application = LIBSSH2_ALLOC(session, app_len + 1);
++            _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
++                                   app_len + 1);
++            memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
+         }
+ 
+         memcpy(method_buf, key_type, strlen(key_type));
+@@ -3791,7 +3793,8 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
+             *key_handle = LIBSSH2_ALLOC(session, *handle_len);
+ 
+             if(*key_handle) {
+-                memcpy((void *)*key_handle, handle, *handle_len);
++                memcpy((void *)LIBSSH2_UNCONST(*key_handle),
++                       handle, *handle_len);
+             }
+         }
+     }
+@@ -3829,9 +3832,10 @@ gen_publickey_from_sk_ecdsa_openssh_priv_data(LIBSSH2_SESSION *session,
+         _libssh2_store_str(&p, (const char *)app, app_len);
+ 
+         if(application && app_len > 0) {
+-            *application = (const char *)LIBSSH2_ALLOC(session, app_len + 1);
+-            _libssh2_explicit_zero((void *)*application, app_len + 1);
+-            memcpy((void *)*application, app, app_len);
++            *application = LIBSSH2_ALLOC(session, app_len + 1);
++            _libssh2_explicit_zero((void *)LIBSSH2_UNCONST(*application),
++                                   app_len + 1);
++            memcpy((void *)LIBSSH2_UNCONST(*application), app, app_len);
+         }
+ 
+         LIBSSH2_FREE(session, *pubkeydata);
+@@ -4663,7 +4667,8 @@ _libssh2_pub_priv_keyfile(LIBSSH2_SESSION *session,
+     }
+ 
+     (void)BIO_reset(bp);
+-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
++    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
++                                 (void *)LIBSSH2_UNCONST(passphrase));
+     BIO_free(bp);
+ 
+     if(!pk) {
+@@ -5003,7 +5008,7 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+                    LIBSSH2_TRACE_AUTH,
+                    "Computing public key from private key."));
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
+     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
+ #else
+     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
+@@ -5013,7 +5018,8 @@ _libssh2_pub_priv_keyfilememory(LIBSSH2_SESSION *session,
+                               "Unable to allocate memory when"
+                               "computing public key");
+     (void)BIO_reset(bp);
+-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
++    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
++                                 (void *)LIBSSH2_UNCONST(passphrase));
+ #ifdef HAVE_SSLERROR_BAD_DECRYPT
+     sslError = ERR_get_error();
+ #endif
+@@ -5114,7 +5120,7 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                    LIBSSH2_TRACE_AUTH,
+                    "Computing public key from private key."));
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x1000200fL
++#if OPENSSL_VERSION_NUMBER >= 0x1000200fL || defined(LIBSSH2_WOLFSSL)
+     bp = BIO_new_mem_buf(privatekeydata, (int)privatekeydata_len);
+ #else
+     bp = BIO_new_mem_buf((char *)privatekeydata, (int)privatekeydata_len);
+@@ -5124,7 +5130,8 @@ _libssh2_sk_pub_keyfilememory(LIBSSH2_SESSION *session,
+                               "Unable to allocate memory when"
+                               "computing public key");
+     (void)BIO_reset(bp);
+-    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL, (void *)passphrase);
++    pk = PEM_read_bio_PrivateKey(bp, NULL, NULL,
++                                 (void *)LIBSSH2_UNCONST(passphrase));
+     BIO_free(bp);
+ 
+     if(!pk) {
+diff --git a/src/packet.c b/src/packet.c
+index ebaddae5..606c449c 100644
+--- a/src/packet.c
++++ b/src/packet.c
+@@ -687,7 +687,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 }
+                 else {
+                     const unsigned char *strict =
+-                    (unsigned char *)"kex-strict-s-v00@openssh.com";
++                        (const unsigned char *)"kex-strict-s-v00@openssh.com";
+                     struct string_buf buf;
+                     unsigned char *algs = NULL;
+                     size_t algs_len = 0;
+@@ -1644,7 +1644,7 @@ _libssh2_packet_requirev(LIBSSH2_SESSION *session,
+             }
+         }
+ 
+-        if(strchr((char *) packet_types, ret)) {
++        if(strchr((const char *) packet_types, ret)) {
+             /* Be lazy, let packet_ask pull it out of the brigade */
+             ret = _libssh2_packet_askv(session, packet_types, data,
+                                        data_len, match_ofs, match_buf,
+diff --git a/src/pem.c b/src/pem.c
+index c9ab7746..63372862 100644
+--- a/src/pem.c
++++ b/src/pem.c
+@@ -219,7 +219,7 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
+         /* Perform key derivation (PBKDF1/MD5) */
+         if(!libssh2_md5_init(&fingerprint_ctx) ||
+            !libssh2_md5_update(fingerprint_ctx, passphrase,
+-                               strlen((char *)passphrase)) ||
++                               strlen((const char *)passphrase)) ||
+            !libssh2_md5_update(fingerprint_ctx, iv, 8) ||
+            !libssh2_md5_final(fingerprint_ctx, secret)) {
+             ret = -1;
+@@ -230,7 +230,8 @@ _libssh2_pem_parse(LIBSSH2_SESSION * session,
+                !libssh2_md5_update(fingerprint_ctx,
+                                    secret, MD5_DIGEST_LENGTH) ||
+                !libssh2_md5_update(fingerprint_ctx,
+-                                   passphrase, strlen((char *)passphrase)) ||
++                                   passphrase,
++                                   strlen((const char *)passphrase)) ||
+                !libssh2_md5_update(fingerprint_ctx, iv, 8) ||
+                !libssh2_md5_final(fingerprint_ctx,
+                                   secret + MD5_DIGEST_LENGTH)) {
+@@ -431,7 +432,7 @@ _libssh2_openssh_pem_parse_data(LIBSSH2_SESSION * session,
+         goto out;
+     }
+ 
+-    if(strncmp((char *) decoded.dataptr, AUTH_MAGIC,
++    if(strncmp((const char *) decoded.dataptr, AUTH_MAGIC,
+                strlen(AUTH_MAGIC)) != 0) {
+         ret = _libssh2_error(session, LIBSSH2_ERROR_PROTO,
+                              "key auth magic mismatch");
+diff --git a/src/publickey.c b/src/publickey.c
+index 9c9fa618..9ff2e5cf 100644
+--- a/src/publickey.c
++++ b/src/publickey.c
+@@ -597,7 +597,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
+     /*  19 = packet_len(4) + add_len(4) + "add"(3) + name_len(4) + {name}
+         blob_len(4) + {blob} */
+     unsigned long i, packet_len = 19 + name_len + blob_len;
+-    unsigned char *comment = NULL;
++    const unsigned char *comment = NULL;
+     unsigned long comment_len = 0;
+     int rc;
+ 
+@@ -619,7 +619,7 @@ libssh2_publickey_add_ex(LIBSSH2_PUBLICKEY *pkey, const unsigned char *name,
+                 if(attrs[i].name_len == (sizeof("comment") - 1) &&
+                     strncmp(attrs[i].name, "comment",
+                             sizeof("comment") - 1) == 0) {
+-                    comment = (unsigned char *) attrs[i].value;
++                    comment = (const unsigned char *) attrs[i].value;
+                     comment_len = attrs[i].value_len;
+                     break;
+                 }
+diff --git a/src/session.c b/src/session.c
+index 2d77b05e..945aa649 100644
+--- a/src/session.c
++++ b/src/session.c
+@@ -212,7 +212,7 @@ banner_receive(LIBSSH2_SESSION * session)
+ static int
+ banner_send(LIBSSH2_SESSION * session)
+ {
+-    char *banner = (char *) LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
++    const char *banner = LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF;
+     size_t banner_len = sizeof(LIBSSH2_SSH_DEFAULT_BANNER_WITH_CRLF) - 1;
+     ssize_t ret;
+ 
+@@ -260,7 +260,8 @@ banner_send(LIBSSH2_SESSION * session)
+         _libssh2_debug((session, LIBSSH2_TRACE_SOCKET,
+                        "Sent %ld/%ld bytes at %p+%ld", (long)ret,
+                        (long)(banner_len - session->banner_TxRx_total_send),
+-                       (void *)banner, (long)session->banner_TxRx_total_send));
++                       (const void *)banner,
++                       (long)session->banner_TxRx_total_send));
+ 
+     if(ret != (ssize_t)(banner_len - session->banner_TxRx_total_send)) {
+         if(ret >= 0 || ret == -EAGAIN) {
+@@ -1158,7 +1159,7 @@ session_free(LIBSSH2_SESSION *session)
+     /* error string */
+     if(session->err_msg &&
+        ((session->err_flags & LIBSSH2_ERR_FLAG_DUP) != 0)) {
+-        LIBSSH2_FREE(session, (char *)session->err_msg);
++        LIBSSH2_FREE(session, (char *)LIBSSH2_UNCONST(session->err_msg));
+     }
+ 
+     LIBSSH2_FREE(session, session);
+@@ -1272,31 +1273,31 @@ libssh2_session_methods(LIBSSH2_SESSION * session, int method_type)
+         break;
+ 
+     case LIBSSH2_METHOD_HOSTKEY:
+-        method = (LIBSSH2_KEX_METHOD *) session->hostkey;
++        method = (const LIBSSH2_KEX_METHOD *) session->hostkey;
+         break;
+ 
+     case LIBSSH2_METHOD_CRYPT_CS:
+-        method = (LIBSSH2_KEX_METHOD *) session->local.crypt;
++        method = (const LIBSSH2_KEX_METHOD *) session->local.crypt;
+         break;
+ 
+     case LIBSSH2_METHOD_CRYPT_SC:
+-        method = (LIBSSH2_KEX_METHOD *) session->remote.crypt;
++        method = (const LIBSSH2_KEX_METHOD *) session->remote.crypt;
+         break;
+ 
+     case LIBSSH2_METHOD_MAC_CS:
+-        method = (LIBSSH2_KEX_METHOD *) session->local.mac;
++        method = (const LIBSSH2_KEX_METHOD *) session->local.mac;
+         break;
+ 
+     case LIBSSH2_METHOD_MAC_SC:
+-        method = (LIBSSH2_KEX_METHOD *) session->remote.mac;
++        method = (const LIBSSH2_KEX_METHOD *) session->remote.mac;
+         break;
+ 
+     case LIBSSH2_METHOD_COMP_CS:
+-        method = (LIBSSH2_KEX_METHOD *) session->local.comp;
++        method = (const LIBSSH2_KEX_METHOD *) session->local.comp;
+         break;
+ 
+     case LIBSSH2_METHOD_COMP_SC:
+-        method = (LIBSSH2_KEX_METHOD *) session->remote.comp;
++        method = (const LIBSSH2_KEX_METHOD *) session->remote.comp;
+         break;
+ 
+     case LIBSSH2_METHOD_LANG_CS:
+@@ -1351,7 +1352,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
+                 }
+             }
+             else {
+-                *errmsg = (char *) "";
++                *errmsg = (char *)LIBSSH2_UNCONST("");
+             }
+         }
+         if(errmsg_len) {
+@@ -1374,7 +1375,7 @@ libssh2_session_last_error(LIBSSH2_SESSION * session, char **errmsg,
+             }
+         }
+         else
+-            *errmsg = (char *)error;
++            *errmsg = (char *)LIBSSH2_UNCONST(error);
+     }
+ 
+     if(errmsg_len) {
+diff --git a/src/sftp.c b/src/sftp.c
+index 43b6ff90..d2c391d0 100644
+--- a/src/sftp.c
++++ b/src/sftp.c
+@@ -675,7 +675,7 @@ sftp_bin2attr(LIBSSH2_SFTP_ATTRIBUTES *attrs, const unsigned char *p,
+ {
+     struct string_buf buf;
+     uint32_t flags = 0;
+-    buf.data = (unsigned char *)p;
++    buf.data = (unsigned char *)LIBSSH2_UNCONST(p);
+     buf.dataptr = buf.data;
+     buf.len = data_len;
+ 
+diff --git a/src/userauth.c b/src/userauth.c
+index 588b83f2..a8e15b47 100644
+--- a/src/userauth.c
++++ b/src/userauth.c
+@@ -107,7 +107,7 @@ static char *userauth_list(LIBSSH2_SESSION *session, const char *username,
+     if(session->userauth_list_state == libssh2_NB_state_created) {
+         rc = _libssh2_transport_send(session, session->userauth_list_data,
+                                      session->userauth_list_data_len,
+-                                     (unsigned char *)"none", 4);
++                                     (const unsigned char *)"none", 4);
+         if(rc == LIBSSH2_ERROR_EAGAIN) {
+             _libssh2_error(session, LIBSSH2_ERROR_EAGAIN,
+                            "Would block requesting userauth list");
+@@ -487,7 +487,8 @@ password_response:
+                         _libssh2_store_str(&s, "password",
+                                            sizeof("password") - 1);
+                         *s++ = 0x01;
+-                        _libssh2_store_str(&s, (char *)password, password_len);
++                        _libssh2_store_str(&s, (const char *)password,
++                                           password_len);
+                         _libssh2_store_u32(&s,
+                                            session->userauth_pswd_newpw_len);
+                         /* send session->userauth_pswd_newpw separately */
+@@ -500,7 +501,7 @@ password_response:
+                         rc = _libssh2_transport_send(session,
+                                             session->userauth_pswd_data,
+                                             session->userauth_pswd_data_len,
+-                                            (unsigned char *)
++                                            (const unsigned char *)
+                                             session->userauth_pswd_newpw,
+                                             session->userauth_pswd_newpw_len);
+                         if(rc == LIBSSH2_ERROR_EAGAIN) {
+@@ -565,7 +566,8 @@ libssh2_userauth_password_ex(LIBSSH2_SESSION *session, const char *username,
+     int rc;
+     BLOCK_ADJUST(rc, session,
+                  userauth_password(session, username, username_len,
+-                                   (unsigned char *)password, password_len,
++                                   (const unsigned char *)password,
++                                   password_len,
+                                    passwd_change_cb));
+     return rc;
+ }
+@@ -776,7 +778,7 @@ memory_read_privatekey(LIBSSH2_SESSION * session,
+ 
+     if((*hostkey_method)->
+         initPEMFromMemory(session, privkeyfiledata, privkeyfiledata_len,
+-                          (unsigned char *) passphrase,
++                          (const unsigned char *) passphrase,
+                           hostkey_abstract)) {
+         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
+                               "Unable to initialize private key from memory");
+@@ -817,7 +819,7 @@ file_read_privatekey(LIBSSH2_SESSION * session,
+     }
+ 
+     if((*hostkey_method)->
+-        initPEM(session, privkeyfile, (unsigned char *) passphrase,
++        initPEM(session, privkeyfile, (const unsigned char *) passphrase,
+                 hostkey_abstract)) {
+         return _libssh2_error(session, LIBSSH2_ERROR_FILE,
+                               "Unable to initialize private key from file");
+@@ -857,7 +859,7 @@ sign_frommemory(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
+         return rc;
+ 
+     libssh2_prepare_iovec(&datavec, 1);
+-    datavec.iov_base = (void *)data;
++    datavec.iov_base = (void *)LIBSSH2_UNCONST(data);
+     datavec.iov_len  = data_len;
+ 
+     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
+@@ -893,7 +895,7 @@ sign_fromfile(LIBSSH2_SESSION *session, unsigned char **sig, size_t *sig_len,
+         return rc;
+ 
+     libssh2_prepare_iovec(&datavec, 1);
+-    datavec.iov_base = (void *)data;
++    datavec.iov_base = (void *)LIBSSH2_UNCONST(data);
+     datavec.iov_len  = data_len;
+ 
+     if(privkeyobj->signv(session, sig, sig_len, 1, &datavec,
+@@ -2463,7 +2465,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                 LIBSSH2_FREE(session, tmp_method);
+             }
+ 
+-            if(!strncmp((char *)publickeydata, ecdsa, strlen(ecdsa))) {
++            if(!strncmp((const char *)publickeydata, ecdsa, strlen(ecdsa))) {
+                 session->userauth_pblc_method_len = strlen(ecdsa);
+                 session->userauth_pblc_method =
+                     LIBSSH2_ALLOC(session, session->userauth_pblc_method_len);
+@@ -2471,7 +2473,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                 memcpy(session->userauth_pblc_method, ecdsa,
+                        session->userauth_pblc_method_len);
+             }
+-            else if(!strncmp((char *)publickeydata, ed25519,
++            else if(!strncmp((const char *)publickeydata, ed25519,
+                              strlen(ed25519))) {
+                 session->userauth_pblc_method_len = strlen(ed25519);
+                 session->userauth_pblc_method =
+@@ -2485,7 +2487,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+                                        &session->userauth_pblc_method,
+                                        &session->userauth_pblc_method_len,
+                                        &pubkeydata, &pubkeydata_len,
+-                                       (char *)publickeydata,
++                                       (const char *)publickeydata,
+                                        publickeydata_len);
+         }
+     }
+@@ -2510,7 +2512,7 @@ libssh2_userauth_publickey_sk(LIBSSH2_SESSION *session,
+         LIBSSH2_FREE(session, tmp_publickeydata);
+ 
+     if(sk_info.application) {
+-        LIBSSH2_FREE(session, (void *)sk_info.application);
++        LIBSSH2_FREE(session, (void *)LIBSSH2_UNCONST(sk_info.application));
+     }
+ 
+     return rc;
+diff --git a/src/wincng.c b/src/wincng.c
+index 5d4b36b7..edad04f1 100644
+--- a/src/wincng.c
++++ b/src/wincng.c
+@@ -431,7 +431,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlgAES_CBC,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_CBC,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_CBC),
+                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgAES_CBC, 0);
+@@ -446,7 +446,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlgAES_ECB,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_ECB,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_ECB),
+                                 sizeof(BCRYPT_CHAIN_MODE_ECB), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgAES_ECB, 0);
+@@ -461,7 +461,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlgRC4_NA,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_NA,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_NA),
+                                 sizeof(BCRYPT_CHAIN_MODE_NA), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlgRC4_NA, 0);
+@@ -476,7 +476,7 @@ _libssh2_wincng_init(void)
+     if(BCRYPT_SUCCESS(ret)) {
+         ret = BCryptSetProperty(_libssh2_wincng.hAlg3DES_CBC,
+                                 BCRYPT_CHAINING_MODE,
+-                                (PBYTE)BCRYPT_CHAIN_MODE_CBC,
++                                (PBYTE)LIBSSH2_UNCONST(BCRYPT_CHAIN_MODE_CBC),
+                                 sizeof(BCRYPT_CHAIN_MODE_CBC), 0);
+         if(!BCRYPT_SUCCESS(ret)) {
+             ret = BCryptCloseAlgorithmProvider(_libssh2_wincng.hAlg3DES_CBC,
+@@ -676,7 +676,8 @@ _libssh2_wincng_hash_update(_libssh2_wincng_hash_ctx *ctx,
+ {
+     int ret;
+ 
+-    ret = BCryptHashData(ctx->hHash, (PUCHAR)data, datalen, 0);
++    ret = BCryptHashData(ctx->hHash,
++                         (PUCHAR)LIBSSH2_UNCONST(data), datalen, 0);
+ 
+     return BCRYPT_SUCCESS(ret) ? 0 : -1;
+ }
+@@ -2887,9 +2888,9 @@ _libssh2_wincng_ecdsa_new_private_frommemory(
+     }
+ 
+     data_buffer.len = data_len;
+-    data_buffer.data = (unsigned char *)data;
+-    data_buffer.dataptr =
+-        (unsigned char *)data + strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
++    data_buffer.data = (unsigned char *)LIBSSH2_UNCONST(data);
++    data_buffer.dataptr = data_buffer.data +
++                          strlen(OPENSSL_PRIVATEKEY_AUTH_MAGIC) + 1;
+ 
+     /* Read ciphername, should be 'none' as we don't support passphrases */
+     result = _libssh2_match_string(&data_buffer, "none");
+-- 
+2.52.0
+

--- a/runtime-optenv32/libssh2+32/spec
+++ b/runtime-optenv32/libssh2+32/spec
@@ -1,4 +1,5 @@
 VER=1.11.1
+REL=1
 SRCS="git::commit=tags/libssh2-${VER}::https://github.com/libssh2/libssh2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1730"

--- a/topics/libssh2-1.11.1-security-fixes-20260626.toml
+++ b/topics/libssh2-1.11.1-security-fixes-20260626.toml
@@ -1,0 +1,14 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libssh2 1.11.1, Revision 1"
+zh_CN = "libssh2 1.11.1，修订 1"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (1 of Critical severity, 3 of High severity)"
+zh_CN = "修复 4 个安全漏洞（含 1 个严重漏洞，3 个高危漏洞）"
+
+[packages-v2]
+"libssh2" = "< 1.11.1-1"
+"libssh2+32" = "< 1.11.1-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add libssh2-1.11.1-security-fixes-20260626.toml
- libssh2+32: fix CVE-2026-7598, CVE-2025-15661, CVE-2026-55199, and CVE-2026-55200
    Track patches at AOSC-Tracking/libssh2 @ aosc/libssh2-1.11.1
    \(HEAD: a1d36ccc365d6941cd63102348966e7444365639\).
- libssh2: fix CVE-2026-7598, CVE-2025-15661, CVE-2026-55199, and CVE-2026-55200
    Track patches at AOSC-Tracking/libssh2 @ aosc/libssh2-1.11.1
    \(HEAD: a1d36ccc365d6941cd63102348966e7444365639\).

Package(s) Affected
-------------------

- libssh2: 1.11.1-1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libssh2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
