### PR TITLE
rustc+32: update to 1.95.0

### DIFF
--- a/runtime-optenv32/rustc+32/autobuild/bootstrap.toml
+++ b/runtime-optenv32/rustc+32/autobuild/bootstrap.toml
@@ -24,6 +24,14 @@ debuginfo-level = 0
 channel = "stable"
 rpath = false
 
+# stage1 options
+[target.x86_64-unknown-linux-gnu]
+cc = "/usr/bin/clang"
+cxx = "/usr/bin/clang++"
+linker = "/usr/bin/clang"
+# Use system LLVM
+llvm-config = "/usr/bin/llvm-config"
+
 [target.i686-unknown-linux-gnu]
 cc = "/opt/32/bin/i686-aosc-linux-gnu-clang"
 cxx = "/opt/32/bin/i686-aosc-linux-gnu-clang++"

--- a/runtime-optenv32/rustc+32/autobuild/build
+++ b/runtime-optenv32/rustc+32/autobuild/build
@@ -17,16 +17,20 @@ abinfo "Building 32-bit Rust libraries ..."
 # Note: We also need to unset a lot of flags from RUSTFLAGS to avoid
 # linker errors.
 #
+# CXXFLAGS and CFLAGS have to be tweaked to avoid breaking stage1,
+# where binaries are built for x86_64.
+#
 # Note: Only installing runtime libraries, 32-bit toolchain will be
 # provided as wrappers.
 RUSTFLAGS='-Ctarget-cpu=x86-64' \
+CFLAGS="${CFLAGS/-m32/}" \
+CXXFLAGS="${CXXFLAGS/-m32/}" \
 python3 \
-    "$SRCDIR"/x.py build \
-    --stage=0 library
+    "$SRCDIR"/x.py build library
 
 abinfo "Installing 32-bit Rust libraries ..."
 mkdir -pv "$PKGDIR"/usr/lib/rustlib/
-cp -arv build/host/stage0-sysroot/lib*/rustlib/i686-unknown-linux-gnu \
+cp -arv build/host/stage2/lib*/rustlib/i686-unknown-linux-gnu \
     "$PKGDIR"/usr/lib/rustlib/
 
 abinfo "Installing 32-bit Rust toolchain wrappers ..."

--- a/runtime-optenv32/rustc+32/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/runtime-optenv32/rustc+32/autobuild/patches/0001-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,0 +1,40 @@
+From 65001cf312cd9145c5a95d10b5a932a36d9dcf35 Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Fri, 9 Feb 2024 18:48:33 -0800
+Subject: [PATCH 1/3] Add i486-unknown-linux-gnu compiler target
+
+---
+ compiler/rustc_target/src/spec/mod.rs                     | 1 +
+ .../src/spec/targets/i486_unknown_linux_gnu.rs            | 8 ++++++++
+ 2 files changed, 9 insertions(+)
+ create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
+
+diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
+index 57effe3a86..752d35ace8 100644
+--- a/compiler/rustc_target/src/spec/mod.rs
++++ b/compiler/rustc_target/src/spec/mod.rs
+@@ -1436,6 +1436,7 @@ supported_targets! {
+     ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
+     ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
+     ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
++    ("i486-unknown-linux-gnu", i486_unknown_linux_gnu),
+     ("loongarch64-unknown-linux-gnu", loongarch64_unknown_linux_gnu),
+     ("loongarch64-unknown-linux-musl", loongarch64_unknown_linux_musl),
+     ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
+diff --git a/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
+new file mode 100644
+index 0000000000..a57ef97626
+--- /dev/null
++++ b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
+@@ -0,0 +1,8 @@
++use crate::spec::Target;
++
++pub(crate) fn target() -> Target {
++    let mut base = super::i686_unknown_linux_gnu::target();
++    base.cpu = "i486".into();
++    base.llvm_target = "i486-unknown-linux-gnu".into();
++    base
++}
+-- 
+2.52.0
+

--- a/runtime-optenv32/rustc+32/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/runtime-optenv32/rustc+32/autobuild/patches/0002-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,0 +1,45 @@
+From 29950909cac95e82214bfbaa9889667c6afd22a0 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 7 Aug 2025 20:12:53 +0200
+Subject: [PATCH 2/3] ARCHLINUX: compiler: Swap primary and secondary lib dirs
+
+Arch Linux (editor's note: also AOSC OS) prefers "lib" over "lib64".
+---
+ compiler/rustc_target/src/lib.rs | 12 +++++++-----
+ 1 file changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/compiler/rustc_target/src/lib.rs b/compiler/rustc_target/src/lib.rs
+index dfa1b23207..fe7d266dea 100644
+--- a/compiler/rustc_target/src/lib.rs
++++ b/compiler/rustc_target/src/lib.rs
+@@ -50,20 +50,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
+     // If --libdir is set during configuration to the value other than
+     // "lib" (i.e., non-default), this value is used (see issue #16552).
+ 
++    const PRIMARY_LIB_DIR: &str = "lib";
++
+     #[cfg(target_pointer_width = "64")]
+-    const PRIMARY_LIB_DIR: &str = "lib64";
++    const SECONDARY_LIB_DIR: &str = "lib64";
+ 
+     #[cfg(target_pointer_width = "32")]
+-    const PRIMARY_LIB_DIR: &str = "lib32";
+-
+-    const SECONDARY_LIB_DIR: &str = "lib";
++    const SECONDARY_LIB_DIR: &str = "lib32";
+ 
+     match option_env!("CFG_LIBDIR_RELATIVE") {
+         None | Some("lib") => {
+             if sysroot.join(PRIMARY_LIB_DIR).join(RUST_LIB_DIR).exists() {
+                 PRIMARY_LIB_DIR.into()
+-            } else {
++            } else if sysroot.join(SECONDARY_LIB_DIR).join(RUST_LIB_DIR).exists() {
+                 SECONDARY_LIB_DIR.into()
++            } else {
++                PRIMARY_LIB_DIR.into()
+             }
+         }
+         Some(libdir) => libdir.into(),
+-- 
+2.52.0
+

--- a/runtime-optenv32/rustc+32/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/runtime-optenv32/rustc+32/autobuild/patches/0003-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,0 +1,29 @@
+From 27b5d77a054b2174357bd9d98ea1e3238b213da0 Mon Sep 17 00:00:00 2001
+From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
+Date: Thu, 7 Aug 2025 19:01:26 +0200
+Subject: [PATCH 3/3] ARCHLINUX: bootstrap: Workaround for system stage0
+
+See: http://github.com/rust-lang/rust/issues/143735
+---
+ src/bootstrap/src/core/build_steps/compile.rs | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
+index 11f2a28bb9..94b3bfb24b 100644
+--- a/src/bootstrap/src/core/build_steps/compile.rs
++++ b/src/bootstrap/src/core/build_steps/compile.rs
+@@ -827,7 +827,10 @@ impl Step for StdLink {
+                 let _ = fs::remove_dir_all(sysroot.join("lib/rustlib/src/rust"));
+             }
+ 
+-            builder.cp_link_r(&builder.initial_sysroot.join("lib"), &sysroot.join("lib"));
++            builder.cp_link_r(
++                &builder.initial_sysroot.join("lib/rustlib"),
++                &sysroot.join("lib/rustlib"),
++            );
+         } else {
+             if builder.download_rustc() {
+                 // Ensure there are no CI-rustc std artifacts.
+-- 
+2.52.0
+

--- a/runtime-optenv32/rustc+32/spec
+++ b/runtime-optenv32/rustc+32/spec
@@ -1,8 +1,8 @@
-VER=1.89.0
+VER=1.95.0
 
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::0b9d55610d8270e06c44f459d1e2b7918a5e673809c592abed9b9c600e33d95a"
+CHKSUMS="sha256::62b67230754da642a264ca0cb9fc08820c54e2ed7b3baba0289876d4cdb48c08"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc+32: update to 1.95.0
    - use stage2 instead of stage0
    - stage0-only builds didn't work in 1.89.0 anyway
    - sync patches with our native rustc to avoid breaking stage0
    - avoid setting -m32 because the same flags are used by
    the x86_64 build in stage1 and the i686 build in stage2

Package(s) Affected
-------------------

- rustc+32: 1.95.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
