### PR TITLE
mbedtls: update to 4.1.0

### DIFF
--- a/runtime-cryptography/mbedtls/spec
+++ b/runtime-cryptography/mbedtls/spec
@@ -1,4 +1,4 @@
-VER=3.6.5
+VER=4.1.0
 SRCS="tbl::https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$VER/mbedtls-$VER.tar.bz2"
-CHKSUMS="sha256::4a11f1777bb95bf4ad96721cac945a26e04bf19f57d905f241fe77ebeddf46d8"
+CHKSUMS="sha256::377a09cf8eb81b5fb2707045e5522d5489d3309fed5006c9874e60558fc81d10"
 CHKUPDATE="anitya::id=13824"


### PR DESCRIPTION
Topic Description
-----------------

- mbedtls: update to 4.1.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- mbedtls: 4.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit mbedtls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
