### PR TITLE
libjpeg-turbo: update to 3.2.0

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -2,4 +2,4 @@ VER=5.2.15
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
 CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
 CHKUPDATE="anitya::id=10918"
-REL=4
+REL=5

--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -2,3 +2,4 @@ VER=4.7
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373975"
+REL=1

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -2,3 +2,4 @@ VER=5.0.1
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"
+REL=1

--- a/app-multimedia/handbrake/spec
+++ b/app-multimedia/handbrake/spec
@@ -1,5 +1,5 @@
 VER=1.10.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/HandBrake/HandBrake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9156"

--- a/app-network/xpra/spec
+++ b/app-network/xpra/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/Xpra-org/xpra"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5445"
+REL=1

--- a/app-network/xrdp/spec
+++ b/app-network/xrdp/spec
@@ -2,3 +2,4 @@ VER=0.10.6
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231006"
+REL=1

--- a/runtime-common/pocl/spec
+++ b/runtime-common/pocl/spec
@@ -2,3 +2,4 @@ VER=7.1
 SRCS="git::commit=tags/v${VER}::https://github.com/pocl/pocl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3676"
+REL=1

--- a/runtime-games/libopenglrecorder/spec
+++ b/runtime-games/libopenglrecorder/spec
@@ -1,5 +1,5 @@
 VER=0.1.0
-REL=7
+REL=8
 SRCS="tbl::https://github.com/Benau/libopenglrecorder/archive/v$VER.tar.gz"
 CHKSUMS="sha256::a90a99c23f868636f77003a8dc6ffe6c3699fc2759c47df5dbd44ff8b42d2e4f"
 CHKUPDATE="anitya::id=230119"

--- a/runtime-imaging/libjpeg-turbo/autobuild/defines
+++ b/runtime-imaging/libjpeg-turbo/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=libjpeg-turbo
 PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
+BUILDDEP__LOONGARCH64="${BUILDDEP} simde"
 PKGDES="JPEG image codec with accelerated baseline compression and decompression"
 
 CMAKE_AFTER=(
@@ -17,15 +18,19 @@ CMAKE_AFTER=(
     '-DWITH_TURBOJPEG=ON'
 )
 
+# NOTE: PowerPC and LoongArch64 SIMD support are provided via simde.
 CMAKE_AFTER__POWERPC=(
     "${CMAKE_AFTER[@]}"
-    '-DWITH_SIMD=OFF'
+    '-DWITH_SIMDE=ON'
+)
+
+CMAKE_AFTER__LOONGARCH64=(
+    "${CMAKE_AFTER[@]}"
+    '-DWITH_SIMDE=ON'
 )
 
 PKGREP="mozjpeg<=3.1-1"
 PKGBREAK="mozjpeg<=3.1-1"
-
-PKGEPOCH=2
 
 AB_FLAGS_O3=1
 

--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"

--- a/runtime-network/neatvnc/spec
+++ b/runtime-network/neatvnc/spec
@@ -2,3 +2,4 @@ VER=1.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/any1/neatvnc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370162"
+REL=1

--- a/runtime-optenv32/gdk-pixbuf+32/spec
+++ b/runtime-optenv32/gdk-pixbuf+32/spec
@@ -1,5 +1,5 @@
 VER=2.42.12
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/gdk-pixbuf/${VER:0:4}/gdk-pixbuf-$VER.tar.xz"
 CHKSUMS="sha256::b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7"
 CHKUPDATE="anitya::id=9533"

--- a/runtime-optenv32/imlib2+32/spec
+++ b/runtime-optenv32/imlib2+32/spec
@@ -1,5 +1,5 @@
 VER=1.5.1
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/enlightenment/files/imlib2-src/$VER/imlib2-$VER.tar.bz2"
 CHKSUMS="sha256::fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae"
 CHKUPDATE="anitya::id=21676"

--- a/runtime-optenv32/libjpeg-turbo+32/spec
+++ b/runtime-optenv32/libjpeg-turbo+32/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"

--- a/runtime-optenv32/libtiff+32/spec
+++ b/runtime-optenv32/libtiff+32/spec
@@ -2,3 +2,4 @@ VER=4.7.1
 SRCS="tbl::https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
 CHKSUMS="sha256::f698d94f3103da8ca7438d84e0344e453fe0ba3b7486e04c5bf7a9a3fabe9b69"
 CHKUPDATE="anitya::id=1738"
+REL=1

--- a/runtime-optenv32/libwebp+32/spec
+++ b/runtime-optenv32/libwebp+32/spec
@@ -2,3 +2,4 @@ VER=1.6.0
 SRCS="tbl::http://downloads.webmproject.org/releases/webp/libwebp-$VER.tar.gz"
 CHKSUMS="sha256::e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564"
 CHKUPDATE="anitya::id=1761"
+REL=1

--- a/runtime-optenv32/mjpegtools+32/spec
+++ b/runtime-optenv32/mjpegtools+32/spec
@@ -1,5 +1,5 @@
 VER=2.1.0
-REL=3
+REL=4
 SRCS="tbl::https://sourceforge.net/projects/mjpeg/files/mjpegtools/$VER/mjpegtools-$VER.tar.gz"
 CHKSUMS="sha256::864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
 CHKUPDATE="anitya::id=14612"

--- a/runtime-optenv32/v4l-utils+32/spec
+++ b/runtime-optenv32/v4l-utils+32/spec
@@ -2,3 +2,4 @@ VER=1.22.1
 SRCS="tbl::https://www.linuxtv.org/downloads/v4l-utils/v4l-utils-$VER.tar.bz2"
 CHKSUMS="sha256::65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31"
 CHKUPDATE="anitya::id=9998"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- v4l-utils+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- mjpegtools+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- libwebp+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- imlib2+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- gdk-pixbuf+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- xrdp: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- xpra: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- pocl: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- neatvnc: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- libopenglrecorder: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>

... and 6 more commits

Package(s) Affected
-------------------

- gdk-pixbuf+32: 2.42.12-2
- godot: 4.7-1
- godot-export-template-amd64: 4.7-1
- godot-export-template-arm64: 4.7-1
- godot-export-template-loongarch64: 4.7-1
- godot-export-template-ppc64el: 4.7-1
- godot-export-template-riscv64: 4.7-1
- handbrake: 1.10.1-2
- imlib2+32: 1.5.1-2
- imv: 5.0.1-1
- krita: 5.2.15-5
- libjpeg-turbo: 3.2.0
- libjpeg-turbo+32: 3.2.0
- libopenglrecorder: 0.1.0-8
- libtiff+32: 4.7.1
- libwebp+32: 1.6.0-1
- mjpegtools+32: 2.1.0-4
- neatvnc: 1.0.0-1
- pocl: 1:7.1-1
- v4l-utils+32: 1.22.1-1
- xpra: 6.4.3-1
- xrdp: 0.10.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo libjpeg-turbo+32 godot handbrake imv krita libopenglrecorder neatvnc pocl xpra xrdp gdk-pixbuf+32 imlib2+32 libtiff+32 libwebp+32 mjpegtools+32 v4l-utils+32
```

Test Build(s) Done
------------------

