### PR TITLE
libjxl: security update to 0.12.0

### DIFF
--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,5 @@
 VER=5.4.1
-REL=5
+REL=6
 EPOCH=1
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"

--- a/app-creativity/gimp/spec
+++ b/app-creativity/gimp/spec
@@ -1,4 +1,5 @@
 VER=3.2.4
+REL=1
 SRCS="tbl::https://download.gimp.org/pub/gimp/v${VER:0:3}/gimp-${VER/~rc/-RC}.tar.xz"
 CHKSUMS="sha256::7312bc53e9c6d2d0056ca7b93f1c6b98707946dd934f714c21b8746ecb601588"
 CHKUPDATE="anitya::id=1161"

--- a/app-creativity/krita/spec
+++ b/app-creativity/krita/spec
@@ -2,4 +2,4 @@ VER=5.2.15
 SRCS="tbl::https://download.kde.org/stable/krita/${VER}/krita-$VER.tar.xz"
 CHKSUMS="sha256::002d52e6e1463ddbbe3028d809f0cfc01152f495fc311a3f5ead38c3a1a0ae52"
 CHKUPDATE="anitya::id=10918"
-REL=5
+REL=6

--- a/app-imaging/imv/spec
+++ b/app-imaging/imv/spec
@@ -1,4 +1,5 @@
 VER=5.0.1
+REL=1
 SRCS="git::commit=tags/v${VER}::https://git.sr.ht/~exec64/imv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=93177"

--- a/app-utils/chafa/spec
+++ b/app-utils/chafa/spec
@@ -1,5 +1,5 @@
 VER=1.16.2
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/hpjansson/chafa"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17542"

--- a/app-utils/graphicsmagick/spec
+++ b/app-utils/graphicsmagick/spec
@@ -1,5 +1,5 @@
 VER=1.3.46
-REL=3
+REL=4
 SRCS="tbl::https://sourceforge.net/projects/graphicsmagick/files/graphicsmagick/$VER/GraphicsMagick-$VER.tar.xz/download"
 CHKSUMS="sha256::c7c706a505e9c6c3764156bb94a0c9644d79131785df15a89c9f8721d1abd061"
 CHKUPDATE="anitya::id=1248"

--- a/app-utils/imagemagick+7/spec
+++ b/app-utils/imagemagick+7/spec
@@ -1,5 +1,5 @@
 VER=7.1.2+19
-REL=3
+REL=4
 SRCS="git::commit=tags/${VER/+/-}::https://github.com/imagemagick/imagemagick"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1372"

--- a/app-utils/imagemagick/spec
+++ b/app-utils/imagemagick/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=6.9.13-44
 VER=${UPSTREAM_VER/\-/+}
-REL=4
+REL=5
 SRCS="git::commit=tags/${UPSTREAM_VER}::https://github.com/ImageMagick/ImageMagick6.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=16253"

--- a/app-utils/wbg/spec
+++ b/app-utils/wbg/spec
@@ -1,4 +1,5 @@
 VER=1.3.0
+REL=1
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/wbg"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375605"

--- a/app-web/netsurf/spec
+++ b/app-web/netsurf/spec
@@ -1,5 +1,5 @@
 VER=3.11
-REL=3
+REL=4
 SRCS="tbl::https://download.netsurf-browser.org/netsurf/releases/source/netsurf-$VER-src.tar.gz"
 CHKSUMS="sha256::c28a626aefee428d053b13f88b5c440922245976522d12eaf137cfd32d201cb2"
 CHKUPDATE="anitya::id=5386"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,4 +1,5 @@
 VER=7.0.1
+REL=1
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
 TDLIBVER=07d3a0973f5113b0827a04d54a93aaaa9e288348

--- a/desktop-gnome/glycin/spec
+++ b/desktop-gnome/glycin/spec
@@ -1,5 +1,5 @@
 VER=2.1.1
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glycin.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371932"

--- a/desktop-kde/digikam/spec
+++ b/desktop-kde/digikam/spec
@@ -1,4 +1,5 @@
 VER=9.1.0
+REL=1
 SRCS="tbl::http://download.kde.org/stable/digikam/$VER/digiKam-$VER.tar.xz \
       file::rename=classification_classes_ILSVRC2012.txt::https://files.kde.org/digikam/autotags/classification_classes_ILSVRC2012.txt \
       file::rename=coco.names::https://files.kde.org/digikam/autotags/coco.names \

--- a/desktop-kde/kimageformats/spec
+++ b/desktop-kde/kimageformats/spec
@@ -1,5 +1,5 @@
 VER=5.115.0
-REL=5
+REL=6
 SRCS="tbl::https://download.kde.org/stable/frameworks/${VER%.*}/kimageformats-$VER.tar.xz"
 CHKSUMS="sha256::9f61020d66f86b8b10bce14e42a39c5e8fd8e40ec9e6ca8b9e9b5ce3e1aa7283"
 CHKUPDATE="anitya::id=8762"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -2,4 +2,4 @@ VER=3.13.1
 SRCS="git::commit=tags/v${VER}::https://github.com/OSGeo/gdal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=881"
-REL=2
+REL=3

--- a/runtime-imaging/libjxl/autobuild/defines
+++ b/runtime-imaging/libjxl/autobuild/defines
@@ -25,6 +25,9 @@ CMAKE_AFTER=(
     "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
 )
 
-PKGBREAK="chafa<=1.14.5-1 darktable<=1:5.0.1-1 gdal<=3.10.1-6 gimp<=2.10.38-2 \
-          glycin<=1.1.4-1 imv<=4.5.0-5 kimageformats<=5.115.0-2 \
-          krita<=5.2.9-1 libvips<=8.16.1-1 webkit2gtk<=1:2.44.2-4"
+PKGBREAK="chafa<=1.16.2-1 darktable<=5.4.1-5 digikam<=9.1.0 gdal<=3.13.1-2 \
+          gimp<=3.2.4 glycin<=2.1.1-1 graphicsmagick<=1.3.46-3 \
+          imagemagick<=6.9.13+44-4 imagemagick+7<=7.1.2+19-3 \
+          imv<=5.0.1 kimageformats<=5.115.0-5 krita<=5.2.15-5 libvips<=8.18.4 \
+          netsurf<=3.11-3 openimageio<=2.5.19.1-10 telegram-desktop<=7.0.1 \
+          wbg<=1.3.0 webkit2gtk<=1:2.50.3-2"

--- a/runtime-imaging/libjxl/autobuild/defines.stage2
+++ b/runtime-imaging/libjxl/autobuild/defines.stage2
@@ -25,6 +25,8 @@ CMAKE_AFTER=(
     "-DJPEGXL_FORCE_SYSTEM_HWY=ON"
 )
 
-PKGBREAK="chafa<=1.14.5-1 darktable<=1:5.0.1-1 gdal<=3.10.1-6 gimp<=2.10.38-2 \
-          glycin<=1.1.4-1 imv<=4.5.0-5 kimageformats<=5.115.0-2 \
-          krita<=5.2.9-1 libvips<=8.16.1-1 webkit2gtk<=1:2.44.2-4"
+PKGBREAK="chafa<=1.16.2-1 darktable<=5.4.1-5 digikam<=9.1.0 gdal<=3.13.1-1 \
+          gimp<=3.2.4 glycin<=2.1.1-1 graphicsmagick<=1.3.46-3 \
+          imagemagick+7<=7.1.2+19-3 imv<=5.0.1 kimageformats<=5.115.0-5 \
+          krita<=5.2.15-4 libvips<=8.18.0-4 netsurf<=3.11-3 \
+          telegram-desktop<=6.9.3-1 wbg<=1.3.0 webkit2gtk<=1:2.50.3-2"

--- a/runtime-imaging/libjxl/spec
+++ b/runtime-imaging/libjxl/spec
@@ -1,5 +1,4 @@
-VER=0.11.2
+VER=0.12.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/libjxl/libjxl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=232764"
-REL=2

--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,4 +1,5 @@
 VER=8.18.4
+REL=1
 SRCS="tbl::https://github.com/libvips/libvips/releases/download/v$VER/vips-$VER.tar.xz"
 CHKSUMS="sha256::2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037"
 CHKUPDATE="anitya::id=5097"

--- a/runtime-imaging/openimageio/spec
+++ b/runtime-imaging/openimageio/spec
@@ -1,5 +1,5 @@
 VER=2.5.19.1
-REL=10
+REL=11
 SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/OpenImageIO"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2548"

--- a/runtime-web/webkit2gtk/spec
+++ b/runtime-web/webkit2gtk/spec
@@ -1,5 +1,5 @@
 VER=2.50.3
-REL=2
+REL=3
 SRCS="https://webkitgtk.org/releases/webkitgtk-$VER.tar.xz"
 CHKSUMS="sha256::70a006b4695bb6b2e157e801f5a0d029f4110f050c6f0882decd8a3bf594d54f"
 CHKUPDATE="anitya::id=324014"

--- a/topics/libjxl-0.12.0.toml
+++ b/topics/libjxl-0.12.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libjxl 0.12.0"
+
+[caution]
+default = "Fixes 29 security vulnerabilities"
+zh_CN = "修复 29 个安全漏洞"
+
+[packages-v2]
+"libjxl" = "< 0.12.0"


### PR DESCRIPTION
Topic Description
-----------------

- webkit2gtk: rebuild for libjxl
- wbg: rebuild for libjxl
- telegram-desktop: rebuild for libjxl
- netsurf: rebuild for libjxl
- libvips: rebuild for libjxl
- krita: rebuild for libjxl
- kimageformats: rebuild for libjxl
- imv: rebuild for libjxl
- imagemagick+7: rebuild for libjxl
- graphicsmagick: rebuild for libjxl

... and 7 more commits

Package(s) Affected
-------------------

- chafa: 1.16.2-2
- darktable: 5.4.1-6
- digikam: 9.1.0-1
- gdal: 3.13.1-2
- gimp: 3.2.4-1
- glycin: 2.1.1-2
- glycin-gtk4: 2.1.1-2
- graphicsmagick: 1.3.46-4
- imagemagick+7: 7.1.2+19-4
- imv: 5.0.1-1
- kimageformats: 5.115.0-6
- krita: 5.2.15-5
- libjxl: 0.12.0
- libvips: 8.18.0-5
- netsurf: 3.11-4
- telegram-desktop: 6.9.3-2
- wbg: 1.3.0-1
- webkit2gtk: 1:2.50.3-3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libjxl:-pkgbreak gimp chafa graphicsmagick darktable digikam gdal glycin imagemagick imagemagick+7 imv kimageformats krita libvips netsurf openimageio telegram-desktop wbg webkit2gtk libjxl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
