### PR TITLE
bitwarden: update to 2026.6.1

### DIFF
--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,4 @@
-VER=2026.6.0
+VER=2026.6.1
 RUST_LANG_LIBC_VER=0.2.178 # Match libc version in bitwarden/apps/desktop/desktop_native/Cargo.lock
 SRCS="git::commit=tags/desktop-v$VER;rename=bitwarden::https://github.com/bitwarden/clients"
 SRCS__LOONGARCH64="$SRCS \


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: update to 2026.6.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- bitwarden: 2026.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
