### PR TITLE
mupdf: security update to 1.28.0

### DIFF
--- a/app-doc/mupdf/spec
+++ b/app-doc/mupdf/spec
@@ -1,4 +1,4 @@
-VER=1.27.2
+VER=1.28.0
 EPOCH=1
 SRCS="git::commit=tags/$VER::https://github.com/ArtifexSoftware/mupdf"
 CHKSUMS="SKIP"

--- a/topics/mupdf-1.28.0.toml
+++ b/topics/mupdf-1.28.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "MuPDF 1.28.0"
+
+[caution]
+default = "Fixes an Out-of-Bounds Read vulnerability (CVE-2026-7233, Severity: Medium)"
+zh_CN = "修复 1 个越界读取漏洞（漏洞编号 CVE-2026-7233，严重性：中）"
+
+[packages-v2]
+"mupdf" = "< 1:1.28.0"


### PR DESCRIPTION
Topic Description
-----------------

- mupdf: security update to 1.28.0

Package(s) Affected
-------------------

- mupdf: 1.28.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit mupdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
