### PR TITLE
libevent: security update to 2.1.13

### DIFF
--- a/runtime-common/libevent/spec
+++ b/runtime-common/libevent/spec
@@ -1,5 +1,4 @@
-VER=2.1.12
-REL=3
+VER=2.1.13
 SRCS="tbl::https://github.com/libevent/libevent/releases/download/release-$VER-stable/libevent-$VER-stable.tar.gz"
-CHKSUMS="sha256::92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
+CHKSUMS="sha256::f7e9383b8c0baa81b687e5b5eecc01beefaf1b19b64151d95ed61647fe7a315c"
 CHKUPDATE="anitya::id=1606"

--- a/topics/libevent-2.1.13.toml
+++ b/topics/libevent-2.1.13.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Libevent 2.1.13"
+
+[caution]
+default = "Fixes 10 security vulnerabilities (including 6 of High and 4 of Moderate severity)"
+zh_CN = "修复 10 个安全漏洞（含 6 个高危漏洞和 4 个中危漏洞）"
+
+[packages-v2]
+"libevent" = "< 2.1.13"


### PR DESCRIPTION
Topic Description
-----------------

- libevent: security update to 2.1.13
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libevent: 2.1.13

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libevent
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
