### PR TITLE
endless-sky: update to 0.11.2

### DIFF
--- a/app-games/endless-sky/autobuild/defines
+++ b/app-games/endless-sky/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=endless-sky
 PKGSEC=games
 PKGDES="Space exploration, trading, and combat game"
-PKGDEP="sdl2 libpng zlib libjpeg-turbo openal-soft libmad util-linux-runtime \
+# FIXME: use SDL3 after https://github.com/endless-sky/endless-sky/pull/12400 merged
+PKGDEP="sdl2-compat libpng zlib libjpeg-turbo libavif openal-soft libmad util-linux-runtime \
         libglvnd glew gcc-runtime glibc x11-lib libxcb libxau libxdmcp minizip flac"
 
 # Note: test require Catch2

--- a/app-games/endless-sky/autobuild/defines
+++ b/app-games/endless-sky/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=endless-sky
 PKGSEC=games
 PKGDES="Space exploration, trading, and combat game"
-PKGDEP="sdl2 libpng zlib libjpeg-turbo openal-soft libmad util-linux-runtime \
+PKGDEP="sdl2 libpng zlib libjpeg-turbo libavif openal-soft libmad util-linux-runtime \
         libglvnd glew gcc-runtime glibc x11-lib libxcb libxau libxdmcp minizip flac"
 
 # Note: test require Catch2

--- a/app-games/endless-sky/spec
+++ b/app-games/endless-sky/spec
@@ -1,4 +1,4 @@
-VER=0.10.14
+VER=0.11.2
 SRCS="git::commit=tags/v$VER::https://github.com/endless-sky/endless-sky.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10359"


### PR DESCRIPTION
Topic Description
-----------------

- endless-sky: update to 0.11.2
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- endless-sky: 0.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit endless-sky
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
