### PR TITLE
osu-lazer: update to 2026.624.0

### DIFF
--- a/app-games/osu-lazer/autobuild/patches/0003-FROMLIST-ffmpeg-7.1.patch.osu-framework
+++ b/app-games/osu-lazer/autobuild/patches/0003-FROMLIST-ffmpeg-7.1.patch.osu-framework
@@ -196,7 +196,7 @@ index 32f6ff8134..7a927b4377 100644
    </PropertyGroup>
    <ItemGroup Label="Package References">
 -    <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
-+    <PackageReference Include="FFmpeg.AutoGen" Version="7.1.1" />
++    <PackageReference Include="FFmpeg.AutoGen" Version="8.1.0" />
      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
      <PackageReference Include="ppy.managed-midi" Version="1.10.2" />
      <PackageReference Include="ppy.ManagedBass" Version="2022.1216.0" />

--- a/app-games/osu-lazer/spec
+++ b/app-games/osu-lazer/spec
@@ -1,6 +1,6 @@
 # Note: Only -lazer-suffixed tags are considered stable.
-UPSTREAM_VER=2026.305.0-lazer
-FRAMEWORK_VER=2026.303.0
+UPSTREAM_VER=2026.624.0-lazer
+FRAMEWORK_VER=2026.623.0
 VER="${UPSTREAM_VER/\-/+}"
 # Note: For components below, use latest versions.
 SRCS="git::commit=tags/${UPSTREAM_VER};rename=osu::https://github.com/ppy/osu \


### PR DESCRIPTION
Topic Description
-----------------

- osu-lazer: update to 2026.624.0

Package(s) Affected
-------------------

- osu-lazer: 2026.624.0+lazer

Security Update?
----------------

No

Build Order
-----------

```
#buildit osu-lazer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
