### PR TITLE
cuda: update to 13.3.1+610.43.02

### DIFF
--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,11 +1,10 @@
-UPSTREAM_VER=13.3.0
+UPSTREAM_VER=13.3.1
 MIN_DRIVER_VER=610.43.02
 VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
 CHKUPDATE="anitya::id=13462"
 
 SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::5f79488b57fe6936bc95a56f9b7e2838ab2f2ee3313b1008942206eebe06352d"
+CHKSUMS__AMD64="sha256::9f98ec1f6c950401041d3f1308e221f0d5db8771a8e10569001b64caaee31a92"
 
 SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::94ec4572197b65532dcf3d327460417c6527fa42ded9d5010e06ddb89e878d4c"
-REL=1
+CHKSUMS__ARM64="sha256::075bbf17cd95badf13a546229e0035af9f38fd9e7cd0102585bd43195603923d"


### PR DESCRIPTION
Topic Description
-----------------

- cuda: update to 13.3.1+610.43.02
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- cuda: 13.3.1+610.43.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit cuda
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
