### PR TITLE
intel-cmt-cat: new, 26.06

### DIFF
--- a/app-admin/intel-cmt-cat/autobuild/build
+++ b/app-admin/intel-cmt-cat/autobuild/build
@@ -1,0 +1,9 @@
+abinfo "Building intel-cmt-cat ..."
+make PREFIX="$PKGDIR"/usr
+
+abinfo "Installing intel-cmt-cat ..."
+make install PREFIX="$PKGDIR"/usr
+
+abinfo "Moving manpage ..."
+mkdir -pv "$PKGDIR"/usr/share
+mv -v "$PKGDIR"/usr/man "$PKGDIR"/usr/share/man

--- a/app-admin/intel-cmt-cat/autobuild/defines
+++ b/app-admin/intel-cmt-cat/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=intel-cmt-cat
+PKGSEC=admin
+PKGDES="User space software for Intel(R) Resource Director Technology "
+PKGDEP="glibc"
+
+# Note: Intel RDT is x86 only
+FAIL_ARCH="!(amd64)"

--- a/app-admin/intel-cmt-cat/spec
+++ b/app-admin/intel-cmt-cat/spec
@@ -1,0 +1,4 @@
+VER=26.06
+SRCS="git::commit=tags/v$VER::https://github.com/intel/intel-cmt-cat.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=378569"


### PR DESCRIPTION
Topic Description
-----------------

- intel-cmt-cat: new, 26.06

Package(s) Affected
-------------------

- intel-cmt-cat: 26.06

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-cmt-cat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
