### PR TITLE
bluez: update to 5.87

### DIFF
--- a/app-devices/bluez/spec
+++ b/app-devices/bluez/spec
@@ -1,4 +1,4 @@
-VER=5.86
+VER=5.87
 SRCS="tbl::https://www.kernel.org/pub/linux/bluetooth/bluez-$VER.tar.xz"
-CHKSUMS="sha256::99f144540c6070591e4c53bcb977eb42664c62b7b36cb35a29cf72ded339621d"
+CHKSUMS="sha256::26bdcf2cebd7310c6f598850606b037ef0c515fe6608ebc54d22c50c4c32b35f"
 CHKUPDATE="anitya::id=10029"


### PR DESCRIPTION
Topic Description
-----------------

- bluez: update to 5.87
    Co-authored-by: xtex \(@xtexx\) <xtex@astrafall.org>

Package(s) Affected
-------------------

- bluez: 5.87

Security Update?
----------------

No

Build Order
-----------

```
#buildit bluez
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
