### PR TITLE
fcitx5-mozc: update to 3.34.6239+fcitx5+git20260629

### DIFF
--- a/app-i18n/fcitx5-mozc/spec
+++ b/app-i18n/fcitx5-mozc/spec
@@ -1,4 +1,5 @@
-VER=3.33.6133+fcitx5+git20260609
+UPSTREAM_VER=3.34.6239
+VER=${UPSTREAM_VER}+fcitx5+git20260609
 
 # NOTE: For each update, use local bazelisk to build mozc_data.inc from
 # fcitx5-mozc/mozc/src using the following command:
@@ -10,11 +11,11 @@ VER=3.33.6133+fcitx5+git20260609
 # aosc-repacks.
 #
 # NOTE: We use fcitx/mozc for input method status icons
-SRCS="git::commit=b8f1cc197fa7a62f9837ef909b1978ae3a0f7b17::https://github.com/fcitx-contrib/fcitx5-mozc.git \
-      git::commit=379a0cd1383b30d5bd30649940ebb040dbf0ae90;rename=mozc;submodule=false::https://github.com/fcitx/mozc.git \
-      file::rename=mozc_data.inc::https://repo.aosc.io/aosc-repacks/mozc_data_3.33.6133%2Bfcitx5%2Bgit20260609.inc"
+SRCS="git::commit=ef28aeecea8fd546ebcee1cad38de58aefa43849::https://github.com/fcitx-contrib/fcitx5-mozc.git \
+      git::commit=35898ee6c4f7424ae73000bbd754510d7ab772d0;rename=mozc;submodule=false::https://github.com/fcitx/mozc.git \
+      file::rename=mozc_data.inc::https://repo.aosc.io/aosc-repacks/mozc_data_${UPSTREAM_VER}.inc"
 CHKSUMS="SKIP \
          SKIP \
-         sha256::8927843f00d006f8c5df818f57b6a8bbf07240ec9f3ce2418baeaa81fd37482a"
+         sha256::a9370b715048459d646f6b90e85e127c13257f6789b3f114a0d56fa549e7f3a0"
 SUBDIR="fcitx5-mozc"
 CHKUPDATE="anitya::id=2016"


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-mozc: update to 3.34.6239+fcitx5+git20260629
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fcitx5-mozc: 3.34.6239+fcitx5+git20260609

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-mozc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
