### PR TITLE
sccache: update to 0.16.0

### DIFF
--- a/app-devel/sccache/autobuild/defines
+++ b/app-devel/sccache/autobuild/defines
@@ -1,13 +1,8 @@
 PKGNAME=sccache
 PKGSEC=devel
-PKGDES="sccache is ccache with cloud storage"
+PKGDES="Cached compiler with cloud storage support"
 PKGDEP="openssl glibc gcc-runtime"
 BUILDDEP="cargo rustc llvm"
 
 ABTYPE=rust
 USECLANG=1
-ABSPLITDBG=0
-
-NOCARGOAUDIT=1
-
-FAIL_ARCH="!(amd64|arm64)"

--- a/app-devel/sccache/spec
+++ b/app-devel/sccache/spec
@@ -1,4 +1,4 @@
-VER=0.15.0
+VER=0.16.0
 SRCS="git::commit=tags/v$VER::https://github.com/mozilla/sccache"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227267"


### PR DESCRIPTION
Topic Description
-----------------

- sccache: update to 0.16.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- sccache: 0.16.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit sccache
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
