### PR TITLE
libjpeg-turbo: update to 3.2.0

### DIFF
--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -2,4 +2,4 @@ VER=5.2.15
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
 CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
 CHKUPDATE="anitya::id=10918"
-REL=4
+REL=5

--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -2,3 +2,4 @@ VER=4.7
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373975"
+REL=1

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -2,3 +2,4 @@ VER=5.0.1
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"
+REL=1

--- a/app-multimedia/handbrake/spec
+++ b/app-multimedia/handbrake/spec
@@ -1,5 +1,5 @@
 VER=1.10.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/HandBrake/HandBrake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=9156"

--- a/app-network/xpra/spec
+++ b/app-network/xpra/spec
@@ -2,3 +2,4 @@ VER=6.4.3
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/Xpra-org/xpra"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5445"
+REL=1

--- a/app-network/xrdp/spec
+++ b/app-network/xrdp/spec
@@ -2,3 +2,4 @@ VER=0.10.6
 SRCS="git::commit=tags/v$VER::https://github.com/neutrinolabs/xrdp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231006"
+REL=1

--- a/runtime-common/pocl/spec
+++ b/runtime-common/pocl/spec
@@ -2,3 +2,4 @@ VER=7.1
 SRCS="git::commit=tags/v${VER}::https://github.com/pocl/pocl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3676"
+REL=1

--- a/runtime-games/libopenglrecorder/spec
+++ b/runtime-games/libopenglrecorder/spec
@@ -1,5 +1,5 @@
 VER=0.1.0
-REL=7
+REL=8
 SRCS="tbl::https://github.com/Benau/libopenglrecorder/archive/v$VER.tar.gz"
 CHKSUMS="sha256::a90a99c23f868636f77003a8dc6ffe6c3699fc2759c47df5dbd44ff8b42d2e4f"
 CHKUPDATE="anitya::id=230119"

--- a/runtime-imaging/libjpeg-turbo/autobuild/defines
+++ b/runtime-imaging/libjpeg-turbo/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=libjpeg-turbo
 PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
+BUILDDEP__LOONGARCH64="${BUILDDEP} simde"
 PKGDES="JPEG image codec with accelerated baseline compression and decompression"
 
 CMAKE_AFTER=(
@@ -17,15 +18,14 @@ CMAKE_AFTER=(
     '-DWITH_TURBOJPEG=ON'
 )
 
-CMAKE_AFTER__POWERPC=(
+# NOTE: LoongArch64 SIMD support are provided via simde.
+CMAKE_AFTER__LOONGARCH64=(
     "${CMAKE_AFTER[@]}"
-    '-DWITH_SIMD=OFF'
+    '-DWITH_SIMDE=ON'
 )
 
 PKGREP="mozjpeg<=3.1-1"
 PKGBREAK="mozjpeg<=3.1-1"
-
-PKGEPOCH=2
 
 AB_FLAGS_O3=1
 

--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"

--- a/runtime-network/neatvnc/spec
+++ b/runtime-network/neatvnc/spec
@@ -2,3 +2,4 @@ VER=1.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/any1/neatvnc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370162"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- xrdp: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- xpra: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- pocl: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- neatvnc: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- libopenglrecorder: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- krita: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- imv: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- handbrake: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- godot: bump REL due to libjpeg-turbo update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- libjpeg-turbo: update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>

Package(s) Affected
-------------------

- godot: 4.7-1
- godot-export-template-amd64: 4.7-1
- godot-export-template-arm64: 4.7-1
- godot-export-template-loongarch64: 4.7-1
- godot-export-template-ppc64el: 4.7-1
- godot-export-template-riscv64: 4.7-1
- libjpeg-turbo: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo godot  handbrake  imv  krita  libopenglrecorder  neatvnc  pocl  xpra  xrdp
```

Test Build(s) Done
------------------

