### PR TITLE
sshpass: update to 1.10

### DIFF
--- a/app-network/sshpass/spec
+++ b/app-network/sshpass/spec
@@ -1,5 +1,4 @@
-VER=1.06
-REL=1
+VER=1.10
 SRCS="tbl::https://downloads.sourceforge.net/sshpass/sshpass-$VER.tar.gz"
-CHKSUMS="sha256::c6324fcee608b99a58f9870157dfa754837f8c48be3df0f5e2f3accf145dee60"
+CHKSUMS="sha256::ad1106c203cbb56185ca3bad8c6ccafca3b4064696194da879f81c8d7bdfeeda"
 CHKUPDATE="anitya::id=12961"


### PR DESCRIPTION
Topic Description
-----------------

- sshpass: update to 1.10
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- sshpass: 1.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit sshpass
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
