### PR TITLE
amo: new, 0.2.0

### DIFF
--- a/app-admin/amo/autobuild/beyond
+++ b/app-admin/amo/autobuild/beyond
@@ -1,0 +1,17 @@
+abinfo "Moving amo to /usr/libexec ..."
+mkdir -pv "$PKGDIR"/usr/libexec
+mv -v "$PKGDIR"/usr/bin/amo \
+    "$PKGDIR"/usr/libexec/
+rmdir -v "$PKGDIR"/usr/bin
+
+abinfo "Installing systemd service ..."
+install -Dvm644 "$SRCDIR"/data/amo.service \
+    "$PKGDIR"/usr/lib/systemd/system/amo.service
+
+abinfo "Installing D-Bus service ..."
+install -Dvm644 "$SRCDIR"/data/io.aosc.Amo.conf \
+    "$PKGDIR"/usr/share/dbus-1/system.d/io.aosc.Amo.conf
+
+abinfo "Installing polkit policy ..."
+install -Dvm644 "$SRCDIR"/data/io.aosc.amo.apply.policy \
+    "$PKGDIR"/usr/share/polkit-1/actions/io.aosc.amo.apply.policy

--- a/app-admin/amo/autobuild/defines
+++ b/app-admin/amo/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=amo
+PKGSEC=admin
+PKGDEP="apt nettle systemd"
+BUILDDEP="llvm rustc"
+PKGDES="Backend D-Bus service for oma"
+
+ABTYPE=rust
+USECLANG=1

--- a/app-admin/amo/autobuild/overrides/usr/lib/systemd/system-preset/40-amo.preset
+++ b/app-admin/amo/autobuild/overrides/usr/lib/systemd/system-preset/40-amo.preset
@@ -1,0 +1,1 @@
+enable amo.service

--- a/app-admin/amo/autobuild/postinst
+++ b/app-admin/amo/autobuild/postinst
@@ -1,0 +1,8 @@
+systemctl preset amo.service
+
+# Derived from scripts automatically added by dh_installinit/13.6ubuntu1
+if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
+        if [ -f "/usr/lib/systemd/system/amo.service" ]; then
+                systemctl enable --now amo.service || true
+        fi
+fi

--- a/app-admin/amo/spec
+++ b/app-admin/amo/spec
@@ -1,0 +1,4 @@
+VER=0.2.0
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/amo"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391048"


### PR DESCRIPTION
Topic Description
-----------------

- amo: new, 0.2.0

Package(s) Affected
-------------------

- amo: 0.2.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit amo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
