### PR TITLE
hostapd: fix OOB write in Wi-Fi 7 MLD association parsing (pre-auth DoS)

### DIFF
--- a/app-network/hostapd/autobuild/config
+++ b/app-network/hostapd/autobuild/config
@@ -1,4 +1,4 @@
-# AOSC OS (Debian) hostapd build time configuration
+# AOSC OS hostapd build time configuration
 #
 # This file lists the configuration options that are used when building the
 # hostapd binary. All lines starting with # are ignored. Configuration option
@@ -19,7 +19,7 @@ CONFIG_DRIVER_WIRED=y
 CONFIG_DRIVER_NL80211=y
 
 # QCA vendor extensions to nl80211
-#CONFIG_DRIVER_NL80211_QCA=y
+CONFIG_DRIVER_NL80211_QCA=y
 
 # driver_nl80211.c requires libnl. If you are compiling it yourself
 # you may need to point hostapd to your version of libnl.
@@ -44,17 +44,11 @@ CONFIG_LIBNL32=y
 # Driver interface for no driver (e.g., RADIUS server only)
 CONFIG_DRIVER_NONE=y
 
-# IEEE 802.11F/IAPP
-CONFIG_IAPP=y
-
 # WPA2/IEEE 802.11i RSN pre-authentication
 CONFIG_RSN_PREAUTH=y
 
-# IEEE 802.11w (management frame protection)
-CONFIG_IEEE80211W=y
-
 # Support Operating Channel Validation
-#CONFIG_OCV=y
+CONFIG_OCV=y
 
 # Integrated EAP server
 CONFIG_EAP=y
@@ -108,10 +102,17 @@ CONFIG_EAP_GPSK=y
 CONFIG_EAP_GPSK_SHA256=y
 
 # EAP-FAST for the integrated EAP server
-# Note: If OpenSSL is used as the TLS library, OpenSSL 1.0 or newer is needed
-# for EAP-FAST support. Older OpenSSL releases would need to be patched, e.g.,
-# with openssl-0.9.8x-tls-extensions.patch, to add the needed functions.
 CONFIG_EAP_FAST=y
+
+# EAP-TEAP for the integrated EAP server
+# Note: The current EAP-TEAP implementation is experimental and should not be
+# enabled for production use. The IETF RFC 7170 that defines EAP-TEAP has number
+# of conflicting statements and missing details and the implementation has
+# vendor specific workarounds for those and as such, may not interoperate with
+# any other implementation. This should not be used for anything else than
+# experimentation and interoperability testing until those issues has been
+# resolved.
+#CONFIG_EAP_TEAP=y
 
 # Wi-Fi Protected Setup (WPS)
 CONFIG_WPS=y
@@ -140,15 +141,15 @@ CONFIG_RADIUS_SERVER=y
 # Build IPv6 support for RADIUS operations
 CONFIG_IPV6=y
 
+# Include support fo RADIUS/TLS into the RADIUS client
+CONFIG_RADIUS_TLS=y
+
 # IEEE Std 802.11r-2008 (Fast BSS Transition)
 CONFIG_IEEE80211R=y
 
 # Use the hostapd's IEEE 802.11 authentication (ACL), but without
 # the IEEE 802.11 Management capability (e.g., FreeBSD/net80211)
-#CONFIG_DRIVER_RADIUS_ACL=y
-
-# IEEE 802.11n (High Throughput) support
-CONFIG_IEEE80211N=y
+CONFIG_DRIVER_RADIUS_ACL=y
 
 # Wireless Network Management (IEEE Std 802.11v-2011)
 # Note: This is experimental and not complete implementation.
@@ -158,10 +159,20 @@ CONFIG_WNM=y
 CONFIG_IEEE80211AC=y
 
 # IEEE 802.11ax HE support
+CONFIG_IEEE80211AX=y
+
+# IEEE 802.11be EHT support
+# CONFIG_IEEE80211AX is mandatory for setting CONFIG_IEEE80211BE.
 # Note: This is experimental and work in progress. The definitions are still
 # subject to change and this should not be expected to interoperate with the
-# final IEEE 802.11ax version.
-#CONFIG_IEEE80211AX=y
+# final IEEE 802.11be version.
+CONFIG_IEEE80211BE=y
+
+# Simultaneous Authentication of Equals (SAE), WPA3-Personal
+CONFIG_SAE=y
+
+# SAE Public Key, WPA3-Personal
+CONFIG_SAE_PK=y
 
 # Remove debugging code that is printing out debug messages to stdout.
 # This can be used to reduce the size of the hostapd considerably if debugging
@@ -170,7 +181,7 @@ CONFIG_IEEE80211AC=y
 
 # Add support for writing debug log to a file: -f /tmp/hostapd.log
 # Disabled by default.
-CONFIG_DEBUG_FILE=y
+#CONFIG_DEBUG_FILE=y
 
 # Send debug messages to syslog instead of stdout
 #CONFIG_DEBUG_SYSLOG=y
@@ -179,7 +190,7 @@ CONFIG_DEBUG_FILE=y
 # to the Linux kernel tracing facility. This helps debug the entire stack by
 # making it easy to record everything happening from the driver up into the
 # same file, e.g., using trace-cmd.
-CONFIG_DEBUG_LINUX_TRACING=y
+#CONFIG_DEBUG_LINUX_TRACING=y
 
 # Remove support for RADIUS accounting
 #CONFIG_NO_ACCOUNTING=y
@@ -301,7 +312,7 @@ CONFIG_TLSV12=y
 # At the cost of about 4 kB of additional binary size, the internal LibTomMath
 # can be configured to include faster routines for exptmod, sqr, and div to
 # speed up DH and RSA calculation considerably
-#CONFIG_INTERNAL_LIBTOMMATH_FAST=y
+CONFIG_INTERNAL_LIBTOMMATH_FAST=y
 
 # Interworking (IEEE 802.11u)
 # This can be used to enable functionality to improve interworking with
@@ -312,7 +323,7 @@ CONFIG_INTERWORKING=y
 CONFIG_HS20=y
 
 # Enable SQLite database support in hlr_auc_gw, EAP-SIM DB, and eap_user_file
-#CONFIG_SQLITE=y
+CONFIG_SQLITE=y
 
 # Enable Fast Session Transfer (FST)
 CONFIG_FST=y
@@ -326,7 +337,7 @@ CONFIG_FST=y
 # connect to this hostapd. These options allow, for example, to drop a
 # certain percentage of probe requests or auth/(re)assoc frames.
 #
-CONFIG_TESTING_OPTIONS=y
+#CONFIG_TESTING_OPTIONS=y
 
 # Automatic Channel Selection
 # This will allow hostapd to pick the channel automatically when channel is set
@@ -348,12 +359,12 @@ CONFIG_TESTING_OPTIONS=y
 # * ath10k
 #
 # For more details refer to:
-# http://wireless.kernel.org/en/users/Documentation/acs
+# https://wireless.wiki.kernel.org/en/users/documentation/acs
 #
 CONFIG_ACS=y
 
 # Multiband Operation support
-# These extentions facilitate efficient use of multiple frequency bands
+# These extensions facilitate efficient use of multiple frequency bands
 # available to the AP and the devices that may associate with it.
 CONFIG_MBO=y
 
@@ -361,7 +372,7 @@ CONFIG_MBO=y
 # Has the AP retain the Probe Request and (Re)Association Request frames from
 # a client, from which a signature can be produced which can identify the model
 # of client device like "Nexus 6P" or "iPhone 5s".
-#CONFIG_TAXONOMY=y
+CONFIG_TAXONOMY=y
 
 # Fast Initial Link Setup (FILS) (IEEE 802.11ai)
 CONFIG_FILS=y
@@ -370,18 +381,47 @@ CONFIG_FILS_SK_PFS=y
 
 # Include internal line edit mode in hostapd_cli. This can be used to provide
 # limited command line editing and history support.
-#CONFIG_WPA_CLI_EDIT=y
+CONFIG_WPA_CLI_EDIT=y
 
 # Opportunistic Wireless Encryption (OWE)
 # Experimental implementation of draft-harkins-owe-07.txt
 CONFIG_OWE=y
 
-# Device Provisioning Protocol (DPP)
-CONFIG_DPP=y
-
-# Simultaneous Authentication of Equals (SAE)
-CONFIG_SAE=y
+# Airtime policy support
+CONFIG_AIRTIME_POLICY=y
 
 # Override default value for the wpa_disable_eapol_key_retries configuration
 # parameter. See that parameter in hostapd.conf for more details.
 #CFLAGS += -DDEFAULT_WPA_DISABLE_EAPOL_KEY_RETRIES=1
+
+# Wired equivalent privacy (WEP)
+# WEP is an obsolete cryptographic data confidentiality algorithm that is not
+# considered secure. It should not be used for anything anymore. The
+# functionality needed to use WEP is available in the current hostapd
+# release under this optional build parameter. This functionality is subject to
+# be completely removed in a future release.
+CONFIG_WEP=y
+
+# Remove all TKIP functionality
+# TKIP is an old cryptographic data confidentiality algorithm that is not
+# considered secure. It should not be used anymore. For now, the default hostapd
+# build includes this to allow mixed mode WPA+WPA2 networks to be enabled, but
+# that functionality is subject to be removed in the future.
+#CONFIG_NO_TKIP=y
+
+# Pre-Association Security Negotiation (PASN)
+# Experimental implementation based on IEEE P802.11z/D2.6 and the protocol
+# design is still subject to change. As such, this should not yet be enabled in
+# production use.
+#CONFIG_PASN=y
+
+# Device Provisioning Protocol (DPP) (also known as Wi-Fi Easy Connect)
+CONFIG_DPP=y
+# DPP version 2 support
+CONFIG_DPP2=y
+# DPP version 3 support (experimental and still changing; do not enable for
+# production use)
+#CONFIG_DPP3=y
+
+# Wi-Fi Aware unsynchronized service discovery (NAN USD)
+CONFIG_NAN_USD=y

--- a/app-network/hostapd/autobuild/patches/0001-BACKPORT-UPSTREAM-AP-MLD-Fix-link-ID-validation-in-B.patch
+++ b/app-network/hostapd/autobuild/patches/0001-BACKPORT-UPSTREAM-AP-MLD-Fix-link-ID-validation-in-B.patch
@@ -1,0 +1,55 @@
+From 4b8681a0bef7eebc7ecb17af93a414414b4fe4b3 Mon Sep 17 00:00:00 2001
+From: Jouni Malinen <jouni.malinen@oss.qualcomm.com>
+Date: Tue, 31 Mar 2026 23:24:04 +0300
+Subject: [PATCH 1/2] BACKPORT: UPSTREAM: AP MLD: Fix link ID validation in
+ Basic MLE parsing
+
+Link ID 15 can be indicated in the field, but that is not a valid value
+and must be rejected to avoid issues pointing beyond the array of links
+for a non-AP MLD. Without this, an invalid MLE could result in writing
+beyond the end of the buffer and causing process termination or
+unexpected behavior.
+
+Fixes: 5f5db9366cde ("AP: MLO: Process Multi-Link element from (Re)Association Request frame")
+Signed-off-by: Jouni Malinen <jouni.malinen@oss.qualcomm.com>
+
+[ Mingcong Bai: Resolved a minor merge conflict in src/ap/ieee802_11_eht.c
+  caused by missing commit 46fc21757675 ("Remove duplicated definition of
+  STA Control field for Basic MLE"), only found on the 2_12 branch. ]
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ src/ap/ieee802_11_eht.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/src/ap/ieee802_11_eht.c b/src/ap/ieee802_11_eht.c
+index b935ee889..1276c4437 100644
+--- a/src/ap/ieee802_11_eht.c
++++ b/src/ap/ieee802_11_eht.c
+@@ -1262,6 +1262,7 @@ u16 hostapd_process_ml_assoc_req(struct hostapd_data *hapd,
+ 		size_t sub_elem_len = *(pos + 1);
+ 		size_t sta_info_len;
+ 		u16 control;
++		u8 link_id;
+ 
+ 		wpa_printf(MSG_DEBUG, "MLD: sub element len=%zu",
+ 			   sub_elem_len);
+@@ -1302,8 +1303,13 @@ u16 hostapd_process_ml_assoc_req(struct hostapd_data *hapd,
+ 			goto out;
+ 		}
+ 		control = WPA_GET_LE16(pos);
+-		link_info = &info->links[control &
+-					 EHT_PER_STA_CTRL_LINK_ID_MSK];
++		link_id = control & EHT_PER_STA_CTRL_LINK_ID_MSK;
++		if (link_id >= MAX_NUM_MLD_LINKS) {
++			wpa_printf(MSG_DEBUG,
++				   "MLD: Invalid Link ID in Per-STA Profile subelement");
++			goto out;
++		}
++		link_info = &info->links[link_id];
+ 		pos += 2;
+ 		ml_len -= 2;
+ 		sub_elem_len -= 2;
+-- 
+2.52.0
+

--- a/app-network/hostapd/autobuild/patches/0002-AOSCOS-fix-hostapd.conf-set-configuration-prefix-as-.patch
+++ b/app-network/hostapd/autobuild/patches/0002-AOSCOS-fix-hostapd.conf-set-configuration-prefix-as-.patch
@@ -1,8 +1,10 @@
-From 88f9d136305532db75034d9824b80b6fbeaaca8f Mon Sep 17 00:00:00 2001
+From e6bfdbccacca6adaaf412f74d118499bc3c3497f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 29 Jul 2024 23:03:44 +0800
-Subject: [PATCH] fix(hostapd.conf): set configuration prefix as /etc/hostapd
+Subject: [PATCH 2/2] AOSCOS: fix(hostapd.conf): set configuration prefix as
+ /etc/hostapd
 
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  hostapd/hostapd.conf | 32 ++++++++++++++++----------------
  1 file changed, 16 insertions(+), 16 deletions(-)
@@ -110,5 +112,5 @@ index d875d5fc6..84fb2c9a5 100644
  # Optionally, WPA passphrase can be received from RADIUS authentication server
  # This requires macaddr_acl to be set to 2 (RADIUS) for wpa_psk_radius values
 -- 
-2.45.2
+2.52.0
 

--- a/app-network/hostapd/spec
+++ b/app-network/hostapd/spec
@@ -1,4 +1,5 @@
 VER=2.11
+REL=1
 SRCS="tbl::https://w1.fi/releases/hostapd-$VER.tar.gz"
 CHKSUMS="sha256::2b3facb632fd4f65e32f4bf82a76b4b72c501f995a4f62e330219fe7aed1747a"
 CHKUPDATE="anitya::id=1325"

--- a/topics/hostapd-2.11-fix-wifi-7-oob-write.toml
+++ b/topics/hostapd-2.11-fix-wifi-7-oob-write.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Host Access Point Daemon (hostapd) 2.11, Revision 1"
+zh_CN = "主机无线接入点守护程序 (hostapd) 2.11，修订 1"
+
+[caution]
+default = "Fixes an Out-of-bounds Write (or Pre-authentication Denial-of-Service) vulnerability"
+zh_CN = "修复一个越界写入 (Out-of-bounds Write)，或预鉴权拒绝服务 (Pre-authentication Denial-of-Service) 漏洞"
+
+[packages-v2]
+"hostapd" = "< 2.11-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add hostapd-2.11-fix-wifi-7-oob-write.toml
- hostapd: fix OOB write in Wi-Fi 7 MLD association parsing \(pre-auth DoS\)
    - Rework default configuration via the upstream defconfig file.
    - Track patches at AOSC-Tracking/hostapd @ aosc/hostap_2_11
    \(HEAD: e6bfdbccacca6adaaf412f74d118499bc3c3497f\).

Package(s) Affected
-------------------

- hostapd: 2.11-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit hostapd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
