### PR TITLE
wine: update to 11.12+gecko2.47.4+mono11.2.0

### DIFF
--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -95,14 +95,9 @@ AUTOTOOLS_AFTER__AMD64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-archs=x86_64,i386'
 )
-# FIXME: disabling winsqlite3 and sqlite3 due to 
-# error: call to undeclared library function '_ReadWriteBarrier' with type 'void (void)';
-# Link: https://bugs.winehq.org/show_bug.cgi?id=59769
 AUTOTOOLS_AFTER__ARM64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-archs=arm64ec,aarch64,x86_64,i386'
-    '--disable-winsqlite3'
-    '--disable-sqlite3'
 )
 AUTOTOOLS_AFTER__I486=(
     "${AUTOTOOLS_AFTER[@]}"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,16 +1,16 @@
 __GECKO_VER=2.47.4
-__MONO_VER=11.1.0
-UPSTREAM_VER=11.11
+__MONO_VER=11.2.0
+UPSTREAM_VER=11.12
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
-CHKSUMS="sha256::57dfd96448bf195efc1b1386131c3ba15d4b2d9faf2feba314e83d743d36d38d \
+CHKSUMS="sha256::d3bc091192d985846c9f20065cc81f21331f01e22b736b131e3449e1306671bc \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::01a7cdc0184c5b22fdf6e7417d50648467b566a107cd51df9c4f3a4acd960c9c"
+         sha256::c9fb2e2823acf30b000b8806177db0f40751786136dd3f8fb2be7897b1643d06"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 11.12+gecko2.47.4+mono11.2.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wine: 3:11.12+gecko2.47.4+mono11.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
