### PR TITLE
pinentry: update to 1.3.3

### DIFF
--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
-REL=7
+VER=1.3.3
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
-CHKSUMS="sha256::8e986ed88561b4da6e9efe0c54fa4ca8923035c99264df0b0464497c5fb94e9e"
+CHKSUMS="sha256::c2970f16d6afb66ecddfca767d743936c86239bff936eed7fd7597a678414b63"
 CHKUPDATE="anitya::id=3643"


### PR DESCRIPTION
Topic Description
-----------------

- pinentry: update to 1.3.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- pinentry: 1.3.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pinentry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
