### PR TITLE
topics: add CVE and severity to hostapd-2.11-fix-wifi-7-oob-write.toml

### DIFF
--- a/topics/hostapd-2.11-fix-wifi-7-oob-write.toml
+++ b/topics/hostapd-2.11-fix-wifi-7-oob-write.toml
@@ -5,8 +5,8 @@ default = "Host Access Point Daemon (hostapd) 2.11, Revision 1"
 zh_CN = "主机无线接入点守护程序 (hostapd) 2.11，修订 1"
 
 [caution]
-default = "Fixes an Out-of-bounds Write (or Pre-authentication Denial-of-Service) vulnerability"
-zh_CN = "修复一个越界写入 (Out-of-bounds Write)，或预鉴权拒绝服务 (Pre-authentication Denial-of-Service) 漏洞"
+default = "Fixes an Out-of-bounds Write (or Pre-authentication Denial-of-Service) vulnerability (CVE-2026-58374, Severity: Moderate)"
+zh_CN = "修复一个越界写入 (Out-of-bounds Write)，或预鉴权拒绝服务 (Pre-authentication Denial-of-Service) 漏洞（CVE-2026-58374，严重性：中）"
 
 [packages-v2]
 "hostapd" = "< 2.11-1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add CVE and severity to hostapd-2.11-fix-wifi-7-oob-write.toml

Package(s) Affected
-------------------



Security Update?
----------------

Yes

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
