### PR TITLE
iosevka-fonts: update to 34.7.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=34.6.3
+VER=34.7.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::ecc5a79fac4d887a130d2ed36e8edf27784277c040bb8a48e295bd4529123074 \
-         sha256::e3b3581e76113c015e95b80c4a469fc05d68385859c1a3d2f55707e2daebc8e8 \
-         sha256::46d73d1dfccd1518a9c5100239b14c688a136491c6018222844f9410ba1f97cf \
-         sha256::cfd3f7b790d093657326e3d11edeeace603b0e8d4224d4d50db0f42ebfbefeb8 \
-         sha256::671501cd1d2b50a2aa66664507d5479369474285e65c4d70efba748c17be3bc7 \
-         sha256::4016f146346992726e92efec6a7561505316eaf090c1730b2532f2c151bc59dd \
-         sha256::7285fafe1f4fca7aaf419fe0cb96ad04aae8b0a16752df3624bd5d25629f52dc \
-         sha256::9d17aa8134c7801e8a9c3fb8a098596834bc87b7834533811fae3d738990b220 \
-         sha256::38fb03eb2dc60a273eec686b01b511917297c049aff7cc399405316e320d2a20 \
-         sha256::b24021712cf9f6531899178b2a08c267958291dc0742f6e3f2c44648b30df21b \
-         sha256::958b5d9ca68460105482c9581c8e742c71d23c95546dcddc1d57f80ae45b5478 \
-         sha256::2756ddcc16db559a4f87f55edc1c93781c50c6206500bb16295b09b22c3dca18 \
-         sha256::b00f5d9c61df7a05b2a72b9e69b73c2349e80d5a07492241f12e679404dcf332 \
-         sha256::e70e08d543694d39ae5a3dc0f3c8e1b670e8ac7a68fa47f3cdf7f6285812db62 \
-         sha256::3cd6524f0a49f6206ae0ecd5379af298802eab419e1bb2408ed6f6596ef27838 \
-         sha256::cf5d31a3a00308fb0bc38bfe96d170901e1396e56505516a1886719ced74735a \
-         sha256::93f3f23469bd7732e4d5febfda33f4413a634c8d29d022a1949f30e74e0278fd \
-         sha256::5d5033e19aac47e5719594ab8baf28753dbd739a6b3db81b300dcf0914380baa \
-         sha256::2a4aaf09f8a32d96ecbcd776f72bd843a7f39fda5f5dedf35bd16110ffe91531 \
-         sha256::50ac7bf327aba3e96604f49382cc98d459d14fabe0b4e260de168dbb8d1a1d3f \
-         sha256::a71cca7b0446a2b0e8aba986080df6993577f8fd0ec2eda7431697e58872eb4c \
-         sha256::9ddb7cfeafcc325d6e94c5eeec61d4682713429e336fca3e8e6b1cccf705a55a \
-         sha256::2a144bc83bec2038c0a58388fd2b3e76d9c37ef62869751b9d4b5e636c022170 \
-         sha256::5997cbbbd22bd017063b91dcfdc9d317e11d3fe2ba69ff8d82bab16d42920c5b \
+CHKSUMS="sha256::aaab707b399828783341c7668ffca5e6e6bbe99ff418efed0bd1ee38ed5d143a \
+         sha256::c4cb3c20cce151e805813a595175242b9f67562f98cd7d68e298af9e26830a25 \
+         sha256::d1736e247d4db21e6c988c034e61fb15ba62be32696a42a11a73d774d970b709 \
+         sha256::afe3262e90e754f3947be785667783d6f89875a739c02145b538c4507c05f78d \
+         sha256::5ccd6ec85544dde53721fd500f2db02a25d02309f815b77a4e46d19c485cf0ad \
+         sha256::b27df29cd04f1800f135bb1ae8d0e45c08dbd6548d28c403b945e4747c9fe2f9 \
+         sha256::700c66b12d78c6b70bc21bc7235781e2f3371613924d9fc5cdf99ee225934dcd \
+         sha256::5e52c9589775dff8d43c78c8f217ec7e809115c70912c2574ea5709e00a722f5 \
+         sha256::6464d4abecf782ba3f8d0ae9d81956136cd85db27afbcbd08b5f80cb018834b8 \
+         sha256::d3917bec91a157186ab06779cd2afde496c00af7aa382dda2e4204b9cc22e582 \
+         sha256::94a8298abba875f35b29efac23730395d0b84c29596c1566fc00837eee8eb227 \
+         sha256::96321951ae324e1697c26848623a787a235061546adc0c7bc69392f78411a55b \
+         sha256::fcf552ff7a533c486ddc773bb062691990c38c1d8d0ea698c674242840aedb3b \
+         sha256::51f56abdaf3b42df977328e1dc4cd8f9e2e1eac4735925ebcdd4def02912f186 \
+         sha256::533c09a121d8da5e83e618c3ab6fd56fc36149a74a804ff629f347ef6ca09fd3 \
+         sha256::3755d4d563f6e91e2686375a6cbc69adc394b701a008a0092cb24d273404ff17 \
+         sha256::1389c32abfa62e26d9cbca51f3be6a124d670e3194d08127d95154dbd2873b4d \
+         sha256::2c9cfdbade7d2fee86c6c918ceb5a98408f88032c4ee1483ee80fe9bfef6d56f \
+         sha256::e43d87fea0339b9196b872edb7650ff36c1e49dfdb5490423c2e25f57271d06c \
+         sha256::d24d80a82455ab94295b06bb59f8571b0b4fba70b56881e5a194c77c9f9208ee \
+         sha256::121823088abb76b103e5f3320302eaf35813bf65e362813e7a7f7b540fd8ad55 \
+         sha256::680c9c3a690cc184779f0ce5f2127b9c3db94d425923f81196493b5d616868e0 \
+         sha256::d72bb739abe40cdd5e3dd4d521124502bf0b0b460dc745203a1f1e7cd6f754fd \
+         sha256::bc532fc003b07a986f65993f86190c618238fd2b84811ed4e2c07eb2738d044e \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.7.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
