### PR TITLE
OpenJDK Survey (Jul. 2026)

### DIFF
--- a/lang-java/openjdk-11/autobuild/build
+++ b/lang-java/openjdk-11/autobuild/build
@@ -2,16 +2,19 @@
 UPDATE=${PKGVER:2:-3}
 BUILD=${PKGVER:(-2)}
 SJAVAC=0
-[ "${CROSS:-$ARCH}" = "amd64" ] && export JARCH="x86_64" CONFARCH="amd64"
-[ "${CROSS:-$ARCH}" = "armel" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "arm64" ] && export JARCH="aarch64" CONFARCH="aarch64"
-[ "${CROSS:-$ARCH}" = "mipsel" ] && export JARCH="mipsel" CONFARCH="mipsel"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export JARCH="ppc" CONFARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export JARCH="ppc64le" CONFARCH="ppc64le"
+ab_match_arch "amd64" && export JARCH="x86_64" CONFARCH="amd64"
+ab_match_arch "armv7hf" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "arm64" && export JARCH="aarch64" CONFARCH="aarch64"
+ab_match_arch "loongson3" && export JARCH="mipsel" CONFARCH="mipsel"
+ab_match_arch "powerpc" && export JARCH="ppc" CONFARCH="ppc"
+ab_match_arch "ppc64el" && export JARCH="ppc64le" CONFARCH="ppc64le"
 
-if [[ "${CROSS:-$ARCH}" != "amd64" && "${CROSS:-$ARCH}" != armel && \
-      "${CROSS:-$ARCH}" != ppc64* && "${CROSS:-$ARCH}" != "arm64" && \
-      "${CROSS:-$ARCH}" != riscv64 ]]; then
+if ! ab_match_arch "amd64" && \
+   ! ab_match_arch "armv7hf" && \
+   ! ab_match_arch "ppc64" && \
+   ! ab_match_arch "ppc64el" && \
+   ! ab_match_arch "arm64" && \
+   ! ab_match_arch "riscv64"; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
     SJAVAC=0
 else
@@ -22,9 +25,7 @@ if [[ "${SJAVAC}" == "1" ]]; then
     use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
-if [[ "${CROSS:-$ARCH}" = armel ]]; then
-    config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
-fi
+ab_match_arch "armv7hf" && config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 
 unset JAVA_HOME
 unset _JAVA_OPTIONS
@@ -53,25 +54,23 @@ make images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java-11
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER="$(readlink -f build/linux-*-normal-*-release/images/)"
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java-11/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk-11/
-mv "$PKGDIR"/usr/lib/java-11/conf "$PKGDIR"/etc/openjdk-11/
-ln -sv /etc/openjdk-11/ "$PKGDIR"/usr/lib/java-11/conf
+mv -v "$PKGDIR"/usr/lib/java-11/conf "$PKGDIR"/etc/openjdk-11/
+ln -sv ../../../etc/openjdk-11/ "$PKGDIR"/usr/lib/java-11/conf
 
 find "$PKGDIR"/usr/lib/java-11/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
 mkdir -pv "$PKGDIR"/usr/src/openjdk-11
-mv "$PKGDIR"/usr/lib/java-11/lib/src.zip "$PKGDIR"/usr/src/openjdk-11/src.zip
-ln -sv /usr/src/openjdk-11/src.zip "$PKGDIR"/usr/lib/java-11/lib/src.zip
+mv -v "$PKGDIR"/usr/lib/java-11/lib/src.zip "$PKGDIR"/usr/src/openjdk-11/src.zip
+ln -sv ../../src/openjdk-11/src.zip "$PKGDIR"/usr/lib/java-11/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
 rm -v "$PKGDIR"/usr/lib/java-11/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java-11/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java-11/lib/security/cacerts
 
 cat > "$SRCDIR"/autobuild/conffiles << EOF
 /etc/openjdk-11/security/java.policy

--- a/lang-java/openjdk-11/autobuild/defines
+++ b/lang-java/openjdk-11/autobuild/defines
@@ -7,7 +7,7 @@ PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment 
 
 PKGPROV="jre-openjdk jre11-openjdk openjdk11"
 NOPARALLEL=1
-PKGEPOCH=3
+ABTYPE=self
 
 # FIXME: Zero issue with hardened builds.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1290936

--- a/lang-java/openjdk-11/spec
+++ b/lang-java/openjdk-11/spec
@@ -1,5 +1,7 @@
 UPSTREAM_VER=11.0.28-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
+EPOCH=3
 SRCS="git::commit=aosc/11/${UPSTREAM_VER}/base::https://github.com/AOSC-Tracking/jdk.git"
 SRCS__RISCV64="git::commit=aosc/11/${UPSTREAM_VER}/riscv::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"

--- a/lang-java/openjdk-17/autobuild/build
+++ b/lang-java/openjdk-17/autobuild/build
@@ -3,18 +3,18 @@ EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-17"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "mipsel" ] && export ADOPTIUM_ARCH="mipsel"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export ADOPTIUM_ARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
+ab_match_arch "mipsel" && export ADOPTIUM_ARCH="mipsel"
+ab_match_arch "powerpc" && export ADOPTIUM_ARCH="ppc"
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -23,9 +23,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
-    config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
-fi
+ab_match_arch "armv7hf" && config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 
 unset JAVA_HOME
 unset _JAVA_OPTIONS
@@ -60,35 +58,34 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -98,4 +95,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JDKBOOTDIR

--- a/lang-java/openjdk-17/autobuild/build.stage2
+++ b/lang-java/openjdk-17/autobuild/build.stage2
@@ -11,15 +11,16 @@ OPENJDK_SUFFIX="-17"
 JDKBOOTDIR=""
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -28,9 +29,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
-    config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
-fi
+ab_match_arch "armv7hf" && config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 
 unset JAVA_HOME
 unset _JAVA_OPTIONS
@@ -46,68 +45,18 @@ if [[ -z "$JDKBOOTDIR" && -n "$ADOPTIUM_ARCH" ]]; then
     export JDKBOOTDIR="$SRCDIR/jdk-${BOOTSTRAP_ADOPTIUM}"
 fi
 
-if [[ -z "$JDKBOOTDIR" && -n "$ALPINE_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-    # abinfo "Resolving Alpine musl version ..."
-    # curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/APKINDEX.tar.gz |
-    #     gzip -d | tar -x APKINDEX
-    # bootmuslversion="$(grep -E "^P:musl$" --max-count=1 -A 30 <APKINDEX |
-    #     grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    # echo "Bootstrap musl version: $bootmuslversion"
-
-    # abinfo "Downloading bootstrap musl ..."
-    # wget -O musl.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/musl-$bootmuslversion.apk"
-
-    abinfo "Resolving Alpine JDK version ..."
-    curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/APKINDEX.tar.gz |
-        gzip -d | tar -x APKINDEX
-    bootversion="$(grep -E "^P:openjdk${JAVA_MAJOR_VERSION}$" --max-count=1 -A 30 <APKINDEX |
-        grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    rm -vf APKINDEX
-
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jdk-$bootversion.apk"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-$bootversion.apk"
-    abinfo "Downloading bootstrap headless JRE ..."
-    wget -O jre-headless.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-headless-$bootversion.apk"
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        tar -xf "$path"
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk"
-fi
-
 if [[ -z "$JDKBOOTDIR" && -n "$DEBIAN_ARCH" ]]; then
     mkdir bootpkgs
     pushd bootpkgs || exit
 
-    abinfo "Resolving Debian sid JDK version ..."
-    bootversion="$(curl -sSL https://ftp.debian.org/debian/dists/$BOOTSTRAP_DEBIAN/main/binary-$DEBIAN_ARCH/Packages.xz |
-        xz -d - | grep -E "^Package: openjdk-${JAVA_MAJOR_VERSION}-jdk$" --max-count 1 -A 30 |
-        grep --max-count 1 -E '^Version: ' | cut -d' ' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
     abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jdk.deb "https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/$DEBIAN_ARCH/jdk.deb"
     abinfo "Downloading bootstrap JDK (headless) ..."
-    wget -O jdk-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk-headless_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jdk-headless.deb "https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/$DEBIAN_ARCH/jdk-headless.deb"
     abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jre.deb "https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/$DEBIAN_ARCH/jre.deb"
     abinfo "Downloading bootstrap JRE (headless) ..."
-    wget -O jre-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre-headless_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jre-headless.deb "https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/$DEBIAN_ARCH/jre-headless.deb"
     popd || exit
 
     pushd / || exit
@@ -122,11 +71,11 @@ fi
 
 if [[ -z "$JDKBOOTDIR" && -n "$LOONGARCH64_BOOT" ]]; then
     abinfo "Downloading LoongArchLinux JRE binary toolchain ..."
-    wget -O bootjre.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
+    wget -O bootjre.tar.zst https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/loongarch64/bootjdk.tar.zst
     abinfo "Downloading LoongArchLinux headless JRE binary toolchain ..."
-    wget -O bootjre-headless.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk-headless/download/
+    wget -O bootjre-headless.tar.zst https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/loongarch64/bootjre-headless.tar.zst
     abinfo "Downloading LoongArchLinux JDK binary toolchain ..."
-    wget -O bootjdk.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
+    wget -O bootjdk.tar.zst https://repo.aosc.io/aosc-repacks/openjdk-17-repacks/loongarch64/bootjdk.tar.zst
 
     mkdir bootjdk
     cd bootjdk || exit
@@ -189,35 +138,34 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER="$(readlink -f build/linux-*-*-release/images/)"
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -227,4 +175,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset ADOPTIUM_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-17/autobuild/defines
+++ b/lang-java/openjdk-17/autobuild/defines
@@ -7,7 +7,7 @@ PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment 
 
 PKGPROV="jre-openjdk jre17-openjdk openjdk17"
 NOPARALLEL=1
-PKGEPOCH=3
+ABTYPE=self
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-17/autobuild/defines.stage2
+++ b/lang-java/openjdk-17/autobuild/defines.stage2
@@ -6,7 +6,7 @@ PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment 
 
 PKGPROV="jre-openjdk jre17-openjdk openjdk17"
 NOPARALLEL=1
-PKGEPOCH=3
+ABTYPE=self
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-17/autobuild/prepare.stage2
+++ b/lang-java/openjdk-17/autobuild/prepare.stage2
@@ -1,3 +1,5 @@
+_JAVA_VERSION=17
+
 abinfo "Overriding GNU config files ..."
 cp -v /usr/share/automake-*/config.* "$SRCDIR"/make/autoconf/build-aux/
 

--- a/lang-java/openjdk-17/spec
+++ b/lang-java/openjdk-17/spec
@@ -1,5 +1,7 @@
 UPSTREAM_VER=17.0.16-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
+EPOCH=3
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235001"

--- a/lang-java/openjdk-21/autobuild/build
+++ b/lang-java/openjdk-21/autobuild/build
@@ -3,18 +3,15 @@ EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-21"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "mipsel" ] && export ADOPTIUM_ARCH="mipsel"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export ADOPTIUM_ARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export JDK_HAS_JIT=y
+ab_match_arch "armv4" && export JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export JDK_HAS_JIT=y
+ab_match_arch "arm64" && export JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export JDK_HAS_JIT=y
+ab_match_arch "riscv64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -23,7 +20,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch armv7hf ; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -61,35 +58,34 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -99,4 +95,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JDKBOOTDIR

--- a/lang-java/openjdk-21/autobuild/build.stage2
+++ b/lang-java/openjdk-21/autobuild/build.stage2
@@ -5,21 +5,22 @@ BOOTSTRAP_ALPINE="v3.20"
 BOOTSTRAP_DEBIAN="sid"
 # the current version of LoongArchLinux jre-openjdk package
 # https://loongarchlinux.org/package/?repo=extra&arch=loong64&name=jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk
-BOOTSTRAP_LOONGARCH64_SUF=""
-BOOTSTRAP_LOONGARCH64="20"
+BOOTSTRAP_LOONGARCH64_SUF="-21"
+BOOTSTRAP_LOONGARCH64="21"
 OPENJDK_SUFFIX="-21"
 JDKBOOTDIR=""
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -28,7 +29,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch armv7hf ; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -46,68 +47,18 @@ if [[ -z "$JDKBOOTDIR" && -n "$ADOPTIUM_ARCH" ]]; then
     export JDKBOOTDIR="$SRCDIR/jdk-${BOOTSTRAP_ADOPTIUM}"
 fi
 
-if [[ -z "$JDKBOOTDIR" && -n "$ALPINE_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-    # abinfo "Resolving Alpine musl version ..."
-    # curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/APKINDEX.tar.gz |
-    #     gzip -d | tar -x APKINDEX
-    # bootmuslversion="$(grep -E "^P:musl$" --max-count=1 -A 30 <APKINDEX |
-    #     grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    # echo "Bootstrap musl version: $bootmuslversion"
-
-    # abinfo "Downloading bootstrap musl ..."
-    # wget -O musl.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/musl-$bootmuslversion.apk"
-
-    abinfo "Resolving Alpine JDK version ..."
-    curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/APKINDEX.tar.gz |
-        gzip -d | tar -x APKINDEX
-    bootversion="$(grep -E "^P:openjdk${JAVA_MAJOR_VERSION}$" --max-count=1 -A 30 <APKINDEX |
-        grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    rm -vf APKINDEX
-
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jdk-$bootversion.apk"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-$bootversion.apk"
-    abinfo "Downloading bootstrap headless JRE ..."
-    wget -O jre-headless.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-headless-$bootversion.apk"
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        tar -xf "$path"
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk"
-fi
-
 if [[ -z "$JDKBOOTDIR" && -n "$DEBIAN_ARCH" ]]; then
     mkdir bootpkgs
     pushd bootpkgs || exit
 
-    abinfo "Resolving Debian sid JDK version ..."
-    bootversion="$(curl -sSL https://ftp.debian.org/debian/dists/$BOOTSTRAP_DEBIAN/main/binary-$DEBIAN_ARCH/Packages.xz |
-        xz -d - | grep -E "^Package: openjdk-${JAVA_MAJOR_VERSION}-jdk$" --max-count 1 -A 30 |
-        grep --max-count 1 -E '^Version: ' | cut -d' ' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
     abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jdk.deb "https://repo.aosc.io/aosc-repacks/openjdk-21-repack/$DEBIAN_ARCH/jdk.deb"
     abinfo "Downloading bootstrap JDK (headless) ..."
-    wget -O jdk-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk-headless_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jdk-headless.deb "https://repo.aosc.io/aosc-repacks/openjdk-21-repack/$DEBIAN_ARCH/jdk-headless.deb"
     abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jre.deb "https://repo.aosc.io/aosc-repacks/openjdk-21-repack/$DEBIAN_ARCH/jre.deb"
     abinfo "Downloading bootstrap JRE (headless) ..."
-    wget -O jre-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre-headless_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jre-headless.deb "https://repo.aosc.io/aosc-repacks/openjdk-21-repack/$DEBIAN_ARCH/jre-headless.deb"
     popd || exit
 
     pushd / || exit
@@ -122,11 +73,11 @@ fi
 
 if [[ -z "$JDKBOOTDIR" && -n "$LOONGARCH64_BOOT" ]]; then
     abinfo "Downloading LoongArchLinux JRE binary toolchain ..."
-    wget -O bootjre.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
+    wget -O bootjre.tar.zst https://repo.aosc.io/aosc-repacks/jre21-openjdk-headless-21.0.9.u10-1-loong64.pkg.tar.zst
     abinfo "Downloading LoongArchLinux headless JRE binary toolchain ..."
-    wget -O bootjre-headless.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk-headless/download/
+    wget -O bootjre-headless.tar.zst https://repo.aosc.io/aosc-repacks/jre21-openjdk-headless-21.0.9.u10-1-loong64.pkg.tar.zst
     abinfo "Downloading LoongArchLinux JDK binary toolchain ..."
-    wget -O bootjdk.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
+    wget -O bootjdk.tar.zst https://repo.aosc.io/aosc-repacks/jdk21-openjdk-21.0.9.u10-1-loong64.pkg.tar.zst
 
     mkdir bootjdk
     cd bootjdk || exit
@@ -190,35 +141,34 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
-cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share/man
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -228,4 +178,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset ADOPTIUM_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-21/autobuild/defines
+++ b/lang-java/openjdk-21/autobuild/defines
@@ -4,10 +4,9 @@ PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 
         cups fontconfig unzip zip cpio"
 BUILDDEP="openjdk-21"
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 21)"
-
+ABTYPE=self
 PKGPROV="jre-openjdk jre${PKGVER%%.*}-openjdk openjdk-${PKGVER%%.*}"
 NOPARALLEL=1
-PKGEPOCH=3
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-21/autobuild/defines.stage2
+++ b/lang-java/openjdk-21/autobuild/defines.stage2
@@ -3,10 +3,9 @@ PKGSEC=java
 PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
         cups fontconfig unzip zip cpio giflib"
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 21)"
-
+ABTYPE=self
 PKGPROV="jre-openjdk jre${PKGVER%%.*}-openjdk openjdk${PKGVER%%.*} openjdk-${PKGVER%%.*}"
 NOPARALLEL=1
-PKGEPOCH=3
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-21/autobuild/prepare.stage2
+++ b/lang-java/openjdk-21/autobuild/prepare.stage2
@@ -1,3 +1,5 @@
+_JAVA_VERSION=21
+
 abinfo "Overriding GNU config files ..."
 cp -v /usr/share/automake-*/config.* "$SRCDIR"/make/autoconf/build-aux/
 

--- a/lang-java/openjdk-21/spec
+++ b/lang-java/openjdk-21/spec
@@ -1,5 +1,7 @@
 UPSTREAM_VER=21.0.8-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
+EPOCH=4
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369281"

--- a/lang-java/openjdk-22/autobuild/build
+++ b/lang-java/openjdk-22/autobuild/build
@@ -3,18 +3,15 @@ EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-22"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "mipsel" ] && export ADOPTIUM_ARCH="mipsel"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export ADOPTIUM_ARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export JDK_HAS_JIT=y
+ab_match_arch "armv4" && export JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export JDK_HAS_JIT=y
+ab_match_arch "arm64" && export JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export JDK_HAS_JIT=y
+ab_match_arch "riscv64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -23,7 +20,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch armv7hf ; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -61,35 +58,34 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
 ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -99,4 +95,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JDKBOOTDIR

--- a/lang-java/openjdk-22/autobuild/build.stage2
+++ b/lang-java/openjdk-22/autobuild/build.stage2
@@ -1,26 +1,19 @@
 ##### Control part variables
 EXTRA_FEATURES="jfr"
-BOOTSTRAP_ADOPTIUM=21.0.4+7
-BOOTSTRAP_ALPINE="v3.20"
-BOOTSTRAP_DEBIAN="sid"
-# the current version of LoongArchLinux jre-openjdk package
-# https://loongarchlinux.org/package/?repo=extra&arch=loong64&name=jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk
-BOOTSTRAP_LOONGARCH64_SUF=""
-BOOTSTRAP_LOONGARCH64="20"
 OPENJDK_SUFFIX="-22"
 # set to /usr/lib/java to bootstrap from AOSC OS JDK
 JDKBOOTDIR="/usr/lib/java-21"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export JDK_HAS_JIT=y
+ab_match_arch "armv4" && export JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export JDK_HAS_JIT=y
+ab_match_arch "arm64" && export JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export JDK_HAS_JIT=y
+ab_match_arch "riscv64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -29,7 +22,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch armv7hf ; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -37,122 +30,6 @@ unset JAVA_HOME
 unset _JAVA_OPTIONS
 
 JAVA_MAJOR_VERSION="${PKGVER%%.*}"
-if [[ -z "$JDKBOOTDIR" && -n "$ADOPTIUM_ARCH" ]]; then
-    abinfo "Downloading Adoptium binary toolchain ..."
-    wget -O bootjdk.tar.gz "https://github.com/adoptium/temurin${JAVA_MAJOR_VERSION}-binaries/releases/download/jdk-${BOOTSTRAP_ADOPTIUM}/OpenJDK${JAVA_MAJOR_VERSION}U-jdk_${ADOPTIUM_ARCH}_linux_hotspot_${BOOTSTRAP_ADOPTIUM/+/_}.tar.gz"
-
-    abinfo "Preparing Adoptium binary toolchain ..."
-    tar -xf bootjdk.tar.gz
-
-    export JDKBOOTDIR="$SRCDIR/jdk-${BOOTSTRAP_ADOPTIUM}"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$ALPINE_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-    # abinfo "Resolving Alpine musl version ..."
-    # curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/APKINDEX.tar.gz |
-    #     gzip -d | tar -x APKINDEX
-    # bootmuslversion="$(grep -E "^P:musl$" --max-count=1 -A 30 <APKINDEX |
-    #     grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    # echo "Bootstrap musl version: $bootmuslversion"
-
-    # abinfo "Downloading bootstrap musl ..."
-    # wget -O musl.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/musl-$bootmuslversion.apk"
-
-    abinfo "Resolving Alpine JDK version ..."
-    curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/APKINDEX.tar.gz |
-        gzip -d | tar -x APKINDEX
-    bootversion="$(grep -E "^P:openjdk${JAVA_MAJOR_VERSION}$" --max-count=1 -A 30 <APKINDEX |
-        grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    rm -vf APKINDEX
-
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jdk-$bootversion.apk"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-$bootversion.apk"
-    abinfo "Downloading bootstrap headless JRE ..."
-    wget -O jre-headless.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-headless-$bootversion.apk"
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        tar -xf "$path"
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$DEBIAN_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-
-    abinfo "Resolving Debian sid JDK version ..."
-    bootversion="$(curl -sSL https://ftp.debian.org/debian/dists/$BOOTSTRAP_DEBIAN/main/binary-$DEBIAN_ARCH/Packages.xz |
-        xz -d - | grep -E "^Package: openjdk-${JAVA_MAJOR_VERSION}-jdk$" --max-count 1 -A 30 |
-        grep --max-count 1 -E '^Version: ' | cut -d' ' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JDK (headless) ..."
-    wget -O jdk-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk-headless_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JRE (headless) ..."
-    wget -O jre-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre-headless_${bootversion}_$DEBIAN_ARCH.deb"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        dpkg-deb --vextract "$path" /
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk-$DEBIAN_ARCH"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$LOONGARCH64_BOOT" ]]; then
-    abinfo "Downloading LoongArchLinux JRE binary toolchain ..."
-    wget -O bootjre.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
-    abinfo "Downloading LoongArchLinux headless JRE binary toolchain ..."
-    wget -O bootjre-headless.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk-headless/download/
-    abinfo "Downloading LoongArchLinux JDK binary toolchain ..."
-    wget -O bootjdk.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
-
-    mkdir bootjdk
-    cd bootjdk || exit
-    abinfo "Extracting JRE binary toolchain ..."
-    tar -xvf ../bootjre.tar.zst
-    abinfo "Extracting JRE-headless binary toolchain ..."
-    tar -xvf ../bootjre-headless.tar.zst
-    abinfo "Extracting JDK binary toolchain ..."
-    tar -xvf ../bootjdk.tar.zst
-
-    if [[ -e etc ]]; then
-        abinfo "Configuring boot JDK ..."
-        while read -r path; do
-            mkdir -pv /"$path"
-        done < <(find etc -type d)
-        while read -r path; do
-            cp -vf "$path" /"$path"
-        done < <(find etc -type f)
-    fi
-
-    cd .. || exit
-
-    export JDKBOOTDIR="$SRCDIR/bootjdk/usr/lib/jvm/java-$BOOTSTRAP_LOONGARCH64-openjdk"
-fi
-
 if [[ -z "$JDKBOOTDIR" ]]; then
     abdie "Could not find a possible bootstrap JDK"
 fi
@@ -191,35 +68,34 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
-cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -229,4 +105,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JDKBOOTDIR

--- a/lang-java/openjdk-22/autobuild/defines
+++ b/lang-java/openjdk-22/autobuild/defines
@@ -4,10 +4,9 @@ PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 
         cups fontconfig unzip zip cpio"
 BUILDDEP="openjdk-22"
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 22)"
-
+ABTYPE=self
 PKGPROV="jre-openjdk jre${PKGVER%%.*}-openjdk openjdk${PKGVER%%.*} openjdk-${PKGVER%%.*}"
 NOPARALLEL=1
-PKGEPOCH=3
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-22/autobuild/defines.stage2
+++ b/lang-java/openjdk-22/autobuild/defines.stage2
@@ -4,10 +4,9 @@ PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 
         cups fontconfig unzip zip cpio giflib"
 BUILDDEP="openjdk-21"
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 22)"
-
+ABTYPE=self
 PKGPROV="jre-openjdk jre${PKGVER%%.*}-openjdk openjdk${PKGVER%%.*} openjdk-${PKGVER%%.*}"
 NOPARALLEL=1
-PKGEPOCH=3
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-22/autobuild/prepare.stage2
+++ b/lang-java/openjdk-22/autobuild/prepare.stage2
@@ -1,3 +1,6 @@
+# Java version.
+_JAVA_VERSION=21
+
 abinfo "Overriding GNU config files ..."
 cp -v /usr/share/automake-*/config.* "$SRCDIR"/make/autoconf/build-aux/
 

--- a/lang-java/openjdk-22/spec
+++ b/lang-java/openjdk-22/spec
@@ -1,6 +1,7 @@
 UPSTREAM_VER=22.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=5
+REL=6
+EPOCH=3
 SRCS="git::commit=aosc/${UPSTREAM_VER%%.*}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373785"

--- a/lang-java/openjdk-23/autobuild/build
+++ b/lang-java/openjdk-23/autobuild/build
@@ -3,18 +3,16 @@ EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-23"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "mipsel" ] && export ADOPTIUM_ARCH="mipsel"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export ADOPTIUM_ARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export JDK_HAS_JIT=y
+ab_match_arch "armv4" && export JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export JDK_HAS_JIT=y
+ab_match_arch "arm64" && export JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export JDK_HAS_JIT=y
+ab_match_arch "riscv64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export JDK_HAS_JIT=y
+
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -23,7 +21,7 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch armv7hf ; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -61,35 +59,38 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
-cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
+
+IMAGE_FOLDER=build/aosc/images/
+abinfo "Copying JDK images ..."
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share/
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
 ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
-        mv -vf "$path" "$path""$OPENJDK_SUFFIX"
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
+        mv -v "$path" "$path""$OPENJDK_SUFFIX"
     done
-    mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
+    mv -v "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
 fi
 
 abinfo "Generating conffiles ..."
@@ -99,4 +100,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JDKBOOTDIR

--- a/lang-java/openjdk-23/autobuild/build.stage2
+++ b/lang-java/openjdk-23/autobuild/build.stage2
@@ -12,15 +12,15 @@ OPENJDK_SUFFIX="-23"
 JDKBOOTDIR="/usr/lib/java-22"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export JDK_HAS_JIT=y
+ab_match_arch "armv4" && export JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export JDK_HAS_JIT=y
+ab_match_arch "arm64" && export JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export JDK_HAS_JIT=y
+ab_match_arch "riscv64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export JDK_HAS_JIT=y
 
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     config_zero="--with-jvm-variants=zero --enable-precompiled-headers"
@@ -29,128 +29,12 @@ else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch "armv7hf" ; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
 unset JAVA_HOME
 unset _JAVA_OPTIONS
-
-if [[ -z "$JDKBOOTDIR" && -n "$ADOPTIUM_ARCH" ]]; then
-    abinfo "Downloading Adoptium binary toolchain ..."
-    wget -O bootjdk.tar.gz "https://github.com/adoptium/temurin${MAJOR_VER}-binaries/releases/download/jdk-${BOOTSTRAP_ADOPTIUM}/OpenJDK${MAJOR_VER}U-jdk_${ADOPTIUM_ARCH}_linux_hotspot_${BOOTSTRAP_ADOPTIUM/+/_}.tar.gz"
-
-    abinfo "Preparing Adoptium binary toolchain ..."
-    tar -xf bootjdk.tar.gz
-
-    export JDKBOOTDIR="$SRCDIR/jdk-${BOOTSTRAP_ADOPTIUM}"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$ALPINE_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-    # abinfo "Resolving Alpine musl version ..."
-    # curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/APKINDEX.tar.gz |
-    #     gzip -d | tar -x APKINDEX
-    # bootmuslversion="$(grep -E "^P:musl$" --max-count=1 -A 30 <APKINDEX |
-    #     grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    # echo "Bootstrap musl version: $bootmuslversion"
-
-    # abinfo "Downloading bootstrap musl ..."
-    # wget -O musl.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/musl-$bootmuslversion.apk"
-
-    abinfo "Resolving Alpine JDK version ..."
-    curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/APKINDEX.tar.gz |
-        gzip -d | tar -x APKINDEX
-    bootversion="$(grep -E "^P:openjdk${MAJOR_VER}$" --max-count=1 -A 30 <APKINDEX |
-        grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    rm -vf APKINDEX
-
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jmods-$bootversion.apk"
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jdk-$bootversion.apk"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jre-$bootversion.apk"
-    abinfo "Downloading bootstrap headless JRE ..."
-    wget -O jre-headless.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jre-headless-$bootversion.apk"
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jmods-$bootversion.apk"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        tar -xf "$path"
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${MAJOR_VER}-openjdk"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$DEBIAN_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-
-    abinfo "Resolving Debian sid JDK version ..."
-    bootversion="$(curl -sSL https://ftp.debian.org/debian/dists/$BOOTSTRAP_DEBIAN/main/binary-$DEBIAN_ARCH/Packages.xz |
-        xz -d - | grep -E "^Package: openjdk-${MAJOR_VER}-jdk$" --max-count 1 -A 30 |
-        grep --max-count 1 -E '^Version: ' | cut -d' ' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jdk_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JDK (headless) ..."
-    wget -O jdk-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jdk-headless_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jre_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JRE (headless) ..."
-    wget -O jre-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jre-headless_${bootversion}_$DEBIAN_ARCH.deb"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        dpkg-deb --vextract "$path" /
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${MAJOR_VER}-openjdk-$DEBIAN_ARCH"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$LOONGARCH64_BOOT" ]]; then
-    abinfo "Downloading LoongArchLinux JRE binary toolchain ..."
-    wget -O bootjre.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
-    abinfo "Downloading LoongArchLinux headless JRE binary toolchain ..."
-    wget -O bootjre-headless.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk-headless/download/
-    abinfo "Downloading LoongArchLinux JDK binary toolchain ..."
-    wget -O bootjdk.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
-
-    mkdir bootjdk
-    cd bootjdk || exit
-    abinfo "Extracting JRE binary toolchain ..."
-    tar -xvf ../bootjre.tar.zst
-    abinfo "Extracting JRE-headless binary toolchain ..."
-    tar -xvf ../bootjre-headless.tar.zst
-    abinfo "Extracting JDK binary toolchain ..."
-    tar -xvf ../bootjdk.tar.zst
-
-    if [[ -e etc ]]; then
-        abinfo "Configuring boot JDK ..."
-        while read -r path; do
-            mkdir -pv /"$path"
-        done < <(find etc -type d)
-        while read -r path; do
-            cp -vf "$path" /"$path"
-        done < <(find etc -type f)
-    fi
-
-    cd .. || exit
-
-    export JDKBOOTDIR="$SRCDIR/bootjdk/usr/lib/jvm/java-$BOOTSTRAP_LOONGARCH64-openjdk"
-fi
 
 if [[ -z "$JDKBOOTDIR" ]]; then
     abdie "Could not find a possible bootstrap JDK"
@@ -190,32 +74,31 @@ make product-images docs
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
+mkdir -pv "$PKGDIR"/usr/share/
 mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
 
 find "$PKGDIR"/usr/share/man -type l -delete
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
+mkdir -pv "$PKGDIR"/usr/src/openjdk
 mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java/lib/security/cacerts
 ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/security/cacerts
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
         mv -vf "$path" "$path""$OPENJDK_SUFFIX"
     done
     mv -vf "$PKGDIR"/usr/share/man/man1 "$PKGDIR"/usr/share/man/man1openjdk"$OPENJDK_SUFFIX"
@@ -228,4 +111,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JDKBOOTDIR

--- a/lang-java/openjdk-23/autobuild/defines
+++ b/lang-java/openjdk-23/autobuild/defines
@@ -4,10 +4,9 @@ PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 
         cups fontconfig unzip zip cpio"
 BUILDDEP="openjdk-23"
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 23)"
-
+ABTYPE=self
 PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"
 NOPARALLEL=1
-PKGEPOCH=3
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-23/autobuild/defines.stage2
+++ b/lang-java/openjdk-23/autobuild/defines.stage2
@@ -4,10 +4,9 @@ PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 
         cups fontconfig unzip zip cpio giflib"
 BUILDDEP="openjdk-22"
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 23)"
-
+ABTYPE=self
 PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"
 NOPARALLEL=1
-PKGEPOCH=3
 
 # FIXME: breaks binary.
 NOLTO=1

--- a/lang-java/openjdk-23/autobuild/prepare.stage2
+++ b/lang-java/openjdk-23/autobuild/prepare.stage2
@@ -1,3 +1,6 @@
+# Java version.
+_JAVA_VERSION=22
+
 abinfo "Overriding GNU config files ..."
 cp -v /usr/share/automake-*/config.* "$SRCDIR"/make/autoconf/build-aux/
 

--- a/lang-java/openjdk-23/spec
+++ b/lang-java/openjdk-23/spec
@@ -1,7 +1,8 @@
 MAJOR_VER=23
 UPSTREAM_VER=23.0.2-ga
 VER=${UPSTREAM_VER/-/+}
-REL=3
+REL=4
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
+EPOCH=3
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=374464"

--- a/lang-java/openjdk-24/autobuild/build
+++ b/lang-java/openjdk-24/autobuild/build
@@ -3,26 +3,24 @@ EXTRA_FEATURES="jfr"
 OPENJDK_SUFFIX="-24"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "mipsel" ] && export ADOPTIUM_ARCH="mipsel"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export ADOPTIUM_ARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="aarch32" JDK_HAS_JIT=y
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
+ab_match_arch "mipsel" && export ADOPTIUM_ARCH="mipsel"
+ab_match_arch "powerpc" && export ADOPTIUM_ARCH="ppc"
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
 
 __JDK_CONFIGURE_AFTER=()
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
     __JDK_CONFIGURE_AFTER+=(
         "--with-jvm-variants=zero"
         "--enable-precompiled-headers"
-        # Note: To address stack overflow when compiling on loongson3
-        "--with-boot-jdk-jvmargs=-Xss256M"
     )
 else
     EXTRA_FEATURES+=",shenandoahgc,zgc"
@@ -61,30 +59,30 @@ make product-images docs JOBS="$(nproc)"
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
-cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
 
-if [[ -e "$PKGDIR"/usr/lib/java/man ]]; then
+#FIXME: No pandoc for Loongson3 for now
+if ! ab_match_arch loongson3; then
+    mkdir -pv "$PKGDIR"/usr/share
     abinfo "Installing man pages ..."
     mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-    ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+    ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
     find "$PKGDIR"/usr/share/man -type l -delete
 else
-    abinfo "Man pages are not generated, skipping ..."
+    abwarn "Loongson3 has no pandoc!Skip copying manpages..."
 fi
 
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
 mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../../usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
 rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
@@ -92,7 +90,7 @@ ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/sec
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
         mv -vf "$path" "$path""$OPENJDK_SUFFIX"
     done
     if [[ -e "$PKGDIR"/usr/share/man/man1 ]]; then

--- a/lang-java/openjdk-24/autobuild/build.stage2
+++ b/lang-java/openjdk-24/autobuild/build.stage2
@@ -1,26 +1,19 @@
 ##### Control part variables
 EXTRA_FEATURES="jfr"
-BOOTSTRAP_ADOPTIUM=23+37
-BOOTSTRAP_ALPINE="v3.20"
-BOOTSTRAP_DEBIAN="sid"
-# the current version of LoongArchLinux jre-openjdk package
-# https://loongarchlinux.org/package/?repo=extra&arch=loong64&name=jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk
-BOOTSTRAP_LOONGARCH64_SUF=""
-BOOTSTRAP_LOONGARCH64="20"
 OPENJDK_SUFFIX="-24"
 # set to /usr/lib/java to bootstrap from AOSC OS JDK
 JDKBOOTDIR="/usr/lib/java-23"
 
 ##### Archtecture mapping
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="arm" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && export DEBIAN_ARCH="riscv64" JDK_HAS_JIT=y
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y" JDK_HAS_JIT=y
+ab_match_arch "amd64" && export JDK_HAS_JIT=y
+ab_match_arch "armv4" && export JDK_HAS_JIT=y
+ab_match_arch "armv6hf" && export JDK_HAS_JIT=y
+ab_match_arch "armv7hf" && export JDK_HAS_JIT=y
+ab_match_arch "arm64" && export JDK_HAS_JIT=y
+ab_match_arch "ppc64el" && export JDK_HAS_JIT=y
+ab_match_arch "riscv64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64" && export JDK_HAS_JIT=y
+ab_match_arch "loongarch64_nosimd" && export JDK_HAS_JIT=y
 
 __JDK_CONFIGURE_AFTER=()
 if [[ -z "${JDK_HAS_JIT:-}" ]]; then
@@ -36,122 +29,6 @@ fi
 
 unset JAVA_HOME
 unset _JAVA_OPTIONS
-
-if [[ -z "$JDKBOOTDIR" && -n "$ADOPTIUM_ARCH" ]]; then
-    abinfo "Downloading Adoptium binary toolchain ..."
-    wget -O bootjdk.tar.gz "https://github.com/adoptium/temurin${MAJOR_VER}-binaries/releases/download/jdk-${BOOTSTRAP_ADOPTIUM}/OpenJDK${MAJOR_VER}U-jdk_${ADOPTIUM_ARCH}_linux_hotspot_${BOOTSTRAP_ADOPTIUM/+/_}.tar.gz"
-
-    abinfo "Preparing Adoptium binary toolchain ..."
-    tar -xf bootjdk.tar.gz
-
-    export JDKBOOTDIR="$SRCDIR/jdk-${BOOTSTRAP_ADOPTIUM}"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$ALPINE_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-    # abinfo "Resolving Alpine musl version ..."
-    # curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/APKINDEX.tar.gz |
-    #     gzip -d | tar -x APKINDEX
-    # bootmuslversion="$(grep -E "^P:musl$" --max-count=1 -A 30 <APKINDEX |
-    #     grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    # echo "Bootstrap musl version: $bootmuslversion"
-
-    # abinfo "Downloading bootstrap musl ..."
-    # wget -O musl.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/main/$ALPINE_ARCH/musl-$bootmuslversion.apk"
-
-    abinfo "Resolving Alpine JDK version ..."
-    curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/APKINDEX.tar.gz |
-        gzip -d | tar -x APKINDEX
-    bootversion="$(grep -E "^P:openjdk${MAJOR_VER}$" --max-count=1 -A 30 <APKINDEX |
-        grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    rm -vf APKINDEX
-
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jmods-$bootversion.apk"
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jdk-$bootversion.apk"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jre-$bootversion.apk"
-    abinfo "Downloading bootstrap headless JRE ..."
-    wget -O jre-headless.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jre-headless-$bootversion.apk"
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${MAJOR_VER}-jmods-$bootversion.apk"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        tar -xf "$path"
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${MAJOR_VER}-openjdk"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$DEBIAN_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-
-    abinfo "Resolving Debian sid JDK version ..."
-    bootversion="$(curl -sSL https://ftp.debian.org/debian/dists/$BOOTSTRAP_DEBIAN/main/binary-$DEBIAN_ARCH/Packages.xz |
-        xz -d - | grep -E "^Package: openjdk-${MAJOR_VER}-jdk$" --max-count 1 -A 30 |
-        grep --max-count 1 -E '^Version: ' | cut -d' ' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jdk_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JDK (headless) ..."
-    wget -O jdk-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jdk-headless_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jre_${bootversion}_$DEBIAN_ARCH.deb"
-    abinfo "Downloading bootstrap JRE (headless) ..."
-    wget -O jre-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${MAJOR_VER}/openjdk-${MAJOR_VER}-jre-headless_${bootversion}_$DEBIAN_ARCH.deb"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        dpkg-deb --vextract "$path" /
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${MAJOR_VER}-openjdk-$DEBIAN_ARCH"
-fi
-
-if [[ -z "$JDKBOOTDIR" && -n "$LOONGARCH64_BOOT" ]]; then
-    abinfo "Downloading LoongArchLinux JRE binary toolchain ..."
-    wget -O bootjre.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
-    abinfo "Downloading LoongArchLinux headless JRE binary toolchain ..."
-    wget -O bootjre-headless.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk-headless/download/
-    abinfo "Downloading LoongArchLinux JDK binary toolchain ..."
-    wget -O bootjdk.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
-
-    mkdir bootjdk
-    cd bootjdk || exit
-    abinfo "Extracting JRE binary toolchain ..."
-    tar -xvf ../bootjre.tar.zst
-    abinfo "Extracting JRE-headless binary toolchain ..."
-    tar -xvf ../bootjre-headless.tar.zst
-    abinfo "Extracting JDK binary toolchain ..."
-    tar -xvf ../bootjdk.tar.zst
-
-    if [[ -e etc ]]; then
-        abinfo "Configuring boot JDK ..."
-        while read -r path; do
-            mkdir -pv /"$path"
-        done < <(find etc -type d)
-        while read -r path; do
-            cp -vf "$path" /"$path"
-        done < <(find etc -type f)
-    fi
-
-    cd .. || exit
-
-    export JDKBOOTDIR="$SRCDIR/bootjdk/usr/lib/jvm/java-$BOOTSTRAP_LOONGARCH64-openjdk"
-fi
 
 if [[ -z "$JDKBOOTDIR" ]]; then
     abdie "Could not find a possible bootstrap JDK"
@@ -190,30 +67,30 @@ make product-images docs JOBS="$(nproc)"
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-install -dv -m 755 "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
-cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
+cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
-ln -sv /etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
 
-if [[ -e "$PKGDIR"/usr/lib/java/man ]]; then
+#FIXME: No pandoc for Loongson3 for now
+if ! ab_match_arch loongson3; then
+    mkdir -pv "$PKGDIR"/usr/share
     abinfo "Installing man pages ..."
     mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
-    ln -sv /usr/share/man "$PKGDIR"/usr/lib/java/man
+    ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
     find "$PKGDIR"/usr/share/man -type l -delete
 else
-    abinfo "Man pages are not generated, skipping ..."
+    abwarn "Loongson3 has no pandoc!Skip copying manpages..."
 fi
 
 find "$PKGDIR" -iname '*.diz' -exec rm {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm {} \;
 
-mkdir -p "$PKGDIR"/usr/src/openjdk
-mv "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv /usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk
+mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
+ln -sv ../../../src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
 rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
@@ -221,7 +98,7 @@ ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java/lib/sec
 
 if [[ -n "$OPENJDK_SUFFIX" ]]; then
     abinfo "Renaming for openjdk suffix ..."
-    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/share/doc/openjdk,/usr/src/openjdk}; do
+    for path in "$PKGDIR"{/etc/openjdk,/usr/lib/java,/usr/src/openjdk}; do
         mv -vf "$path" "$path""$OPENJDK_SUFFIX"
     done
     if [[ -e "$PKGDIR"/usr/share/man/man1 ]]; then
@@ -236,4 +113,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset ADOPTIUM_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-24/autobuild/defines
+++ b/lang-java/openjdk-24/autobuild/defines
@@ -2,12 +2,19 @@ PKGNAME=openjdk-24
 PKGSEC=java
 PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
         cups fontconfig unzip zip cpio"
-BUILDDEP="openjdk-24"
-# FIXME: pandoc is only available on amd64 and arm64
-BUILDDEP__AMD64="${BUILDDEP} pandoc graphviz"
-BUILDDEP__ARM64="${BUILDDEP} pandoc graphviz"
-PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 24)"
+BUILDDEP="openjdk-24 graphviz"
 
+#FIXME: loongson3 has no pandoc for now
+BUILDDEP__PANDOC="${BUILDDEP} pandoc"
+BUILDDEP__AMD64="${BUILDDEP__PANDOC}"
+BUILDDEP__ARM64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP__PANDOC}"
+BUILDDEP__RISCV64="${BUILDDEP__PANDOC}"
+BUILDDEP__PPC64EL="${BUILDDEP__PANDOC}"
+
+PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 24)"
+ABTYPE=self
 PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"
 
 # Note: openjdk uses "make JOBS=n"

--- a/lang-java/openjdk-24/autobuild/defines.stage2
+++ b/lang-java/openjdk-24/autobuild/defines.stage2
@@ -1,10 +1,20 @@
 PKGNAME=openjdk-24
 PKGSEC=java
 PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
-        cups fontconfig unzip zip cpio"
-BUILDDEP="openjdk-23"
-PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 24)"
+        cups fontconfig unzip zip cpio "
+BUILDDEP="openjdk-23 graphviz"
 
+#FIXME: loongson3 has no pandoc for now
+BUILDDEP__PANDOC="${BUILDDEP} pandoc"
+BUILDDEP__AMD64="${BUILDDEP__PANDOC}"
+BUILDDEP__ARM64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP__PANDOC}"
+BUILDDEP__RISCV64="${BUILDDEP__PANDOC}"
+BUILDDEP__PPC64EL="${BUILDDEP__PANDOC}"
+
+PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 24)"
+ABTYPE=self
 PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"
 
 # Note: openjdk uses "make JOBS=n"

--- a/lang-java/openjdk-24/autobuild/prepare.stage2
+++ b/lang-java/openjdk-24/autobuild/prepare.stage2
@@ -1,5 +1,8 @@
+# Java version.
+_JAVA_VERSION=23
+
 abinfo "Overriding GNU config files ..."
-cp -v /usr/share/automake-*/config.* "$SRCDIR"/make/autoconf/build-aux/
+cp -v /usr/bin/config.* "$SRCDIR"/make/autoconf/build-aux/
 
 abinfo "Setting compilation flags ..."
 

--- a/lang-java/openjdk-24/spec
+++ b/lang-java/openjdk-24/spec
@@ -1,6 +1,7 @@
 MAJOR_VER=24
 UPSTREAM_VER=24.0.2-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376246"

--- a/lang-java/openjdk-25/autobuild/build
+++ b/lang-java/openjdk-25/autobuild/build
@@ -63,24 +63,24 @@ make product-images docs JOBS="$(nproc)"
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-# Not installing docs
-# mkdir -pv "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -av "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-# Not installing docs
-# cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
 ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
-# FIXME: no pandoc for other architecture for now
-if ab_match_arch amd64 || ab_match_arch arm64 ; then
+
+#FIXME: No pandoc for Loongson3 for now
+if ! ab_match_arch loongson3; then
     mkdir -pv "$PKGDIR"/usr/share
     abinfo "Installing man pages ..."
     mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
     ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
     find "$PKGDIR"/usr/share/man -type l -delete
+else
+    abwarn "Loongson3 has no pandoc!Skip copying manpages..."
 fi
+
 find "$PKGDIR" -iname '*.diz' -exec rm -v {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm -v {} \;
 

--- a/lang-java/openjdk-25/autobuild/build.stage2
+++ b/lang-java/openjdk-25/autobuild/build.stage2
@@ -79,31 +79,30 @@ make product-images docs JOBS="$(nproc)"
 
 mkdir -pv "$PKGDIR"/usr/lib/java
 mkdir -pv "$PKGDIR/etc/"
-# disabling docs
-# mkdir -pv "$PKGDIR"/usr/share/doc
 
 IMAGE_FOLDER=build/aosc/images/
 abinfo "Copying JDK images ..."
 cp -rv "${IMAGE_FOLDER}"/jdk/* "$PKGDIR"/usr/lib/java/
-# disabling docs
-# cp -rv "${IMAGE_FOLDER}"/docs "$PKGDIR"/usr/share/doc/openjdk/
 mv -v "$PKGDIR"/usr/lib/java/conf "$PKGDIR"/etc/openjdk/
-ln -sv ../../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
+ln -sv ../../../etc/openjdk"$OPENJDK_SUFFIX"/ "$PKGDIR"/usr/lib/java/conf
 
-# FIXME: no pandoc for other architecture for now
-if ab_match_arch amd64 || ab_match_arch arm64 ; then
-    abinfo "Installing man pages ..."
+#FIXME: No pandoc for Loongson3 for now
+if ! ab_match_arch loongson3; then
     mkdir -pv "$PKGDIR"/usr/share
+    abinfo "Installing man pages ..."
     mv -v "$PKGDIR"/usr/lib/java/man "$PKGDIR"/usr/share/man
     ln -sv ../../share/man "$PKGDIR"/usr/lib/java/man
     find "$PKGDIR"/usr/share/man -type l -delete
+else
+    abwarn "Loongson3 has no pandoc!Skip copying manpages..."
 fi
+
 find "$PKGDIR" -iname '*.diz' -exec rm -v {} \;
 find "$PKGDIR" -iname '*.debuginfo' -exec rm -v {} \;
 
 mkdir -pv "$PKGDIR"/usr/src/openjdk
 mv -v "$PKGDIR"/usr/lib/java/lib/src.zip "$PKGDIR"/usr/src/openjdk/src.zip
-ln -sv ../../../../usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
+ln -sv ../../../usr/src/openjdk"$OPENJDK_SUFFIX"/src.zip "$PKGDIR"/usr/lib/java/lib/src.zip
 
 abinfo "Linking system CA certificate store ..."
 rm -fv "$PKGDIR"/usr/lib/java/lib/security/cacerts
@@ -126,4 +125,4 @@ while read -r path; do
 done < <(find etc/openjdk"$OPENJDK_SUFFIX" -type f)
 popd || exit
 
-unset ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset ADOPTIUM_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-25/autobuild/defines
+++ b/lang-java/openjdk-25/autobuild/defines
@@ -2,10 +2,17 @@ PKGNAME=openjdk-25
 PKGSEC=java
 PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
         cups fontconfig unzip zip cpio"
-BUILDDEP="openjdk-25"
-# FIXME: pandoc is only available on amd64 and arm64
-BUILDDEP__AMD64="${BUILDDEP} pandoc graphviz"
-BUILDDEP__ARM64="${BUILDDEP} pandoc graphviz"
+BUILDDEP="openjdk-25 graphviz"
+
+#FIXME: loongson3 has no pandoc for now
+BUILDDEP__PANDOC="${BUILDDEP} pandoc"
+BUILDDEP__AMD64="${BUILDDEP__PANDOC}"
+BUILDDEP__ARM64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP__PANDOC}"
+BUILDDEP__RISCV64="${BUILDDEP__PANDOC}"
+BUILDDEP__PPC64EL="${BUILDDEP__PANDOC}"
+
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 25)"
 ABTYPE=self
 PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"

--- a/lang-java/openjdk-25/autobuild/defines.stage2
+++ b/lang-java/openjdk-25/autobuild/defines.stage2
@@ -2,10 +2,17 @@ PKGNAME=openjdk-25
 PKGSEC=java
 PKGDEP="openjdk-common ca-certs nss xdg-utils hicolor-icon-theme alsa-lib gtk-2 \
         cups fontconfig unzip zip cpio"
-BUILDDEP="openjdk-24"
-# FIXME: pandoc is only available on amd64 and arm64
-BUILDDEP__AMD64="${BUILDDEP} pandoc graphviz"
-BUILDDEP__ARM64="${BUILDDEP} pandoc graphviz"
+BUILDDEP="openjdk-25 graphviz"
+
+#FIXME: loongson3 has no pandoc for now
+BUILDDEP__PANDOC="${BUILDDEP} pandoc"
+BUILDDEP__AMD64="${BUILDDEP__PANDOC}"
+BUILDDEP__ARM64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64="${BUILDDEP__PANDOC}"
+BUILDDEP__LOONGARCH64_NOSIMD="${BUILDDEP__PANDOC}"
+BUILDDEP__RISCV64="${BUILDDEP__PANDOC}"
+BUILDDEP__PPC64EL="${BUILDDEP__PANDOC}"
+
 PKGDES="OpenJDK Java Runtime Environment (JRE) and Java Development Environment (JDK) (version 25)"
 
 PKGPROV="jre-openjdk jre${MAJOR_VER}-openjdk openjdk${MAJOR_VER} openjdk-${MAJOR_VER}"

--- a/lang-java/openjdk-25/spec
+++ b/lang-java/openjdk-25/spec
@@ -2,5 +2,6 @@ MAJOR_VER=25
 UPSTREAM_VER=25.0.2-ga
 VER=${UPSTREAM_VER/-/+}
 SRCS="git::commit=aosc/${MAJOR_VER}/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk"
+REL=1
 CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=376246"
+CHKUPDATE="anitya::id=378887"

--- a/lang-java/openjdk-8/autobuild/build
+++ b/lang-java/openjdk-8/autobuild/build
@@ -2,33 +2,34 @@
 UPDATE=${PKGVER:2:-3}
 BUILD=${PKGVER:(-2)}
 SJAVAC=1
-[ "${CROSS:-$ARCH}" = "amd64" ] && export JARCH="x86_64" CONFARCH="amd64"
-[ "${CROSS:-$ARCH}" = "armv4" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "arm64" ] && export JARCH="aarch64" CONFARCH="aarch64"
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export JARCH="mips64" CONFARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export JARCH="loongarch64" CONFARCH="loongarch64"
-[ "${CROSS:-$ARCH}" = "loongarch64_nosimd" ] && export JARCH="loongarch64" CONFARCH="loongarch64"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export JARCH="ppc" CONFARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64" ] && export JARCH="ppc64" CONFARCH="ppc64"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export JARCH="ppc64le" CONFARCH="ppc64le"
+ab_match_arch "amd64" && export JARCH="x86_64" CONFARCH="amd64"
+ab_match_arch "armv4" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "armv6hf" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "armv7hf" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "arm64" && export JARCH="aarch64" CONFARCH="aarch64"
+ab_match_arch "loongson3" && export JARCH="mips64" CONFARCH="mips64el"
+ab_match_arch "loongarch64" && export JARCH="loongarch64" CONFARCH="loongarch64"
+ab_match_arch "loongarch64_nosimd" && export JARCH="loongarch64" CONFARCH="loongarch64"
+ab_match_arch "powerpc" && export JARCH="ppc" CONFARCH="ppc"
+ab_match_arch "ppc64" && export JARCH="ppc64" CONFARCH="ppc64"
+ab_match_arch "ppc64el" && export JARCH="ppc64le" CONFARCH="ppc64le"
 
-if [[ "${CROSS:-$ARCH}" != "amd64" && \
-      "${CROSS:-$ARCH}" != "arm64" && \
-      "${CROSS:-$ARCH}" != ppc64* && \
-      "${CROSS:-$ARCH}" != "loongson3" && \
-      "${CROSS:-$ARCH}" != "loongarch64" && \
-      "${CROSS:-$ARCH}" != "loongarch64_nosimd" ]]; then
+if ! ab_match_arch "amd64" && \
+   ! ab_match_arch "arm64" && \
+   ! ab_match_arch "ppc64" && \
+   ! ab_match_arch "ppc64el" && \
+   ! ab_match_arch "loongson3" && \
+   ! ab_match_arch "loongarch64" && \
+   ! ab_match_arch "loongarch64_nosimd"; then
     config_zero="--with-jvm-variants=zero"
     SJAVAC=0
 else
     config_zero=" "
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv4" || \
-      "${CROSS:-$ARCH}" = "armv6hf" || \
-      "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch "armv4" || \
+   ab_match_arch "armv6hf" || \
+   ab_match_arch "armv7hf"; then
     config_zero="--with-jvm-variants=client"
 fi
 
@@ -36,9 +37,9 @@ if [[ "${SJAVAC}" == "1" ]]; then
     use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv4" || \
-      "${CROSS:-$ARCH}" = "armv6hf" || \
-      "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch "armv4" || \
+   ab_match_arch "armv6hf" || \
+   ab_match_arch "armv7hf"; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -79,13 +80,13 @@ find . -iname '*.diz' -exec rm {} \;
 find . -iname '*.debuginfo' -exec rm {} \;
 popd
 
-mkdir -p "$PKGDIR"/usr/lib/java-8
-cp -r image/jvm/openjdk-1.8.0_${UPDATE}-AOSC/* "$PKGDIR"/usr/lib/java-8/
+mkdir -vp "$PKGDIR"/usr/lib/java-8
+cp -vr image/jvm/openjdk-1.8.0_${UPDATE}-AOSC/* "$PKGDIR"/usr/lib/java-8/
 
-mv "$PKGDIR"/usr/lib/java-8/jre/lib/management/jmxremote.password{.template,}
-mv "$PKGDIR"/usr/lib/java-8/jre/lib/management/snmp.acl{.template,}
+mv -v "$PKGDIR"/usr/lib/java-8/jre/lib/management/jmxremote.password{.template,}
+mv -v "$PKGDIR"/usr/lib/java-8/jre/lib/management/snmp.acl{.template,}
 
-mkdir -p "$PKGDIR"/etc/openjdk-8/
+mkdir -vp "$PKGDIR"/etc/openjdk-8/
 for i in ${CONFARCH}/jvm.cfg \
          calendars.properties \
          content-types.properties \
@@ -106,42 +107,20 @@ for i in ${CONFARCH}/jvm.cfg \
     install -D -m 644 ${_filepkgpath} "$PKGDIR"/etc/openjdk-8/${i}
 done
 
-mkdir -p "$PKGDIR"/usr/src/openjdk-8
-mv "$PKGDIR"/usr/lib/java-8/src.zip "$PKGDIR"/usr/src/openjdk-8/src.zip
-ln -sv /usr/src/openjdk-8/src.zip "$PKGDIR"/usr/lib/java-8/src.zip
+mkdir -pv "$PKGDIR"/usr/src/openjdk-8
+mv -v "$PKGDIR"/usr/lib/java-8/src.zip "$PKGDIR"/usr/src/openjdk-8/src.zip
+ln -sv ../../../src/openjdk-8/src.zip "$PKGDIR"/usr/lib/java-8/src.zip
 
-install -d -m 755 "$PKGDIR"/usr/share/doc/openjdk-8
-if [[ "${CROSS:-$ARCH}" != "amd64" && \
-       "${CROSS:-$ARCH}" != "arm64" && \
-       "${CROSS:-$ARCH}" != "armv4" && \
-       "${CROSS:-$ARCH}" != "armv6hf" && \
-       "${CROSS:-$ARCH}" != armv7hf && \
-       "${CROSS:-$ARCH}" != ppc64* && \
-       "${CROSS:-$ARCH}" != "loongson3" && \
-       "${CROSS:-$ARCH}" != "loongarch64" && \
-       "${CROSS:-$ARCH}" != "loongarch64_nosimd" ]]; then
-    cp -r build/linux-${JARCH}-normal-zero-release/docs/* \
-        "$PKGDIR"/usr/share/doc/openjdk-8/
-elif [[ "${CROSS:-$ARCH}" = "armv4" || \
-        "${CROSS:-$ARCH}" = "armv6hf" || \
-        "${CROSS:-$ARCH}" = "armv7hf" ]]; then # 32-bit architectures are "client" variants
-    cp -r build/linux-${JARCH}-normal-client-release/docs/* \
-        "$PKGDIR"/usr/share/doc/openjdk-8/
-else
-    cp -r build/linux-${JARCH}-normal-server-release/docs/* \
-        "$PKGDIR"/usr/share/doc/openjdk-8/
-fi
-
-cp -r "$PKGDIR"/usr/lib/java-8/jre/* "$PKGDIR"/usr/lib/java-8/
-rm -rf "$PKGDIR"/usr/lib/java-8/jre/
-mkdir -p "$PKGDIR"/usr/lib/java-8/jre/lib/
+cp -rv "$PKGDIR"/usr/lib/java-8/jre/* "$PKGDIR"/usr/lib/java-8/
+rm -rv "$PKGDIR"/usr/lib/java-8/jre/
+mkdir -pv "$PKGDIR"/usr/lib/java-8/jre/lib/
 pushd "$PKGDIR"/usr/lib/java-8/jre/lib/
 ln -sv ../../lib/* .
 popd
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
 
 cat > "$SRCDIR"/autobuild/conffiles << EOF
 /etc/openjdk-8/${CONFARCH}/jvm.cfg
@@ -162,7 +141,7 @@ cat > "$SRCDIR"/autobuild/conffiles << EOF
 /etc/openjdk-8/sound.properties
 EOF
 
-mkdir -p "$SRCDIR"/autobuild/overrides/etc/ld.so.conf.d/
+mkdir -pv "$SRCDIR"/autobuild/overrides/etc/ld.so.conf.d/
 cat > "$SRCDIR"/autobuild/overrides/etc/ld.so.conf.d/openjdk-8.conf << EOF
 /usr/lib/java-8/lib/${CONFARCH}
 /usr/lib/java-8/lib/${CONFARCH}/jli

--- a/lang-java/openjdk-8/autobuild/build.stage2
+++ b/lang-java/openjdk-8/autobuild/build.stage2
@@ -10,41 +10,42 @@ BOOTSTRAP_DEBIAN="sid"
 BOOTSTRAP_LOONGARCH64_SUF="8"
 BOOTSTRAP_LOONGARCH64="8"
 
-[ "${CROSS:-$ARCH}" = "amd64" ] && export JARCH="x86_64" CONFARCH="amd64"
-[ "${CROSS:-$ARCH}" = "armv4" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export JARCH="aarch32" CONFARCH="aarch32"
-[ "${CROSS:-$ARCH}" = "arm64" ] && export JARCH="aarch64" CONFARCH="aarch64"
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export JARCH="mips64" CONFARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export JARCH="loongarch64" CONFARCH="loongarch64"
-[ "${CROSS:-$ARCH}" = "powerpc" ] && export JARCH="ppc" CONFARCH="ppc"
-[ "${CROSS:-$ARCH}" = "ppc64" ] && export JARCH="ppc64" CONFARCH="ppc64"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export JARCH="ppc64le" CONFARCH="ppc64le"
+ab_match_arch "amd64" && export JARCH="x86_64" CONFARCH="amd64"
+ab_match_arch "armv4" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "armv6hf" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "armv7hf" && export JARCH="aarch32" CONFARCH="aarch32"
+ab_match_arch "arm64" && export JARCH="aarch64" CONFARCH="aarch64"
+ab_match_arch "loongson3" && export JARCH="mips64" CONFARCH="mips64el"
+ab_match_arch "loongarch64" && export JARCH="loongarch64" CONFARCH="loongarch64"
+ab_match_arch "powerpc" && export JARCH="ppc" CONFARCH="ppc"
+ab_match_arch "ppc64" && export JARCH="ppc64" CONFARCH="ppc64"
+ab_match_arch "ppc64el" && export JARCH="ppc64le" CONFARCH="ppc64le"
 
-[ "${CROSS:-$ARCH}" = "amd64" ] && export ADOPTIUM_ARCH="x64"
-[ "${CROSS:-$ARCH}" = "armv4" ] && export ADOPTIUM_ARCH="arm"
-[ "${CROSS:-$ARCH}" = "armv6hf" ] && export ADOPTIUM_ARCH="arm"
-[ "${CROSS:-$ARCH}" = "armv7hf" ] && export ADOPTIUM_ARCH="arm"
-[ "${CROSS:-$ARCH}" = "arm64" ] && export ADOPTIUM_ARCH="aarch64"
-[ "${CROSS:-$ARCH}" = "ppc64el" ] && export ADOPTIUM_ARCH="ppc64le"
-[ "${CROSS:-$ARCH}" = "loongson3" ] && export DEBIAN_ARCH="mips64el"
-[ "${CROSS:-$ARCH}" = "riscv64" ] && abdie "riscv64 is not supported"
-[ "${CROSS:-$ARCH}" = "loongarch64" ] && export LOONGARCH64_BOOT="y"
+ab_match_arch "amd64" && export ADOPTIUM_ARCH="x64"
+ab_match_arch "armv4" && export ADOPTIUM_ARCH="arm"
+ab_match_arch "armv6hf" && export ADOPTIUM_ARCH="arm"
+ab_match_arch "armv7hf" && export ADOPTIUM_ARCH="arm"
+ab_match_arch "arm64" && export ADOPTIUM_ARCH="aarch64"
+ab_match_arch "ppc64el" && export ADOPTIUM_ARCH="ppc64le"
+ab_match_arch "loongson3" && export DEBIAN_ARCH="mips64el"
+ab_match_arch "riscv64" && abdie "riscv64 is not supported"
+ab_match_arch "loongarch64" && export LOONGARCH64_BOOT="y"
 
-if [[ "${CROSS:-$ARCH}" != "amd64" && \
-      "${CROSS:-$ARCH}" != "arm64" && \
-      "${CROSS:-$ARCH}" != ppc64* && \
-      "${CROSS:-$ARCH}" != "loongson3" && \
-      "${CROSS:-$ARCH}" != "loongarch64" ]]; then
+if ! ab_match_arch "amd64" && \
+   ! ab_match_arch "arm64" && \
+   ! ab_match_arch "ppc64" && \
+   ! ab_match_arch "ppc64el" && \
+   ! ab_match_arch "loongson3" && \
+   ! ab_match_arch "loongarch64"; then
     config_zero="--with-jvm-variants=zero"
     SJAVAC=0
 else
     config_zero=" "
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv4" || \
-      "${CROSS:-$ARCH}" = "armv6hf" || \
-      "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch "armv4" || \
+   ab_match_arch "armv6hf" || \
+   ab_match_arch "armv7hf"; then
     config_zero="--with-jvm-variants=client"
 fi
 
@@ -52,9 +53,9 @@ if [[ "${SJAVAC}" == "1" ]]; then
     use_sjavac="--enable-sjavac" # Just a simple switch. And sjavac.jar is not needed, since JDK 8 has built-in a similar routine
 fi
 
-if [[ "${CROSS:-$ARCH}" = "armv4" || \
-      "${CROSS:-$ARCH}" = "armv6hf" || \
-      "${CROSS:-$ARCH}" = "armv7hf" ]]; then
+if ab_match_arch "armv4" || \
+   ab_match_arch "armv6hf" || \
+   ab_match_arch "armv7hf"; then
     config_bits="--host=armv7a-hardfloat-linux-gnueabi --build=armv7a-hardfloat-linux-gnueabi"
 fi
 
@@ -70,59 +71,18 @@ if [[ -z "$JDKBOOTDIR" && -n "$ADOPTIUM_ARCH" ]]; then
     export JDKBOOTDIR="$SRCDIR/jdk${BOOTSTRAP_ADOPTIUM}"
 fi
 
-if [[ -z "$JDKBOOTDIR" && -n "$ALPINE_ARCH" ]]; then
-    mkdir bootpkgs
-    pushd bootpkgs || exit
-
-    abinfo "Resolving Alpine JDK version ..."
-    curl -sSL https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/APKINDEX.tar.gz |
-        gzip -d | tar -x APKINDEX
-    bootversion="$(grep -E "^P:openjdk${JAVA_MAJOR_VERSION}$" --max-count=1 -A 30 <APKINDEX |
-        grep --max-count=1 -F 'V:' | cut -d':' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
-    rm -vf APKINDEX
-
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jdk-$bootversion.apk"
-    abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-$bootversion.apk"
-    abinfo "Downloading bootstrap headless JRE ..."
-    wget -O jre-headless.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jre-headless-$bootversion.apk"
-    abinfo "Downloading bootstrap Jmods ..."
-    wget -O jmods.apk "https://dl-cdn.alpinelinux.org/alpine/$BOOTSTRAP_ALPINE/community/$ALPINE_ARCH/openjdk${JAVA_MAJOR_VERSION}-jmods-$bootversion.apk"
-    popd || exit
-
-    pushd / || exit
-    for path in "$SRCDIR"/bootpkgs/*; do
-        abinfo "Extracting bootstrap package: $(basename "$path") ..."
-        tar -xf "$path"
-    done
-    popd || exit
-
-    export JDKBOOTDIR="/usr/lib/jvm/java-${JAVA_MAJOR_VERSION}-openjdk"
-fi
-
 if [[ -z "$JDKBOOTDIR" && -n "$DEBIAN_ARCH" ]]; then
     mkdir bootpkgs
     pushd bootpkgs || exit
 
-    abinfo "Resolving Debian sid JDK version ..."
-    bootversion="$(curl -sSL https://ftp.debian.org/debian/dists/$BOOTSTRAP_DEBIAN/main/binary-$DEBIAN_ARCH/Packages.xz |
-        xz -d - | grep -E "^Package: openjdk-${JAVA_MAJOR_VERSION}-jdk$" --max-count 1 -A 30 |
-        grep --max-count 1 -E '^Version: ' | cut -d' ' -f2)"
-    echo "Bootstrap JDK version: $bootversion"
-
     abinfo "Downloading bootstrap JDK ..."
-    wget -O jdk.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jdk.deb "https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/$DEBIAN_ARCH/jdk.deb"
     abinfo "Downloading bootstrap JDK (headless) ..."
-    wget -O jdk-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jdk-headless_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jdk-headless.deb "https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/$DEBIAN_ARCH/jdk-headless.deb"
     abinfo "Downloading bootstrap JRE ..."
-    wget -O jre.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jre.deb "https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/$DEBIAN_ARCH/jre.deb"
     abinfo "Downloading bootstrap JRE (headless) ..."
-    wget -O jre-headless.deb "https://ftp.debian.org/debian/pool/main/o/openjdk-${JAVA_MAJOR_VERSION}/openjdk-${JAVA_MAJOR_VERSION}-jre-headless_${bootversion}_$DEBIAN_ARCH.deb"
+    wget -O jre-headless.deb "https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/$DEBIAN_ARCH/jre-headless.deb"
     popd || exit
 
     pushd / || exit
@@ -137,11 +97,11 @@ fi
 
 if [[ -z "$JDKBOOTDIR" && -n "$LOONGARCH64_BOOT" ]]; then
     abinfo "Downloading LoongArchLinux JRE binary toolchain ..."
-    wget -O bootjre.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
+    wget -O bootjre.tar.zst https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/loongarch64/bootjre.tar.zst
     abinfo "Downloading LoongArchLinux headless JRE binary toolchain ..."
-    wget -O bootjre-headless.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jre${BOOTSTRAP_LOONGARCH64_SUF}-openjdk-headless/download/
+    wget -O bootjre-headless.tar.zst https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/loongarch64/bootjre-headless.tar.zst
     abinfo "Downloading LoongArchLinux JDK binary toolchain ..."
-    wget -O bootjdk.tar.zst https://archapi.zhcn.cc/api/v1/extra/loong64/jdk${BOOTSTRAP_LOONGARCH64_SUF}-openjdk/download/
+    wget -O bootjdk.tar.zst https://repo.aosc.io/aosc-repacks/openjdk-8-repacks/loongarch64/bootjdk.tar.zst
 
     mkdir bootjdk
     cd bootjdk || exit
@@ -210,13 +170,13 @@ find . -iname '*.diz' -exec rm {} \;
 find . -iname '*.debuginfo' -exec rm {} \;
 popd
 
-mkdir -p "$PKGDIR"/usr/lib/java-8
-cp -r image/jvm/openjdk-1.8.0_${UPDATE}-AOSC/* "$PKGDIR"/usr/lib/java-8/
+mkdir -pv "$PKGDIR"/usr/lib/java-8
+cp -rv image/jvm/openjdk-1.8.0_${UPDATE}-AOSC/* "$PKGDIR"/usr/lib/java-8/
 
-mv "$PKGDIR"/usr/lib/java-8/jre/lib/management/jmxremote.password{.template,}
-mv "$PKGDIR"/usr/lib/java-8/jre/lib/management/snmp.acl{.template,}
+mv -v "$PKGDIR"/usr/lib/java-8/jre/lib/management/jmxremote.password{.template,}
+mv -v "$PKGDIR"/usr/lib/java-8/jre/lib/management/snmp.acl{.template,}
 
-mkdir -p "$PKGDIR"/etc/openjdk-8/
+mkdir -pv "$PKGDIR"/etc/openjdk-8/
 for i in ${CONFARCH}/jvm.cfg \
          calendars.properties \
          content-types.properties \
@@ -237,41 +197,20 @@ for i in ${CONFARCH}/jvm.cfg \
     install -D -m 644 ${_filepkgpath} "$PKGDIR"/etc/openjdk-8/${i}
 done
 
-mkdir -p "$PKGDIR"/usr/src/openjdk-8
+mkdir -pv "$PKGDIR"/usr/src/openjdk-8
 mv "$PKGDIR"/usr/lib/java-8/src.zip "$PKGDIR"/usr/src/openjdk-8/src.zip
-ln -sv /usr/src/openjdk-8/src.zip "$PKGDIR"/usr/lib/java-8/src.zip
+ln -sv ../../../src/openjdk-8/src.zip "$PKGDIR"/usr/lib/java-8/src.zip
 
-install -d -m 755 "$PKGDIR"/usr/share/doc/openjdk-8
-if [[ "${CROSS:-$ARCH}" != "amd64" && \
-       "${CROSS:-$ARCH}" != "arm64" && \
-       "${CROSS:-$ARCH}" != "armv4" && \
-       "${CROSS:-$ARCH}" != "armv6hf" && \
-       "${CROSS:-$ARCH}" != armv7hf && \
-       "${CROSS:-$ARCH}" != ppc64* && \
-       "${CROSS:-$ARCH}" != "loongson3" && \
-       "${CROSS:-$ARCH}" != "loongarch64" ]]; then
-    cp -r build/linux-${JARCH}-normal-zero-release/docs/* \
-        "$PKGDIR"/usr/share/doc/openjdk-8/
-elif [[ "${CROSS:-$ARCH}" = "armv4" || \
-        "${CROSS:-$ARCH}" = "armv6hf" || \
-        "${CROSS:-$ARCH}" = "armv7hf" ]]; then # 32-bit architectures are "client" variants
-    cp -r build/linux-${JARCH}-normal-client-release/docs/* \
-        "$PKGDIR"/usr/share/doc/openjdk-8/
-else
-    cp -r build/linux-${JARCH}-normal-server-release/docs/* \
-        "$PKGDIR"/usr/share/doc/openjdk-8/
-fi
-
-cp -r "$PKGDIR"/usr/lib/java-8/jre/* "$PKGDIR"/usr/lib/java-8/
-rm -rf "$PKGDIR"/usr/lib/java-8/jre/
-mkdir -p "$PKGDIR"/usr/lib/java-8/jre/lib/
+cp -rv "$PKGDIR"/usr/lib/java-8/jre/* "$PKGDIR"/usr/lib/java-8/
+rm -v "$PKGDIR"/usr/lib/java-8/jre/
+mkdir -pv "$PKGDIR"/usr/lib/java-8/jre/lib/
 pushd "$PKGDIR"/usr/lib/java-8/jre/lib/
 ln -sv ../../lib/* .
 popd
 
 abinfo "Linking system CA certificate store ..."
-rm -fv "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
-ln -sfv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
+rm -v "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
+ln -sv ../../../../../etc/ssl/certs/java/cacerts "$PKGDIR"/usr/lib/java-8/lib/security/cacerts
 
 cat > "$SRCDIR"/autobuild/conffiles << EOF
 /etc/openjdk-8/${CONFARCH}/jvm.cfg
@@ -292,11 +231,11 @@ cat > "$SRCDIR"/autobuild/conffiles << EOF
 /etc/openjdk-8/sound.properties
 EOF
 
-mkdir -p "$SRCDIR"/autobuild/overrides/etc/ld.so.conf.d/
+mkdir -pv "$SRCDIR"/autobuild/overrides/etc/ld.so.conf.d/
 cat > "$SRCDIR"/autobuild/overrides/etc/ld.so.conf.d/openjdk-8.conf << EOF
 /usr/lib/java-8/lib/${CONFARCH}
 /usr/lib/java-8/lib/${CONFARCH}/jli
 /usr/lib/java-8/lib/${CONFARCH}/server
 EOF
 
-unset JARCH CONFARCH ADOPTIUM_ARCH ALPINE_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR
+unset JARCH CONFARCH ADOPTIUM_ARCH DEBIAN_ARCH LOONGARCH64_BOOT JDKBOOTDIR

--- a/lang-java/openjdk-8/autobuild/defines
+++ b/lang-java/openjdk-8/autobuild/defines
@@ -9,7 +9,7 @@ PKGPROV="icedtea jre-openjdk jre8-openjdk openjdk8"
 PKGREP="openjdk<=9u00b00"
 PKGBREAK="openjdk<=9u00b00"
 NOPARALLEL=1
-PKGEPOCH=3
+ABTYPE=self
 
 # FIXME: Zero issue with hardened builds.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1290936

--- a/lang-java/openjdk-8/autobuild/defines.stage2
+++ b/lang-java/openjdk-8/autobuild/defines.stage2
@@ -9,7 +9,7 @@ PKGPROV="icedtea jre-openjdk jre8-openjdk openjdk8"
 PKGREP="openjdk<=9u00b00"
 PKGBREAK="openjdk<=9u00b00"
 NOPARALLEL=1
-PKGEPOCH=3
+ABTYPE=self
 
 # FIXME: Zero issue with hardened builds.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1290936

--- a/lang-java/openjdk-8/autobuild/prepare
+++ b/lang-java/openjdk-8/autobuild/prepare
@@ -7,7 +7,9 @@ find "$SRCDIR" '(' -name config.guess -o -name config.sub ')' \
     || abdie "Failed to copy replacement: $?."
 
 abinfo "Setting compilation flags ..."
-export EXTRA_CFLAGS="${CPPFLAGS} ${CFLAGS/-fexceptions/}"
+# FIXME: Add "-std=gnu99" to fix bool typedef issue
+# see also: https://bugs.openjdk.org/browse/JDK-8356144
+export EXTRA_CFLAGS="${CPPFLAGS} ${CFLAGS/-fexceptions/} -std=gnu99"
 export EXTRA_CPP_FLAGS="${CPPFLAGS} ${CXXFLAGS/-fexceptions/}"
 export JAVA_HOME="/usr/lib/java-${_JAVA_VERSION}"
 

--- a/lang-java/openjdk-8/autobuild/prepare.stage2
+++ b/lang-java/openjdk-8/autobuild/prepare.stage2
@@ -1,6 +1,10 @@
+_JAVA_VERSION=8
+
 # FIXME: Re-enable ${CFLAGS} when possible
 abinfo "Setting up compilation flags..."
-export EXTRA_CFLAGS="${CPPFLAGS} -Wno-error"
+# FIXME: Add "-std=gnu99" to fix bool typedef issue
+# see also: https://bugs.openjdk.org/browse/JDK-8356144
+export EXTRA_CFLAGS="${CPPFLAGS} -Wno-error -std=gnu99"
 export EXTRA_CPP_FLAGS="${CPPFLAGS} ${CXXFLAGS} -Wno-error"
 
 # Hack for new GCC

--- a/lang-java/openjdk-8/spec
+++ b/lang-java/openjdk-8/spec
@@ -1,5 +1,7 @@
 UPSTREAM_VER=8u462-ga
 VER=${UPSTREAM_VER/-/+}
+REL=1
+EPOCH=3
 SRCS="git::commit=aosc/8/${UPSTREAM_VER}/${REL:-0}::https://github.com/AOSC-Tracking/jdk.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17307"


### PR DESCRIPTION
Topic Description
-----------------

- openjdk-8: refactor build script
- openjdk-11: refactor build script
- openjdk-17: refactor build script
- openjdk-21: refactor build script
- openjdk-22: refactor build script
- openjdk-23: refactor build script
- openjdk-25: make pandoc a builddep for every architecture & refactor build script
- openjdk-24: refactor build script

Package(s) Affected
-------------------

- openjdk-11: 3:11.0.28+ga-1
- openjdk-17: 3:17.0.16+ga-1
- openjdk-21: 4:21.0.8+ga-1
- openjdk-22: 3:22.0.2+ga-6
- openjdk-23: 3:23.0.2+ga-4
- openjdk-24: 24.0.2+ga-1
- openjdk-25: 25.0.2+ga-1
- openjdk-8: 3:8u462+ga-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openjdk-25 openjdk-24 openjdk-23 openjdk-22 openjdk-21 openjdk-17 openjdk-11 openjdk-8
```

Test Build(s) Done
------------------

