### PR TITLE
gnupg: update to 2.5.21

### DIFF
--- a/app-cryptography/gnupg/spec
+++ b/app-cryptography/gnupg/spec
@@ -1,4 +1,4 @@
-VER=2.5.20
+VER=2.5.21
 SRCS="tbl::https://www.gnupg.org/ftp/gcrypt/gnupg/gnupg-$VER.tar.bz2"
-CHKSUMS="sha256::6461266e99c308419a379abe6c356d54c214136c4589bd65951091138989ffc6"
+CHKSUMS="sha256::e3af2c8caa46a66a9329fa7c6880af260451914d819595beabc2c26597b31352"
 CHKUPDATE="anitya::id=1215"


### PR DESCRIPTION
Topic Description
-----------------

- gnupg: update to 2.5.21
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- gnupg: 2:2.5.21

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnupg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
