### PR TITLE
zathura: update to 2026.07.02

### DIFF
--- a/app-doc/zathura-cb/spec
+++ b/app-doc/zathura-cb/spec
@@ -1,4 +1,5 @@
 VER=2026.05.10
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-cb"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14845"

--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,4 +1,5 @@
 VER=2026.05.10
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,4 +1,5 @@
 VER=2026.05.10
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,4 +1,5 @@
 VER=2026.02.03
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"

--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=zathura
 PKGSEC=doc
-PKGDEP="gtk-3 glib json-glib girara sqlite file libseccomp texlive"
+PKGDEP="gtk-4 glib json-glib girara sqlite file libseccomp texlive xxhash"
 BUILDDEP="sphinx bash-completion fish librsvg gettext"
 PKGDES="Document viewer"
 
@@ -13,3 +13,6 @@ MESON_AFTER=(
     '-Dtests=disabled'
     '-Dconvert-icon=enabled'
 )
+
+PKGBREAK="zathura-cb<=2026.05.10 zathura-djvu<=2026.05.10 \
+          zathura-pdf-poppler<=2026.05.10 zathura-ps<=2026.02.03"

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=2026.05.20
+VER=2026.07.02
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"

--- a/runtime-desktop/girara/autobuild/defines
+++ b/runtime-desktop/girara/autobuild/defines
@@ -9,5 +9,4 @@ PKGBREAK="zathura-djvu<=0.2.11 zathura<=0.5.14 zathura-pdf-poppler<=0.3.4 \
 ABTYPE=meson
 MESON_AFTER=(
     '-Ddocs=disabled'
-    '-Dtests=disabled'
 )

--- a/runtime-desktop/girara/spec
+++ b/runtime-desktop/girara/spec
@@ -1,4 +1,4 @@
-VER=2026.02.04
+VER=2026.07.07
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/girara"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6750"


### PR DESCRIPTION
Topic Description
-----------------

- zathura: update to 2026.07.02
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- zathura: 2026.07.02

Security Update?
----------------

No

Build Order
-----------

```
#buildit girara zathura:-pkgbreak zathura-cb zathura-djvu zathura-pdf-poppler zathura-ps zathura
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
