### PR TITLE
systemd-boot-friend: update to 0.28.0

### DIFF
--- a/app-admin/systemd-boot-friend/spec
+++ b/app-admin/systemd-boot-friend/spec
@@ -1,4 +1,4 @@
-VER=0.27.5
+VER=0.28.0
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/systemd-boot-friend-rs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226819"


### PR DESCRIPTION
Topic Description
-----------------

- systemd-boot-friend: update to 0.28.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- systemd-boot-friend: 0.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit systemd-boot-friend
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
