### PR TITLE
cryptsetup: update to 2.8.6; migrate plain hash presets; fix keyring leaks

### DIFF
--- a/app-admin/cryptsetup/autobuild/defines
+++ b/app-admin/cryptsetup/autobuild/defines
@@ -5,9 +5,9 @@ BUILDDEP="asciidoctor"
 PKGDES="Utilities and libraries for handling encrypted disks"
 
 # Note: For all cipher related options, refer to configure --help for defaults.
-# FIXME: FIPS is incompatible with static builds.
 AUTOTOOLS_AFTER=(
     '--disable-static'
+    '--enable-fips'
     '--enable-shared'
     '--enable-fast-install'
     '--enable-libtool-lock'
@@ -38,9 +38,9 @@ AUTOTOOLS_AFTER=(
     '--disable-dev-random'
     '--enable-luks-adjust-xts-keysize'
     '--with-crypto_backend=openssl'
-    '--with-plain-hash=ripemd160'
+    '--with-plain-hash=sha256'
     '--with-plain-cipher=aes'
-    '--with-plain-mode=cbc-essiv:sha256'
+    '--with-plain-mode=xts-plain64'
     '--with-plain-keybits=256'
     '--with-luks1-hash=sha256'
     '--with-luks1-cipher=aes'

--- a/app-admin/cryptsetup/autobuild/patches/0001-BACKPORT-Add-keyring-key-type.patch
+++ b/app-admin/cryptsetup/autobuild/patches/0001-BACKPORT-Add-keyring-key-type.patch
@@ -1,0 +1,41 @@
+From 0e8ad6d22929faf6f47469df24cb0b4e96505c07 Mon Sep 17 00:00:00 2001
+From: Ondrej Kozina <okozina@redhat.com>
+Date: Fri, 19 Jun 2026 16:41:47 +0200
+Subject: [PATCH 1/3] BACKPORT: Add keyring key type.
+
+(cherry picked from commit b6fb6fc0fdc661afba734f4c29350fa6be2ede8f)
+---
+ lib/utils_keyring.c | 1 +
+ lib/utils_keyring.h | 2 +-
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/lib/utils_keyring.c b/lib/utils_keyring.c
+index 73df3461be99..67e8db0498ac 100644
+--- a/lib/utils_keyring.c
++++ b/lib/utils_keyring.c
+@@ -32,6 +32,7 @@ static const struct {
+ 	{ BIG_KEY,       "big_key" },
+ 	{ TRUSTED_KEY,   "trusted" },
+ 	{ ENCRYPTED_KEY, "encrypted" },
++	{ KEYRING_KEY,	 "keyring" },
+ };
+ 
+ #include <linux/keyctl.h>
+diff --git a/lib/utils_keyring.h b/lib/utils_keyring.h
+index 67debf62a946..20c08293b52b 100644
+--- a/lib/utils_keyring.h
++++ b/lib/utils_keyring.h
+@@ -17,7 +17,7 @@
+ typedef int32_t key_serial_t;
+ #endif
+ 
+-typedef enum { LOGON_KEY = 0, USER_KEY, BIG_KEY, TRUSTED_KEY, ENCRYPTED_KEY, INVALID_KEY } key_type_t;
++typedef enum { LOGON_KEY = 0, USER_KEY, BIG_KEY, TRUSTED_KEY, ENCRYPTED_KEY, KEYRING_KEY, INVALID_KEY } key_type_t;
+ 
+ const char *key_type_name(key_type_t ktype);
+ key_type_t key_type_by_name(const char *name);
+
+base-commit: 738e7001cac91c555cd6798cca9194bb19e54e96
+-- 
+2.52.0
+

--- a/app-admin/cryptsetup/autobuild/patches/0002-BACKPORT-Load-volume-keys-in-intermediary-keyring-li.patch
+++ b/app-admin/cryptsetup/autobuild/patches/0002-BACKPORT-Load-volume-keys-in-intermediary-keyring-li.patch
@@ -1,0 +1,250 @@
+From 980636d3ee40b02d8dbf4947fcc5abf4219fcf4b Mon Sep 17 00:00:00 2001
+From: Ondrej Kozina <okozina@redhat.com>
+Date: Thu, 25 Jun 2026 12:05:53 +0200
+Subject: [PATCH 2/3] BACKPORT: Load volume keys in intermediary keyring linked
+ in thread keyring.
+
+Instead of loading volume keys directly in the thread keyring, create
+an intermediary keyring linked in the thread keyring and load volume
+keys there. The intermediary keyring is bulk-cleaned on crypt_free().
+
+This avoids undesired pinning of all volume keys (via the thread
+keyring) through the caller's credentials when the kernel opens
+a file, as was the case with
+https://lore.kernel.org/all/20240123-vfs-bdev-file-v2-4-adbd023e19cc@kernel.org/
+
+Fixes: #993.
+(cherry picked from commit 413a3dd04ec07ad7c3afaed84561cbc7a42f108f)
+---
+ lib/internal.h  |  6 ++--
+ lib/setup.c     | 89 ++++++++++++++++++++++++++++++++++++-------------
+ lib/volumekey.c | 12 +++----
+ 3 files changed, 74 insertions(+), 33 deletions(-)
+
+diff --git a/lib/internal.h b/lib/internal.h
+index 56efa46b22c1..4096f4d28cbd 100644
+--- a/lib/internal.h
++++ b/lib/internal.h
+@@ -75,7 +75,7 @@ struct volume_key *crypt_volume_key_next(struct volume_key *vk);
+ struct volume_key *crypt_volume_key_by_id(struct volume_key *vk, int id);
+ void crypt_volume_key_pass_safe_alloc(struct volume_key *vk, void **safe_alloc);
+ bool crypt_volume_key_is_set(const struct volume_key *vk);
+-bool crypt_volume_key_upload_kernel_key(struct volume_key *vk);
++bool crypt_volume_key_upload_kernel_key(struct volume_key *vk, key_serial_t keyring);
+ void crypt_volume_key_drop_uploaded_kernel_key(struct crypt_device *cd, struct volume_key *vk);
+ void crypt_volume_key_drop_kernel_key(struct crypt_device *cd, struct volume_key *vk);
+ 
+@@ -248,9 +248,9 @@ int crypt_keyring_get_keysize_by_name(struct crypt_device *cd,
+ 		size_t *r_key_size);
+ 
+ int crypt_use_keyring_for_vk(struct crypt_device *cd);
+-void crypt_unlink_key_from_thread_keyring(struct crypt_device *cd,
++void crypt_unlink_key_from_keyring(struct crypt_device *cd,
+ 		key_serial_t key_id);
+-void crypt_unlink_key_by_description_from_thread_keyring(struct crypt_device *cd,
++void crypt_unlink_key_by_description_from_keyring(struct crypt_device *cd,
+ 		const char *key_description,
+ 		key_type_t ktype);
+ void crypt_drop_uploaded_keyring_key(struct crypt_device *cd, struct volume_key *vks);
+diff --git a/lib/setup.c b/lib/setup.c
+index 0466323e07de..cf4ddd04f530 100644
+--- a/lib/setup.c
++++ b/lib/setup.c
+@@ -52,6 +52,9 @@ struct crypt_device {
+ 	const char *user_key_name2;
+ 	key_type_t keyring_key_type;
+ 
++	const char *keyring_description;
++	key_serial_t keyring_id;
++
+ 	uint64_t data_offset;
+ 	uint64_t metadata_size; /* Used in LUKS2 format */
+ 	uint64_t keyslots_size; /* Used in LUKS2 format */
+@@ -4092,6 +4095,15 @@ int crypt_header_is_detached(struct crypt_device *cd)
+ 	return r ? 0 : 1;
+ }
+ 
++static void crypt_unlink_keyring_from_thread_keyring(struct crypt_device *cd,
++		key_serial_t keyring_id)
++{
++	log_dbg(cd, "Unlinking keyring (id: %" PRIi32 ") from thread keyring.", keyring_id);
++
++	if (keyring_unlink_key_from_thread_keyring(keyring_id))
++		log_dbg(cd, "keyring_unlink_key_from_thread_keyring failed with errno %d.", errno);
++}
++
+ void crypt_free(struct crypt_device *cd)
+ {
+ 	if (!cd)
+@@ -4102,6 +4114,11 @@ void crypt_free(struct crypt_device *cd)
+ 	dm_backend_exit(cd);
+ 	crypt_free_volume_key(cd->volume_key);
+ 
++	if (cd->keyring_description) {
++		crypt_unlink_keyring_from_thread_keyring(cd, cd->keyring_id);
++		free(CONST_CAST(void*)cd->keyring_description);
++	}
++
+ 	crypt_free_type(cd, NULL);
+ 
+ 	device_free(cd, cd->device);
+@@ -4286,18 +4303,35 @@ static int resume_luks1_by_volume_key(struct crypt_device *cd,
+ 	return r;
+ }
+ 
+-static void crypt_unlink_key_from_custom_keyring(struct crypt_device *cd, key_serial_t kid)
++static bool unlink_key_from_keyring(struct crypt_device *cd, key_serial_t kid, key_serial_t keyring_id)
+ {
+-	assert(cd);
+-	assert(cd->keyring_to_link_vk);
+-
+ 	log_dbg(cd, "Unlinking volume key (id: %" PRIi32 ") from kernel keyring (id: %" PRIi32 ").",
+-		kid, cd->keyring_to_link_vk);
++		kid, keyring_id);
+ 
+-	if (!keyring_unlink_key_from_keyring(kid, cd->keyring_to_link_vk))
+-		return;
++	if (!keyring_unlink_key_from_keyring(kid, keyring_id))
++		return true;
+ 
+ 	log_dbg(cd, "keyring_unlink_key_from_keyring failed with errno %d.", errno);
++
++	return false;
++}
++
++/* internal only */
++void crypt_unlink_key_from_keyring(struct crypt_device *cd,
++		key_serial_t key_id)
++{
++	(void)unlink_key_from_keyring(cd, key_id, cd->keyring_id);
++}
++
++static void crypt_unlink_key_from_custom_keyring(struct crypt_device *cd, key_serial_t kid)
++{
++	assert(cd);
++	assert(cd->keyring_to_link_vk);
++
++
++	if (unlink_key_from_keyring(cd, kid, cd->keyring_to_link_vk))
++		return;
++
+ 	log_err(cd, _("Failed to unlink volume key from user specified keyring."));
+ }
+ 
+@@ -7532,6 +7566,8 @@ int crypt_volume_key_keyring(struct crypt_device *cd __attribute__((unused)), in
+ /* internal only */
+ int crypt_volume_key_load_in_keyring(struct crypt_device *cd, struct volume_key *vk)
+ {
++	key_serial_t keyring_id;
++
+ 	if (!vk || !cd)
+ 		return -EINVAL;
+ 
+@@ -7540,14 +7576,31 @@ int crypt_volume_key_load_in_keyring(struct crypt_device *cd, struct volume_key
+ 		return -EINVAL;
+ 	}
+ 
+-	log_dbg(cd, "Loading key (type logon, name %s) in thread keyring.",
+-		crypt_volume_key_description(vk));
++	if (!cd->keyring_description) {
++		cd->keyring_description = strdup("cryptsetup-keyring");
++		if (!cd->keyring_description)
++			return -ENOMEM;
+ 
+-	if (crypt_volume_key_upload_kernel_key(vk)) {
++		log_dbg(cd, "Loading key (type keyring, name %s) in thread keyring.", cd->keyring_description);
++		keyring_id = keyring_add_key_in_thread_keyring(KEYRING_KEY, cd->keyring_description, NULL, 0);
++		if (keyring_id < 0) {
++			free(CONST_CAST(void*)cd->keyring_description);
++			cd->keyring_description = NULL;
++			log_dbg(cd, "keyring_add_key_in_thread_keyring failed (error %d)", errno);
++			log_err(cd, _("Failed to load key in kernel keyring."));
++			return -EINVAL;
++		}
++		cd->keyring_id = keyring_id;
++	}
++
++	log_dbg(cd, "Loading key (type logon, name %s) in %s keyring.",
++		crypt_volume_key_description(vk), cd->keyring_description);
++
++	if (crypt_volume_key_upload_kernel_key(vk, cd->keyring_id)) {
+ 		crypt_set_key_in_keyring(cd, 1);
+ 		return 0;
+ 	} else {
+-		log_dbg(cd, "keyring_add_key_in_thread_keyring failed (error %d)", errno);
++		log_dbg(cd, "keyring_add_key_to_keyring failed (error %d)", errno);
+ 		log_err(cd, _("Failed to load key in kernel keyring."));
+ 		return -EINVAL;
+ 	}
+@@ -7663,17 +7716,7 @@ void crypt_set_key_in_keyring(struct crypt_device *cd, unsigned key_in_keyring)
+ 	cd->key_in_keyring = key_in_keyring;
+ }
+ 
+-/* internal only */
+-void crypt_unlink_key_from_thread_keyring(struct crypt_device *cd,
+-		key_serial_t key_id)
+-{
+-	log_dbg(cd, "Unlinking volume key (id: %" PRIi32 ") from thread keyring.", key_id);
+-
+-	if (keyring_unlink_key_from_thread_keyring(key_id))
+-		log_dbg(cd, "keyring_unlink_key_from_thread_keyring failed with errno %d.", errno);
+-}
+-
+-void crypt_unlink_key_by_description_from_thread_keyring(struct crypt_device *cd,
++void crypt_unlink_key_by_description_from_keyring(struct crypt_device *cd,
+ 		const char *key_description,
+ 		key_type_t ktype)
+ {
+@@ -7696,7 +7739,7 @@ void crypt_unlink_key_by_description_from_thread_keyring(struct crypt_device *cd
+ 		return;
+ 	}
+ 
+-	crypt_unlink_key_from_thread_keyring(cd, kid);
++	crypt_unlink_key_from_keyring(cd, kid);
+ }
+ 
+ int crypt_set_keyring_to_link(struct crypt_device *cd, const char *key_description,
+diff --git a/lib/volumekey.c b/lib/volumekey.c
+index afa0cb898987..6cdfd589eb61 100644
+--- a/lib/volumekey.c
++++ b/lib/volumekey.c
+@@ -243,14 +243,14 @@ bool crypt_volume_key_is_set(const struct volume_key *vk)
+ 	return vk && vk->key;
+ }
+ 
+-bool crypt_volume_key_upload_kernel_key(struct volume_key *vk)
++bool crypt_volume_key_upload_kernel_key(struct volume_key *vk, key_serial_t keyring)
+ {
+ 	key_serial_t kid;
+ 
+ 	assert(vk && vk->key && vk->key_description && vk->keyring_key_type != INVALID_KEY);
+ 
+-	kid = keyring_add_key_in_thread_keyring(vk->keyring_key_type, vk->key_description,
+-					 vk->key, vk->keylength);
++	kid = keyring_add_key_to_keyring(vk->keyring_key_type, vk->key_description, vk->key,
++					 vk->keylength, keyring);
+ 	if (kid >= 0) {
+ 		vk->key_id = kid;
+ 		return true;
+@@ -265,9 +265,7 @@ void crypt_volume_key_drop_kernel_key(struct crypt_device *cd, struct volume_key
+ 	assert(vk->key_description || vk->keyring_key_type == INVALID_KEY);
+ 	assert(!vk->key_description || vk->keyring_key_type != INVALID_KEY);
+ 
+-	crypt_unlink_key_by_description_from_thread_keyring(cd,
+-							    vk->key_description,
+-							    vk->keyring_key_type);
++	crypt_unlink_key_by_description_from_keyring(cd, vk->key_description, vk->keyring_key_type);
+ }
+ 
+ void crypt_volume_key_drop_uploaded_kernel_key(struct crypt_device *cd, struct volume_key *vk)
+@@ -277,6 +275,6 @@ void crypt_volume_key_drop_uploaded_kernel_key(struct crypt_device *cd, struct v
+ 	if (vk->key_id < 0)
+ 		return;
+ 
+-	crypt_unlink_key_from_thread_keyring(cd, vk->key_id);
++	crypt_unlink_key_from_keyring(cd, vk->key_id);
+ 	vk->key_id = -1;
+ }
+-- 
+2.52.0
+

--- a/app-admin/cryptsetup/autobuild/patches/0003-BACKPORT-Use-unique-intermediary-keyring-name-per-de.patch
+++ b/app-admin/cryptsetup/autobuild/patches/0003-BACKPORT-Use-unique-intermediary-keyring-name-per-de.patch
@@ -1,0 +1,70 @@
+From 67313c334f5892830413cff74e1d9b680690be74 Mon Sep 17 00:00:00 2001
+From: Ondrej Kozina <okozina@redhat.com>
+Date: Fri, 19 Jun 2026 16:45:49 +0200
+Subject: [PATCH 3/3] BACKPORT: Use unique intermediary keyring name per
+ device.
+
+Replace the static "cryptsetup-keyring" name with
+"cryptsetup-<uuid_prefix>-<random>" to avoid collisions when
+multiple LUKS devices are opened by the same process.
+
+Fixes: #993.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+(cherry picked from commit 04ef07a7070fc8f71dc8da57d6cc23423e1b632e)
+---
+ lib/setup.c | 23 +++++++++++++++++------
+ 1 file changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/lib/setup.c b/lib/setup.c
+index cf4ddd04f530..759c3f905ca4 100644
+--- a/lib/setup.c
++++ b/lib/setup.c
+@@ -7567,6 +7567,9 @@ int crypt_volume_key_keyring(struct crypt_device *cd __attribute__((unused)), in
+ int crypt_volume_key_load_in_keyring(struct crypt_device *cd, struct volume_key *vk)
+ {
+ 	key_serial_t keyring_id;
++	char *keyring_description;
++	char rnd[4];
++	const char *uuid;
+ 
+ 	if (!vk || !cd)
+ 		return -EINVAL;
+@@ -7577,20 +7580,28 @@ int crypt_volume_key_load_in_keyring(struct crypt_device *cd, struct volume_key
+ 	}
+ 
+ 	if (!cd->keyring_description) {
+-		cd->keyring_description = strdup("cryptsetup-keyring");
+-		if (!cd->keyring_description)
++		uuid = crypt_get_uuid(cd);
++		if (!uuid)
++			return -EINVAL;
++
++		if (crypt_random_get(cd, rnd, sizeof(rnd), CRYPT_RND_NORMAL) < 0)
++			return -EINVAL;
++
++		if (asprintf(&keyring_description, "cryptsetup-%.8s-%02x%02x%02x%02x",
++			     uuid, (unsigned char)rnd[0], (unsigned char)rnd[1],
++			     (unsigned char)rnd[2], (unsigned char)rnd[3]) < 0)
+ 			return -ENOMEM;
+ 
+-		log_dbg(cd, "Loading key (type keyring, name %s) in thread keyring.", cd->keyring_description);
+-		keyring_id = keyring_add_key_in_thread_keyring(KEYRING_KEY, cd->keyring_description, NULL, 0);
++		log_dbg(cd, "Loading key (type keyring, name %s) in thread keyring.", keyring_description);
++		keyring_id = keyring_add_key_in_thread_keyring(KEYRING_KEY, keyring_description, NULL, 0);
+ 		if (keyring_id < 0) {
+-			free(CONST_CAST(void*)cd->keyring_description);
+-			cd->keyring_description = NULL;
++			free(keyring_description);
+ 			log_dbg(cd, "keyring_add_key_in_thread_keyring failed (error %d)", errno);
+ 			log_err(cd, _("Failed to load key in kernel keyring."));
+ 			return -EINVAL;
+ 		}
+ 		cd->keyring_id = keyring_id;
++		cd->keyring_description = keyring_description;
+ 	}
+ 
+ 	log_dbg(cd, "Loading key (type logon, name %s) in %s keyring.",
+-- 
+2.52.0
+

--- a/app-admin/cryptsetup/spec
+++ b/app-admin/cryptsetup/spec
@@ -1,4 +1,4 @@
-VER=2.8.1
+VER=2.8.6
 SRCS="https://www.kernel.org/pub/linux/utils/cryptsetup/v${VER:0:3}/cryptsetup-$VER.tar.xz"
-CHKSUMS="sha256::2c3379eb76597dcab50911449b013e2697c4bffcc716dbbf0d9b0e8fbbb46fb4"
+CHKSUMS="sha256::8004265fd993885d08f7b633dbe056851de1a210307613a4ebddc743fccefe5a"
 CHKUPDATE="anitya::id=13709"

--- a/topics/cryptsetup-2.8.6.toml
+++ b/topics/cryptsetup-2.8.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Cryptsetup 2.8.6"
+
+[caution]
+default = "Fixes the unintended kernel keyring leak vulnerability in LUKS subcommands"
+zh_CN = "修复 LUKS 子命令中非预期的内核密钥环泄漏漏洞"
+
+[packages-v2]
+cryptsetup = "< 2.8.6"


### PR DESCRIPTION
Topic Description
-----------------

- cryptsetup: update to 2.8.6; migrate plain hash presets; fix keyring leaks
    Link: https://gitlab.com/cryptsetup/cryptsetup/-/work_items/758
    Link: https://lore.kernel.org/all/ajKwRtP8izwRsMmv@quasitopos/
    Link: https://gitlab.com/cryptsetup/cryptsetup/-/work_items/993

Package(s) Affected
-------------------

- cryptsetup: 2.8.6

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit cryptsetup
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
