### PR TITLE
distrobox: update to 1.8.2.5

### DIFF
--- a/app-utils/distrobox/autobuild/defines
+++ b/app-utils/distrobox/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=distrobox
 PKGSEC=utils
 PKGDEP="bash"
 PKGDES="Wrapper around Docker or Podman to create and start containers"
-PKGRECOM="docker"
-PKGSUG="podman"
+PKGRECOM="podman"
+PKGSUG="docker"
 
 ABHOST=noarch

--- a/app-utils/distrobox/spec
+++ b/app-utils/distrobox/spec
@@ -1,4 +1,4 @@
-VER=1.8.2.2
+VER=1.8.2.5
 SRCS="git::commit=tags/$VER::https://github.com/89luca89/distrobox"
 CHKUPDATE="anitya::id=242098"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- distrobox: update to 1.8.2.5

Package(s) Affected
-------------------

- distrobox: 1.8.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit distrobox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
