### PR TITLE
makemkv: revive, 1.18.4

### DIFF
--- a/app-multimedia/makemkv/autobuild/beyond
+++ b/app-multimedia/makemkv/autobuild/beyond
@@ -1,0 +1,24 @@
+abinfo "Installing closed-source parts ..."
+pushd "$SRCDIR/../makemkv-bin-$PKGVER"
+
+abinfo "Accepting to the EULA ..."
+mkdir -pv tmp/
+# set the flag for unattended installation
+echo "accepted" | tee tmp/eula_accepted
+
+abinfo "Copying files ..."
+make install DESTDIR="$PKGDIR" PREFIX=/usr
+
+abinfo "Copying licenses ..."
+mkdir -pv "$PKGDIR/usr/share/makemkv/"
+install -Dvm644 "$SRCDIR/../makemkv-bin-$PKGVER/src/eula_en_linux.txt" "$PKGDIR/usr/share/makemkv/"
+install -Dvm644 "$SRCDIR/License.txt" "$SRCDIR/LICENSE"
+
+abinfo "Fixing permission bits ..."
+chmod -v a+x "$PKGDIR/usr/lib/"*
+
+abinfo "Installing modprobe hooks ..."
+mkdir -pv "$PKGDIR/usr/lib/modules-load.d/"
+echo 'sg' > "$PKGDIR/usr/lib/modules-load.d/makemkv-sg.conf"
+
+popd

--- a/app-multimedia/makemkv/autobuild/beyond
+++ b/app-multimedia/makemkv/autobuild/beyond
@@ -21,4 +21,7 @@ abinfo "Installing modprobe hooks ..."
 mkdir -pv "$PKGDIR/usr/lib/modules-load.d/"
 echo 'sg' > "$PKGDIR/usr/lib/modules-load.d/makemkv-sg.conf"
 
+abinfo "Copying debug symbols for open-source parts ..."
+abelf_copy_dbg_parallel "$SRCDIR"/out "${SYMDIR}"
+
 popd

--- a/app-multimedia/makemkv/autobuild/defines
+++ b/app-multimedia/makemkv/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=makemkv
+PKGSEC="non-free/video"
+PKGDES="A converter to convert video clips from proprietary discs into a set of MKV files"
+PKGDEP="zlib qt-5 mesa openssl ffmpeg expat"
+
+# License issues
+ABSTRIP=0
+ABSPLITDBG=0
+
+ABTYPE=autotools
+ABSHADOW=0
+RECONF=0
+
+FAIL_ARCH="!(amd64|arm64)"

--- a/app-multimedia/makemkv/autobuild/defines
+++ b/app-multimedia/makemkv/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=makemkv
 PKGSEC="non-free/video"
 PKGDES="A converter to convert video clips from proprietary discs into a set of MKV files"
-PKGDEP="zlib qt-5 mesa openssl ffmpeg expat"
+PKGDEP="zlib qt-5 mesa openssl ffmpeg expat debconf"
 
 # License issues
 ABSTRIP=0

--- a/app-multimedia/makemkv/autobuild/defines
+++ b/app-multimedia/makemkv/autobuild/defines
@@ -11,4 +11,6 @@ ABTYPE=autotools
 ABSHADOW=0
 RECONF=0
 
+AUTOTOOLS_AFTER="--enable-debug"
+
 FAIL_ARCH="!(amd64|arm64)"

--- a/app-multimedia/makemkv/autobuild/postinst
+++ b/app-multimedia/makemkv/autobuild/postinst
@@ -1,0 +1,8 @@
+echo "Loading necessary kernel modules ..."
+modprobe -v sg
+
+cat << EOF
+By installing MakeMKV, you agree to the EULA of this software.
+A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt.
+If you do not read and agree to this EULA, please uninstall this package.
+EOF

--- a/app-multimedia/makemkv/autobuild/postinst
+++ b/app-multimedia/makemkv/autobuild/postinst
@@ -1,8 +1,8 @@
-echo "Loading necessary kernel modules ..."
+# Source Debconf module.
+source /usr/share/debconf/confmodule
+
+echo "Loading necessary kernel modules ..." >&2
 modprobe -v sg
 
-cat << EOF
-By installing MakeMKV, you agree to the EULA of this software.
-A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt.
-If you do not read and agree to this EULA, please uninstall this package.
-EOF
+db_input high makemkv/eula_confirm || true
+db_go || true

--- a/app-multimedia/makemkv/autobuild/postinst
+++ b/app-multimedia/makemkv/autobuild/postinst
@@ -1,8 +1,12 @@
 # Source Debconf module.
 source /usr/share/debconf/confmodule
 
-echo "Loading necessary kernel modules ..." >&2
-modprobe -v sg
+if systemd-detect-virt -cq || systemd-detect-virt -rq; then
+  echo 'Inside a container or chroot, not loading kernel modules automatically.' >&2
+else
+  echo 'Loading necessary kernel modules ...' >&2
+  modprobe -v sg
+fi
 
 db_input high makemkv/eula_confirm || true
 db_go || true

--- a/app-multimedia/makemkv/autobuild/templates
+++ b/app-multimedia/makemkv/autobuild/templates
@@ -1,0 +1,8 @@
+Template: makemkv/eula_confirm
+Type: note
+Description: By installing MakeMKV, you agree to its EULA. 
+ A copy of the EULA is available at /usr/share/makemkv/eula_en_linux.txt. 
+ If you do not read or agree to this EULA, please uninstall this package.
+Description-zh_CN.UTF-8: 安装 MakeMKV 即表示您同意其最终用户许可协议（EULA）。
+ MakeMKV 的最终用户许可协议文本位于 /usr/share/makemkv/eula_en_linux.txt。
+ 如果您未阅读或不同意该最终用户许可协议，请卸载此软件包。

--- a/app-multimedia/makemkv/spec
+++ b/app-multimedia/makemkv/spec
@@ -1,0 +1,8 @@
+VER=1.18.4
+SRCS="tbl::https://www.makemkv.com/download/makemkv-bin-$VER.tar.gz \
+      tbl::https://www.makemkv.com/download/makemkv-oss-$VER.tar.gz"
+# package oss parts first
+SUBDIR="makemkv-oss-$VER"
+CHKSUMS="sha256::cee56de0baa5531abed16bd862742d308d772b4ab4dae16ee865bf74f04a1608 \
+         sha256::8590063648d42ec2a958b74573d7022f0f4c334e4e4fe7dd53b70c6e748ba453"
+CHKUPDATE="anitya::id=177148"

--- a/groups/ffmpeg-rebuilds
+++ b/groups/ffmpeg-rebuilds
@@ -21,6 +21,7 @@ app-multimedia/ffms2
 app-multimedia/harvid
 app-multimedia/kid3
 app-multimedia/kodi
+app-multimedia/makemkv
 app-multimedia/mocp
 app-multimedia/moonlight-embedded
 app-multimedia/moonlight-qt

--- a/groups/openssl-rebuilds
+++ b/groups/openssl-rebuilds
@@ -148,6 +148,7 @@ app-network/lighttpd
 app-network/rsync
 app-admin/lxc
 lang-python/m2crypto
+app-multimedia/makemkv
 app-i18n/meowdict
 app-creativity/mixxx
 app-multimedia/moonlight-embedded


### PR DESCRIPTION
Topic Description
-----------------

- makemkv: skip modprobe if running inside a container
- makemkv: use debconf to show EULA warning message
- makemkv: save debugging symbols for open-source parts
- makemkv: revive, 1.18.4
    This reverts commit 445f7167bd92cfa87eebb4e61a1171e1d491200d.

Package(s) Affected
-------------------

- makemkv: 1.18.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit makemkv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
