### PR TITLE
popub-5: new, 5.0.1

### DIFF
--- a/app-network/popub-5/autobuild/build
+++ b/app-network/popub-5/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building popub ..."
+make
+
+abinfo "Installing popub ..."
+make DESTDIR="$PKGDIR" PREFIX=/usr install

--- a/app-network/popub-5/autobuild/defines
+++ b/app-network/popub-5/autobuild/defines
@@ -3,5 +3,3 @@ PKGSEC=net
 PKGDEP="glibc"
 BUILDDEP="go"
 PKGDES="Publish a service from localhost onto your server (v5)"
-
-ABSPLITDBG=0

--- a/app-network/popub-5/autobuild/defines
+++ b/app-network/popub-5/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=popub-5
+PKGSEC=net
+PKGDEP="glibc"
+BUILDDEP="go"
+PKGDES="Publish a service from localhost onto your server (v5)"
+
+ABSPLITDBG=0

--- a/app-network/popub-5/autobuild/prepare
+++ b/app-network/popub-5/autobuild/prepare
@@ -1,0 +1,2 @@
+abinfo "Setting GO111MODULE to auto ..."
+export GO111MODULE=auto

--- a/app-network/popub-5/spec
+++ b/app-network/popub-5/spec
@@ -2,3 +2,4 @@ VER=5.0.1
 REL=1
 SRCS="git::commit=tags/aosc/v$VER::https://github.com/AOSC-Tracking/popub.git"
 CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391256"

--- a/app-network/popub-5/spec
+++ b/app-network/popub-5/spec
@@ -1,0 +1,3 @@
+VER=5.0.1
+SRCS="git::commit=tags/v$VER::https://github.com/m13253/popub.git"
+CHKSUMS="SKIP"

--- a/app-network/popub-5/spec
+++ b/app-network/popub-5/spec
@@ -1,3 +1,3 @@
 VER=5.0.1
-SRCS="git::commit=tags/v$VER::https://github.com/m13253/popub.git"
+SRCS="git::commit=tags/aosc/v$VER::https://github.com/AOSC-Tracking/popub.git"
 CHKSUMS="SKIP"

--- a/app-network/popub-5/spec
+++ b/app-network/popub-5/spec
@@ -1,3 +1,4 @@
 VER=5.0.1
+REL=1
 SRCS="git::commit=tags/aosc/v$VER::https://github.com/AOSC-Tracking/popub.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- popub-5: remove ABSPLITDPG directive
- popub-5: switch to AOSC-Tracking fork
    The AOSC-Tracking fork renames installed files to avoid conflict with
    the legacy popub package:
    - Binaries: popub-local -> popub-5-local, popub-relay -> popub-5-relay
    - Systemd units: popub-local@.service -> popub-5-local@.service
    - Config directory: /etc/popub/ -> /etc/popub-5/
    This commit is authored with assistance from AI/LLM:
    - Model: mimo-v2.5-pro
    - Platform: MiMoCode
    - Agent platform: MiMoCode
    - Prompt:
    Now make an update to the package, using
    https://github.com/AOSC-Tracking/popub.git as the new upstream and
    aosc/v5.0.1 as the tag, also write a commit message based on what's
    changed in the upstream.
- popub-5: new, 5.0.1
    This commit is authored with assistance from AI/LLM:
    - Model: mimo-v2.5-pro
    - Platform: MiMoCode
    - Agent platform: MiMoCode
    - Prompt:
    Add a new package, popub-5, next to popub, using tag
    https://github.com/m13253/popub/releases/tag/v5.0.1.

Package(s) Affected
-------------------

- popub-5: 5.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit popub-5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
