### PR TITLE
gopass: new, 1.16.1

### DIFF
--- a/app-utils/gopass/autobuild/defines
+++ b/app-utils/gopass/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=gopass
+PKGSEC=utils
+PKGDEP="glibc"
+PKGRECOM="gnupg"
+PKGSUG="git xdotool xsel xclip wl-clipboard"
+BUILDDEP="go git"
+PKGDES="Unix password manager for teams"
+
+ABTYPE=gomod

--- a/app-utils/gopass/spec
+++ b/app-utils/gopass/spec
@@ -1,0 +1,5 @@
+VER=1.16.1
+
+SRCS="git::commit=tags/v${VER}::https://github.com/gopasspw/gopass.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242942"


### PR DESCRIPTION
Topic Description
-----------------

gopass: new, 1.16.1

Package(s) Affected
-------------------

gopass: 1.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gopass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

