### PR TITLE
ostree: update to 2026.2

### DIFF
--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,4 @@
-VER=2026.1
+VER=2026.2
 SRCS="tbl::https://github.com/ostreedev/ostree/releases/download/v$VER/libostree-$VER.tar.xz"
-CHKSUMS="sha256::8e77c285dd6fa5ec5fb063130390977be727fe11107335ed8778a40385069e95"
+CHKSUMS="sha256::a281f2db631f3721ecd4b9e2779a1eaf56e2d03f2cc47629a9f0117f12016a83"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: update to 2026.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ostree: 2026.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
