### PR TITLE
libjpeg-turbo: update to 3.2.0

### DIFF
--- a/runtime-imaging/libjpeg-turbo/autobuild/defines
+++ b/runtime-imaging/libjpeg-turbo/autobuild/defines
@@ -2,6 +2,7 @@ PKGNAME=libjpeg-turbo
 PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
+BUILDDEP__LOONGARCH64="${BUILDDEP} simde"
 PKGDES="JPEG image codec with accelerated baseline compression and decompression"
 
 CMAKE_AFTER=(
@@ -17,9 +18,10 @@ CMAKE_AFTER=(
     '-DWITH_TURBOJPEG=ON'
 )
 
-CMAKE_AFTER__POWERPC=(
+# NOTE: LoongArch64 SIMD support is provided by simde.
+CMAKE_AFTER__LOONGARCH64=(
     "${CMAKE_AFTER[@]}"
-    '-DWITH_SIMD=OFF'
+    '-DWITH_SIMDE=ON'
 )
 
 PKGREP="mozjpeg<=3.1-1"

--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"


### PR DESCRIPTION
Topic Description
-----------------

- libjpeg-turbo: update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>

Package(s) Affected
-------------------

- libjpeg-turbo: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo
```

Test Build(s) Done
------------------

