### PR TITLE
wine-emukit: update to 11.12+gecko2.47.4+mono11.2.0

### DIFF
--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,10 +1,10 @@
 # Note: Sync with main `wine' package.
 EPOCH=3
 __GECKO_VER=2.47.4
-__MONO_VER=11.1.0
-UPSTREAM_VER=11.11
+__MONO_VER=11.2.0
+UPSTREAM_VER=11.12
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
 SRCS="file::rename=wine.deb::https://repo.aosc.io/anthon/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::de09ba5923a20068031f9ab76dc7bdfa75aff7092763f056a7a61df8bda95690"
+CHKSUMS="sha256::56d5fc5392711c22103bfce3493fa8dc3523e70cd8d5548779918a59da833cad"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- wine-emukit: update to 11.12+gecko2.47.4+mono11.2.0

Package(s) Affected
-------------------

- wine: 11.12+gecko2.47.4+mono11.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine-emukit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
