### PR TITLE
quickjs: update to 2026-06-04

### DIFF
--- a/lang-js/quickjs/autobuild/defines
+++ b/lang-js/quickjs/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=quickjs
 PKGSEC=devel
-PKGDES="A small and embeddable JavaScript engine"
+PKGDES="Small and embeddable JavaScript engine"
 PKGDEP="glibc gcc-runtime"
 
 # https://github.com/bellard/quickjs/issues/195

--- a/lang-js/quickjs/spec
+++ b/lang-js/quickjs/spec
@@ -1,4 +1,5 @@
-VER=2025.09.13.2
-SRCS="https://bellard.org/quickjs/quickjs-${VER//./-}.tar.xz"
-CHKSUMS="sha256::996c6b5018fc955ad4d06426d0e9cb713685a00c825aa5c0418bd53f7df8b0b4"
+UPSTREAM_VER=2026-06-04
+VER=${UPSTREAM_VER//\-/.}
+SRCS="https://bellard.org/quickjs/quickjs-$UPSTREAM_VER.tar.xz"
+CHKSUMS="sha256::b376e839b322978313d929fd20663b11ba58b75df5a46c126dd19ea2fa70ad2a"
 CHKUPDATE="anitya::id=138263"


### PR DESCRIPTION
Topic Description
-----------------

- quickjs: update to 2026-06-04
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- quickjs: 2026-06-04

Security Update?
----------------

No

Build Order
-----------

```
#buildit quickjs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
