### PR TITLE
libmpdclient: update to 2.26

### DIFF
--- a/runtime-multimedia/libmpdclient/spec
+++ b/runtime-multimedia/libmpdclient/spec
@@ -1,4 +1,4 @@
-VER=2.25
+VER=2.26
 SRCS="tbl::https://www.musicpd.org/download/libmpdclient/${VER%.*}/libmpdclient-${VER}.tar.xz"
-CHKSUMS="sha256::5170a9ae998241a936fce150e6859d84db92330b80ad2d0f2adce6689eeb5401"
+CHKSUMS="sha256::35785c6d6318ade47e2c27b00fc6938f5e09d04714080fea3f5e5c522ba3e036"
 CHKUPDATE="anitya::id=21364"


### PR DESCRIPTION
Topic Description
-----------------

- libmpdclient: update to 2.26
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libmpdclient: 2.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmpdclient
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
