### PR TITLE
anki: new, 26.05

### DIFF
--- a/app-productivity/anki/autobuild/build
+++ b/app-productivity/anki/autobuild/build
@@ -1,0 +1,16 @@
+abinfo "Building runner binary ..."
+cargo build -p runner --release
+
+abinfo "Building wheels ..."
+"$SRCDIR"/out/rust/release/runner build -- wheels -v
+
+abinfo "Installing Python wheels ..."
+for file in "$SRCDIR"/out/wheels/*.whl; do
+    python3 -m installer --destdir="$PKGDIR" "$file"
+done
+
+abinfo "Installing desktop integration files ..."
+install -vDm644 -t "$PKGDIR"/usr/share/applications "$SRCDIR"/qt/launcher/lin/anki.desktop
+install -vDm644 -t "$PKGDIR"/usr/share/pixmaps "$SRCDIR"/qt/launcher/lin/anki.png "$SRCDIR"/qt/launcher/lin/anki.xpm
+install -vDm644 -t "$PKGDIR"/usr/share/man/man1 "$SRCDIR"/qt/launcher/lin/anki.1
+install -vDm644 -t "$PKGDIR"/usr/share/mime/packages "$SRCDIR"/qt/launcher/lin/anki.xml

--- a/app-productivity/anki/autobuild/defines
+++ b/app-productivity/anki/autobuild/defines
@@ -1,0 +1,16 @@
+PKGNAME=anki
+PKGSEC=doc
+PKGDEP="python-3 gcc-runtime glibc beautifulsoup4 decorator distro flask \
+        flask-cors jsonschema markdown orjson python-protobuf pyqt6 \
+        pyqt6-webengine pysocks requests send2trash waitress qt-6 sqlite \
+        zstd mpv"
+BUILDDEP="cargo rustc git ninja protobuf python-installer wheel rsync uv \
+          nodejs yarn llvm"
+PKGDES="Repetition flashcard program"
+ABTYPE=self
+# FIXME: anki only supports amd64 and arm64 officially
+FAIL_ARCH="!(amd64|arm64|loongarch64)"
+# FIXME: Build fails with LTO
+# ld.lld: error: undefined symbol: ring_core_0_17_14__LIMBS_less_than
+NOLTO=1
+NOPYTHON2=1

--- a/app-productivity/anki/autobuild/patches/0001-Disable-corepack-yarn-setup-in-build-system.patch
+++ b/app-productivity/anki/autobuild/patches/0001-Disable-corepack-yarn-setup-in-build-system.patch
@@ -1,0 +1,39 @@
+From b78f9948a89e0a75d144df235782172e439fe171 Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Sun, 28 Jun 2026 16:48:37 +0800
+Subject: [PATCH 1/6] Disable corepack yarn setup in build system
+
+Use no-corepack.patch from Arch Linux
+---
+ build/ninja_gen/src/node.rs | 2 +-
+ package.json                | 3 +--
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/build/ninja_gen/src/node.rs b/build/ninja_gen/src/node.rs
+index 38baa8f62..0e80b24a0 100644
+--- a/build/ninja_gen/src/node.rs
++++ b/build/ninja_gen/src/node.rs
+@@ -52,7 +52,7 @@ impl BuildAction for YarnSetup {
+         if cfg!(windows) {
+             "corepack.cmd enable yarn"
+         } else {
+-            "corepack enable yarn"
++            "true"
+         }
+     }
+ 
+diff --git a/package.json b/package.json
+index f67d62dd3..ebfe07dbd 100644
+--- a/package.json
++++ b/package.json
+@@ -99,6 +99,5 @@
+         "Chrome 77",
+         "iOS 14.5"
+     ],
+-    "type": "module",
+-    "packageManager": "yarn@4.11.0"
++    "type": "module"
+ }
+-- 
+2.52.0
+

--- a/app-productivity/anki/autobuild/patches/0002-Remove-auto-formatting-step-from-hooks-generation.patch
+++ b/app-productivity/anki/autobuild/patches/0002-Remove-auto-formatting-step-from-hooks-generation.patch
@@ -1,0 +1,22 @@
+From 9197fdb2c1b2a6427024a8f996b1a53498c7b0ba Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Sun, 28 Jun 2026 16:48:38 +0800
+Subject: [PATCH 2/6] Remove auto-formatting step from hooks generation
+
+Use strip-formatter-deps.patch from Arch Linux
+---
+ pylib/tools/hookslib.py | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/pylib/tools/hookslib.py b/pylib/tools/hookslib.py
+index 99f08fa1e..9f60ae9dc 100644
+--- a/pylib/tools/hookslib.py
++++ b/pylib/tools/hookslib.py
+@@ -205,4 +205,3 @@ def write_file(path: str, hooks: list[Hook], prefix: str, suffix: str):
+ 
+     with open(path, "wb") as file:
+         file.write(code.encode("utf8"))
+-    subprocess.run([sys.executable, "-m", "ruff", "format", "-q", path], check=True)
+-- 
+2.52.0
+

--- a/app-productivity/anki/autobuild/patches/0003-Use-.version-file-for-SvelteKit-version-for-reproduc.patch
+++ b/app-productivity/anki/autobuild/patches/0003-Use-.version-file-for-SvelteKit-version-for-reproduc.patch
@@ -1,0 +1,35 @@
+From ba9f36539f0e85134fc4d4466bf88612ded9dadd Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Sun, 28 Jun 2026 16:48:38 +0800
+Subject: [PATCH 3/6] Use .version file for SvelteKit version for reproducible
+ builds
+
+Use reproducible-sveltekit.patch from Arch Linux
+---
+ ts/svelte.config.js | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/ts/svelte.config.js b/ts/svelte.config.js
+index 874bb9cec..ea836df30 100644
+--- a/ts/svelte.config.js
++++ b/ts/svelte.config.js
+@@ -1,5 +1,6 @@
+ import adapter from "@sveltejs/adapter-static";
+ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
++import { readFileSync } from "fs";
+ import { dirname, join } from "path";
+ import preprocess from "svelte-preprocess";
+ import { fileURLToPath } from "url";
+@@ -17,6 +18,9 @@ const config = {
+         adapter: adapter(
+             { pages: "../out/sveltekit", fallback: "index.html", precompress: false },
+         ),
++        version: {
++            name: readFileSync(join(tsFolder, "../.version"), "utf-8").trim(),
++        },
+         alias: {
+             "@tslib": join(tsFolder, "lib/tslib"),
+             "@generated": join(tsFolder, "../out/ts/lib/generated"),
+-- 
+2.52.0
+

--- a/app-productivity/anki/autobuild/patches/0004-Strip-mypy-protobuf-type-checking-dependencies-from-.patch
+++ b/app-productivity/anki/autobuild/patches/0004-Strip-mypy-protobuf-type-checking-dependencies-from-.patch
@@ -1,0 +1,35 @@
+From 1c3bc4a5ab8ef1c9a649d899f30b8c6b99b90421 Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Sun, 28 Jun 2026 16:48:38 +0800
+Subject: [PATCH 4/6] Strip mypy-protobuf type-checking dependencies from build
+
+Use strip-type-checking-deps.patch from Arch Linux
+---
+ build/configure/src/python.rs | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/build/configure/src/python.rs b/build/configure/src/python.rs
+index 947582fa4..fd5e9479d 100644
+--- a/build/configure/src/python.rs
++++ b/build/configure/src/python.rs
+@@ -88,9 +88,7 @@ pub struct GenPythonProto {
+ impl BuildAction for GenPythonProto {
+     fn command(&self) -> &str {
+         "$protoc $
+-        --plugin=protoc-gen-mypy=$protoc-gen-mypy $
+         --python_out=$builddir/pylib $
+-        --mypy_out=$builddir/pylib $
+         -Iproto $in"
+     }
+ 
+@@ -108,7 +106,6 @@ impl BuildAction for GenPythonProto {
+             .collect();
+         build.add_inputs("in", &self.proto_files);
+         build.add_inputs("protoc", inputs![":protoc_binary"]);
+-        build.add_inputs("protoc-gen-mypy", inputs![":pyenv:protoc-gen-mypy"]);
+         build.add_outputs("", python_outputs);
+     }
+ 
+-- 
+2.52.0
+

--- a/app-productivity/anki/autobuild/patches/0005-Add-LoongArch64-architecture-support.patch
+++ b/app-productivity/anki/autobuild/patches/0005-Add-LoongArch64-architecture-support.patch
@@ -1,0 +1,163 @@
+From 7e34dfe2a72fbba5bf25f4b91622a400e9d42abe Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Sun, 28 Jun 2026 16:49:45 +0800
+Subject: [PATCH 5/6] Add LoongArch64 architecture support
+
+Use deepseek-v4-pro for add new architecture support and review by myself
+---
+ build/configure/src/platform.rs |  3 +++
+ build/configure/src/python.rs   |  1 +
+ build/ninja_gen/src/archives.rs |  5 ++++-
+ build/ninja_gen/src/node.rs     |  4 ++++
+ build/ninja_gen/src/protobuf.rs | 13 +++++++++++++
+ build/ninja_gen/src/python.rs   |  6 ++++++
+ qt/launcher/src/platform/mod.rs |  2 ++
+ 7 files changed, 33 insertions(+), 1 deletion(-)
+
+diff --git a/build/configure/src/platform.rs b/build/configure/src/platform.rs
+index 3b0dd88e1..d6fb6a839 100644
+--- a/build/configure/src/platform.rs
++++ b/build/configure/src/platform.rs
+@@ -13,11 +13,14 @@ pub fn overriden_rust_target_triple() -> Option<&'static str> {
+ /// Usually None to use the host architecture, but:
+ /// If MAC_X86 is set, an X86 wheel will be built on macOS ARM.
+ /// If LIN_ARM64 is set, an ARM64 wheel will be built on Linux AMD64.
++/// If LIN_LOONG64 is set, a LoongArch64 wheel will be built on Linux AMD64.
+ pub fn overriden_python_wheel_platform() -> Option<Platform> {
+     if env::var("MAC_X86").is_ok() {
+         Some(Platform::MacX64)
+     } else if env::var("LIN_ARM64").is_ok() {
+         Some(Platform::LinuxArm)
++    } else if env::var("LIN_LOONG64").is_ok() {
++        Some(Platform::LinuxLoong64)
+     } else {
+         None
+     }
+diff --git a/build/configure/src/python.rs b/build/configure/src/python.rs
+index fd5e9479d..5180b2193 100644
+--- a/build/configure/src/python.rs
++++ b/build/configure/src/python.rs
+@@ -156,6 +156,7 @@ impl BuildAction for BuildWheel {
+                 Platform::MacArm => "macosx_12_0_arm64",
+                 Platform::WindowsX64 => "win_amd64",
+                 Platform::WindowsArm => "win_arm64",
++                Platform::LinuxLoong64 => "manylinux_2_36_loongarch64",
+             };
+             format!("cp310-abi3-{platform_tag}")
+         } else {
+diff --git a/build/ninja_gen/src/archives.rs b/build/ninja_gen/src/archives.rs
+index 3d2120b06..bfa34edd4 100644
+--- a/build/ninja_gen/src/archives.rs
++++ b/build/ninja_gen/src/archives.rs
+@@ -23,6 +23,7 @@ pub struct OnlineArchive {
+ pub enum Platform {
+     LinuxX64,
+     LinuxArm,
++    LinuxLoong64,
+     MacX64,
+     MacArm,
+     WindowsX64,
+@@ -36,6 +37,7 @@ impl Platform {
+         match (os, arch) {
+             ("linux", "x86_64") => Self::LinuxX64,
+             ("linux", "aarch64") => Self::LinuxArm,
++            ("linux", "loongarch64") => Self::LinuxLoong64,
+             ("macos", "x86_64") => Self::MacX64,
+             ("macos", "aarch64") => Self::MacArm,
+             ("windows", "x86_64") => Self::WindowsX64,
+@@ -49,7 +51,7 @@ impl Platform {
+             // On Linux, wheels are not allowed to link to OpenSSL, and linking setup
+             // caused pain for AnkiDroid in the past. On other platforms, we stick to
+             // native libraries, for smaller binaries.
+-            Platform::LinuxX64 | Platform::LinuxArm => "rustls",
++            Platform::LinuxX64 | Platform::LinuxArm | Platform::LinuxLoong64 => "rustls",
+             _ => "native-tls",
+         }
+     }
+@@ -58,6 +60,7 @@ impl Platform {
+         match self {
+             Platform::LinuxX64 => "x86_64-unknown-linux-gnu",
+             Platform::LinuxArm => "aarch64-unknown-linux-gnu",
++            Platform::LinuxLoong64 => "loongarch64-unknown-linux-gnu",
+             Platform::MacX64 => "x86_64-apple-darwin",
+             Platform::MacArm => "aarch64-apple-darwin",
+             Platform::WindowsX64 => "x86_64-pc-windows-msvc",
+diff --git a/build/ninja_gen/src/node.rs b/build/ninja_gen/src/node.rs
+index 0e80b24a0..bb9193633 100644
+--- a/build/ninja_gen/src/node.rs
++++ b/build/ninja_gen/src/node.rs
+@@ -42,6 +42,10 @@ pub fn node_archive(platform: Platform) -> OnlineArchive {
+             url: "https://nodejs.org/dist/v22.17.0/node-v22.17.0-win-arm64.zip",
+             sha256: "78355dc9ca117bb71d3f081e4b1b281855e2b134f3939bb0ca314f7567b0e621",
+         },
++        Platform::LinuxLoong64 => OnlineArchive {
++            url: "https://nodejs.org/dist/v22.17.0/node-v22.17.0-linux-x64.tar.xz",
++            sha256: "325c0f1261e0c61bcae369a1274028e9cfb7ab7949c05512c5b1e630f7e80e12",
++        },
+     }
+ }
+ 
+diff --git a/build/ninja_gen/src/protobuf.rs b/build/ninja_gen/src/protobuf.rs
+index 1198f653d..59243287f 100644
+--- a/build/ninja_gen/src/protobuf.rs
++++ b/build/ninja_gen/src/protobuf.rs
+@@ -43,6 +43,12 @@ pub fn protoc_archive(platform: Platform) -> OnlineArchive {
+                 sha256: "70381b116ab0d71cb6a5177d9b17c7c13415866603a0fd40d513dafe32d56c35",
+             }
+         }
++        Platform::LinuxLoong64 => {
++            OnlineArchive {
++                url: "https://github.com/protocolbuffers/protobuf/releases/download/v31.1/protoc-31.1-linux-x86_64.zip",
++                sha256: "96553041f1a91ea0efee963cb16f462f5985b4d65365f3907414c360044d8065",
++            }
++        },
+     }
+ }
+ 
+@@ -61,6 +67,13 @@ fn clang_format_archive(platform: Platform) -> OnlineArchive {
+                 sha256: "64060bc4dbca30d0d96aab9344e2783008b16e1cae019a2532f1126ca5ec5449",
+             }
+         }
++        Platform::LinuxLoong64 => {
++            // todo: replace with loong64 binary
++            OnlineArchive {
++                url: "https://github.com/ankitects/clang-format-binaries/releases/download/anki-2021-01-09/clang-format_linux_x86_64.zip",
++                sha256: "64060bc4dbca30d0d96aab9344e2783008b16e1cae019a2532f1126ca5ec5449",
++            }
++        }
+         Platform::MacX64 | Platform::MacArm => {
+             OnlineArchive {
+                 url: "https://github.com/ankitects/clang-format-binaries/releases/download/anki-2021-01-09/clang-format_macos_x86_64.zip",
+diff --git a/build/ninja_gen/src/python.rs b/build/ninja_gen/src/python.rs
+index 25fd1afca..e83e78815 100644
+--- a/build/ninja_gen/src/python.rs
++++ b/build/ninja_gen/src/python.rs
+@@ -61,6 +61,12 @@ pub fn uv_archive(platform: Platform) -> OnlineArchive {
+                 sha256: "bb48716e74e4998993f15bc57a55e4d0d73ccbd27a66d7cbed37605f7c67d747",
+             }
+         }
++        Platform::LinuxLoong64 => {
++            OnlineArchive {
++                url: "https://github.com/astral-sh/uv/releases/download/0.7.13/uv-x86_64-unknown-linux-gnu.tar.gz",
++                sha256: "e011ddad353d84d86f5060308d09c08f66b0eac6bf30b268dc63f7959f0e5e6d",
++            }
++        },
+     }
+ }
+ 
+diff --git a/qt/launcher/src/platform/mod.rs b/qt/launcher/src/platform/mod.rs
+index eec7634f1..a39f98860 100644
+--- a/qt/launcher/src/platform/mod.rs
++++ b/qt/launcher/src/platform/mod.rs
+@@ -44,6 +44,8 @@ pub fn get_uv_binary_name() -> &'static str {
+         "uv"
+     } else if cfg!(target_arch = "x86_64") {
+         "uv.amd64"
++    } else if cfg!(target_arch = "loongarch64") {
++        "uv.loong64"
+     } else {
+         "uv.arm64"
+     }
+-- 
+2.52.0
+

--- a/app-productivity/anki/autobuild/patches/0006-Remove-update-check.patch
+++ b/app-productivity/anki/autobuild/patches/0006-Remove-update-check.patch
@@ -1,0 +1,161 @@
+From 6b94ccbaa9d1fa9017c633db9d40120de47f0ce7 Mon Sep 17 00:00:00 2001
+From: SignKirigami <prcups@krgm.moe>
+Date: Wed, 1 Jul 2026 16:02:02 +0800
+Subject: [PATCH 6/6] Remove update check
+
+Use gpt-5.4
+---
+ qt/aqt/forms/main.ui          | 12 ------------
+ qt/aqt/forms/preferences.ui   |  8 --------
+ qt/aqt/main.py                | 10 +---------
+ qt/aqt/preferences.py         |  3 ---
+ qt/launcher/addon/__init__.py | 14 +-------------
+ 5 files changed, 2 insertions(+), 45 deletions(-)
+
+diff --git a/qt/aqt/forms/main.ui b/qt/aqt/forms/main.ui
+index 8aedece1b..3decde05f 100644
+--- a/qt/aqt/forms/main.ui
++++ b/qt/aqt/forms/main.ui
+@@ -93,8 +93,6 @@
+     <addaction name="actionAdd_ons"/>
+     <addaction name="separator"/>
+     <addaction name="actionNoteTypes"/>
+-    <addaction name="action_upgrade_downgrade"/>
+-    <addaction name="action_check_for_updates"/>
+     <addaction name="actionPreferences"/>
+    </widget>
+    <widget class="QMenu" name="menuqt_accel_view">
+@@ -285,16 +283,6 @@
+     <string>qt_accel_load_backup</string>
+    </property>
+   </action>
+-  <action name="action_upgrade_downgrade">
+-   <property name="text">
+-    <string>qt_accel_upgrade_downgrade</string>
+-   </property>
+-  </action>
+-  <action name="action_check_for_updates">
+-   <property name="text">
+-    <string>addons_check_for_updates</string>
+-   </property>
+-  </action>
+  </widget>
+  <resources>
+   <include location="icons.qrc"/>
+diff --git a/qt/aqt/forms/preferences.ui b/qt/aqt/forms/preferences.ui
+index 67cd67a5f..4e7c1b607 100644
+--- a/qt/aqt/forms/preferences.ui
++++ b/qt/aqt/forms/preferences.ui
+@@ -91,13 +91,6 @@
+           <string>preferences_updates</string>
+          </property>
+          <layout class="QVBoxLayout" name="updatesLayout">
+-          <item>
+-           <widget class="QCheckBox" name="check_for_updates">
+-            <property name="text">
+-             <string>preferences_check_for_updates</string>
+-            </property>
+-           </widget>
+-          </item>
+           <item>
+            <widget class="QCheckBox" name="check_for_addon_updates">
+             <property name="text">
+@@ -1263,7 +1256,6 @@
+  <tabstops>
+   <tabstop>lang</tabstop>
+   <tabstop>video_driver</tabstop>
+-  <tabstop>check_for_updates</tabstop>
+   <tabstop>check_for_addon_updates</tabstop>
+   <tabstop>theme</tabstop>
+   <tabstop>styleComboBox</tabstop>
+diff --git a/qt/aqt/main.py b/qt/aqt/main.py
+index 1b507213b..cd2642fd6 100644
+--- a/qt/aqt/main.py
++++ b/qt/aqt/main.py
+@@ -526,7 +526,7 @@ class AnkiQt(QMainWindow):
+             if onsuccess:
+                 onsuccess()
+             if not self.safeMode:
+-                self.maybe_check_for_addon_updates(self.setup_auto_update)
++                self.maybe_check_for_addon_updates()
+ 
+         last_day_cutoff = self.col.sched.day_cutoff
+ 
+@@ -1424,8 +1424,6 @@ title="{}" {}>{}</button>""".format(
+     ##########################################################################
+ 
+     def setupMenus(self) -> None:
+-        from aqt.package import launcher_executable
+-
+         m = self.form
+ 
+         # File
+@@ -1455,12 +1453,6 @@ title="{}" {}>{}</button>""".format(
+         qconnect(m.actionCreateFiltered.triggered, self.onCram)
+         qconnect(m.actionEmptyCards.triggered, self.onEmptyCards)
+         qconnect(m.actionNoteTypes.triggered, self.onNoteTypes)
+-        qconnect(m.action_upgrade_downgrade.triggered, self.on_upgrade_downgrade)
+-        qconnect(m.action_check_for_updates.triggered, self.on_check_for_updates)
+-        if launcher_executable():
+-            m.action_check_for_updates.setVisible(False)
+-        else:
+-            m.action_upgrade_downgrade.setVisible(False)
+         qconnect(m.actionPreferences.triggered, self.onPrefs)
+ 
+         # View
+diff --git a/qt/aqt/preferences.py b/qt/aqt/preferences.py
+index f7f616cfa..fcd76fdfc 100644
+--- a/qt/aqt/preferences.py
++++ b/qt/aqt/preferences.py
+@@ -219,9 +219,6 @@ class Preferences(QDialog):
+         self.form.custom_sync_url.setText(self.mw.pm.custom_sync_url())
+         self.form.network_timeout.setValue(self.mw.pm.network_timeout())
+ 
+-        self.form.check_for_updates.setChecked(self.mw.pm.check_for_updates())
+-        qconnect(self.form.check_for_updates.stateChanged, self.mw.pm.set_update_check)
+-
+         self.form.check_for_addon_updates.setChecked(
+             self.mw.pm.check_for_addon_updates()
+         )
+diff --git a/qt/launcher/addon/__init__.py b/qt/launcher/addon/__init__.py
+index 4ef348b9f..b92d15e2d 100644
+--- a/qt/launcher/addon/__init__.py
++++ b/qt/launcher/addon/__init__.py
+@@ -12,8 +12,7 @@ from typing import Any
+ 
+ from anki.utils import pointVersion
+ from aqt import mw
+-from aqt.qt import QAction
+-from aqt.utils import askUser, is_mac, is_win, showInfo
++from aqt.utils import is_mac, is_win, showInfo
+ 
+ 
+ def launcher_executable() -> str | None:
+@@ -112,12 +111,6 @@ def update_and_restart() -> None:
+     mw.app.quit()
+ 
+ 
+-def confirm_then_upgrade():
+-    if not askUser("Change to a different Anki version?"):
+-        return
+-    update_and_restart()
+-
+-
+ # return modified command array that points to bundled command, and return
+ # required environment
+ def _packagedCmd(cmd: list[str]) -> tuple[Any, dict[str, str]]:
+@@ -166,11 +159,6 @@ def setup():
+     if not launcher_executable():
+         return
+ 
+-    # Add action to tools menu
+-    action = QAction("Upgrade/Downgrade", mw)
+-    action.triggered.connect(confirm_then_upgrade)
+-    mw.form.menuTools.addAction(action)
+-
+     # Monkey-patch audio tools to use anki-audio
+     if is_win or is_mac:
+         import aqt
+-- 
+2.52.0
+

--- a/app-productivity/anki/autobuild/prepare
+++ b/app-productivity/anki/autobuild/prepare
@@ -1,0 +1,30 @@
+abinfo "Fetching Rust dependencies ..."
+cargo fetch --locked --target "$(rustc --print host-tuple)"
+
+abinfo "Installing yarn via npm ..."
+mkdir -pv "$SRCDIR"/.yarn
+npm install --prefix "$SRCDIR"/.yarn yarn
+export PATH="$SRCDIR/.yarn/node_modules/.bin:$PATH"
+
+abinfo "Preparing Node.js dependencies ..."
+rm -v yarn.lock
+yarn install --immutable --modules-folder "$SRCDIR"/out/node_modules --ignore-scripts
+ln -sv out/node_modules "$SRCDIR"
+
+abinfo "Setting up Python virtual environment ..."
+python3 -m venv --system-site-packages --without-pip "$SRCDIR"/out/pyenv
+
+abinfo "Covering Python version ..."
+python3 --version | cut -d ' ' -f 2 > "$SRCDIR"/.python-version
+
+abinfo "Setting up build environment ..."
+export PYTHON_BINARY=/usr/bin/python3
+export PROTOC_BINARY=/usr/bin/protoc
+export NODE_BINARY=/usr/bin/node
+export YARN_BINARY="$SRCDIR"/.yarn/node_modules/.bin/yarn
+export UV_BINARY=/usr/bin/uv
+export RELEASE=2
+export OFFLINE_BUILD=1
+export CARGO_TARGET_DIR="$SRCDIR"/out/rust
+export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+export ZSTD_SYS_USE_PKG_CONFIG=1

--- a/app-productivity/anki/spec
+++ b/app-productivity/anki/spec
@@ -1,0 +1,4 @@
+VER=26.05
+SRCS="git::copy-repo=true;commit=tags/$VER::https://github.com/ankitects/anki"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=49"

--- a/lang-python/flask-cors/autobuild/defines
+++ b/lang-python/flask-cors/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=flask-cors
+PKGSEC=python
+PKGDEP="flask werkzeug"
+BUILDDEP="setuptools setuptools-scm"
+PKGDES="Flask extension for handling Cross Origin Resource Sharing (CORS)"
+
+ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/flask-cors/spec
+++ b/lang-python/flask-cors/spec
@@ -1,0 +1,4 @@
+VER=6.0.5
+SRCS="pypi::version=$VER::flask-cors"
+CHKSUMS="sha256::30c5031552cd59f620ac0c8211dac45b345d3b2df310e7721879e4f46ef9c601"
+CHKUPDATE="anitya::id=129599"

--- a/lang-python/send2trash/autobuild/defines
+++ b/lang-python/send2trash/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=send2trash
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Python module to send files to trash natively on all platforms"
+
+ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/send2trash/spec
+++ b/lang-python/send2trash/spec
@@ -1,0 +1,4 @@
+VER=2.1.0
+SRCS="pypi::version=$VER::send2trash"
+CHKSUMS="sha256::1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459"
+CHKUPDATE="anitya::id=193677"

--- a/lang-python/uv/autobuild/prepare
+++ b/lang-python/uv/autobuild/prepare
@@ -7,3 +7,9 @@ if ab_match_arch riscv64; then
 	abinfo "Adding libatomic for riscv64 ..."
 	export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-latomic"
 fi
+
+if ab_match_arch arm64; then
+	abinfo "Set jemalloc page size for arm64 ..."
+	export JEMALLOC_SYS_WITH_LG_PAGE=16
+	export JEMALLOC_SYS_WITH_LG_HUGEPAGE=25
+fi

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,5 @@
 VER=0.11.25
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"

--- a/lang-python/waitress/autobuild/defines
+++ b/lang-python/waitress/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=waitress
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools"
+PKGDES="Python-based WSGI server"
+
+ABHOST=noarch
+ABTYPE=pep517
+
+NOPYTHON2=1

--- a/lang-python/waitress/spec
+++ b/lang-python/waitress/spec
@@ -1,0 +1,4 @@
+VER=3.0.2
+SRCS="pypi::version=$VER::waitress"
+CHKSUMS="sha256::682aaaf2af0c44ada4abfb70ded36393f0e307f4ab9456a215ce0020baefc31f"
+CHKUPDATE="anitya::id=4085"


### PR DESCRIPTION
Topic Description
-----------------
Use Deepseek V4 Pro to add loongarch64 support and convert from Arch Linux.

- uv: change page size for arm64
- anki: new, 26.05
- waitress: new, 3.0.2
- send2trash: new, 2.1.0
- flask-cors: new, 6.0.5

Package(s) Affected
-------------------

- anki: 26.05
- flask-cors: 6.0.5
- send2trash: 2.1.0
- uv: 0.11.23-1
- waitress: 3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit flask-cors send2trash waitress uv anki
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
