### PR TITLE
ouch: update to 0.8.1

### DIFF
--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,4 +1,4 @@
-VER=0.8.0
+VER=0.8.1
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"


### PR DESCRIPTION
Topic Description
-----------------

- ouch: update to 0.8.1
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- ouch: 0.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
