### PR TITLE
topics: add DirtyClone to linux-kernel-7.0.y.toml

### DIFF
--- a/topics/linux-kernel-7.0.y.toml
+++ b/topics/linux-kernel-7.0.y.toml
@@ -1,12 +1,12 @@
-security = false
+security = true
 
 [name]
 default = "Linux Kernel 7.0"
 zh_CN = "Linux 内核，版本 7.0"
 
 [caution]
-default = "Includes support for new devices and functionality fixes, notably, this update fixes dynamic frequency scaling and boosting on LoongArch-based platforms (when used in conjunction with UEFI firmware versions 202605 or newer that includes preliminary mainline-compatible SMC patch), fixes NVMe command timeouts and boot hangs on Loongson 7A1000-based platforms (mostly MIPS-based Loongson 3A4000/3B4000 systems), and continues to improve support for CIX Technology's P1 (SKY1) SoCs"
-zh_CN = "包含大量新设备支持及功能修复，较为重要的更新包括修复龙架构平台动态调频调压及睿频 (Boost) 支持（须搭配带有主线兼容的 SMC 补丁的，版本为 202605 或更新的 UEFI 固件使用），修复龙芯 7A1000 平台（主要是基于 MIPS 的龙芯 3A4000/3B4000 设备）上的 NVMe 指令超时及启动时死机问题，并继续改进对此芯科技 P1 (SKY1) SoC 的支持"
+default = "Includes support for new devices and functionality fixes, notably, this update fixes dynamic frequency scaling and boosting on LoongArch-based platforms (when used in conjunction with UEFI firmware versions 202605 or newer that includes preliminary mainline-compatible SMC patch), fixes NVMe command timeouts and boot hangs on Loongson 7A1000-based platforms (mostly MIPS-based Loongson 3A4000/3B4000 systems), and continues to improve support for CIX Technology's P1 (SKY1) SoCs. Also fixes a Local Privilege Escalation vulnerability codenamed \"DirtyClone\" (CVE-2026-43503, Severity: High)"
+zh_CN = "包含大量新设备支持及功能修复，较为重要的更新包括修复龙架构平台动态调频调压及睿频 (Boost) 支持（须搭配带有主线兼容的 SMC 补丁的，版本为 202605 或更新的 UEFI 固件使用），修复龙芯 7A1000 平台（主要是基于 MIPS 的龙芯 3A4000/3B4000 设备）上的 NVMe 指令超时及启动时死机问题，并继续改进对此芯科技 P1 (SKY1) SoC 的支持；本版内核还修复了一个代号为 \"DirtyClone\" 的本地提权漏洞（CVE-2026-43503，严重性：高）"
 
 [packages-v2]
 "linux+kernel" = "< 3:7.0.11"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add DirtyClone to linux-kernel-7.0.y.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
