### PR TITLE
bpftrace: update to 0.26.1

### DIFF
--- a/app-admin/bpftrace/spec
+++ b/app-admin/bpftrace/spec
@@ -1,4 +1,4 @@
-VER=0.24.2
+VER=0.26.1
 SRCS="git::commit=tags/v$VER;submodule=false::https://github.com/bpftrace/bpftrace"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141354"

--- a/runtime-kernel/libbpf/autobuild/build
+++ b/runtime-kernel/libbpf/autobuild/build
@@ -2,7 +2,7 @@ pushd "${SRCDIR}"/src
 abinfo "Building binaries ..."
 make
 abinfo "Installing binaries ..."
-make install DESTDIR="${PKGDIR}" LIBSUBDIR=lib install install_headers
+make DESTDIR="${PKGDIR}" LIBSUBDIR=lib install install_headers
 popd
 
 abinfo "Installing readme documents ..."

--- a/runtime-kernel/libbpf/autobuild/defines
+++ b/runtime-kernel/libbpf/autobuild/defines
@@ -4,6 +4,9 @@ PKGDEP="elfutils"
 BUILDDEP="linux+api rsync"
 PKGDES="Library for loading eBPF programs from userspace"
 
+# Note: Required by bpftrace, etc.
+NOSTATIC=0
+
 PKGBREAK="""
 bcc<=0.22.0-1
 bpftrace<=0.14.1

--- a/runtime-kernel/libbpf/spec
+++ b/runtime-kernel/libbpf/spec
@@ -1,4 +1,4 @@
-VER=1.6.1
+VER=1.7.0
 SRCS="git::commit=tags/v$VER::https://github.com/libbpf/libbpf"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141355"


### PR DESCRIPTION
Topic Description
-----------------

- libbpf: update to 1.7.0
- bpftrace: update to 0.26.1

Package(s) Affected
-------------------

- bpftrace: 0.26.1
- libbpf: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libbpf bpftrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
