### PR TITLE
ipython: update to 9.15.0

### DIFF
--- a/lang-python/ipython/spec
+++ b/lang-python/ipython/spec
@@ -1,4 +1,4 @@
-VER=9.14.1
+VER=9.15.0
 SRCS="tbl::https://pypi.io/packages/source/i/ipython/ipython-$VER.tar.gz"
-CHKSUMS="sha256::f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b"
+CHKSUMS="sha256::da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756"
 CHKUPDATE="anitya::id=1399"


### PR DESCRIPTION
Topic Description
-----------------

- ipython: update to 9.15.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ipython: 9.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
