### PR TITLE
incus: update to 7.2.0

### DIFF
--- a/app-containers/incus/01-incus/defines
+++ b/app-containers/incus/01-incus/defines
@@ -11,7 +11,6 @@ GO_PACKAGES=(
     "cmd/incus"
     "cmd/incusd"
     "cmd/lxc-to-incus"
-    "cmd/lxd-to-incus"
     "cmd/incus-migrate"
     "cmd/incus-user"
     "cmd/incus-benchmark"

--- a/app-containers/incus/spec
+++ b/app-containers/incus/spec
@@ -1,4 +1,4 @@
-VER=7.1.0
+VER=7.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/lxc/incus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=369938"

--- a/topics/incus-7.2.0.toml
+++ b/topics/incus-7.2.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Incus 7.2.0"
+
+[caution]
+default = "Fixes 8 security vulnerabilities (including 6 of critical severity and 2 of high severity)"
+zh_CN = "修复 8 处安全漏洞（含 6 个严重漏洞和 2 个高危漏洞）"
+
+[packages-v2]
+"incus" = "< 7.2.0"


### PR DESCRIPTION
Topic Description
-----------------

- incus: update to 7.2.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- incus: 7.2.0
- incus-agent: 7.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit incus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
