### PR TITLE
libjpeg-turbo+32: update to 3.2.0

### DIFF
--- a/runtime-optenv32/gdk-pixbuf+32/spec
+++ b/runtime-optenv32/gdk-pixbuf+32/spec
@@ -1,5 +1,5 @@
 VER=2.42.12
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/gdk-pixbuf/${VER:0:4}/gdk-pixbuf-$VER.tar.xz"
 CHKSUMS="sha256::b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7"
 CHKUPDATE="anitya::id=9533"

--- a/runtime-optenv32/imlib2+32/spec
+++ b/runtime-optenv32/imlib2+32/spec
@@ -1,5 +1,5 @@
 VER=1.5.1
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/enlightenment/files/imlib2-src/$VER/imlib2-$VER.tar.bz2"
 CHKSUMS="sha256::fa4e57452b8843f4a70f70fd435c746ae2ace813250f8c65f977db5d7914baae"
 CHKUPDATE="anitya::id=21676"

--- a/runtime-optenv32/libjpeg-turbo+32/spec
+++ b/runtime-optenv32/libjpeg-turbo+32/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"

--- a/runtime-optenv32/libtiff+32/spec
+++ b/runtime-optenv32/libtiff+32/spec
@@ -2,3 +2,4 @@ VER=4.7.1
 SRCS="tbl::https://download.osgeo.org/libtiff/tiff-$VER.tar.gz"
 CHKSUMS="sha256::f698d94f3103da8ca7438d84e0344e453fe0ba3b7486e04c5bf7a9a3fabe9b69"
 CHKUPDATE="anitya::id=1738"
+REL=1

--- a/runtime-optenv32/libwebp+32/spec
+++ b/runtime-optenv32/libwebp+32/spec
@@ -2,3 +2,4 @@ VER=1.6.0
 SRCS="tbl::http://downloads.webmproject.org/releases/webp/libwebp-$VER.tar.gz"
 CHKSUMS="sha256::e4ab7009bf0629fd11982d4c2aa83964cf244cffba7347ecd39019a9e38c4564"
 CHKUPDATE="anitya::id=1761"
+REL=1

--- a/runtime-optenv32/mjpegtools+32/spec
+++ b/runtime-optenv32/mjpegtools+32/spec
@@ -1,5 +1,5 @@
 VER=2.1.0
-REL=3
+REL=4
 SRCS="tbl::https://sourceforge.net/projects/mjpeg/files/mjpegtools/$VER/mjpegtools-$VER.tar.gz"
 CHKSUMS="sha256::864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
 CHKUPDATE="anitya::id=14612"

--- a/runtime-optenv32/v4l-utils+32/spec
+++ b/runtime-optenv32/v4l-utils+32/spec
@@ -2,3 +2,4 @@ VER=1.22.1
 SRCS="tbl::https://www.linuxtv.org/downloads/v4l-utils/v4l-utils-$VER.tar.bz2"
 CHKSUMS="sha256::65c6fbe830a44ca105c443b027182c1b2c9053a91d1e72ad849dfab388b94e31"
 CHKUPDATE="anitya::id=9998"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libtiff+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- v4l-utils+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- mjpegtools+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- libwebp+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- imlib2+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- gdk-pixbuf+32: bump REL due to libjpeg-turbo+32 update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>
- libjpeg-turbo+32: update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>

Package(s) Affected
-------------------

- gdk-pixbuf+32: 2.42.12-2
- libjpeg-turbo+32: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo+32 gdk-pixbuf+32  imlib2+32  libtiff+32  libwebp+32  mjpegtools+32  v4l-utils+32
```

Test Build(s) Done
------------------

