### PR TITLE
deb-installer: update to 0.3.4

### DIFF
--- a/app-admin/deb-installer/spec
+++ b/app-admin/deb-installer/spec
@@ -1,4 +1,4 @@
-VER=0.3.3
+VER=0.3.4
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/deb-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375467"


### PR DESCRIPTION
Topic Description
-----------------

- deb-installer: update to 0.3.4
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- deb-installer: 0.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit deb-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
