### PR TITLE
surfer: update to 0.7.0+git20260830

### DIFF
--- a/app-electronics/surfer/autobuild/defines
+++ b/app-electronics/surfer/autobuild/defines
@@ -1,12 +1,8 @@
 PKGNAME=surfer
-PKGDES="A waveform viewer"
+PKGDES="Waveform viewer with support for VCD, FST, and GHW formats"
 PKGSEC=electronics
-PKGDEP="openssl"
-BUILDDEP="rustc llvm openssl pkg-config pkgconf"
+PKGDEP="gcc-runtime glibc"
+BUILDDEP="rustc llvm pkg-config pkgconf"
 ABTYPE=rust
 
 USECLANG=1
-
-# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; recompile with -fPIC
-NOLTO__LOONGSON3=1
-USECLANG__LOONGSON3=0

--- a/app-electronics/surfer/autobuild/defines
+++ b/app-electronics/surfer/autobuild/defines
@@ -1,12 +1,8 @@
 PKGNAME=surfer
-PKGDES="A waveform viewer"
+PKGDES="Waveform viewer which supports VCD, FST, GHW loading"
 PKGSEC=electronics
 PKGDEP="openssl"
 BUILDDEP="rustc llvm openssl pkg-config pkgconf"
 ABTYPE=rust
 
 USECLANG=1
-
-# FIXME: ld.lld: error: relocation R_MIPS_64 cannot be used against local symbol; recompile with -fPIC
-NOLTO__LOONGSON3=1
-USECLANG__LOONGSON3=0

--- a/app-electronics/surfer/autobuild/prepare
+++ b/app-electronics/surfer/autobuild/prepare
@@ -1,0 +1,2 @@
+# FIXME: Use lld to workaround aws-lc-rs discovery issue.
+export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-fuse-ld=lld"

--- a/app-electronics/surfer/spec
+++ b/app-electronics/surfer/spec
@@ -1,6 +1,6 @@
-VER=0.4.0
+VER=0.7.0+git20260830
 
-SRCS="git::commit=tags/v$VER::https://gitlab.com/surfer-project/surfer"
+SRCS="git::commit=6577d75fab1aa0d72bdb0fa6223aa01de514d1f2::https://gitlab.com/surfer-project/surfer"
 CHKSUMS="SKIP"
 
 # Note: Prefer larger RAM.

--- a/app-electronics/surfer/spec
+++ b/app-electronics/surfer/spec
@@ -1,4 +1,4 @@
-VER=0.4.0
+VER=0.7.0
 
 SRCS="git::commit=tags/v$VER::https://gitlab.com/surfer-project/surfer"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- surfer: update to 0.7.0+git20260830
    The 0.7.0 tag used \`aws-lc-rs\`, which caused symbol loss error during LTO.
    The upstream mainline version removed aws-lc-rs, but it has not been
    released, and there are too many changes in between that tag, making it
    difficult to backport patches. Therefore, 20260830 is used directly.

Package(s) Affected
-------------------

- surfer: 0.7.0+git20260830

Security Update?
----------------

No

Build Order
-----------

```
#buildit surfer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
