### PR TITLE
gst-plugins-rs: update to 0.15.3

### DIFF
--- a/runtime-multimedia/gst-plugins-rs/autobuild/defines
+++ b/runtime-multimedia/gst-plugins-rs/autobuild/defines
@@ -44,3 +44,7 @@ MESON_AFTER__RISCV64=(
     '-Dskia=disabled'
     '-Dsodium=disabled'
 )
+
+# FIXME: FTBFS on riscv64
+# ggml/src/ggml-cpu/arch/riscv/quants.c:585:17: error: operand must be e[8|16|32|64],m[1|2|4|8|f2|f4|f8],[ta|tu],[ma|mu]
+FAIL_ARCH="riscv64"

--- a/runtime-multimedia/gst-plugins-rs/spec
+++ b/runtime-multimedia/gst-plugins-rs/spec
@@ -1,4 +1,4 @@
-VER=0.15.2
+VER=0.15.3
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328366"


### PR DESCRIPTION
Topic Description
-----------------

- gst-plugins-rs: update to 0.15.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gst-plugins-rs: 0.15.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit gst-plugins-rs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
