### PR TITLE
mbedtls: update to 3.6.6

### DIFF
--- a/runtime-cryptography/mbedtls/spec
+++ b/runtime-cryptography/mbedtls/spec
@@ -1,4 +1,4 @@
-VER=3.6.5
+VER=3.6.6
 SRCS="tbl::https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$VER/mbedtls-$VER.tar.bz2"
-CHKSUMS="sha256::4a11f1777bb95bf4ad96721cac945a26e04bf19f57d905f241fe77ebeddf46d8"
+CHKSUMS="sha256::8fb65fae8dcae5840f793c0a334860a411f884cc537ea290ce1c52bb64ca007a"
 CHKUPDATE="anitya::id=13824"

--- a/runtime-optenv32/mbedtls+32/spec
+++ b/runtime-optenv32/mbedtls+32/spec
@@ -1,4 +1,4 @@
-VER=3.6.5
+VER=3.6.6
 SRCS="tbl::https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-$VER/mbedtls-$VER.tar.bz2"
-CHKSUMS="sha256::4a11f1777bb95bf4ad96721cac945a26e04bf19f57d905f241fe77ebeddf46d8"
+CHKSUMS="sha256::8fb65fae8dcae5840f793c0a334860a411f884cc537ea290ce1c52bb64ca007a"
 CHKUPDATE="anitya::id=13824"

--- a/topics/mbedtls-3.6.6.toml
+++ b/topics/mbedtls-3.6.6.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "Mbed TLS 3.6.6"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (including 3 of high severity and 1 of medium severity)"
+zh_CN = "修复 4 个安全漏洞（含 3 个高危漏洞, 1 个中危漏洞）"
+
+[packages-v2]
+"mbedtls" = "< 3.6.6"
+"mbedtls+32" = "< 3.6.6"


### PR DESCRIPTION
Topic Description
-----------------

- mbedtls: update to 3.6.6
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- mbedtls: 3.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit mbedtls
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
