### PR TITLE
hmcl: update to 3.15.2

### DIFF
--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,5 +1,4 @@
-VER=3.14.1
+VER=3.15.2
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKUPDATE="anitya::id=371893"
 CHKSUMS="SKIP"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.15.2
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- hmcl: 3.15.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
