### PR TITLE
topics: add a missing space in virtualbox-7.2.10.toml

### DIFF
--- a/topics/virtualbox-7.2.10.toml
+++ b/topics/virtualbox-7.2.10.toml
@@ -5,7 +5,7 @@ default = "Oracle VM VirtualBox 7.2.10"
 
 [caution]
 default = "Fixes 33 security vulnerabilities disclosed in Oracle Critical Patch Update Advisory - January, April 2026 and Critical Security Patch Update Advisory - June 2026 (19 of High severity)"
-zh_CN = "修复 Oracle 重要更新公告（2026 年 1 月、4月）和 Oracle 重要安全更新公告（2026 年 6 月）中披露的 33 个安全漏洞（含 19 个高危漏洞）"
+zh_CN = "修复 Oracle 重要更新公告（2026 年 1 月、4 月）和 Oracle 重要安全更新公告（2026 年 6 月）中披露的 33 个安全漏洞（含 19 个高危漏洞）"
 
 [packages-v2]
 "virtualbox" = ">= 7.2.4 && < 7.2.10"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add a missing space in virtualbox-7.2.10.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
