### PR TITLE
tuned: compile Python code cache


### DIFF
--- a/app-admin/tuned/autobuild/build
+++ b/app-admin/tuned/autobuild/build
@@ -6,3 +6,8 @@ make install install-ppd \
     DESTDIR="$PKGDIR" \
     SBINDIR=/usr/bin \
     DOCDIR=/usr/share/doc/"$PKGNAME"
+
+abinfo "Compiling tuned Python code ..."
+python3 -m compileall \
+    "$PKGDIR"/usr/bin/{powertop2tuned,tuned,tuned-adm,tuned-gui,tuned-ppd,varnetload} \
+    "$PKGDIR"/usr/lib/python*/site-packages/tuned/

--- a/app-admin/tuned/spec
+++ b/app-admin/tuned/spec
@@ -1,5 +1,5 @@
 VER=2.26.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/redhat-performance/tuned.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11277"


### PR DESCRIPTION
Topic Description
-----------------

- tuned: compile Python code cache

Package(s) Affected
-------------------

- tuned: 2.26.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tuned
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
