### PR TITLE
nvidia+580: update to 580.173.02

### DIFF
--- a/runtime-display/nvidia+580/spec
+++ b/runtime-display/nvidia+580/spec
@@ -1,8 +1,8 @@
-VER=580.159.04
+VER=580.173.02
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::c1e66761b088d17b3adf6cb6979de9af38be2684d102b001a176dcfafabdca1e"
+CHKSUMS__AMD64="sha256::8d8eb9001e05a9a8a663d3d5d304feb64ef2844ee185ccdfd952786820f46e1b"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::8912f2623bc7c839765f36fcee3db4a3531834a2caff3aa5d49c1259b2372aeb"
+CHKSUMS__ARM64="sha256::d65bd56087ef4d78f04a808da7883c35a5901c5fd37e95d150a7602eba97aa80"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=387790"


### PR DESCRIPTION
Topic Description
-----------------

- nvidia+580: update to 580.173.02
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- nvidia+580: 580.173.02
- nvidia-firmware+580: 580.173.02
- nvidia-utils+580: 580.173.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia+580
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
