### PR TITLE
tesseract: update to 5.5.2

### DIFF
--- a/app-utils/tesseract/autobuild/beyond
+++ b/app-utils/tesseract/autobuild/beyond
@@ -1,16 +1,8 @@
 abinfo "Packing trained data..."
-mkdir -vp "$PKGDIR"/usr/share/tessdata
 
 pushd ../tessdata_fast
 
-for i in *.traineddata; do
-        cp "${i}" "$PKGDIR"/usr/share/tessdata/
-done
+install -Dvm644 *.traineddata \
+    -t "$PKGDIR"/usr/share/tessdata/
 
 popd
-
-find "$PKGDIR"/usr/share/tessdata -type f -exec chmod 0644 '{}' ';'
-
-mkdir -vp "$PKGDIR"/usr/share/cmake
-mv -v "$PKGDIR"/usr/lib/cmake/tesseract/* "$PKGDIR"/usr/share/cmake/
-rm -vr "$PKGDIR"/usr/lib/cmake

--- a/app-utils/tesseract/autobuild/defines
+++ b/app-utils/tesseract/autobuild/defines
@@ -1,8 +1,12 @@
 PKGNAME=tesseract
 PKGSEC=libs
 PKGDEP="leptonica icu cairo pango openjpeg libpng libtiff libjpeg-turbo giflib gcc-runtime"
-PKGDES="An OCR program"
+PKGDES="Tesseract OCR engine and command-line tools"
 
 ABTYPE=cmakeninja
-CMAKE_AFTER="-DBUILD_SHARED_LIBS=ON -DTESSDATA_PREFIX=/usr/share"
+CMAKE_AFTER=(
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DTESSDATA_PREFIX=/usr/share"
+    "-DUSE_SYSTEM_ICU=ON"
+)
 PKGBREAK="crow-translate<=2.11.1-2 opencv<=4.9.0-4 skanpage<=23.08.5-2"

--- a/app-utils/tesseract/autobuild/prepare
+++ b/app-utils/tesseract/autobuild/prepare
@@ -1,6 +1,0 @@
-export TESSDATA_PREFIX=/usr/share/
-
-if [[ "${CROSS:-$ARCH}" != "amd64" ]]; then
-    abinfo "Dropping extraneous SIMD enablement ..."
-    sed -i 's/-mavx2//g;s/-mavx//g;s/-msse4.1//g' CMakeLists.txt
-fi

--- a/app-utils/tesseract/spec
+++ b/app-utils/tesseract/spec
@@ -1,4 +1,4 @@
-VER=5.5.0
+VER=5.5.2
 FASTVER=4.1.0
 SRCS="git::commit=tags/$VER::https://github.com/tesseract-ocr/tesseract \
       git::commit=tags/$FASTVER;rename=tessdata_fast::https://github.com/tesseract-ocr/tessdata_fast"


### PR DESCRIPTION
Topic Description
-----------------

- tesseract: update to 5.5.2
    - Cleanup scripts.
    - Convert CMAKE_AFTER to array.
    - Rework PKGDES.
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- tesseract: 5.5.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tesseract
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
