### PR TITLE
nsd: update to 4.14.3

### DIFF
--- a/app-network/nsd/autobuild/beyond
+++ b/app-network/nsd/autobuild/beyond
@@ -8,8 +8,8 @@ for name in control server; do
         touch "$PKGDIR"/etc/nsd/nsd_${name}.${extension}
     done
 done
-mkdir -pv "$PKGDIR"/etc/nsd/conf.d
-mkdir -pv "$PKGDIR"/etc/nsd/server.d
+install -dvm755 \
+    "$PKGDIR"/etc/nsd/{conf,server}.d
 
 abinfo "Removing extraenous /tmp ..."
 rm -rv "$PKGDIR"/tmp

--- a/app-network/nsd/autobuild/defines
+++ b/app-network/nsd/autobuild/defines
@@ -1,16 +1,22 @@
 PKGNAME=nsd
 PKGSEC=net
 PKGDEP="libevent openssl systemd"
-PKGDES="Fast and lean authoritative DNS Name Server"
+PKGDES="Authoritative DNS name server"
 
-AUTOTOOLS_AFTER="--enable-bind8-stats \
-                 --enable-checking \
-                 --enable-nsec3 \
-                 --with-pidfile=/run/nsd/nsd.pid \
-                 --with-zonelistfile=/var/lib/nsd/zone.list \
-                 --with-ssl \
-                 --with-user=nsd \
-                 --with-xfrdfile=/var/lib/nsd/ixfr.state \
-                 --with-dbfile= \
-                 --enable-ratelimit"
-ABSHADOW=0
+ABTYPE=autotools
+# Note: Multi-level source tree.
+#
+# configure: error: unrecognized options: --enable-bind8-stats, --enable-checking, --enable-nsec3, --with-pidfile, --with-zonelistfile, --with-ssl, --with-user, --with-xfrdfile, --with-dbfile, --enable-ratelimit
+AUTOTOOLS_STRICT=0
+AUTOTOOLS_AFTER=(
+    '--enable-bind8-stats'
+    '--enable-checking'
+    '--enable-nsec3'
+    '--with-pidfile=/run/nsd/nsd.pid'
+    '--with-zonelistfile=/var/lib/nsd/zone.list'
+    '--with-ssl'
+    '--with-user=nsd'
+    '--with-xfrdfile=/var/lib/nsd/ixfr.state'
+    '--with-dbfile='
+    '--enable-ratelimit'
+)

--- a/app-network/nsd/autobuild/overrides/usr/lib/sysusers.d/nsd.conf
+++ b/app-network/nsd/autobuild/overrides/usr/lib/sysusers.d/nsd.conf
@@ -1,0 +1,1 @@
+u nsd - 'NSD Daemon Owner' /etc/nsd -

--- a/app-network/nsd/autobuild/postinst
+++ b/app-network/nsd/autobuild/postinst
@@ -1,4 +1,1 @@
-getent group nsd >/dev/null || groupadd -r nsd
-getent passwd nsd >/dev/null || \
-useradd -r -g nsd -d /etc/nsd -s /sbin/nologin \
-    -c "nsd daemon owner" nsd
+systemd-sysusers nsd.conf

--- a/app-network/nsd/spec
+++ b/app-network/nsd/spec
@@ -1,4 +1,4 @@
-VER=4.7.0
+VER=4.14.3
 SRCS="tbl::https://www.nlnetlabs.nl/downloads/nsd/nsd-$VER.tar.gz"
-CHKSUMS="sha256::8faca44e299ad2915fa000887ab1632631ea68709c62ce35f110bfe721ecf214"
+CHKSUMS="sha256::9629ad64d9c1b019bbe22296d5148d7ae65f588ce265a6424750740f052bb12b"
 CHKUPDATE="anitya::id=2500"

--- a/topics/nsd-4.14.3.toml
+++ b/topics/nsd-4.14.3.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "NLnet Labs Name Server Daemon 4.14.3"
+zh_CN = "NLnet Labs 名称服务器守护程序 4.14.3"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (4 of High severity)"
+zh_CN = "修复 4 个安全漏洞（含 4 个高危漏洞）"
+
+[packages-v2]
+"nsd" = "< 4.14.3"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add nsd-4.14.3.toml
- nsd: update to 4.14.3
    - Clean up scripts in accordance with the Styling Manual.
    - Use systemd-sysusers.

Package(s) Affected
-------------------

- nsd: 4.14.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit nsd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
