### PR TITLE
libjpeg-turbo+32: update to 3.2.0

### DIFF
--- a/runtime-optenv32/libjpeg-turbo+32/spec
+++ b/runtime-optenv32/libjpeg-turbo+32/spec
@@ -1,4 +1,4 @@
-VER=3.1.3
+VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"


### PR DESCRIPTION
Topic Description
-----------------

- libjpeg-turbo+32: update to 3.2.0
    Signed-off-by: elysia-best <a.elysia@proton.me>

Package(s) Affected
-------------------

- libjpeg-turbo+32: 3.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
