### PR TITLE
corefreq: update to 2.1.2

### DIFF
--- a/app-utils/corefreq/spec
+++ b/app-utils/corefreq/spec
@@ -1,4 +1,4 @@
-VER=2.1.1
+VER=2.1.2
 SRCS="git::commit=tags/$VER::https://github.com/cyring/CoreFreq"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231571"


### PR DESCRIPTION
Topic Description
-----------------

- corefreq: update to 2.1.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- corefreq: 1:2.1.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit corefreq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
