### PR TITLE
libjpeg-turbo: add LSX/LASX optimisation patch

### DIFF
--- a/runtime-imaging/libjpeg-turbo/autobuild/defines
+++ b/runtime-imaging/libjpeg-turbo/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=libjpeg-turbo
 PKGSEC=libs
 PKGDEP="glibc"
 BUILDDEP__AMD64="${BUILDDEP} nasm"
-BUILDDEP__LOONGARCH64="${BUILDDEP} simde"
 PKGDES="JPEG image codec with accelerated baseline compression and decompression"
 
 CMAKE_AFTER=(
@@ -16,12 +15,6 @@ CMAKE_AFTER=(
     '-DWITH_JAVA=OFF'
     '-DWITH_SIMD=ON'
     '-DWITH_TURBOJPEG=ON'
-)
-
-# NOTE: LoongArch64 SIMD support is provided by simde.
-CMAKE_AFTER__LOONGARCH64=(
-    "${CMAKE_AFTER[@]}"
-    '-DWITH_SIMDE=ON'
 )
 
 PKGREP="mozjpeg<=3.1-1"

--- a/runtime-imaging/libjpeg-turbo/autobuild/patches/0001-FROMLIST-LoongArch64-LSX-and-LASX-SIMD-implementatio.patch
+++ b/runtime-imaging/libjpeg-turbo/autobuild/patches/0001-FROMLIST-LoongArch64-LSX-and-LASX-SIMD-implementatio.patch
@@ -1,0 +1,13566 @@
+From 7df8d51810c822833e98bfe77184fcb3fa882b28 Mon Sep 17 00:00:00 2001
+From: Song Ding <songding@loongson.cn>
+Date: Wed, 26 Apr 2023 11:43:22 +0800
+Subject: [PATCH 1/2] FROMLIST: LoongArch64 LSX and LASX SIMD implementation.
+
+Full-color compression speedups relative to libjpeg-turo 2.1.91:
+  2.5 GHz LoongArch 3A5000(LSX),  Linux, 64-bit: 111.62-161.37% (avg.136.35%)
+  2.5 GHz LoongArch 3A5000(LASX), Linux, 64-bit: 127.39-185.19% (avg.154.02%)
+
+Full-color decompression speedups relative to libjpeg-turo 2.1.91:
+  2.5 GHz LoongArch 3A5000(LSX),  Linux, 64-bit: 42.16-91.93% (avg. 72.62%)
+  2.5 GHz LoongArch 3A5000(LASX), Linux, 64-bit: 42.37-94.98% (avg. 76.21%)
+
+Link: https://github.com/libjpeg-turbo/libjpeg-turbo/pull/689
+Signed-off-by: elysia <a.elysia@proton.me>
+---
+ CMakeLists.txt                         |    2 +-
+ simd/CMakeLists.txt                    |   77 +
+ simd/loongarch64/generic_macros_lasx.h | 3528 ++++++++++++++++++++++++
+ simd/loongarch64/generic_macros_lsx.h  | 1039 +++++++
+ simd/loongarch64/jccolext-lasx.c       |  229 ++
+ simd/loongarch64/jccolext-lsx.c        |  227 ++
+ simd/loongarch64/jccolor-lasx.c        |  144 +
+ simd/loongarch64/jccolor-lsx.c         |  144 +
+ simd/loongarch64/jcgray-lasx.c         |  124 +
+ simd/loongarch64/jcgray-lsx.c          |  124 +
+ simd/loongarch64/jcgryext-lasx.c       |  188 ++
+ simd/loongarch64/jcgryext-lsx.c        |  187 ++
+ simd/loongarch64/jcsample-lasx.c       |  183 ++
+ simd/loongarch64/jcsample-lsx.c        |  181 ++
+ simd/loongarch64/jcsample.h            |   28 +
+ simd/loongarch64/jdcolext-lasx.c       |  312 +++
+ simd/loongarch64/jdcolext-lsx.c        |  279 ++
+ simd/loongarch64/jdcolor-lasx.c        |  144 +
+ simd/loongarch64/jdcolor-lsx.c         |  129 +
+ simd/loongarch64/jdmerge-lasx.c        |  141 +
+ simd/loongarch64/jdmerge-lsx.c         |  141 +
+ simd/loongarch64/jdmrgext-lasx.c       |  335 +++
+ simd/loongarch64/jdmrgext-lsx.c        |  317 +++
+ simd/loongarch64/jdsample-lasx.c       |  424 +++
+ simd/loongarch64/jdsample-lsx.c        |  425 +++
+ simd/loongarch64/jfdctfst-lasx.c       |  123 +
+ simd/loongarch64/jfdctfst-lsx.c        |  119 +
+ simd/loongarch64/jfdctint-lasx.c       |  221 ++
+ simd/loongarch64/jfdctint-lsx.c        |  247 ++
+ simd/loongarch64/jidctfst-lasx.c       |  246 ++
+ simd/loongarch64/jidctfst-lsx.c        |  264 ++
+ simd/loongarch64/jidctint-lasx.c       |  309 +++
+ simd/loongarch64/jidctint-lsx.c        |  413 +++
+ simd/loongarch64/jidctred-lasx.c       |  308 +++
+ simd/loongarch64/jidctred-lsx.c        |  323 +++
+ simd/loongarch64/jmacros_lasx.h        |  111 +
+ simd/loongarch64/jmacros_lsx.h         |  114 +
+ simd/loongarch64/jquanti-lasx.c        |  152 +
+ simd/loongarch64/jquanti-lsx.c         |  155 ++
+ simd/loongarch64/jsimd.c               | 1060 +++++++
+ 40 files changed, 13216 insertions(+), 1 deletion(-)
+ create mode 100644 simd/loongarch64/generic_macros_lasx.h
+ create mode 100644 simd/loongarch64/generic_macros_lsx.h
+ create mode 100644 simd/loongarch64/jccolext-lasx.c
+ create mode 100644 simd/loongarch64/jccolext-lsx.c
+ create mode 100644 simd/loongarch64/jccolor-lasx.c
+ create mode 100644 simd/loongarch64/jccolor-lsx.c
+ create mode 100644 simd/loongarch64/jcgray-lasx.c
+ create mode 100644 simd/loongarch64/jcgray-lsx.c
+ create mode 100644 simd/loongarch64/jcgryext-lasx.c
+ create mode 100644 simd/loongarch64/jcgryext-lsx.c
+ create mode 100644 simd/loongarch64/jcsample-lasx.c
+ create mode 100644 simd/loongarch64/jcsample-lsx.c
+ create mode 100644 simd/loongarch64/jcsample.h
+ create mode 100644 simd/loongarch64/jdcolext-lasx.c
+ create mode 100644 simd/loongarch64/jdcolext-lsx.c
+ create mode 100644 simd/loongarch64/jdcolor-lasx.c
+ create mode 100644 simd/loongarch64/jdcolor-lsx.c
+ create mode 100644 simd/loongarch64/jdmerge-lasx.c
+ create mode 100644 simd/loongarch64/jdmerge-lsx.c
+ create mode 100644 simd/loongarch64/jdmrgext-lasx.c
+ create mode 100644 simd/loongarch64/jdmrgext-lsx.c
+ create mode 100644 simd/loongarch64/jdsample-lasx.c
+ create mode 100644 simd/loongarch64/jdsample-lsx.c
+ create mode 100644 simd/loongarch64/jfdctfst-lasx.c
+ create mode 100644 simd/loongarch64/jfdctfst-lsx.c
+ create mode 100644 simd/loongarch64/jfdctint-lasx.c
+ create mode 100644 simd/loongarch64/jfdctint-lsx.c
+ create mode 100644 simd/loongarch64/jidctfst-lasx.c
+ create mode 100644 simd/loongarch64/jidctfst-lsx.c
+ create mode 100644 simd/loongarch64/jidctint-lasx.c
+ create mode 100644 simd/loongarch64/jidctint-lsx.c
+ create mode 100644 simd/loongarch64/jidctred-lasx.c
+ create mode 100644 simd/loongarch64/jidctred-lsx.c
+ create mode 100644 simd/loongarch64/jmacros_lasx.h
+ create mode 100644 simd/loongarch64/jmacros_lsx.h
+ create mode 100644 simd/loongarch64/jquanti-lasx.c
+ create mode 100644 simd/loongarch64/jquanti-lsx.c
+ create mode 100644 simd/loongarch64/jsimd.c
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index e0078919..4524441c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1093,7 +1093,7 @@ if(CPU_TYPE STREQUAL "x86_64" OR CPU_TYPE STREQUAL "i386")
+   elseif(CPU_TYPE STREQUAL "x86_64")
+     set(DEFAULT_FLOATTEST8 no-fp-contract)
+   endif()
+-elseif(CPU_TYPE STREQUAL "powerpc" OR CPU_TYPE STREQUAL "arm64")
++elseif(CPU_TYPE STREQUAL "powerpc" OR CPU_TYPE STREQUAL "arm64" OR CPU_TYPE STREQUAL "loongarch64")
+   if(CMAKE_C_COMPILER_ID MATCHES "Clang")
+     if(CMAKE_C_COMPILER_ID MATCHES "AppleClang")
+       # Xcode 14.3 and later
+diff --git a/simd/CMakeLists.txt b/simd/CMakeLists.txt
+index 48f215d3..4840864c 100644
+--- a/simd/CMakeLists.txt
++++ b/simd/CMakeLists.txt
+@@ -554,6 +554,83 @@ if(CMAKE_POSITION_INDEPENDENT_CODE OR ENABLE_SHARED)
+   set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)
+ endif()
+ 
++###############################################################################
++# LoongArch64 (Intrinsics)
++###############################################################################
++
++elseif(CPU_TYPE STREQUAL "loongarch64")
++
++set(CMAKE_REQUIRED_FLAGS -mlsx)
++check_c_source_compiles("
++  #include <lsxintrin.h>
++  int main(void) {
++    __m128i a, b, c;
++    a = __lsx_vadd_w(b, c);
++    return 0;
++  }" HAVE_LSX)
++unset(CMAKE_REQUIRED_FLAGS)
++
++set(CMAKE_REQUIRED_FLAGS -mlasx)
++check_c_source_compiles("
++  #include <lasxintrin.h>
++  int main(void) {
++    __m256i a, b, c;
++    a = __lasx_xvadd_w(b, c);
++    return 0;
++  }" HAVE_LASX)
++unset(CMAKE_REQUIRED_FLAGS)
++
++if(NOT HAVE_LSX)
++  simd_fail("SIMD extensions not available for this CPU (LoongArch64)")
++  return()
++endif()
++
++set(SIMD_SOURCES loongarch64/jccolor-lsx.c loongarch64/jcgray-lsx.c
++  loongarch64/jcsample-lsx.c loongarch64/jdcolor-lsx.c loongarch64/jdmerge-lsx.c
++  loongarch64/jdsample-lsx.c loongarch64/jfdctfst-lsx.c loongarch64/jfdctint-lsx.c
++  loongarch64/jidctfst-lsx.c loongarch64/jidctint-lsx.c loongarch64/jidctred-lsx.c
++  loongarch64/jquanti-lsx.c
++  loongarch64/jccolor-lasx.c loongarch64/jcgray-lasx.c loongarch64/jcsample-lasx.c
++  loongarch64/jdcolor-lasx.c loongarch64/jdmerge-lasx.c loongarch64/jdsample-lasx.c
++  loongarch64/jfdctfst-lasx.c loongarch64/jfdctint-lasx.c loongarch64/jidctfst-lasx.c
++  loongarch64/jidctint-lasx.c loongarch64/jidctred-lasx.c loongarch64/jquanti-lasx.c)
++
++foreach(file ${SIMD_SOURCES})
++  set(OBJECT_DEPENDS "")
++  if(${file} MATCHES jccolor)
++    string(REGEX REPLACE "jccolor" "jccolext" DEPFILE ${file})
++    set(OBJECT_DEPENDS ${OBJECT_DEPENDS}
++      ${CMAKE_CURRENT_SOURCE_DIR}/${DEPFILE})
++  endif()
++  if(${file} MATCHES jcgray)
++    string(REGEX REPLACE "jcgray" "jcgryext" DEPFILE ${file})
++    set(OBJECT_DEPENDS ${OBJECT_DEPENDS}
++      ${CMAKE_CURRENT_SOURCE_DIR}/${DEPFILE})
++  endif()
++  if(${file} MATCHES jdcolor)
++    string(REGEX REPLACE "jdcolor" "jdcolext" DEPFILE ${file})
++    set(OBJECT_DEPENDS ${OBJECT_DEPENDS}
++      ${CMAKE_CURRENT_SOURCE_DIR}/${DEPFILE})
++  endif()
++  if(${file} MATCHES jdmerge)
++    string(REGEX REPLACE "jdmerge" "jdmrgext" DEPFILE ${file})
++    set(OBJECT_DEPENDS ${OBJECT_DEPENDS}
++      ${CMAKE_CURRENT_SOURCE_DIR}/${DEPFILE})
++  endif()
++  set(OBJECT_DEPENDS ${OBJECT_DEPENDS} ${INC_FILES})
++  set_source_files_properties(${file} PROPERTIES OBJECT_DEPENDS
++    "${OBJECT_DEPENDS}")
++endforeach()
++
++set_source_files_properties(${SIMD_SOURCES} PROPERTIES
++  COMPILE_FLAGS -mlasx)
++
++add_library(simd OBJECT ${SIMD_SOURCES} ${CPU_TYPE}/jsimd.c)
++
++if(CMAKE_POSITION_INDEPENDENT_CODE OR ENABLE_SHARED)
++  set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)
++endif()
++
+ 
+ ###############################################################################
+ # None
+diff --git a/simd/loongarch64/generic_macros_lasx.h b/simd/loongarch64/generic_macros_lasx.h
+new file mode 100644
+index 00000000..6596ff1d
+--- /dev/null
++++ b/simd/loongarch64/generic_macros_lasx.h
+@@ -0,0 +1,3528 @@
++/*
++ * Copyright (c) 2020 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Shiyou Yin   <yinshiyou-hf@loongson.cn>
++ *                Xiwei Gu     <guxiwei-hf@loongson.cn>
++ *                Jin Bo       <jinbo@loongson.cn>
++ *                Hao Chen     <chenhao@loongson.cn>
++ *                Lu Wang      <wanglu@loongson.cn>
++ *                Peng Zhou    <zhoupeng@loongson.cn>
++ *
++ * This file is maintained in LSOM project, don't change it directly.
++ * You can get the latest version of this header from: ***
++ *
++ */
++
++#ifndef GENERIC_MACROS_LASX_H
++#define GENERIC_MACROS_LASX_H
++
++#include <stdint.h>
++#include <lasxintrin.h>
++
++/**
++ * MAJOR version: Macro usage changes.
++ * MINOR version: Add new macros, or bug fix.
++ * MICRO version: Comment changes or implementation changes。
++ */
++#define LSOM_LASX_VERSION_MAJOR 3
++#define LSOM_LASX_VERSION_MINOR 0
++#define LSOM_LASX_VERSION_MICRO 0
++
++/* Description : Load 256-bit vector data with stride
++ * Arguments   : Inputs  - psrc    (source pointer to load from)
++ *                       - stride
++ *               Outputs - out0, out1, ~
++ * Details     : Load 256-bit data in 'out0' from (psrc)
++ *               Load 256-bit data in 'out1' from (psrc + stride)
++ */
++#define LASX_LD(psrc) *((__m256i *)(psrc))
++
++#define LASX_LD_2(psrc, stride, out0, out1)                                 \
++{                                                                           \
++    out0 = LASX_LD(psrc);                                                   \
++    out1 = LASX_LD((psrc) + stride);                                        \
++}
++
++#define LASX_LD_4(psrc, stride, out0, out1, out2, out3)                     \
++{                                                                           \
++    LASX_LD_2((psrc), stride, out0, out1);                                  \
++    LASX_LD_2((psrc) + 2 * stride , stride, out2, out3);                    \
++}
++
++#define LASX_LD_8(psrc, stride, out0, out1, out2, out3, out4, out5,         \
++                  out6, out7)                                               \
++{                                                                           \
++    LASX_LD_4((psrc), stride, out0, out1, out2, out3);                      \
++    LASX_LD_4((psrc) + 4 * stride, stride, out4, out5, out6, out7);         \
++}
++
++/* Description : Store 256-bit vector data with stride
++ * Arguments   : Inputs  - in0, in1, ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store 256-bit data from 'in0' to (pdst)
++ *               Store 256-bit data from 'in1' to (pdst + stride)
++ */
++#define LASX_ST(in, pdst) *((__m256i *)(pdst)) = (in)
++
++#define LASX_ST_2(in0, in1, pdst, stride)                                   \
++{                                                                           \
++    LASX_ST(in0, (pdst));                                                   \
++    LASX_ST(in1, (pdst) + stride);                                          \
++}
++
++#define LASX_ST_4(in0, in1, in2, in3, pdst, stride)                         \
++{                                                                           \
++    LASX_ST_2(in0, in1, (pdst), stride);                                    \
++    LASX_ST_2(in2, in3, (pdst) + 2 * stride, stride);                       \
++}
++
++#define LASX_ST_8(in0, in1, in2, in3, in4, in5, in6, in7, pdst, stride)     \
++{                                                                           \
++    LASX_ST_4(in0, in1, in2, in3, (pdst), stride);                          \
++    LASX_ST_4(in4, in5, in6, in7, (pdst) + 4 * stride, stride);             \
++}
++
++/* Description : Store half word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1,  ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store half word 'idx0' from 'in' to (pdst)
++ *               Store half word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : LASX_ST_H(in, idx, pdst)
++ *          in : 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
++ *        idx0 : 0x01
++ *        out0 : 2
++ */
++#define LASX_ST_H(in, idx, pdst)                                          \
++{                                                                         \
++    __lasx_xvstelm_h(in, pdst, 0, idx);                                   \
++}
++
++#define LASX_ST_H_2(in, idx0, idx1, pdst, stride)                         \
++{                                                                         \
++    LASX_ST_H(in, idx0, (pdst));                                          \
++    LASX_ST_H(in, idx1, (pdst) + stride);                                 \
++}
++
++#define LASX_ST_H_4(in, idx0, idx1, idx2, idx3, pdst, stride)             \
++{                                                                         \
++    LASX_ST_H_2(in, idx0, idx1, (pdst), stride);                          \
++    LASX_ST_H_2(in, idx2, idx3, (pdst) + 2 * stride, stride);             \
++}
++
++
++/* Description : Store word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1,  ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store word 'idx0' from 'in' to (pdst)
++ *               Store word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : LASX_ST_W(in, idx, pdst)
++ *          in : 1, 2, 3, 4, 5, 6, 7, 8
++ *        idx0 : 0x01
++ *        out0 : 2
++ */
++#define LASX_ST_W(in, idx, pdst)                                          \
++{                                                                         \
++    __lasx_xvstelm_w(in, pdst, 0, idx);                                   \
++}
++
++#define LASX_ST_W_2(in, idx0, idx1, pdst, stride)                         \
++{                                                                         \
++    LASX_ST_W(in, idx0, (pdst));                                          \
++    LASX_ST_W(in, idx1, (pdst) + stride);                                 \
++}
++
++#define LASX_ST_W_4(in, idx0, idx1, idx2, idx3, pdst, stride)             \
++{                                                                         \
++    LASX_ST_W_2(in, idx0, idx1, (pdst), stride);                          \
++    LASX_ST_W_2(in, idx2, idx3, (pdst) + 2 * stride, stride);             \
++}
++
++#define LASX_ST_W_8(in, idx0, idx1, idx2, idx3, idx4, idx5, idx6, idx7,   \
++                    pdst, stride)                                         \
++{                                                                         \
++    LASX_ST_W_4(in, idx0, idx1, idx2, idx3, (pdst), stride);              \
++    LASX_ST_W_4(in, idx4, idx5, idx6, idx7, (pdst) + 4 * stride, stride); \
++}
++
++/* Description : Store double word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1, ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store double word 'idx0' from 'in' to (pdst)
++ *               Store double word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : See LASX_ST_W(in, idx, pdst)
++ */
++#define LASX_ST_D(in, idx, pdst)                                         \
++{                                                                        \
++    __lasx_xvstelm_d(in, pdst, 0, idx);                                  \
++}
++
++#define LASX_ST_D_2(in, idx0, idx1, pdst, stride)                        \
++{                                                                        \
++    LASX_ST_D(in, idx0, (pdst));                                         \
++    LASX_ST_D(in, idx1, (pdst) + stride);                                \
++}
++
++#define LASX_ST_D_4(in, idx0, idx1, idx2, idx3, pdst, stride)            \
++{                                                                        \
++    LASX_ST_D_2(in, idx0, idx1, (pdst), stride);                         \
++    LASX_ST_D_2(in, idx2, idx3, (pdst) + 2 * stride, stride);            \
++}
++
++/* Description : Store quad word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1, ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store quad word 'idx0' from 'in' to (pdst)
++ *               Store quad word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : See LASX_ST_W(in, idx, pdst)
++ */
++#define LASX_ST_Q(in, idx, pdst)                                         \
++{                                                                        \
++    LASX_ST_D(in, (idx << 1), pdst);                                     \
++    LASX_ST_D(in, (( idx << 1) + 1), (char*)(pdst) + 8);                 \
++}
++
++#define LASX_ST_Q_2(in, idx0, idx1, pdst, stride)                        \
++{                                                                        \
++    LASX_ST_Q(in, idx0, (pdst));                                         \
++    LASX_ST_Q(in, idx1, (pdst) + stride);                                \
++}
++
++#define LASX_ST_Q_4(in, idx0, idx1, idx2, idx3, pdst, stride)            \
++{                                                                        \
++    LASX_ST_Q_2(in, idx0, idx1, (pdst), stride);                         \
++    LASX_ST_Q_2(in, idx2, idx3, (pdst) + 2 * stride, stride);            \
++}
++
++/* Description : Dot product of byte vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - unsigned halfword
++ * Details     : Unsigned byte elements from in0 are iniplied with
++ *               unsigned byte elements from in0 producing a result
++ *               twice the size of input i.e. unsigned halfword.
++ *               Then this iniplication results of adjacent odd-even elements
++ *               are added together and stored to the out vector
++ *               (2 unsigned halfword results)
++ * Example     : see LASX_DP2_W_H
++ */
++#define LASX_DP2_H_BU(in0, in1, out0)                   \
++{                                                       \
++    __m256i _tmp0_m ;                                   \
++                                                        \
++    _tmp0_m = __lasx_xvmulwev_h_bu( in0, in1 );         \
++    out0 = __lasx_xvmaddwod_h_bu( _tmp0_m, in0, in1 );  \
++}
++#define LASX_DP2_H_BU_2(in0, in1, in2, in3, out0, out1) \
++{                                                       \
++    LASX_DP2_H_BU(in0, in1, out0);                      \
++    LASX_DP2_H_BU(in2, in3, out1);                      \
++}
++#define LASX_DP2_H_BU_4(in0, in1, in2, in3,             \
++                        in4, in5, in6, in7,             \
++                        out0, out1, out2, out3)         \
++{                                                       \
++    LASX_DP2_H_BU_2(in0, in1, in0, in1, out0, out1);    \
++    LASX_DP2_H_BU_2(in4, in5, in6, in7, out2, out3);    \
++}
++
++/* Description : Dot product of byte vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - signed halfword
++ * Details     : Signed byte elements from in0 are iniplied with
++ *               signed byte elements from in0 producing a result
++ *               twice the size of input i.e. signed halfword.
++ *               Then this iniplication results of adjacent odd-even elements
++ *               are added together and stored to the out vector
++ *               (2 signed halfword results)
++ * Example     : see LASX_DP2_W_H
++ */
++#define LASX_DP2_H_B(in0, in1, out0)                      \
++{                                                         \
++    __m256i _tmp0_m ;                                     \
++                                                          \
++    _tmp0_m = __lasx_xvmulwev_h_b( in0, in1 );            \
++    out0 = __lasx_xvmaddwod_h_b( _tmp0_m, in0, in1 );     \
++}
++#define LASX_DP2_H_B_2(in0, in1, in2, in3, out0, out1)    \
++{                                                         \
++    LASX_DP2_H_B(in0, in1, out0);                         \
++    LASX_DP2_H_B(in2, in3, out1);                         \
++}
++#define LASX_DP2_H_B_4(in0, in1, in2, in3,                \
++                       in4, in5, in6, in7,                \
++                       out0, out1, out2, out3)            \
++{                                                         \
++    LASX_DP2_H_B_2(in0, in1, in2, in3, out0, out1);       \
++    LASX_DP2_H_B_2(in4, in5, in6, in7, out2, out3);       \
++}
++
++/* Description : Dot product of half word vector elements
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ *               Return Type - signed word
++ * Details     : Signed half word elements from in* are iniplied with
++ *               signed half word elements from in* producing a result
++ *               twice the size of input i.e. signed word.
++ *               Then this iniplication results of adjacent odd-even elements
++ *               are added together and stored to the out vector.
++ * Example     : LASX_DP2_W_H(in0, in1, out0)
++ *               in0:   1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8,
++ *               in0:   8,7,6,5, 4,3,2,1, 8,7,6,5, 4,3,2,1,
++ *               out0:  22,38,38,22, 22,38,38,22
++ */
++#define LASX_DP2_W_H(in0, in1, out0)                   \
++{                                                      \
++    __m256i _tmp0_m ;                                  \
++                                                       \
++    _tmp0_m = __lasx_xvmulwev_w_h( in0, in1 );         \
++    out0 = __lasx_xvmaddwod_w_h( _tmp0_m, in0, in1 );  \
++}
++#define LASX_DP2_W_H_2(in0, in1, in2, in3, out0, out1)             \
++{                                                                  \
++    LASX_DP2_W_H(in0, in1, out0);                                  \
++    LASX_DP2_W_H(in2, in3, out1);                                  \
++}
++#define LASX_DP2_W_H_4(in0, in1, in2, in3,                         \
++                       in4, in5, in6, in7, out0, out1, out2, out3) \
++{                                                                  \
++    LASX_DP2_W_H_2(in0, in1, in2, in3, out0, out1);                \
++    LASX_DP2_W_H_2(in4, in5, in6, in7, out2, out3);                \
++}
++#define LASX_DP2_W_H_8(in0, in1, in2, in3, in4, in5, in6, in7,         \
++                       in8, in9, in10, in11, in12, in13, in14, in15,   \
++                       out0, out1, out2, out3, out4, out5, out6, out7) \
++{                                                                      \
++    LASX_DP2_W_H_4(in0, in1, in2, in3, in4, in5, in6, in7,             \
++                   out0, out1, out2, out3);                            \
++    LASX_DP2_W_H_4(in8, in9, in10, in11, in12, in13, in14, in15,       \
++                   out4, out5, out6, out7);                            \
++}
++
++/* Description : Dot product of word vector elements
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ *               Retrun Type - signed double
++ * Details     : Signed word elements from in* are iniplied with
++ *               signed word elements from in* producing a result
++ *               twice the size of input i.e. signed double word.
++ *               Then this iniplication results of adjacent odd-even elements
++ *               are added together and stored to the out vector.
++ * Example     : see LASX_DP2_W_H
++ */
++#define LASX_DP2_D_W(in0, in1, out0)                    \
++{                                                       \
++    __m256i _tmp0_m ;                                   \
++                                                        \
++    _tmp0_m = __lasx_xvmulwev_d_w( in0, in1 );          \
++    out0 = __lasx_xvmaddwod_d_w( _tmp0_m, in0, in1 );   \
++}
++#define LASX_DP2_D_W_2(in0, in1, in2, in3, out0, out1)  \
++{                                                       \
++    LASX_DP2_D_W(in0, in1, out0);                       \
++    LASX_DP2_D_W(in2, in3, out1);                       \
++}
++#define LASX_DP2_D_W_4(in0, in1, in2, in3,                             \
++                       in4, in5, in6, in7, out0, out1, out2, out3)     \
++{                                                                      \
++    LASX_DP2_D_W_2(in0, in1, in2, in3, out0, out1);                    \
++    LASX_DP2_D_W_2(in4, in5, in6, in7, out2, out3);                    \
++}
++#define LASX_DP2_D_W_8(in0, in1, in2, in3, in4, in5, in6, in7,         \
++                       in8, in9, in10, in11, in12, in13, in14, in15,   \
++                       out0, out1, out2, out3, out4, out5, out6, out7) \
++{                                                                      \
++    LASX_DP2_D_W_4(in0, in1, in2, in3, in4, in5, in6, in7,             \
++                   out0, out1, out2, out3);                            \
++    LASX_DP2_D_W_4(in8, in9, in10, in11, in12, in13, in14, in15,       \
++                   out4, out5, out6, out7);                            \
++}
++
++/* Description : Dot product of halfword vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Unsigned halfword elements from 'in0' are iniplied with
++ *               halfword elements from 'in0' producing a result
++ *               twice the size of input i.e. unsigned word.
++ *               Multiplication result of adjacent odd-even elements
++ *               are added together and written to the 'out0' vector
++ */
++#define LASX_DP2_W_HU_H(in0, in1, out0)                   \
++{                                                         \
++    __m256i _tmp0_m;                                      \
++                                                          \
++    _tmp0_m = __lasx_xvmulwev_w_hu_h( in0, in1 );         \
++    out0 = __lasx_xvmaddwod_w_hu_h( _tmp0_m, in0, in1 );  \
++}
++
++#define LASX_DP2_W_HU_H_2(in0, in1, in2, in3, out0, out1) \
++{                                                         \
++    LASX_DP2_W_HU_H(in0, in1, out0);                      \
++    LASX_DP2_W_HU_H(in2, in3, out1);                      \
++}
++
++#define LASX_DP2_W_HU_H_4(in0, in1, in2, in3,             \
++                          in4, in5, in6, in7,             \
++                          out0, out1, out2, out3)         \
++{                                                         \
++    LASX_DP2_W_HU_H_2(in0, in1, in2, in3, out0, out1);    \
++    LASX_DP2_W_HU_H_2(in4, in5, in6, in7, out2, out3);    \
++}
++
++/* Description : Dot product & addition of byte vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Retrun Type - halfword
++ * Details     : Signed byte elements from in0 are iniplied with
++ *               signed byte elements from in0 producing a result
++ *               twice the size of input i.e. signed halfword.
++ *               Then this iniplication results of adjacent odd-even elements
++ *               are added to the out vector
++ *               (2 signed halfword results)
++ * Example     : LASX_DP2ADD_H_B(in0, in1, in2, out0)
++ *               in0:  1,2,3,4, 1,2,3,4, 1,2,3,4, 1,2,3,4,
++ *               in1:  1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8,
++ *                     1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8
++ *               in2:  8,7,6,5, 4,3,2,1, 8,7,6,5, 4,3,2,1,
++ *                     8,7,6,5, 4,3,2,1, 8,7,6,5, 4,3,2,1
++ *               out0: 23,40,41,26, 23,40,41,26, 23,40,41,26, 23,40,41,26
++ */
++#define LASX_DP2ADD_H_B(in0, in1, in2, out0)                 \
++{                                                            \
++    __m256i _tmp0_m;                                         \
++                                                             \
++    _tmp0_m = __lasx_xvmaddwev_h_b( in0, in1, in2 );         \
++    out0 = __lasx_xvmaddwod_h_b( _tmp0_m, in1, in2 );        \
++}
++#define LASX_DP2ADD_H_B_2(in0, in1, in2, in3, in4, in5, out0, out1)  \
++{                                                                    \
++    LASX_DP2ADD_H_B(in0, in1, in2, out0);                            \
++    LASX_DP2ADD_H_B(in3, in4, in5, out1);                            \
++}
++#define LASX_DP2ADD_H_B_4(in0, in1, in2, in3, in4, in5,                \
++                          in6, in7, in8, in9, in10, in11,              \
++                          out0, out1, out2, out3)                      \
++{                                                                      \
++    LASX_DP2ADD_H_B_2(in0, in1, in2, in3, in4, in5, out0, out1);       \
++    LASX_DP2ADD_H_B_2(in6, in7, in8, in9, in10, in11, out2, out3);     \
++}
++
++/* Description : Dot product of halfword vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Signed halfword elements from 'in0' are iniplied with
++ *               signed halfword elements from 'in0' producing a result
++ *               twice the size of input i.e. signed word.
++ *               Multiplication result of adjacent odd-even elements
++ *               are added together and written to the 'out0' vector
++ */
++#define LASX_DP2ADD_W_H(in0, in1, in2, out0)                 \
++{                                                            \
++    __m256i _tmp0_m;                                         \
++                                                             \
++    _tmp0_m = __lasx_xvmaddwev_w_h( in0, in1, in2 );         \
++    out0 = __lasx_xvmaddwod_w_h( _tmp0_m, in1, in2 );        \
++}
++#define LASX_DP2ADD_W_H_2(in0, in1, in2, in3, in4, in5, out0, out1 ) \
++{                                                                    \
++    LASX_DP2ADD_W_H(in0, in1, in2, out0);                            \
++    LASX_DP2ADD_W_H(in3, in4, in5, out1);                            \
++}
++#define LASX_DP2ADD_W_H_4(in0, in1, in2, in3, in4, in5,              \
++                          in6, in7, in8, in9, in10, in11,            \
++                          out0, out1, out2, out3)                    \
++{                                                                    \
++    LASX_DP2ADD_W_H_2(in0, in1, in2, in3, in4, in5, out0, out1);     \
++    LASX_DP2ADD_W_H_2(in6, in7, in8, in9, in10, in11, out2, out3);   \
++}
++
++/* Description : Dot product of halfword vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Unsigned halfword elements from 'in0' are iniplied with
++ *               unsigned halfword elements from 'in0' producing a result
++ *               twice the size of input i.e. unsigned word.
++ *               Multiplication result of adjacent odd-even elements
++ *               are added together and written to the 'out0' vector
++ */
++#define LASX_DP2ADD_W_HU(in0, in1, in2, out0)          \
++{                                                      \
++    __m256i _tmp0_m;                                   \
++                                                       \
++    _tmp0_m = __lasx_xvmaddwev_w_hu( in0, in1, in2 );  \
++    out0 = __lasx_xvmaddwod_w_hu( _tmp0_m, in1, in2 ); \
++}
++#define LASX_DP2ADD_W_HU_2(in0, in1, in2, in3, in4, in5, out0, out1) \
++{                                                                    \
++    LASX_DP2ADD_W_HU(in0, in1, in2, out0);                           \
++    LASX_DP2ADD_W_HU(in3, in4, in5, out1);                           \
++}
++#define LASX_DP2ADD_W_HU_4(in0, in1, in2, in3, in4, in5,             \
++                           in6, in7, in8, in9, in10, in11,           \
++                           out0, out1, out2, out3)                   \
++{                                                                    \
++    LASX_DP2ADD_W_HU_2(in0, in1, in2, in3, in4, in5, out0, out1);    \
++    LASX_DP2ADD_W_HU_2(in6, in7, in8, in9, in10, in11, out2, out3);  \
++}
++
++/* Description : Dot product of halfword vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Unsigned halfword elements from 'in0' are iniplied with
++ *               halfword elements from 'in0' producing a result
++ *               twice the size of input i.e. unsigned word.
++ *               Multiplication result of adjacent odd-even elements
++ *               are added together and written to the 'out0' vector
++ */
++#define LASX_DP2ADD_W_HU_H(in0, in1, in2, out0)           \
++{                                                         \
++    __m256i _tmp0_m;                                      \
++                                                          \
++    _tmp0_m = __lasx_xvmaddwev_w_hu_h( in0, in1, in2 );   \
++    out0 = __lasx_xvmaddwod_w_hu_h( _tmp0_m, in1, in2 );  \
++}
++
++#define LASX_DP2ADD_W_HU_H_2(in0, in1, in2, in3, in4, in5, out0, out1) \
++{                                                                      \
++    LASX_DP2ADD_W_HU_H(in0, in1, in2, out0);                           \
++    LASX_DP2ADD_W_HU_H(in3, in4, in5, out1);                           \
++}
++
++#define LASX_DP2ADD_W_HU_H_4(in0, in1, in2, in3, in4, in5,             \
++                             in6, in7, in8, in9, in10, in11,           \
++                             out0, out1, out2, out3)                   \
++{                                                                      \
++    LASX_DP2ADD_W_HU_H_2(in0, in1, in2, in3, in4, in5, out0, out1);    \
++    LASX_DP2ADD_W_HU_H_2(in6, in7, in8, in9, in10, in11, out2, out3);  \
++}
++
++/* Description : Vector Unsigned Dot Product and Subtract.
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Unsigned byte elements from 'in0' are iniplied with
++ *               unsigned byte elements from 'in0' producing a result
++ *               twice the size of input i.e. signed word.
++ *               Multiplication result of adjacent odd-even elements
++ *               are added together and subtract from double width elements,
++ *               then written to the 'out0' vector.
++ */
++#define LASX_DP2SUB_H_BU(in0, in1, in2, out0)             \
++{                                                         \
++    __m256i _tmp0_m;                                      \
++                                                          \
++    _tmp0_m = __lasx_xvmulwev_h_bu( in1, in2 );           \
++    _tmp0_m = __lasx_xvmaddwod_h_bu( _tmp0_m, in1, in2 ); \
++    out0 = __lasx_xvsub_h( in0, _tmp0_m );                \
++}
++
++#define LASX_DP2SUB_H_BU_2(in0, in1, in2, in3, in4, in5, out0, out1) \
++{                                                                    \
++    LASX_DP2SUB_H_BU(in0, in1, in2, out0);                           \
++    LASX_DP2SUB_H_BU(in0, in1, in2, out0);                           \
++}
++
++#define LASX_DP2SUB_H_BU_4(in0, in1, in2, in3, in4, in5,             \
++                           in6, in7, in8, in9, in10, in11,           \
++                           out0, out1, out2, out3)                   \
++{                                                                    \
++    LASX_DP2SUB_H_BU_2(in0, in1, in2, in3, in4, in5, out0, out1);    \
++    LASX_DP2SUB_H_BU_2(in6, in7, in8, in9, in10, in11, out2, out3);  \
++}
++
++/* Description : Vector Signed Dot Product and Subtract.
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Signed halfword elements from 'in0' are iniplied with
++ *               signed halfword elements from 'in0' producing a result
++ *               twice the size of input i.e. signed word.
++ *               Multiplication result of adjacent odd-even elements
++ *               are added together and subtract from double width elements,
++ *               then written to the 'out0' vector.
++ */
++#define LASX_DP2SUB_W_H(in0, in1, in2, out0)             \
++{                                                        \
++    __m256i _tmp0_m;                                     \
++                                                         \
++    _tmp0_m = __lasx_xvmulwev_w_h( in1, in2 );           \
++    _tmp0_m = __lasx_xvmaddwod_w_h( _tmp0_m, in1, in2 ); \
++    out0 = __lasx_xvsub_w( in0, _tmp0_m );               \
++}
++
++#define LASX_DP2SUB_W_H_2(in0, in1, in2, in3, in4, in5, out0, out1) \
++{                                                                   \
++    LASX_DP2SUB_W_H(in0, in1, in2, out0);                           \
++    LASX_DP2SUB_W_H(in3, in4, in5, out1);                           \
++}
++
++#define LASX_DP2SUB_W_H_4(in0, in1, in2, in3, in4, in5,             \
++                          in6, in7, in8, in9, in10, in11,           \
++                          out0, out1, out2, out3)                   \
++{                                                                   \
++    LASX_DP2SUB_W_H_2(in0, in1, in2, in3, in4, in5, out0, out1);    \
++    LASX_DP2SUB_W_H_2(in6, in7, in8, in9, in10, in11, out2, out3);  \
++}
++
++/* Description : Dot product of half word vector elements
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ *               Return Type - signed word
++ * Details     : Signed half word elements from in* are iniplied with
++ *               signed half word elements from in* producing a result
++ *               twice the size of input i.e. signed word.
++ *               Then this iniplication results of four adjacent elements
++ *               are added together and stored to the out vector.
++ * Example     : LASX_DP2_W_H(in0, in0, out0)
++ *               in0:   3,1,3,0, 0,0,0,1, 0,0,1,-1, 0,0,0,1,
++ *               in0:   -2,1,1,0, 1,0,0,0, 0,0,1,0, 1,0,0,1,
++ *               out0:  -2,0,1,1,
++ */
++#define LASX_DP4_D_H(in0, in1, out0)                         \
++{                                                            \
++    __m256i _tmp0_m ;                                        \
++                                                             \
++    _tmp0_m = __lasx_xvmulwev_w_h( in0, in1 );               \
++    _tmp0_m = __lasx_xvmaddwod_w_h( _tmp0_m, in0, in1 );     \
++    out0  = __lasx_xvhaddw_d_w( _tmp0_m, _tmp0_m );          \
++}
++#define LASX_DP4_D_H_2(in0, in1, in2, in3, out0, out1)       \
++{                                                            \
++    LASX_DP4_D_H(in0, in1, out0);                            \
++    LASX_DP4_D_H(in2, in3, out1);                            \
++}
++#define LASX_DP4_D_H_4(in0, in1, in2, in3,                            \
++                       in4, in5, in6, in7, out0, out1, out2, out3)    \
++{                                                                     \
++    LASX_DP4_D_H_2(in0, in1, in2, in3, out0, out1);                   \
++    LASX_DP4_D_H_2(in4, in5, in6, in7, out2, out3);                   \
++}
++
++/* Description : The high half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in0 vector and the in1 vector are added after the
++ *               higher half of the two-fold sign extension ( signed byte
++ *               to signed half word ) and stored to the out vector.
++ * Example     : see LASX_ADDWL_W_H_128SV
++ */
++#define LASX_ADDWH_H_B_128SV(in0, in1, out0)                                  \
++{                                                                             \
++    __m256i _tmp0_m, _tmp1_m;                                                 \
++                                                                              \
++    _tmp0_m = __lasx_xvilvh_b( in0, in0 );                                    \
++    _tmp1_m = __lasx_xvilvh_b( in1, in1 );                                    \
++    out0 = __lasx_xvaddwev_h_b( _tmp0_m, _tmp1_m );                           \
++}
++#define LASX_ADDWH_H_B_2_128SV(in0, in1, in2, in3, out0, out1)                \
++{                                                                             \
++    LASX_ADDWH_H_B_128SV(in0, in1, out0);                                     \
++    LASX_ADDWH_H_B_128SV(in2, in3, out1);                                     \
++}
++#define LASX_ADDWH_H_B_4_128SV(in0, in1, in2, in3,                            \
++                               in4, in5, in6, in7, out0, out1, out2, out3)    \
++{                                                                             \
++    LASX_ADDWH_H_B_2_128SV(in0, in1, in2, in3, out0, out1);                   \
++    LASX_ADDWH_H_B_2_128SV(in4, in5, in6, in7, out2, out3);                   \
++}
++
++/* Description : The high half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in0 vector and the in1 vector are added after the
++ *               higher half of the two-fold sign extension ( signed half word
++ *               to signed word ) and stored to the out vector.
++ * Example     : see LASX_ADDWL_W_H_128SV
++ */
++#define LASX_ADDWH_W_H_128SV(in0, in1, out0)                                  \
++{                                                                             \
++    __m256i _tmp0_m, _tmp1_m;                                                 \
++                                                                              \
++    _tmp0_m = __lasx_xvilvh_h( in0, in0 );                                    \
++    _tmp1_m = __lasx_xvilvh_h( in1, in1 );                                    \
++    out0 = __lasx_xvaddwev_w_h( _tmp0_m, _tmp1_m );                           \
++}
++#define LASX_ADDWH_W_H_2_128SV(in0, in1, in2, in3, out0, out1)                \
++{                                                                             \
++    LASX_ADDWH_W_H_128SV(in0, in1, out0);                                     \
++    LASX_ADDWH_W_H_128SV(in2, in3, out1);                                     \
++}
++#define LASX_ADDWH_W_H_4_128SV(in0, in1, in2, in3,                            \
++                               in4, in5, in6, in7, out0, out1, out2, out3)    \
++{                                                                             \
++    LASX_ADDWH_W_H_2_128SV(in0, in1, in2, in3, out0, out1);                   \
++    LASX_ADDWH_W_H_2_128SV(in4, in5, in6, in7, out2, out3);                   \
++}
++
++/* Description : The low half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in0 vector and the in1 vector are added after the
++ *               lower half of the two-fold sign extension ( signed byte
++ *               to signed half word ) and stored to the out vector.
++ * Example     : see LASX_ADDWL_W_H_128SV
++ */
++#define LASX_ADDWL_H_B_128SV(in0, in1, out0)                                  \
++{                                                                             \
++    __m256i _tmp0_m, _tmp1_m;                                                 \
++                                                                              \
++    _tmp0_m = __lasx_xvsllwil_h_b( in0, 0 );                                  \
++    _tmp1_m = __lasx_xvsllwil_h_b( in1, 0 );                                  \
++    out0 = __lasx_xvadd_h( _tmp0_m, _tmp1_m );                                \
++}
++#define LASX_ADDWL_H_B_2_128SV(in0, in1, in2, in3, out0, out1)                \
++{                                                                             \
++    LASX_ADDWL_H_B_128SV(in0, in1, out0);                                     \
++    LASX_ADDWL_H_B_128SV(in2, in3, out1);                                     \
++}
++#define LASX_ADDWL_H_B_4_128SV(in0, in1, in2, in3,                            \
++                               in4, in5, in6, in7, out0, out1, out2, out3)    \
++{                                                                             \
++    LASX_ADDWL_H_B_2_128SV(in0, in1, in2, in3, out0, out1);                   \
++    LASX_ADDWL_H_B_2_128SV(in4, in5, in6, in7, out2, out3);                   \
++}
++
++/* Description : The low half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in0 vector and the in1 vector are added after the
++ *               lower half of the two-fold sign extension ( signed half word
++ *               to signed word ) and stored to the out vector.
++ * Example     : LASX_ADDWL_W_H_128SV(in0, in1, out0)
++ *               in0   3,0,3,0, 0,0,0,-1, 0,0,1,-1, 0,0,0,1,
++ *               in1   2,-1,1,2, 1,0,0,0, 1,0,1,0, 1,0,0,1,
++ *               out0  5,-1,4,2, 1,0,2,-1,
++ */
++#define LASX_ADDWL_W_H_128SV(in0, in1, out0)                                  \
++{                                                                             \
++    __m256i _tmp0_m;                                                          \
++                                                                              \
++    _tmp0_m = __lasx_xvilvl_h(in1, in0);                                      \
++    out0 = __lasx_xvhaddw_w_h( _tmp0_m, _tmp0_m );                            \
++}
++#define LASX_ADDWL_W_H_2_128SV(in0, in1, in2, in3, out0, out1)                \
++{                                                                             \
++    LASX_ADDWL_W_H_128SV(in0, in1, out0);                                     \
++    LASX_ADDWL_W_H_128SV(in2, in3, out1);                                     \
++}
++#define LASX_ADDWL_W_H_4_128SV(in0, in1, in2, in3,                            \
++                               in4, in5, in6, in7, out0, out1, out2, out3)    \
++{                                                                             \
++    LASX_ADDWL_W_H_2_128SV(in0, in1, in2, in3, out0, out1);                   \
++    LASX_ADDWL_W_H_2_128SV(in4, in5, in6, in7, out2, out3);                   \
++}
++
++/* Description : The low half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in0 vector and the in1 vector are added after the
++ *               lower half of the two-fold zero extension ( unsigned byte
++ *               to unsigned half word ) and stored to the out vector.
++ */
++#define LASX_ADDWL_H_BU_128SV(in0, in1, out0)                                 \
++{                                                                             \
++    __m256i _tmp0_m;                                                          \
++                                                                              \
++    _tmp0_m = __lasx_xvilvl_b(in1, in0);                                      \
++    out0 = __lasx_xvhaddw_hu_bu( _tmp0_m, _tmp0_m );                          \
++}
++#define LASX_ADDWL_H_BU_2_128SV(in0, in1, in2, in3, out0, out1)               \
++{                                                                             \
++    LASX_ADDWL_H_BU_128SV(in0, in1, out0);                                    \
++    LASX_ADDWL_H_BU_128SV(in2, in3, out1);                                    \
++}
++#define LASX_ADDWL_H_BU_4_128SV(in0, in1, in2, in3,                           \
++                                in4, in5, in6, in7, out0, out1, out2, out3)   \
++{                                                                             \
++    LASX_ADDWL_H_BU_2_128SV(in0, in1, in2, in3, out0, out1);                  \
++    LASX_ADDWL_H_BU_2_128SV(in4, in5, in6, in7, out2, out3);                  \
++}
++
++/* Description : The low half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : In1 vector plus in0 vector after double zero extension
++ *               ( unsigned byte to half word ),add and stored to the out vector.
++ * Example     : reference to LASX_ADDW_W_W_H_128SV(in0, in1, out0)
++ */
++#define LASX_ADDW_H_H_BU_128SV(in0, in1, out0)                                \
++{                                                                             \
++    __m256i _tmp1_m;                                                          \
++                                                                              \
++    _tmp1_m = __lasx_xvsllwil_hu_bu( in1, 0 );                                \
++    out0 = __lasx_xvadd_h( in0, _tmp1_m );                                    \
++}
++#define LASX_ADDW_H_H_BU_2_128SV(in0, in1, in2, in3, out0, out1)              \
++{                                                                             \
++    LASX_ADDW_H_H_BU_128SV(in0, in1, out0);                                   \
++    LASX_ADDW_H_H_BU_128SV(in2, in3, out1);                                   \
++}
++#define LASX_ADDW_H_H_BU_4_128SV(in0, in1, in2, in3,                          \
++                                 in4, in5, in6, in7, out0, out1, out2, out3)  \
++{                                                                             \
++    LASX_ADDW_H_H_BU_2_128SV(in0, in1, in2, in3, out0, out1);                 \
++    LASX_ADDW_H_H_BU_2_128SV(in4, in5, in6, in7, out2, out3);                 \
++}
++
++/* Description : The low half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : In1 vector plus in0 vector after double sign extension
++ *               ( signed half word to word ),add and stored to the out vector.
++ * Example     : LASX_ADDW_W_W_H_128SV(in0, in1, out0)
++ *               in0   0,1,0,0, -1,0,0,1,
++ *               in1   2,-1,1,2, 1,0,0,0, 0,0,1,0, 1,0,0,1,
++ *               out0  2,0,1,2, -1,0,1,1,
++ */
++#define LASX_ADDW_W_W_H_128SV(in0, in1, out0)                                 \
++{                                                                             \
++    __m256i _tmp1_m;                                                          \
++                                                                              \
++    _tmp1_m = __lasx_xvsllwil_w_h( in1, 0 );                                  \
++    out0 = __lasx_xvadd_w( in0, _tmp1_m );                                    \
++}
++#define LASX_ADDW_W_W_H_2_128SV(in0, in1, in2, in3, out0, out1)               \
++{                                                                             \
++    LASX_ADDW_W_W_H_128SV(in0, in1, out0);                                    \
++    LASX_ADDW_W_W_H_128SV(in2, in3, out1);                                    \
++}
++#define LASX_ADDW_W_W_H_4_128SV(in0, in1, in2, in3,                           \
++                                in4, in5, in6, in7, out0, out1, out2, out3)   \
++{                                                                             \
++    LASX_ADDW_W_W_H_2_128SV(in0, in1, in2, in3, out0, out1);                  \
++    LASX_ADDW_W_W_H_2_128SV(in4, in5, in6, in7, out2, out3);                  \
++}
++
++/* Description : Multiplication and addition calculation after expansion
++ *               of the lower half of the vector
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in1 vector and the in0 vector are multiplied after
++ *               the lower half of the two-fold sign extension ( signed
++ *               half word to signed word ) , and the result is added to
++ *               the vector in0, the stored to the out vector.
++ * Example     : LASX_MADDWL_W_H_128SV(in0, in1, in2, out0)
++ *               in0   1,2,3,4, 5,6,7 8
++ *               in1   1,2,3,4, 1,2,3,4, 5,6,7,8, 5,6,7,8
++ *               in2   200,300,400,500, 2000,3000,4000,5000,
++ *                     -200,-300,-400,-500, -2000,-3000,-4000,-5000
++ *               out0  5,-1,4,2, 1,0,2,-1,
++ */
++#define LASX_MADDWL_W_H_128SV(in0, in1, in2, out0)                            \
++{                                                                             \
++    __m256i _tmp0_m, _tmp1_m;                                                 \
++                                                                              \
++    _tmp0_m = __lasx_xvsllwil_w_h( in1, 0 );                                  \
++    _tmp1_m = __lasx_xvsllwil_w_h( in2, 0 );                                  \
++    _tmp0_m = __lasx_xvmul_w( _tmp0_m, _tmp1_m );                             \
++    out0 = __lasx_xvadd_w( _tmp0_m, in0 );                                    \
++}
++#define LASX_MADDWL_W_H_2_128SV(in0, in1, in2, in3, in4, in5, out0, out1)     \
++{                                                                             \
++    LASX_MADDWL_W_H_128SV(in0, in1, in2, out0);                               \
++    LASX_MADDWL_W_H_128SV(in3, in4, in5, out1);                               \
++}
++#define LASX_MADDWL_W_H_4_128SV(in0, in1, in2, in3, in4, in5,                \
++                                in6, in7, in8, in9, in10, in11,              \
++                                out0, out1, out2, out3)                      \
++{                                                                            \
++    LASX_MADDWL_W_H_2_128SV(in0, in1, in2, in3, in4, in5, out0, out1);       \
++    LASX_MADDWL_W_H_2_128SV(in6, in7, in8, in9, in10, in11, out2, out3);     \
++}
++
++/* Description : Multiplication and addition calculation after expansion
++ *               of the higher half of the vector
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in1 vector and the in0 vector are multiplied after
++ *               the higher half of the two-fold sign extension ( signed
++ *               half word to signed word ) , and the result is added to
++ *               the vector in0, the stored to the out vector.
++ * Example     : see LASX_MADDWL_W_H_128SV
++ */
++#define LASX_MADDWH_W_H_128SV(in0, in1, in2, out0)                            \
++{                                                                             \
++    __m256i _tmp0_m, _tmp1_m;                                                 \
++                                                                              \
++    _tmp0_m = __lasx_xvilvh_h( in1, in1 );                                    \
++    _tmp1_m = __lasx_xvilvh_h( in2, in2 );                                    \
++    _tmp0_m = __lasx_xvmulwev_w_h( _tmp0_m, _tmp1_m );                        \
++    out0 = __lasx_xvadd_w( _tmp0_m, in0 );                                    \
++}
++#define LASX_MADDWH_W_H_2_128SV(in0, in1, in2, in3, in4, in5, out0, out1)     \
++{                                                                             \
++    LASX_MADDWH_W_H_128SV(in0, in1, in2, out0);                               \
++    LASX_MADDWH_W_H_128SV(in3, in4, in5, out1);                               \
++}
++#define LASX_MADDWH_W_H_4_128SV(in0, in1, in2, in3, in4, in5,                \
++                                in6, in7, in8, in9, in10, in11,              \
++                                out0, out1, out2, out3)                      \
++{                                                                            \
++    LASX_MADDWH_W_H_2_128SV(in0, in1, in2, in3, in4, in5, out0, out1);       \
++    LASX_MADDWH_W_H_2_128SV(in6, in7, in8, in9, in10, in11, out2, out3);     \
++}
++
++/* Description : Multiplication calculation after expansion
++ *               of the lower half of the vector
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in1 vector and the in0 vector are multiplied after
++ *               the lower half of the two-fold sign extension ( signed
++ *               half word to signed word ) , the stored to the out vector.
++ * Example     : LASX_MULWL_W_H_128SV(in0, in1, out0)
++ *               in0   3,-1,3,0, 0,0,0,-1, 0,0,1,-1, 0,0,0,1,
++ *               in1   2,-1,1,2, 1,0,0,0,  0,0,1,0, 1,0,0,1,
++ *               out0  6,1,3,0, 0,0,1,0,
++ */
++#define LASX_MULWL_W_H_128SV(in0, in1, out0)                    \
++{                                                               \
++    __m256i _tmp0_m, _tmp1_m;                                   \
++                                                                \
++    _tmp0_m = __lasx_xvsllwil_w_h( in0, 0 );                    \
++    _tmp1_m = __lasx_xvsllwil_w_h( in1, 0 );                    \
++    out0 = __lasx_xvmul_w( _tmp0_m, _tmp1_m );                  \
++}
++#define LASX_MULWL_W_H_2_128SV(in0, in1, in2, in3, out0, out1)  \
++{                                                               \
++    LASX_MULWL_W_H_128SV(in0, in1, out0);                       \
++    LASX_MULWL_W_H_128SV(in2, in3, out1);                       \
++}
++#define LASX_MULWL_W_H_4_128SV(in0, in1, in2, in3,              \
++                               in4, in5, in6, in7,              \
++                               out0, out1, out2, out3)          \
++{                                                               \
++    LASX_MULWL_W_H_2_128SV(in0, in1, in2, in3, out0, out1);     \
++    LASX_MULWL_W_H_2_128SV(in4, in5, in6, in7, out2, out3);     \
++}
++
++/* Description : Multiplication calculation after expansion
++ *               of the lower half of the vector
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in1 vector and the in0 vector are multiplied after
++ *               the lower half of the two-fold sign extension ( signed
++ *               half word to signed word ) , the stored to the out vector.
++ * Example     : see LASX_MULWL_W_H_128SV
++ */
++#define LASX_MULWH_W_H_128SV(in0, in1, out0)                    \
++{                                                               \
++    __m256i _tmp0_m, _tmp1_m;                                   \
++                                                                \
++    _tmp0_m = __lasx_xvilvh_h( in0, in0 );                      \
++    _tmp1_m = __lasx_xvilvh_h( in1, in1 );                      \
++    out0 = __lasx_xvmulwev_w_h( _tmp0_m, _tmp1_m );             \
++}
++#define LASX_MULWH_W_H_2_128SV(in0, in1, in2, in3, out0, out1)  \
++{                                                               \
++    LASX_MULWH_W_H_128SV(in0, in1, out0);                       \
++    LASX_MULWH_W_H_128SV(in2, in3, out1);                       \
++}
++#define LASX_MULWH_W_H_4_128SV(in0, in1, in2, in3,              \
++                               in4, in5, in6, in7,              \
++                               out0, out1, out2, out3)          \
++{                                                               \
++    LASX_MULWH_W_H_2_128SV(in0, in1, in2, in3, out0, out1);     \
++    LASX_MULWH_W_H_2_128SV(in4, in5, in6, in7, out2, out3);     \
++}
++
++/* Description : The low half of the vector elements are expanded and
++ *               added after being doubled
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ * Details     : The in1 vector add the in0 vector after the
++ *               lower half of the two-fold zero extension ( unsigned byte
++ *               to unsigned half word ) and stored to the out vector.
++ */
++#define LASX_SADDW_HU_HU_BU_128SV(in0, in1, out0)                    \
++{                                                                    \
++    __m256i _tmp1_m;                                                 \
++    __m256i _zero_m = { 0 };                                         \
++                                                                     \
++    _tmp1_m = __lasx_xvilvl_b( _zero_m, in1 );                       \
++    out0 = __lasx_xvsadd_hu( in0, _tmp1_m );                         \
++}
++#define LASX_SADDW_HU_HU_BU_2_128SV(in0, in1, in2, in3, out0, out1)  \
++{                                                                    \
++    LASX_SADDW_HU_HU_BU_128SV(in0, in1, out0);                       \
++    LASX_SADDW_HU_HU_BU_128SV(in2, in3, out1);                       \
++}
++#define LASX_SADDW_HU_HU_BU_4_128SV(in0, in1, in2, in3,              \
++                                    in4, in5, in6, in7,              \
++                                    out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_SADDW_HU_HU_BU_2_128SV(in0, in1, in2, in3, out0, out1);     \
++    LASX_SADDW_HU_HU_BU_2_128SV(in4, in5, in6, in7, out2, out3);     \
++}
++
++/* Description : Low 8-bit vector elements unsigned extension to halfword
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low 8-bit elements from in0 unsigned extension to halfword,
++ *               written to output vector out0. Similar for in1.
++ * Example     : See LASX_UNPCK_L_W_H(in0, out0)
++ */
++#define LASX_UNPCK_L_HU_BU(in0, out0)                                          \
++{                                                                              \
++    out0 = __lasx_vext2xv_hu_bu(in0);                                          \
++}
++
++#define LASX_UNPCK_L_HU_BU_2(in0, in1, out0, out1)                             \
++{                                                                              \
++    LASX_UNPCK_L_HU_BU(in0, out0);                                             \
++    LASX_UNPCK_L_HU_BU(in1, out1);                                             \
++}
++
++#define LASX_UNPCK_L_HU_BU_4(in0, in1, in2, in3, out0, out1, out2, out3)       \
++{                                                                              \
++    LASX_UNPCK_L_HU_BU_2(in0, in1, out0, out1);                                \
++    LASX_UNPCK_L_HU_BU_2(in2, in3, out2, out3);                                \
++}
++
++#define LASX_UNPCK_L_HU_BU_8(in0, in1, in2, in3, in4, in5, in6, in7,           \
++                             out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                              \
++    LASX_UNPCK_L_HU_BU_4(in0, in1, in2, in3, out0, out1, out2, out3);          \
++    LASX_UNPCK_L_HU_BU_4(in4, in5, in6, in7, out4, out5, out6, out7);          \
++}
++
++/* Description : Low 8-bit vector elements unsigned extension to word
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low 8-bit elements from in0 unsigned extension to word,
++ *               written to output vector out0. Similar for in1.
++ * Example     : See LASX_UNPCK_L_W_H(in0, out0)
++ */
++#define LASX_UNPCK_L_WU_BU(in0, out0)                                         \
++{                                                                             \
++    out0 = __lasx_vext2xv_wu_bu(in0);                                         \
++}
++
++#define LASX_UNPCK_L_WU_BU_2(in0, in1, out0, out1)                            \
++{                                                                             \
++    LASX_UNPCK_L_WU_BU(in0, out0);                                            \
++    LASX_UNPCK_L_WU_BU(in1, out1);                                            \
++}
++
++#define LASX_UNPCK_L_WU_BU_4(in0, in1, in2, in3, out0, out1, out2, out3)      \
++{                                                                             \
++    LASX_UNPCK_L_WU_BU_2(in0, in1, out0, out1);                               \
++    LASX_UNPCK_L_WU_BU_2(in2, in3, out2, out3);                               \
++}
++
++#define LASX_UNPCK_L_WU_BU_8(in0, in1, in2, in3, in4, in5, in6, in7,          \
++                             out0, out1, out2, out3, out4, out5, out6, out7)  \
++{                                                                             \
++    LASX_UNPCK_L_WU_BU_4(in0, in1, in2, in3, out0, out1, out2, out3);         \
++    LASX_UNPCK_L_WU_BU_4(in4, in5, in6, in7, out4, out5, out6, out7);         \
++}
++
++/* Description : Low 8-bit vector elements signed extension to halfword
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low 8-bit elements from in0 signed extension to halfword,
++ *               written to output vector out0. Similar for in1.
++ * Example     : See LASX_UNPCK_L_W_H(in0, out0)
++ */
++#define LASX_UNPCK_L_H_B(in0, out0)                                          \
++{                                                                            \
++    out0 = __lasx_vext2xv_h_b(in0);                                          \
++}
++
++#define LASX_UNPCK_L_H_B_2(in0, in1, out0, out1)                             \
++{                                                                            \
++    LASX_UNPCK_L_H_B(in0, out0);                                             \
++    LASX_UNPCK_L_H_B(in1, out1);                                             \
++}
++
++#define LASX_UNPCK_L_H_B_4(in0, in1, in2, in3, out0, out1, out2, out3)       \
++{                                                                            \
++    LASX_UNPCK_L_H_B_2(in0, in1, out0, out1);                                \
++    LASX_UNPCK_L_H_B_2(in2, in3, out2, out3);                                \
++}
++
++/* Description : Low halfword vector elements signed extension to word
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low halfword elements from in0 signed extension to
++ *               word, written to output vector out0. Similar for in1.
++ *               Similar for other pairs.
++ * Example     : LASX_UNPCK_L_W_H(in0, out0)
++ *         in0 : 3, 0, 3, 0,  0, 0, 0, -1,  0, 0, 1, 1,  0, 0, 0, 1
++ *        out0 : 3, 0, 3, 0,  0, 0, 0, -1
++ */
++#define LASX_UNPCK_L_W_H(in0, out0)                                         \
++{                                                                           \
++    out0 = __lasx_vext2xv_w_h(in0);                                         \
++}
++
++#define LASX_UNPCK_L_W_H_2(in0, in1, out0, out1)                            \
++{                                                                           \
++    LASX_UNPCK_L_W_H(in0, out0);                                            \
++    LASX_UNPCK_L_W_H(in1, out1);                                            \
++}
++
++#define LASX_UNPCK_L_W_H_4(in0, in1, in2, in3, out0, out1, out2, out3)      \
++{                                                                           \
++    LASX_UNPCK_L_W_H_2(in0, in1, out0, out1);                               \
++    LASX_UNPCK_L_W_H_2(in2, in3, out2, out3);                               \
++}
++
++#define LASX_UNPCK_L_W_H_8(in0, in1, in2, in3, in4, in5, in6, in7,          \
++                           out0, out1, out2, out3, out4, out5, out6, out7)  \
++{                                                                           \
++    LASX_UNPCK_L_W_H_4(in0, in1, in2, in3, out0, out1, out2, out3);         \
++    LASX_UNPCK_L_W_H_4(in4, in5, in6, in7, out4, out5, out6, out7);         \
++}
++
++/* Description : Interleave odd byte elements from vectors.
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out, out0, ~
++ * Details     : Odd byte elements of in_h and odd byte
++ *               elements of in_l are interleaved and copied to out.
++ * Example     : See LASX_ILVOD_W(in_h, in_l, out)
++ */
++#define LASX_ILVOD_B(in_h, in_l, out)                                            \
++{                                                                                \
++    out = __lasx_xvpackod_b((in_h, in1_l);                                       \
++}
++
++#define LASX_ILVOD_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                   \
++{                                                                                \
++    LASX_ILVOD_B(in0_h, in0_l, out0);                                            \
++    LASX_ILVOD_B(in1_h, in1_l, out1);                                            \
++}
++
++#define LASX_ILVOD_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,   \
++                       out0, out1, out2, out3)                                   \
++{                                                                                \
++    LASX_ILVOD_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                      \
++    LASX_ILVOD_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                      \
++}
++
++/* Description : Interleave odd half word elements from vectors.
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out, out0, ~
++ * Details     : Odd half word elements of in_h and odd half word
++ *               elements of in_l are interleaved and copied to out.
++ * Example     : See LASX_ILVOD_W(in_h, in_l, out)
++ */
++#define LASX_ILVOD_H(in_h, in_l, out)                                           \
++{                                                                               \
++    out = __lasx_xvpackod_h(in_h, in_l);                                        \
++}
++
++#define LASX_ILVOD_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                  \
++{                                                                               \
++    LASX_ILVOD_H(in0_h, in0_l, out0);                                           \
++    LASX_ILVOD_H(in1_h, in1_l, out1);                                           \
++}
++
++#define LASX_ILVOD_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                       out0, out1, out2, out3)                                  \
++{                                                                               \
++    LASX_ILVOD_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                     \
++    LASX_ILVOD_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                     \
++}
++
++/* Description : Interleave odd word elements from vectors.
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out, out0, ~
++ * Details     : Odd word elements of in_h and odd word
++ *               elements of in_l are interleaved and copied to out.
++ * Example     : See LASX_ILVOD_W(in_h, in_l, out)
++ *        in_h : 1, 2, 3, 4,   5, 6, 7, 8
++ *        in_l : 1, 0, 3, 1,   1, 2, 3, 4
++ *         out : 0, 2, 1, 4,   2, 6, 4, 8
++ */
++#define LASX_ILVOD_W(in_h, in_l, out)                                           \
++{                                                                               \
++    out = __lasx_xvpackod_w(in_h, in_l);                                        \
++}
++
++#define LASX_ILVOD_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                  \
++{                                                                               \
++    LASX_ILVOD_W(in0_h, in0_l, out0);                                           \
++    LASX_ILVOD_W(in1_h, in1_l, out1);                                           \
++}
++
++#define LASX_ILVOD_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                       out0, out1, out2, out3)                                  \
++{                                                                               \
++    LASX_ILVOD_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                     \
++    LASX_ILVOD_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                     \
++}
++
++/* Description : Interleave odd double word elements from vectors.
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out, out0, ~
++ * Details     : Odd double word elements of in_h and odd double word
++ *               elements of in_l are interleaved and copied to out.
++ * Example     : LASX_ILVOD_W(in_h, in_l, out)
++ */
++#define LASX_ILVOD_D(in_h, in_l, out)                                           \
++{                                                                               \
++    out = __lasx_xvpackod_d(in_h, in_l);                                        \
++}
++
++#define LASX_ILVOD_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                  \
++{                                                                               \
++    LASX_ILVOD_D(in0_h, in0_l, out0);                                           \
++    LASX_ILVOD_D(in1_h, in1_l, out1);                                           \
++}
++
++#define LASX_ILVOD_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                       out0, out1, out2, out3)                                  \
++{                                                                               \
++    LASX_ILVOD_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                     \
++    LASX_ILVOD_D_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                     \
++}
++
++/* Description : Interleave right half of byte elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of byte elements of in_l and high half of byte
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : See LASX_ILVL_W(in_h, in_l, out0)
++ */
++#define LASX_ILVL_B(in_h, in_l, out0)                                      \
++{                                                                          \
++    __m256i tmp0, tmp1;                                                    \
++    tmp0 = __lasx_xvilvl_b(in_h, in_l);                                    \
++    tmp1 = __lasx_xvilvh_b(in_h, in_l);                                    \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                             \
++}
++
++#define LASX_ILVL_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVL_B(in0_h, in0_l, out0)                                  \
++    LASX_ILVL_B(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVL_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVL_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVL_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVL_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVL_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVL_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave low half of byte elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of byte elements of in_l and low half of byte
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : See LASX_ILVL_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_ILVL_B_128SV(in_h, in_l, out0)                                   \
++{                                                                             \
++    out0 = __lasx_xvilvl_b(in_h, in_l);                                       \
++}
++
++#define LASX_ILVL_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVL_B_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVL_B_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVL_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVL_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVL_B_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVL_B_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVL_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVL_B_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave low half of half word elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of half word elements of in_l and right half of
++ *               half word elements of in_h are interleaved and copied to
++ *               out0. Similar for other pairs.
++ * Example     : See LASX_ILVL_W(in_h, in_l, out0)
++ */
++#define LASX_ILVL_H(in_h, in_l, out0)                                      \
++{                                                                          \
++    __m256i tmp0, tmp1;                                                    \
++    tmp0 = __lasx_xvilvl_h(in_h, in_l);                                    \
++    tmp1 = __lasx_xvilvh_h(in_h, in_l);                                    \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                             \
++}
++
++#define LASX_ILVL_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVL_H(in0_h, in0_l, out0)                                  \
++    LASX_ILVL_H(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVL_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVL_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVL_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVL_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVL_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVL_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave low half of half word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of half word elements of in_l and low half of half
++ *               word elements of in_h are interleaved and copied to
++ *               out0. Similar for other pairs.
++ * Example     : See LASX_ILVL_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_ILVL_H_128SV(in_h, in_l, out0)                                   \
++{                                                                             \
++    out0 = __lasx_xvilvl_h(in_h, in_l);                                       \
++}
++
++#define LASX_ILVL_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVL_H_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVL_H_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVL_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVL_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVL_H_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVL_H_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVL_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVL_H_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave low half of word elements from vectors
++ * Arguments   : Inputs  - in0_h, in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of halfword elements of in_l and low half of word
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : LASX_ILVL_W(in_h, in_l, out0)
++ *        in_h : 0, 1, 0, 1,  0, 1, 0, 1
++ *        in_l : 1, 2, 3, 4,  5, 6, 7, 8
++ *        out0 : 1, 0, 2, 1,  3, 0, 4, 1
++ */
++#define LASX_ILVL_W(in_h, in_l, out0)                                      \
++{                                                                          \
++    __m256i tmp0, tmp1;                                                    \
++    tmp0 = __lasx_xvilvl_w(in_h, in_l);                                    \
++    tmp1 = __lasx_xvilvh_w(in_h, in_l);                                    \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                             \
++}
++
++#define LASX_ILVL_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVL_W(in0_h, in0_l, out0)                                  \
++    LASX_ILVL_W(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVL_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVL_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVL_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVL_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVL_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVL_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave low half of word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h, in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of halfword elements of in_l and low half of word
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : LASX_ILVL_W_128SV(in_h, in_l, out0)
++ *        in_h : 0, 1, 0, 1, 0, 1, 0, 1
++ *        in_l : 1, 2, 3, 4, 5, 6, 7, 8
++ *        out0 : 1, 0, 2, 1, 5, 0, 6, 1
++ */
++#define LASX_ILVL_W_128SV(in_h, in_l, out0)                             \
++{                                                                       \
++    out0 = __lasx_xvilvl_w(in_h, in_l);                                 \
++}
++
++#define LASX_ILVL_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVL_W_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVL_W_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVL_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVL_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVL_W_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVL_W_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVL_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVL_W_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave low half of double word elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of double word elements of in_l and low half of
++ *               double word elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : See LASX_ILVL_W(in_h, in_l, out0)
++ */
++#define LASX_ILVL_D(in_h, in_l, out0)                                   \
++{                                                                       \
++    __m256i tmp0, tmp1;                                                 \
++    tmp0 = __lasx_xvilvl_d(in_h, in_l);                                 \
++    tmp1 = __lasx_xvilvh_d(in_h, in_l);                                 \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                          \
++}
++
++#define LASX_ILVL_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVL_D(in0_h, in0_l, out0)                                  \
++    LASX_ILVL_D(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVL_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVL_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVL_D_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVL_D_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVL_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVL_D_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave right half of double word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Right half of double word elements of in_l and right half of
++ *               double word elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs.
++ * Example     : See LASX_ILVL_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_ILVL_D_128SV(in_h, in_l, out0)                              \
++{                                                                        \
++    out0 = __lasx_xvilvl_d(in_h, in_l);                                  \
++}
++
++#define LASX_ILVL_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVL_D_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVL_D_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVL_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVL_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVL_D_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVL_D_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVL_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVL_D_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of byte elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of byte elements of in_l and high half of
++ *               byte
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVH_W(in_h, in_l, out0)
++ */
++#define LASX_ILVH_B(in_h, in_l, out0)                            \
++{                                                                \
++    __m256i tmp0, tmp1;                                          \
++    tmp0 = __lasx_xvilvl_b(in_h, in_l);                          \
++    tmp1 = __lasx_xvilvh_b(in_h, in_l);                          \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                   \
++}
++
++#define LASX_ILVH_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVH_B(in0_h, in0_l, out0)                                  \
++    LASX_ILVH_B(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVH_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVH_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVH_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVH_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of byte elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of  byte elements  of  in_l and high half
++ *               of byte elements of in_h are interleaved and copied
++ *               to out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVH_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_ILVH_B_128SV(in_h, in_l, out0)                     \
++{                                                               \
++    out0 = __lasx_xvilvh_b(in_h, in_l);                         \
++}
++
++#define LASX_ILVH_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVH_B_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVH_B_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVH_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVH_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVH_B_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVH_B_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVH_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVH_B_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of half word elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of half word elements of in_l and high half of
++ *               half word
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVH_W(in_h, in_l, out0)
++ */
++#define LASX_ILVH_H(in_h, in_l, out0)                           \
++{                                                                \
++    __m256i tmp0, tmp1;                                          \
++    tmp0 = __lasx_xvilvl_h(in_h, in_l);                          \
++    tmp1 = __lasx_xvilvh_h(in_h, in_l);                          \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                   \
++}
++
++#define LASX_ILVH_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVH_H(in0_h, in0_l, out0)                                  \
++    LASX_ILVH_H(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVH_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVH_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVH_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVH_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVH_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVH_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of half word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of  half word elements  of  in_l and high half
++ *               of half word elements of in_h are interleaved and copied
++ *               to out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVH_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_ILVH_H_128SV(in_h, in_l, out0)                     \
++{                                                               \
++    out0 = __lasx_xvilvh_h(in_h, in_l);                         \
++}
++
++#define LASX_ILVH_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVH_H_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVH_H_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVH_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVH_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVH_H_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVH_H_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVH_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVH_H_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of word elements from vectors
++ * Arguments   : Inputs  - in0_h, in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of word elements of in_l and high half of
++ *               word elements of in_h are interleaved and copied to
++ *               out0.
++ *               Similar for other pairs.
++ * Example     : LASX_ILVH_W(in_h, in_l, out0)
++ *         in_h:-1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l: 1,  2,  3,  4,  5,  6,  7,  8
++ *         out0: 5, -5,  6, -6,  7, -7,  8, -8
++ */
++#define LASX_ILVH_W(in_h, in_l, out0)                            \
++{                                                                \
++    __m256i tmp0, tmp1;                                          \
++    tmp0 = __lasx_xvilvl_w(in_h, in_l);                          \
++    tmp1 = __lasx_xvilvh_w(in_h, in_l);                          \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                   \
++}
++
++#define LASX_ILVH_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVH_W(in0_h, in0_l, out0)                                  \
++    LASX_ILVH_W(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVH_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVH_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVH_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVH_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h, in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of word elements of every 128-bit of in_l
++ *               and high half of word elements of every 128-bit of
++ *               in_h are interleaved and copied to out0.
++ *               Similar for other pairs.
++ * Example     : LASX_ILVH_W_128SV(in_h, in_l, out0)
++ *         in_h:-1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l: 1,  2,  3,  4,  5,  6,  7,  8
++ *         out0: 3, -3,  4, -4,  7, -7,  8, -8*
++ */
++#define LASX_ILVH_W_128SV(in_h, in_l, out0)                        \
++{                                                                  \
++    out0 = __lasx_xvilvh_w(in_h, in_l);                            \
++}
++
++#define LASX_ILVH_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVH_W_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVH_W_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVH_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVH_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVH_W_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVH_W_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVH_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVH_W_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of double word elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out0, out1, ~
++ :* Details    : High half of double word elements of in_l and high half of
++ *               double word elements of in_h are interleaved and copied to
++ *               out0.
++ *               Similar for other pairs.
++ * Example    : see LASX_ILVH_W(in_h, in_l, out0)
++ */
++#define LASX_ILVH_D(in_h, in_l, out0)                           \
++{                                                               \
++    __m256i tmp0, tmp1;                                         \
++    tmp0 = __lasx_xvilvl_d(in_h, in_l);                         \
++    tmp1 = __lasx_xvilvh_d(in_h, in_l);                         \
++    out0 = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                  \
++}
++
++#define LASX_ILVH_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)        \
++{                                                                    \
++    LASX_ILVH_D(in0_h, in0_l, out0)                                  \
++    LASX_ILVH_D(in1_h, in1_l, out1)                                  \
++}
++
++#define LASX_ILVH_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                      in3_h, in3_l, out0, out1, out2, out3)          \
++{                                                                    \
++    LASX_ILVH_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)            \
++    LASX_ILVH_D_2(in2_h, in2_l, in3_h, in3_l, out2, out3)            \
++}
++
++#define LASX_ILVH_D_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LASX_ILVH_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                  out0, out1, out2, out3);                                     \
++    LASX_ILVH_D_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                  out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave high half of double word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of double word elements of every 128-bit in_l and
++ *               high half of double word elements of every 128-bit in_h are
++ *               interleaved and copied to out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVH_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_ILVH_D_128SV(in_h, in_l, out0)                             \
++{                                                                       \
++    out0 = __lasx_xvilvh_d(in_h, in_l);                                 \
++}
++
++#define LASX_ILVH_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)           \
++{                                                                             \
++    LASX_ILVH_D_128SV(in0_h, in0_l, out0);                                    \
++    LASX_ILVH_D_128SV(in1_h, in1_l, out1);                                    \
++}
++
++#define LASX_ILVH_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,         \
++                            in3_h, in3_l, out0, out1, out2, out3)             \
++{                                                                             \
++    LASX_ILVH_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);              \
++    LASX_ILVH_D_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);              \
++}
++
++#define LASX_ILVH_D_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                            in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                            out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                                    \
++    LASX_ILVH_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,      \
++                        out0, out1, out2, out3);                                     \
++    LASX_ILVH_D_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,      \
++                        out4, out5, out6, out7);                                     \
++}
++
++/* Description : Interleave byte elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of  byte elements  of in_l and low half of byte
++ *               elements  of in_h  are interleaved  and copied  to  out_l.
++ *               High half of byte elements of in_l and high half of byte
++ *               elements of in_h are interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVLH_W(in_h, in_l, out_l, out_h)
++ */
++#define LASX_ILVLH_B(in_h, in_l, out_h, out_l)                          \
++{                                                                       \
++    __m256i tmp0, tmp1;                                                 \
++    tmp0  = __lasx_xvilvl_b(in_h, in_l);                                \
++    tmp1  = __lasx_xvilvh_b(in_h, in_l);                                \
++    out_l = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                         \
++    out_h = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                         \
++}
++
++#define LASX_ILVLH_B_2(in0_h, in0_l, in1_h, in1_l,                      \
++                       out0_h, out0_l, out1_h, out1_l)                  \
++{                                                                       \
++    LASX_ILVLH_B(in0_h, in0_l, out0_h, out0_l);                         \
++    LASX_ILVLH_B(in1_h, in1_l, out1_h, out1_l);                         \
++}
++
++#define LASX_ILVLH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                       \
++    LASX_ILVLH_B_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LASX_ILVLH_B_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LASX_ILVLH_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                       out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                       \
++    LASX_ILVLH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                   out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                   out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave byte elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of byte elements of in_l and low half of byte elements
++ *               of in_h are interleaved and copied to out_l. High  half  of byte
++ *               elements  of in_h  and high half  of byte elements  of in_l  are
++ *               interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVLH_W_128SV(in_h, in_l, out_h, out_l)
++ */
++#define LASX_ILVLH_B_128SV(in_h, in_l, out_h, out_l)                           \
++{                                                                              \
++    LASX_ILVL_B_128SV(in_h, in_l, out_l);                                      \
++    LASX_ILVH_B_128SV(in_h, in_l, out_h);                                      \
++}
++
++#define LASX_ILVLH_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l)  \
++{                                                                                         \
++    LASX_ILVLH_B_128SV(in0_h, in0_l, out0_h, out0_l);                                     \
++    LASX_ILVLH_B_128SV(in1_h, in1_l, out1_h, out1_l);                                     \
++}
++
++#define LASX_ILVLH_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,           \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)   \
++{                                                                                              \
++    LASX_ILVLH_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);          \
++    LASX_ILVLH_B_2_128SV(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);          \
++}
++
++#define LASX_ILVLH_B_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                             in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                             out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                             \
++    LASX_ILVLH_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                         out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_B_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                         out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave half word elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of  half word elements  of in_l and low half of half
++ *               word elements of in_h  are  interleaved  and  copied  to out_l.
++ *               High half of half word elements of in_l and high half of half
++ *               word elements of in_h are interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVLH_W(in_h, in_l, out_h, out_l)
++ */
++#define LASX_ILVLH_H(in_h, in_l, out_h, out_l)                           \
++{                                                                        \
++    __m256i tmp0, tmp1;                                                  \
++    tmp0  = __lasx_xvilvl_h(in_h, in_l);                                 \
++    tmp1  = __lasx_xvilvh_h(in_h, in_l);                                 \
++    out_l = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                          \
++    out_h = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                          \
++}
++
++#define LASX_ILVLH_H_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l,       \
++                       out1_h, out1_l)                                   \
++{                                                                        \
++    LASX_ILVLH_H(in0_h, in0_l, out0_h, out0_l);                          \
++    LASX_ILVLH_H(in1_h, in1_l, out1_h, out1_l);                          \
++}
++
++#define LASX_ILVLH_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                       \
++    LASX_ILVLH_H_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LASX_ILVLH_H_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LASX_ILVLH_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                       out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                       \
++    LASX_ILVLH_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                   out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                   out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave half word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l,  ~
++ *               Outputs - out0_h, out0_l, ~
++ * Details     : Low half of half word elements  of every 128-bit of in_l and
++ *               low half of half word elements  of every 128-bit of in_h are
++ *               interleaved and copied to out_l.
++ *               High half of half word elements of every 128-bit of in_l and
++ *               high half of half word elements of every 128-bit of in_h are
++ *               interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVLH_W_128SV(in_h, in_l, out_h, out_l)
++ */
++#define LASX_ILVLH_H_128SV(in_h, in_l, out_h, out_l)                            \
++{                                                                               \
++    LASX_ILVL_H_128SV(in_h, in_l, out_l);                                       \
++    LASX_ILVH_H_128SV(in_h, in_l, out_h);                                       \
++}
++
++#define LASX_ILVLH_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l)  \
++{                                                                                         \
++    LASX_ILVLH_H_128SV(in0_h, in0_l, out0_h, out0_l);                                     \
++    LASX_ILVLH_H_128SV(in1_h, in1_l, out1_h, out1_l);                                     \
++}
++
++#define LASX_ILVLH_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,           \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)   \
++{                                                                                              \
++    LASX_ILVLH_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);          \
++    LASX_ILVLH_H_2_128SV(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);          \
++}
++
++#define LASX_ILVLH_H_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                             in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                             out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                             \
++    LASX_ILVLH_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                         out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_H_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                         out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave word elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of  word elements  of in_l and low half of word
++ *               elements of in_h  are  interleaved  and  copied  to out_l.
++ *               High half of word elements of in_l and high half of word
++ *               elements of in_h are interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : LASX_ILVLH_W(in_h, in_l, out_h, out_l)
++ *         in_h:-1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l: 1,  2,  3,  4,  5,  6,  7,  8
++ *        out_h: 5, -5,  6, -6,  7, -7,  8, -8
++ *        out_l: 1, -1,  2, -2,  3, -3,  4, -4
++ */
++#define LASX_ILVLH_W(in_h, in_l, out_h, out_l)                           \
++{                                                                        \
++    __m256i tmp0, tmp1;                                                  \
++    tmp0  = __lasx_xvilvl_w(in_h, in_l);                                 \
++    tmp1  = __lasx_xvilvh_w(in_h, in_l);                                 \
++    out_l = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                          \
++    out_h = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                          \
++}
++
++#define LASX_ILVLH_W_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l,       \
++                       out1_h, out1_l)                                   \
++{                                                                        \
++    LASX_ILVLH_W(in0_h, in0_l, out0_h, out0_l);                          \
++    LASX_ILVLH_W(in1_h, in1_l, out1_h, out1_l);                          \
++}
++
++#define LASX_ILVLH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                       \
++    LASX_ILVLH_W_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LASX_ILVLH_W_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LASX_ILVLH_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                       out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                       \
++    LASX_ILVLH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                   out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                   out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in0_h,  in0_l,  ~
++ *               Outputs - out0_h, out0_l, ~
++ * Details     : Low half of word elements  of every 128-bit of in_l and
++ *               low half of word elements  of every 128-bit of in_h are
++ *               interleaved and copied to out_l.
++ *               High half of word elements of every 128-bit of in_l and
++ *               high half of word elements of every 128-bit of in_h are
++ *               interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : LASX_ILVLH_W_128SV(in_h, in_l, out_h, out_l)
++ *         in_h:-1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l: 1,  2,  3,  4,  5,  6,  7,  8
++ *        out_h: 3, -3,  4, -4,  7, -7,  8, -8
++ *        out_l: 1, -1,  2, -2,  5, -5,  6, -6
++ */
++#define LASX_ILVLH_W_128SV(in_h, in_l, out_h, out_l)                            \
++{                                                                               \
++    LASX_ILVL_W_128SV(in_h, in_l, out_l);                                       \
++    LASX_ILVH_W_128SV(in_h, in_l, out_h);                                       \
++}
++
++#define LASX_ILVLH_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l)  \
++{                                                                                         \
++    LASX_ILVLH_W_128SV(in0_h, in0_l, out0_h, out0_l);                                     \
++    LASX_ILVLH_W_128SV(in1_h, in1_l, out1_h, out1_l);                                     \
++}
++
++#define LASX_ILVLH_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,           \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)   \
++{                                                                                              \
++    LASX_ILVLH_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);          \
++    LASX_ILVLH_W_2_128SV(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);          \
++}
++
++#define LASX_ILVLH_W_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                             in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                             out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                             \
++    LASX_ILVLH_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                         out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_W_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                         out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave double word elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of double word  elements  of in_l and low half of
++ *               double word elements of in_h are interleaved and copied to
++ *               out_l. High half of double word  elements  of in_l and high
++ *               half of double word  elements  of in_h are interleaved and
++ *               copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVLH_W(in_h, in_l, out_h, out_l)
++ */
++#define LASX_ILVLH_D(in_h, in_l, out_h, out_l)                           \
++{                                                                        \
++    __m256i tmp0, tmp1;                                                  \
++    tmp0  = __lasx_xvilvl_d(in_h, in_l);                                 \
++    tmp1  = __lasx_xvilvh_d(in_h, in_l);                                 \
++    out_l = __lasx_xvpermi_q(tmp0, tmp1, 0x02);                          \
++    out_h = __lasx_xvpermi_q(tmp0, tmp1, 0x13);                          \
++}
++
++#define LASX_ILVLH_D_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l,       \
++                       out1_h, out1_l)                                   \
++{                                                                        \
++    LASX_ILVLH_D(in0_h, in0_l, out0_h, out0_l);                          \
++    LASX_ILVLH_D(in1_h, in1_l, out1_h, out1_l);                          \
++}
++
++#define LASX_ILVLH_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                       \
++    LASX_ILVLH_D_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LASX_ILVLH_D_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LASX_ILVLH_D_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                       out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                       out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                       \
++    LASX_ILVLH_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                   out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_D_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                   out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave double word elements from vectors
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of double word elements of every 128-bit  of in_l and
++ *               low half of double word elements of every 128-bit  of in_h are
++ *               interleaved and copied to out_l.
++ *               High half of double word elements of every 128-bit of in_l and
++ *               high half of double word elements of every 128-bit of in_h are
++ *               interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LASX_ILVLH_W_128SV(in_h, in_l, out_h, out_l)
++ */
++#define LASX_ILVLH_D_128SV(in_h, in_l, out_h, out_l)                            \
++{                                                                               \
++    LASX_ILVL_D_128SV(in_h, in_l, out_l);                                       \
++    LASX_ILVH_D_128SV(in_h, in_l, out_h);                                       \
++}
++
++#define LASX_ILVLH_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l)  \
++{                                                                                         \
++    LASX_ILVLH_D_128SV(in0_h, in0_l, out0_h, out0_l);                                     \
++    LASX_ILVLH_D_128SV(in1_h, in1_l, out1_h, out1_l);                                     \
++}
++
++#define LASX_ILVLH_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,           \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)   \
++{                                                                                              \
++    LASX_ILVLH_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);          \
++    LASX_ILVLH_D_2_128SV(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);          \
++}
++
++#define LASX_ILVLH_D_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                             in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                             out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                             out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                             \
++    LASX_ILVLH_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                         out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LASX_ILVLH_D_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                         out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Immediate number of columns to slide with zero
++ * Arguments   : Inputs  - in0, in1, slide_val, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Byte elements from every 128-bit of in0 vector
++ *               are slide into  out0  by  number  of  elements
++ *               specified by slide_val.
++ * Example     : LASX_SLDI_B_0_128SV(in0, out0, slide_val)
++ *          in0: 1, 2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,
++ *               19,20,21,22,23,24,25,26,27,28,29,30,31,32
++ *         out0: 4, 5,6,7,8,9,10,11,12,13,14,15,16,0,0,0,20,21,
++ *               22,23,24,25,26,27,28,29,30,31,32,0,0,0
++ *    slide_val: 3
++ */
++#define LASX_SLDI_B_0_128SV(in0, out0, slide_val)                   \
++{                                                                   \
++    out0 = __lasx_xvbsrl_v(in0, slide_val);                         \
++}
++
++#define LASX_SLDI_B_2_0_128SV(in0, in1, out0, out1, slide_val)      \
++{                                                                   \
++    LASX_SLDI_B_0_128SV(in0, out0, slide_val);                      \
++    LASX_SLDI_B_0_128SV(in1, out1, slide_val);                      \
++}
++
++#define LASX_SLDI_B_4_0_128SV(in0, in1, in2, in3,                   \
++                              out0, out1, out2, out3, slide_val)    \
++{                                                                   \
++    LASX_SLDI_B_2_0_128SV(in0, in1, out0, out1, slide_val);         \
++    LASX_SLDI_B_2_0_128SV(in2, in3, out2, out3, slide_val);         \
++}
++
++/* Description : Pack even byte elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even byte elements of in_l are copied to the low half of
++ *               out0.  Even byte elements of in_h are copied to the high
++ *               half of out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_PCKEV_W(in_h, in_l, out0)
++ */
++#define LASX_PCKEV_B(in_h, in_l, out0)                                  \
++{                                                                       \
++    out0 = __lasx_xvpickev_b(in_h, in_l);                               \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                                \
++}
++
++#define LASX_PCKEV_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)          \
++{                                                                       \
++    LASX_PCKEV_B(in0_h, in0_l, out0);                                   \
++    LASX_PCKEV_B(in1_h, in1_l, out1);                                   \
++}
++
++#define LASX_PCKEV_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,        \
++                       in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                       \
++    LASX_PCKEV_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1);             \
++    LASX_PCKEV_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3);             \
++}
++
++#define LASX_PCKEV_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKEV_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKEV_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack even byte elements of vector pairs
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even byte elements of in_l are copied to the low half of
++ *               out0.  Even byte elements of in_h are copied to the high
++ *               half of out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_PCKEV_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_PCKEV_B_128SV(in_h, in_l, out0)                            \
++{                                                                       \
++    out0 = __lasx_xvpickev_b(in_h, in_l);                               \
++}
++
++#define LASX_PCKEV_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                       \
++    LASX_PCKEV_B_128SV(in0_h, in0_l, out0);                             \
++    LASX_PCKEV_B_128SV(in1_h, in1_l, out1);                             \
++}
++
++#define LASX_PCKEV_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                             in3_h, in3_l, out0, out1, out2, out3)      \
++{                                                                       \
++    LASX_PCKEV_B_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LASX_PCKEV_B_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LASX_PCKEV_B_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                             in3_h, in3_l, in4_h, in4_l, in5_h, in5_l,  \
++                             in6_h, in6_l, in7_h, in7_l, out0, out1,    \
++                             out2, out3, out4, out5, out6, out7)        \
++{                                                                       \
++    LASX_PCKEV_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                         in3_h, in3_l, out0, out1, out2, out3);         \
++    LASX_PCKEV_B_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,      \
++                         in7_h, in7_l, out4, out5, out6, out7);         \
++}
++
++/* Description : Pack even half word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even half word elements of in_l are copied to the  low
++ *               half of out0.  Even  half  word  elements  of in_h are
++ *               copied to the high half of out0.
++ * Example     : see LASX_PCKEV_W(in_h, in_l, out0)
++ */
++#define LASX_PCKEV_H(in_h, in_l, out0)                                 \
++{                                                                      \
++    out0 = __lasx_xvpickev_h(in_h, in_l);                              \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                               \
++}
++
++#define LASX_PCKEV_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)          \
++{                                                                       \
++    LASX_PCKEV_H(in0_h, in0_l, out0);                                   \
++    LASX_PCKEV_H(in1_h, in1_l, out1);                                   \
++}
++
++#define LASX_PCKEV_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,        \
++                       in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                       \
++    LASX_PCKEV_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1);             \
++    LASX_PCKEV_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3);             \
++}
++
++#define LASX_PCKEV_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKEV_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKEV_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack even half word elements of vector pairs
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even half word elements of in_l are copied to the  low
++ *               half of out0.  Even  half  word  elements  of in_h are
++ *               copied to the high half of out0.
++ * Example     : see LASX_PCKEV_W_128SV(in_h, in_l, out0)
++ */
++#define LASX_PCKEV_H_128SV(in_h, in_l, out0)                            \
++{                                                                       \
++    out0 = __lasx_xvpickev_h(in_h, in_l);                               \
++}
++
++#define LASX_PCKEV_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                       \
++    LASX_PCKEV_H_128SV(in0_h, in0_l, out0);                             \
++    LASX_PCKEV_H_128SV(in1_h, in1_l, out1);                             \
++}
++
++#define LASX_PCKEV_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                       in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                       \
++    LASX_PCKEV_H_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LASX_PCKEV_H_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LASX_PCKEV_H_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                             in3_h, in3_l, in4_h, in4_l, in5_h, in5_l,  \
++                             in6_h, in6_l, in7_h, in7_l, out0, out1,    \
++                             out2, out3, out4, out5, out6, out7)        \
++{                                                                       \
++    LASX_PCKEV_H_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,      \
++                   in3_h, in3_l, out0, out1, out2, out3);               \
++    LASX_PCKEV_H_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,      \
++                   in7_h, in7_l, out4, out5, out6, out7);               \
++}
++
++/* Description : Pack even word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even word  elements  of  in_l are copied to
++ *               the low  half of out0.  Even word elements
++ *               of in_h are copied to the high half of out0.
++ * Example     : LASX_PCKEV_W(in_h, in_l, out0)
++ *         in_h: -1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l:  1,  2,  3,  4,  5,  6,  7,  8
++ *         out0:  1,  3,  5,  7, -1, -3, -5, -7
++ */
++#define LASX_PCKEV_W(in_h, in_l, out0)                    \
++{                                                         \
++    out0 = __lasx_xvpickev_w(in_h, in_l);                 \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                  \
++}
++
++#define LASX_PCKEV_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)          \
++{                                                                       \
++    LASX_PCKEV_W(in0_h, in0_l, out0);                                   \
++    LASX_PCKEV_W(in1_h, in1_l, out1);                                   \
++}
++
++#define LASX_PCKEV_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,        \
++                       in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                       \
++    LASX_PCKEV_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1);             \
++    LASX_PCKEV_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3);             \
++}
++
++#define LASX_PCKEV_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKEV_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKEV_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack even word elements of vector pairs
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even word  elements  of  in_l are copied to
++ *               the low  half of out0.  Even word elements
++ *               of in_h are copied to the high half of out0.
++ * Example     : LASX_PCKEV_W_128SV(in_h, in_l, out0)
++ *         in_h: -1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l:  1,  2,  3,  4,  5,  6,  7,  8
++ *         out0:  1,  3, -1, -3,  5,  7, -5, -7
++ */
++#define LASX_PCKEV_W_128SV(in_h, in_l, out0)                           \
++{                                                                      \
++    out0 = __lasx_xvpickev_w(in_h, in_l);                              \
++}
++
++#define LASX_PCKEV_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)   \
++{                                                                      \
++    LASX_PCKEV_W_128SV(in0_h, in0_l, out0);                            \
++    LASX_PCKEV_W_128SV(in1_h, in1_l, out1);                            \
++}
++
++#define LASX_PCKEV_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, \
++                             in3_h, in3_l, out0, out1, out2, out3)     \
++{                                                                      \
++    LASX_PCKEV_W_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1);      \
++    LASX_PCKEV_W_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3);      \
++}
++
++#define LASX_PCKEV_W_8_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, \
++                             in3_h, in3_l, in4_h, in4_l, in5_h, in5_l, \
++                             in6_h, in6_l, in7_h, in7_l, out0, out1,   \
++                             out2, out3, out4, out5, out6, out7)       \
++{                                                                      \
++    LASX_PCKEV_W_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,     \
++                         in3_h, in3_l, out0, out1, out2, out3);        \
++    LASX_PCKEV_W_4_128SV(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,     \
++                         in7_h, in7_l, out4, out5, out6, out7);        \
++}
++
++/* Description : Pack even half word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even half word elements of in_l are copied to the  low
++ *               half of out0.  Even  half  word  elements  of in_h are
++ *               copied to the high half of out0.
++ * Example     : See LASX_PCKEV_W(in_h, in_l, out0)
++ */
++#define LASX_PCKEV_D(in_h, in_l, out0)                                        \
++{                                                                             \
++    out0 = __lasx_xvpickev_d(in_h, in_l);                                     \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                                      \
++}
++
++#define LASX_PCKEV_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                \
++{                                                                             \
++    LASX_PCKEV_D(in0_h, in0_l, out0)                                          \
++    LASX_PCKEV_D(in1_h, in1_l, out1)                                          \
++}
++
++#define LASX_PCKEV_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,              \
++                       in3_h, in3_l, out0, out1, out2, out3)                  \
++{                                                                             \
++    LASX_PCKEV_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                    \
++    LASX_PCKEV_D_2(in2_h, in2_l, in3_h, in3_l, out2, out3)                    \
++}
++
++/* Description : Pack even half word elements of vector pairs
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even half word elements of in_l are copied to the  low
++ *               half of out0.  Even  half  word  elements  of in_h are
++ *               copied to the high half of out0.
++ * Example     : LASX_PCKEV_D_128SV(in_h, in_l, out0)
++ *        in_h : 1, 2, 3, 4
++ *        in_l : 5, 6, 7, 8
++ *        out0 : 5, 1, 7, 3
++ */
++#define LASX_PCKEV_D_128SV(in_h, in_l, out0)                                  \
++{                                                                             \
++    out0 = __lasx_xvpickev_d(in_h, in_l);                                     \
++}
++
++#define LASX_PCKEV_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)          \
++{                                                                             \
++    LASX_PCKEV_D_128SV(in0_h, in0_l, out0)                                    \
++    LASX_PCKEV_D_128SV(in1_h, in1_l, out1)                                    \
++}
++
++#define LASX_PCKEV_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,        \
++                             in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                             \
++    LASX_PCKEV_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)              \
++    LASX_PCKEV_D_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3)              \
++}
++
++/* Description : Pack even quad word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even quad elements of in_l are copied to the low
++ *               half of out0. Even  quad  elements  of  in_h are
++ *               copied to the high half of out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_PCKEV_W(in_h, in_l, out0)
++ */
++#define LASX_PCKEV_Q(in_h, in_l, out0)                          \
++{                                                               \
++    out0 = __lasx_xvpermi_q(in_h, in_l, 0x20);                  \
++}
++
++#define LASX_PCKEV_Q_2(in0_h, in0_l, in1_h, in1_l, out0, out1)          \
++{                                                                       \
++    LASX_PCKEV_Q(in0_h, in0_l, out0);                                   \
++    LASX_PCKEV_Q(in1_h, in1_l, out1);                                   \
++}
++
++#define LASX_PCKEV_Q_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,        \
++                       in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                       \
++    LASX_PCKEV_Q_2(in0_h, in0_l, in1_h, in1_l, out0, out1);             \
++    LASX_PCKEV_Q_2(in2_h, in2_l, in3_h, in3_l, out2, out3);             \
++}
++
++#define LASX_PCKEV_Q_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKEV_Q_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKEV_Q_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack odd byte elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd byte elements of in_l are copied to the low half of
++ *               out0. Odd byte elements of in_h are copied to the high
++ *               half of out0.
++ *               Similar for other pairs.
++ * Example     : see LASX_PCKOD_W(in_h, in_l, out0)
++ */
++#define LASX_PCKOD_B(in_h, in_l, out0)                                         \
++{                                                                              \
++    out0 = __lasx_xvpickod_b(in_h, in_l);                                      \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                                       \
++}
++
++#define LASX_PCKOD_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                 \
++{                                                                              \
++    LASX_PCKOD_B(in0_h, in0_l, out0);                                          \
++    LASX_PCKOD_B(in1_h, in1_l, out1);                                          \
++}
++
++#define LASX_PCKOD_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,               \
++                       in3_h, in3_l, out0, out1, out2, out3)                   \
++{                                                                              \
++    LASX_PCKOD_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                    \
++    LASX_PCKOD_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                    \
++}
++
++#define LASX_PCKOD_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKOD_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKOD_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack odd half word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd half word elements of in_l are copied to the low
++ *               half of out0. Odd half word elements of in_h are copied
++ *               to the high half of out0.
++ * Example     : see LASX_PCKOD_W(in_h, in_l, out0)
++ */
++#define LASX_PCKOD_H(in_h, in_l, out0)                                         \
++{                                                                              \
++    out0 = __lasx_xvpickod_h(in_h, in_l);                                      \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                                       \
++}
++
++#define LASX_PCKOD_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                 \
++{                                                                              \
++    LASX_PCKOD_H(in0_h, in0_l, out0);                                          \
++    LASX_PCKOD_H(in1_h, in1_l, out1);                                          \
++}
++
++#define LASX_PCKOD_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,               \
++                       in3_h, in3_l, out0, out1, out2, out3)                   \
++{                                                                              \
++    LASX_PCKOD_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                    \
++    LASX_PCKOD_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                    \
++}
++
++#define LASX_PCKOD_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKOD_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKOD_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack odd word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd word elements of in_l are copied to the low half of out0.
++ *               Odd word elements of in_h are copied to the high half of out0.
++ * Example     : LASX_PCKOD_W(in_h, in_l, out0)
++ *         in_h: -1, -2, -3, -4, -5, -6, -7, -8
++ *         in_l:  1,  2,  3,  4,  5,  6,  7,  8
++ *         out0:  2,  4,  6,  8, -2, -4, -6, -8
++ */
++#define LASX_PCKOD_W(in_h, in_l, out0)                                         \
++{                                                                              \
++    out0 = __lasx_xvpickod_w(in_h, in_l);                                      \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                                       \
++}
++
++#define LASX_PCKOD_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                 \
++{                                                                              \
++    LASX_PCKOD_W(in0_h, in0_l, out0);                                          \
++    LASX_PCKOD_W(in1_h, in1_l, out1);                                          \
++}
++
++#define LASX_PCKOD_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,               \
++                       in3_h, in3_l, out0, out1, out2, out3)                   \
++{                                                                              \
++    LASX_PCKOD_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                    \
++    LASX_PCKOD_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                    \
++}
++
++#define LASX_PCKOD_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKOD_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKOD_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack odd half word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd half word elements of in_l are copied to the low
++ *               half of out0. Odd half word elements of in_h are
++ *               copied to the high half of out0.
++ * Example     : See LASX_PCKOD_W(in_h, in_l, out0)
++ */
++#define LASX_PCKOD_D(in_h, in_l, out0)                                        \
++{                                                                             \
++    out0 = __lasx_xvpickod_d(in_h, in_l);                                     \
++    out0 = __lasx_xvpermi_d(out0, 0xd8);                                      \
++}
++
++#define LASX_PCKOD_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                \
++{                                                                             \
++    LASX_PCKOD_D(in0_h, in0_l, out0)                                          \
++    LASX_PCKOD_D(in1_h, in1_l, out1)                                          \
++}
++
++#define LASX_PCKOD_D_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,              \
++                       in3_h, in3_l, out0, out1, out2, out3)                  \
++{                                                                             \
++    LASX_PCKOD_D_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                    \
++    LASX_PCKOD_D_2(in2_h, in2_l, in3_h, in3_l, out2, out3)                    \
++}
++
++/* Description : Pack odd quad word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd quad elements of in0_h are copied to the high half of
++ *               out0 & odd quad elements of in0_l are copied to the low
++ *               half of out0.
++ *               Odd quad elements of in1_h are copied to the high half of
++ *               out1 & odd quad elements of in1_l are copied to the low
++ *               half of out1.
++ *               LASX_PCKOD_Q(in_h, in_l, out0)
++ *               in_h:   0,0,0,0, 0,0,0,0, 19,10,11,12, 13,14,15,16
++ *               in_l:   0,0,0,0, 0,0,0,0, 1,2,3,4, 5,6,7,8
++ *               out0:  1,2,3,4, 5,6,7,8, 19,10,11,12, 13,14,15,16
++ */
++#define LASX_PCKOD_Q(in_h, in_l, out0)                                         \
++{                                                                              \
++    out0 = __lasx_xvpermi_q(in_h, in_l, 0x31);                                 \
++}
++
++#define LASX_PCKOD_Q_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                 \
++{                                                                              \
++    LASX_PCKOD_Q(in0_h, in0_l, out0);                                          \
++    LASX_PCKOD_Q(in1_h, in1_l, out1);                                          \
++}
++
++#define LASX_PCKOD_Q_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,               \
++                       in3_h, in3_l, out0, out1, out2, out3)                   \
++{                                                                              \
++    LASX_PCKOD_Q_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                    \
++    LASX_PCKOD_Q_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                    \
++}
++
++#define LASX_PCKOD_Q_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l, \
++                       in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l, \
++                       out0, out1, out2, out3, out4, out5, out6, out7)         \
++{                                                                              \
++    LASX_PCKOD_Q_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                   \
++                   in3_h, in3_l, out0, out1, out2, out3);                      \
++    LASX_PCKOD_Q_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                   \
++                   in7_h, in7_l, out4, out5, out6, out7);                      \
++}
++
++/* Description : Pack odd half word elements of vector pairsi
++ *               (128-bit symmetry version)
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd half word elements of in_l are copied to the low
++ *               half of out0 of . Odd half word elements of in_h are
++ *               copied to the high half of out0.
++ * Example     : LASX_PCKOD_D_128SV(in_h, in_l, out0)
++ *        in_h : 1, 2, 3, 4
++ *        in_l : 5, 6, 7, 8
++ *        out0 : 6, 2, 8, 4
++ */
++#define LASX_PCKOD_D_128SV(in_h, in_l, out0)                                  \
++{                                                                             \
++    out0 = __lasx_xvpickod_d(in_h, in_l);                                     \
++}
++
++#define LASX_PCKOD_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)          \
++{                                                                             \
++    LASX_PCKOD_D_128SV(in0_h, in0_l, out0)                                    \
++    LASX_PCKOD_D_128SV(in1_h, in1_l, out1)                                    \
++}
++
++#define LASX_PCKOD_D_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,        \
++                             in3_h, in3_l, out0, out1, out2, out3)            \
++{                                                                             \
++    LASX_PCKOD_D_2_128SV(in0_h, in0_l, in1_h, in1_l, out0, out1)              \
++    LASX_PCKOD_D_2_128SV(in2_h, in2_l, in3_h, in3_l, out2, out3)              \
++}
++
++
++/* Description : Transposes 8x8 block with half word elements in vectors.
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0, out1, ~
++ * Details     : The rows of the matrix become columns, and the columns become rows.
++ * Example     : LASX_TRANSPOSE8x8_H_128SV
++ *         in0 : 1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8
++ *         in1 : 8,2,3,4, 5,6,7,8, 8,2,3,4, 5,6,7,8
++ *         in2 : 8,2,3,4, 5,6,7,8, 8,2,3,4, 5,6,7,8
++ *         in3 : 1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8
++ *         in4 : 9,2,3,4, 5,6,7,8, 9,2,3,4, 5,6,7,8
++ *         in5 : 1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8
++ *         in6 : 1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8
++ *         in7 : 9,2,3,4, 5,6,7,8, 9,2,3,4, 5,6,7,8
++ *
++ *        out0 : 1,8,8,1, 9,1,1,9, 1,8,8,1, 9,1,1,9
++ *        out1 : 2,2,2,2, 2,2,2,2, 2,2,2,2, 2,2,2,2
++ *        out2 : 3,3,3,3, 3,3,3,3, 3,3,3,3, 3,3,3,3
++ *        out3 : 4,4,4,4, 4,4,4,4, 4,4,4,4, 4,4,4,4
++ *        out4 : 5,5,5,5, 5,5,5,5, 5,5,5,5, 5,5,5,5
++ *        out5 : 6,6,6,6, 6,6,6,6, 6,6,6,6, 6,6,6,6
++ *        out6 : 7,7,7,7, 7,7,7,7, 7,7,7,7, 7,7,7,7
++ *        out7 : 8,8,8,8, 8,8,8,8, 8,8,8,8, 8,8,8,8
++ */
++#define LASX_TRANSPOSE8x8_H_128SV(in0, in1, in2, in3, in4, in5, in6, in7,           \
++                                  out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                                   \
++    __m256i s0_m, s1_m;                                                             \
++    __m256i tmp0_m, tmp1_m, tmp2_m, tmp3_m;                                         \
++    __m256i tmp4_m, tmp5_m, tmp6_m, tmp7_m;                                         \
++                                                                                    \
++    LASX_ILVL_H_2_128SV(in6, in4, in7, in5, s0_m, s1_m);                            \
++    LASX_ILVLH_H_128SV(s1_m, s0_m, tmp1_m, tmp0_m);                                 \
++    LASX_ILVH_H_2_128SV(in6, in4, in7, in5, s0_m, s1_m);                            \
++    LASX_ILVLH_H_128SV(s1_m, s0_m, tmp3_m, tmp2_m);                                 \
++                                                                                    \
++    LASX_ILVL_H_2_128SV(in2, in0, in3, in1, s0_m, s1_m);                            \
++    LASX_ILVLH_H_128SV(s1_m, s0_m, tmp5_m, tmp4_m);                                 \
++    LASX_ILVH_H_2_128SV(in2, in0, in3, in1, s0_m, s1_m);                            \
++    LASX_ILVLH_H_128SV(s1_m, s0_m, tmp7_m, tmp6_m);                                 \
++                                                                                    \
++    LASX_PCKEV_D_4_128SV(tmp0_m, tmp4_m, tmp1_m, tmp5_m, tmp2_m, tmp6_m,            \
++                         tmp3_m, tmp7_m, out0, out2, out4, out6);                   \
++    LASX_PCKOD_D_4_128SV(tmp0_m, tmp4_m, tmp1_m, tmp5_m, tmp2_m, tmp6_m,            \
++                         tmp3_m, tmp7_m, out1, out3, out5, out7);                   \
++}
++
++/* Description : Transposes 8x8 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ * Details     :
++ */
++#define LASX_TRANSPOSE8x8_W(in0, in1, in2, in3, in4, in5, in6, in7,         \
++                            out0, out1, out2, out3, out4, out5, out6, out7) \
++{                                                                           \
++    __m256i s0_m, s1_m;                                                     \
++    __m256i tmp0_m, tmp1_m, tmp2_m, tmp3_m;                                 \
++    __m256i tmp4_m, tmp5_m, tmp6_m, tmp7_m;                                 \
++                                                                            \
++    LASX_ILVL_W_2_128SV(in2, in0, in3, in1, s0_m, s1_m);                    \
++    LASX_ILVLH_W_128SV(s1_m, s0_m, tmp1_m, tmp0_m);                         \
++    LASX_ILVH_W_2_128SV(in2, in0, in3, in1, s0_m, s1_m);                    \
++    LASX_ILVLH_W_128SV(s1_m, s0_m, tmp3_m, tmp2_m);                         \
++                                                                            \
++    LASX_ILVL_W_2_128SV(in6, in4, in7, in5, s0_m, s1_m);                    \
++    LASX_ILVLH_W_128SV(s1_m, s0_m, tmp5_m, tmp4_m);                         \
++    LASX_ILVH_W_2_128SV(in6, in4, in7, in5, s0_m, s1_m);                    \
++    LASX_ILVLH_W_128SV(s1_m, s0_m, tmp7_m, tmp6_m);                         \
++    LASX_PCKEV_Q_4(tmp4_m, tmp0_m, tmp5_m, tmp1_m, tmp6_m, tmp2_m,          \
++                   tmp7_m, tmp3_m, out0, out1, out2, out3);                 \
++    LASX_PCKOD_Q_4(tmp4_m, tmp0_m, tmp5_m, tmp1_m, tmp6_m, tmp2_m,          \
++                   tmp7_m, tmp3_m, out4, out5, out6, out7);                 \
++}
++
++/* Description : Transposes 2x2 block with quad word elements in vectors
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ * Details     :
++ */
++#define LASX_TRANSPOSE2x2_Q(in0, in1, out0, out1) \
++{                                                 \
++    __m256i tmp0;                                 \
++    tmp0 = __lasx_xvpermi_q(in1, in0, 0x02);      \
++    out1 = __lasx_xvpermi_q(in1, in0, 0x13);      \
++    out0 = tmp0;                                  \
++}
++
++/* Description : Transposes 4x4 block with double word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     :
++ */
++#define LASX_TRANSPOSE4x4_D(in0, in1, in2, in3, out0, out1, out2, out3) \
++{                                                                       \
++    __m256i tmp0, tmp1, tmp2, tmp3;                                     \
++    LASX_ILVLH_D_2_128SV(in1, in0, in3, in2, tmp0, tmp1, tmp2, tmp3);   \
++    out0 = __lasx_xvpermi_q(tmp2, tmp0, 0x20);                          \
++    out2 = __lasx_xvpermi_q(tmp2, tmp0, 0x31);                          \
++    out1 = __lasx_xvpermi_q(tmp3, tmp1, 0x20);                          \
++    out3 = __lasx_xvpermi_q(tmp3, tmp1, 0x31);                          \
++}
++
++/* Description : Transpose 4x4 block with half word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ *               Return Type - signed halfword
++ */
++#define LASX_TRANSPOSE4x4_H_128SV(in0, in1, in2, in3, out0, out1, out2, out3) \
++{                                                                             \
++    __m256i s0_m, s1_m;                                                       \
++                                                                              \
++    LASX_ILVL_H_2_128SV(in1, in0, in3, in2, s0_m, s1_m);                      \
++    LASX_ILVLH_W_128SV(s1_m, s0_m, out2, out0);                               \
++    out1 = __lasx_xvilvh_d(out0, out0);                                       \
++    out3 = __lasx_xvilvh_d(out2, out2);                                       \
++}
++
++/* Description : Transposes input 8x8 byte block
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *                         (input 8x8 byte block)
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ *                         (output 8x8 byte block)
++ * Details     :
++ */
++#define LASX_TRANSPOSE8x8_B(in0, in1, in2, in3, in4, in5, in6, in7,         \
++                            out0, out1, out2, out3, out4, out5, out6, out7) \
++{                                                                           \
++    __m256i tmp0_m, tmp1_m, tmp2_m, tmp3_m;                                 \
++    __m256i tmp4_m, tmp5_m, tmp6_m, tmp7_m;                                 \
++    LASX_ILVL_B_4_128SV(in2, in0, in3, in1, in6, in4, in7, in5,             \
++                       tmp0_m, tmp1_m, tmp2_m, tmp3_m);                     \
++    LASX_ILVLH_B_128SV(tmp1_m, tmp0_m, tmp5_m, tmp4_m);                     \
++    LASX_ILVLH_B_128SV(tmp3_m, tmp2_m, tmp7_m, tmp6_m);                     \
++    LASX_ILVLH_W_128SV(tmp6_m, tmp4_m, out2, out0);                         \
++    LASX_ILVLH_W_128SV(tmp7_m, tmp5_m, out6, out4);                         \
++    LASX_SLDI_B_2_0_128SV(out0, out2, out1, out3, 8);                       \
++    LASX_SLDI_B_2_0_128SV(out4, out6, out5, out7, 8);                       \
++}
++
++/* Description : Transposes input 16x8 byte block
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7,
++ *                         in8, in9, in10, in11, in12, in13, in14, in15
++ *                         (input 16x8 byte block)
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ *                         (output 8x16 byte block)
++ * Details     :
++ */
++#define LASX_TRANSPOSE16x8_B(in0, in1, in2, in3, in4, in5, in6, in7,              \
++                             in8, in9, in10, in11, in12, in13, in14, in15,        \
++                             out0, out1, out2, out3, out4, out5, out6, out7)      \
++{                                                                                 \
++    __m256i tmp0_m, tmp1_m, tmp2_m, tmp3_m;                                       \
++    __m256i tmp4_m, tmp5_m, tmp6_m, tmp7_m;                                       \
++    __m256i t0, t1, t2, t3, t4, t5, t6, t7;                                       \
++    LASX_ILVL_B_8_128SV(in2, in0, in3, in1, in6, in4, in7, in5,                   \
++                        in10, in8, in11, in9, in14, in12, in15, in13,             \
++                        tmp0_m, tmp1_m, tmp2_m, tmp3_m,                           \
++                        tmp4_m, tmp5_m, tmp6_m, tmp7_m);                          \
++    LASX_ILVLH_B_2_128SV(tmp1_m, tmp0_m, tmp3_m, tmp2_m, t1, t0, t3, t2);         \
++    LASX_ILVLH_B_2_128SV(tmp5_m, tmp4_m, tmp7_m, tmp6_m, t5, t4, t7, t6);         \
++    LASX_ILVLH_W_2_128SV(t2, t0, t3, t1, tmp2_m, tmp0_m, tmp6_m, tmp4_m);         \
++    LASX_ILVLH_W_2_128SV(t6, t4, t7, t5, tmp3_m, tmp1_m, tmp7_m, tmp5_m);         \
++    LASX_ILVLH_D_2_128SV(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out1, out0, out3, out2); \
++    LASX_ILVLH_D_2_128SV(tmp5_m, tmp4_m, tmp7_m, tmp6_m, out5, out4, out7, out6); \
++}
++
++/* Description : Transposes input 16x8 byte block
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7,
++ *                         in8, in9, in10, in11, in12, in13, in14, in15
++ *                         (input 16x8 byte block)
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ *                         (output 8x16 byte block)
++ * Details     : The rows of the matrix become columns, and the columns become rows.
++ * Example     : LASX_TRANSPOSE16x8_H
++ *         in0 : 1,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in1 : 2,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in2 : 3,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in3 : 4,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in4 : 5,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in5 : 6,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in6 : 7,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in7 : 8,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in8 : 9,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *         in9 : 1,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *        in10 : 0,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *        in11 : 2,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *        in12 : 3,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *        in13 : 7,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *        in14 : 5,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *        in15 : 6,2,3,4,5,6,7,8,0,0,0,0,0,0,0,0
++ *
++ *        out0 : 1,2,3,4,5,6,7,8,9,1,0,2,3,7,5,6
++ *        out1 : 2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2
++ *        out2 : 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3
++ *        out3 : 4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4
++ *        out4 : 5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
++ *        out5 : 6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6
++ *        out6 : 7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7
++ *        out7 : 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8
++ */
++#define LASX_TRANSPOSE16x8_H(in0, in1, in2, in3, in4, in5, in6, in7,              \
++                             in8, in9, in10, in11, in12, in13, in14, in15,        \
++                             out0, out1, out2, out3, out4, out5, out6, out7)      \
++{                                                                                 \
++    __m256i tmp0_m, tmp1_m, tmp2_m, tmp3_m;                                       \
++    __m256i tmp4_m, tmp5_m, tmp6_m, tmp7_m;                                       \
++    __m256i t0, t1, t2, t3, t4, t5, t6, t7;                                       \
++    LASX_ILVL_H_8_128SV(in2, in0, in3, in1, in6, in4, in7, in5,                   \
++                        in10, in8, in11, in9, in14, in12, in15, in13,             \
++                        tmp0_m, tmp1_m, tmp2_m, tmp3_m,                           \
++                        tmp4_m, tmp5_m, tmp6_m, tmp7_m);                          \
++    LASX_ILVLH_H_2_128SV(tmp1_m, tmp0_m, tmp3_m, tmp2_m, t1, t0, t3, t2);         \
++    LASX_ILVLH_H_2_128SV(tmp5_m, tmp4_m, tmp7_m, tmp6_m, t5, t4, t7, t6);         \
++    LASX_ILVLH_D_2_128SV(t2, t0, t3, t1, tmp2_m, tmp0_m, tmp6_m, tmp4_m);         \
++    LASX_ILVLH_D_2_128SV(t6, t4, t7, t5, tmp3_m, tmp1_m, tmp7_m, tmp5_m);         \
++    LASX_PCKEV_Q_2(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out0, out1);                   \
++    LASX_PCKEV_Q_2(tmp5_m, tmp4_m, tmp7_m, tmp6_m, out2, out3);                   \
++                                                                                  \
++    LASX_ILVH_H_8_128SV(in2, in0, in3, in1, in6, in4, in7, in5,                   \
++                        in10, in8, in11, in9, in14, in12, in15, in13,             \
++                        tmp0_m, tmp1_m, tmp2_m, tmp3_m,                           \
++                        tmp4_m, tmp5_m, tmp6_m, tmp7_m);                          \
++    LASX_ILVLH_H_2_128SV(tmp1_m, tmp0_m, tmp3_m, tmp2_m, t1, t0, t3, t2);         \
++    LASX_ILVLH_H_2_128SV(tmp5_m, tmp4_m, tmp7_m, tmp6_m, t5, t4, t7, t6);         \
++    LASX_ILVLH_D_2_128SV(t2, t0, t3, t1, tmp2_m, tmp0_m, tmp6_m, tmp4_m);         \
++    LASX_ILVLH_D_2_128SV(t6, t4, t7, t5, tmp3_m, tmp1_m, tmp7_m, tmp5_m);         \
++    LASX_PCKEV_Q_2(tmp1_m, tmp0_m, tmp3_m, tmp2_m, out4, out5);                   \
++    LASX_PCKEV_Q_2(tmp5_m, tmp4_m, tmp7_m, tmp6_m, out6, out7);                   \
++}
++
++/* Description : Clips all signed word elements of input vector
++ *               between 0 & 255
++ * Arguments   : Inputs  - in       (input vector)
++ *               Outputs - out_m    (output vector with clipped elements)
++ *               Return Type - signed word
++ */
++#define LASX_CLIP_W_0_255(in, out_m)        \
++{                                           \
++    out_m = __lasx_xvmaxi_w(in, 0);         \
++    out_m = __lasx_xvsat_wu(out_m, 7);      \
++}
++
++#define LASX_CLIP_W_0_255_2(in0, in1, out0, out1)  \
++{                                                  \
++    LASX_CLIP_W_0_255(in0, out0);                  \
++    LASX_CLIP_W_0_255(in1, out1);                  \
++}
++
++#define LASX_CLIP_W_0_255_4(in0, in1, in2, in3, out0, out1, out2, out3)  \
++{                                                                        \
++    LASX_CLIP_W_0_255_2(in0, in1, out0, out1);                           \
++    LASX_CLIP_W_0_255_2(in2, in3, out2, out3);                           \
++}
++
++/* Description : Clips all signed halfword elements of input vector
++ *               between 0 & 255
++ * Arguments   : Inputs  - in       (input vector)
++ *               Outputs - out_m    (output vector with clipped elements)
++ *               Return Type - signed halfword
++ */
++#define LASX_CLIP_H_0_255(in, out_m)        \
++{                                           \
++    out_m = __lasx_xvmaxi_h(in, 0);         \
++    out_m = __lasx_xvsat_hu(out_m, 7);      \
++}
++
++#define LASX_CLIP_H_0_255_2(in0, in1, out0, out1)  \
++{                                                  \
++    LASX_CLIP_H_0_255(in0, out0);                  \
++    LASX_CLIP_H_0_255(in1, out1);                  \
++}
++
++#define LASX_CLIP_H_0_255_4(in0, in1, in2, in3, out0, out1, out2, out3)  \
++{                                                                        \
++    LASX_CLIP_H_0_255_2(in0, in1, out0, out1);                           \
++    LASX_CLIP_H_0_255_2(in2, in3, out2, out3);                           \
++}
++
++/* Description : Clips all halfword elements of input vector between min & max
++ *               out = ((in) < (min)) ? (min) : (((in) > (max)) ? (max) : (in))
++ * Arguments   : Inputs  - in    (input vector)
++ *                       - min   (min threshold)
++ *                       - max   (max threshold)
++ *               Outputs - in    (output vector with clipped elements)
++ *               Return Type - signed halfword
++ */
++#define LASX_CLIP_H(in, min, max)    \
++{                                    \
++    in = __lasx_xvmax_h(min, in);    \
++    in = __lasx_xvmin_h(max, in);    \
++}
++
++/* Description : Dot product and addition of 3 signed byte input vectors
++ * Arguments   : Inputs  - in0, in1, in2, coeff0, coeff1, coeff2
++ *               Outputs - out0_m
++ *               Return Type - signed halfword
++ * Details     : Dot product of 'in0' with 'coeff0'
++ *               Dot product of 'in1' with 'coeff1'
++ *               Dot product of 'in2' with 'coeff2'
++ *               Addition of all the 3 vector results
++ *               out0_m = (in0 * coeff0) + (in1 * coeff1) + (in2 * coeff2)
++ */
++#define LASX_DP2ADD_H_B_3(in0, in1, in2, out0_m, coeff0, coeff1, coeff2) \
++{                                                                        \
++    LASX_DP2_H_B(in0, coeff0, out0_m);                                   \
++    LASX_DP2ADD_H_B(out0_m, in1, coeff1, out0_m);                        \
++    LASX_DP2ADD_H_B(out0_m, in2, coeff2, out0_m);                        \
++}
++
++/* Description : Each byte element is logically xor'ed with immediate 128
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - in0, in1 (in-place)
++ * Details     : Each unsigned byte element from input vector 'in0' is
++ *               logically xor'ed with 128 and result is in-place stored in
++ *               'in0' vector
++ *               Each unsigned byte element from input vector 'in1' is
++ *               logically xor'ed with 128 and result is in-place stored in
++ *               'in1' vector
++ *               Similar for other pairs
++ * Example     : LASX_XORI_B_128(in0)
++ *               in0: 9,10,11,12, 13,14,15,16, 121,122,123,124, 125,126,127,128, 17,18,19,20, 21,22,23,24,
++ *               248,249,250,251, 252,253,254,255,
++ *               in0: 137,138,139,140, 141,142,143,144, 249,250,251,252, 253,254,255,0, 145,146,147,148,
++ *               149,150,151,152, 120,121,122,123, 124,125,126,127
++ */
++#define LASX_XORI_B_128(in0)                                 \
++{                                                            \
++    in0 = __lasx_xvxori_b(in0, 128);                         \
++}
++#define LASX_XORI_B_2_128(in0, in1)                          \
++{                                                            \
++    LASX_XORI_B_128(in0);                                    \
++    LASX_XORI_B_128(in1);                                    \
++}
++#define LASX_XORI_B_4_128(in0, in1, in2, in3)                \
++{                                                            \
++    LASX_XORI_B_2_128(in0, in1);                             \
++    LASX_XORI_B_2_128(in2, in3);                             \
++}
++#define LASX_XORI_B_8_128(in0, in1, in2, in3, in4, in5, in6, in7)  \
++{                                                                  \
++    LASX_XORI_B_4_128(in0, in1, in2, in3);                         \
++    LASX_XORI_B_4_128(in4, in5, in6, in7);                         \
++}
++
++/* Description : Indexed halfword element values are replicated to all
++ *               elements in output vector. If 'indx0 < 8' use SPLATI_R_*,
++ *               if 'indx0 >= 8' use SPLATI_L_*
++ * Arguments   : Inputs  - in, idx0, idx1
++ *               Outputs - out0, out1
++ * Details     : 'idx0' element value from 'in' vector is replicated to all
++ *                elements in 'out0' vector
++ *                Valid index range for halfword operation is 0-7
++ */
++#define LASX_SPLATI_L_H(in, idx0, out0)                        \
++{                                                              \
++    in = __lasx_xvpermi_q(in, in, 0x02);                       \
++    out0 = __lasx_xvrepl128vei_h(in, idx0);                    \
++}
++#define LASX_SPLATI_H_H(in, idx0, out0)                        \
++{                                                              \
++    in = __lasx_xvpermi_q(in, in, 0X13);                       \
++    out0 = __lasx_xvrepl128vei_h(in, idx0 - 8);                \
++}
++#define LASX_SPLATI_L_H_2(in, idx0, idx1, out0, out1)          \
++{                                                              \
++    LASX_SPLATI_L_H(in, idx0, out0);                           \
++    out1 = __lasx_xvrepl128vei_h(in, idx1);                    \
++}
++#define LASX_SPLATI_H_H_2(in, idx0, idx1, out0, out1)          \
++{                                                              \
++    LASX_SPLATI_H_H(in, idx0, out0);                           \
++    out1 = __lasx_xvrepl128vei_h(in, idx1 - 8);                \
++}
++#define LASX_SPLATI_L_H_4(in, idx0, idx1, idx2, idx3,          \
++                          out0, out1, out2, out3)              \
++{                                                              \
++    LASX_SPLATI_L_H_2(in, idx0, idx1, out0, out1);             \
++    out2 = __lasx_xvrepl128vei_h(in, idx2);                    \
++    out3 = __lasx_xvrepl128vei_h(in, idx3);                    \
++}
++#define SPLATI_H_H_4(in, idx0, idx1, idx2, idx3,               \
++                     out0, out1, out2, out3)                   \
++{                                                              \
++    LASX_SPLATI_H_H_2(in, idx0, idx1, out0, out1);             \
++    out2 = __lasx_xvrepl128vei_h(in, idx2 - 8);                \
++    out3 = __lasx_xvrepl128vei_h(in, idx3 - 8);                \
++}
++
++/* Description : Pack even elements of input vectors & xor with 128
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out_m
++ * Details     : Signed byte even elements from 'in0' and 'in1' are packed
++ *               together in one vector and the resulted vector is xor'ed with
++ *               128 to shift the range from signed to unsigned byte
++ */
++#define LASX_PICKEV_XORI128_B(in0, in1, out_m)  \
++{                                               \
++    out_m = __lasx_xvpickev_b(in1, in0);        \
++    out_m = __lasx_xvxori_b(out_m, 128);        \
++}
++
++/* Description : Shift right logical all byte elements of vector.
++ * Arguments   : Inputs  - in, shift
++ *               Outputs - in (in place)
++ * Details     : Each element of vector in is shifted right logical by
++ *               number of bits respective element holds in vector shift and
++ *               result is in place written to in.
++ *               Here, shift is a vector passed in.
++ * Example     : See LASX_SRL_W(in, shift)
++     */
++#define LASX_SRL_B(in, shift)                                         \
++{                                                                     \
++    in = __lasx_xvsrl_b(in, shift);                                   \
++}
++
++#define LASX_SRL_B_2(in0, in1, shift)                                 \
++{                                                                     \
++    LASX_SRL_B(in0, shift);                                           \
++    LASX_SRL_B(in1, shift);                                           \
++}
++
++#define LASX_SRL_B_4(in0, in1, in2, in3, shift)                       \
++{                                                                     \
++    LASX_SRL_B_2(in0, in1, shift);                                    \
++    LASX_SRL_B_2(in2, in3, shift);                                    \
++}
++
++/* Description : Shift right logical all halfword elements of vector.
++ * Arguments   : Inputs  - in, shift
++ *               Outputs - in (in place)
++ * Details     : Each element of vector in is shifted right logical by
++ *               number of bits respective element holds in vector shift and
++ *               result is in place written to in.
++ *               Here, shift is a vector passed in.
++ * Example     : See LASX_SRL_W(in, shift)
++ */
++#define LASX_SRL_H(in, shift)                                         \
++{                                                                     \
++    in = __lasx_xvsrl_h(in, shift);                                   \
++}
++
++#define LASX_SRL_H_2(in0, in1, shift)                                 \
++{                                                                     \
++    LASX_SRL_H(in0, shift);                                           \
++    LASX_SRL_H(in1, shift);                                           \
++}
++
++#define LASX_SRL_H_4(in0, in1, in2, in3, shift)                       \
++{                                                                     \
++    LASX_SRL_H_2(in0, in1, shift);                                    \
++    LASX_SRL_H_2(in2, in3, shift);                                    \
++}
++
++/* Description : Shift right logical all word elements of vector.
++ * Arguments   : Inputs  - in, shift
++ *               Outputs - in (in place)
++ * Details     : Each element of vector in is shifted right logical by
++ *               number of bits respective element holds in vector shift and
++ *               result is in place written to in.
++ *               Here, shift is a vector passed in.
++ * Example     : LASX_SRL_W(in, shift)
++ *          in : 1, 3, 2, -4,      0, -2, 25, 0
++ *       shift : 1, 1, 1, 1,       2, 2, 2, 2
++ *  in(output) : 0, 1, 1, 32766,   0, 16383, 6, 0
++ */
++#define LASX_SRL_W(in, shift)                                         \
++{                                                                     \
++    in = __lasx_xvsrl_w(in, shift);                                   \
++}
++
++#define LASX_SRL_W_2(in0, in1, shift)                                 \
++{                                                                     \
++    LASX_SRL_W(in0, shift);                                           \
++    LASX_SRL_W(in1, shift);                                           \
++}
++
++#define LASX_SRL_W_4(in0, in1, in2, in3, shift)                       \
++{                                                                     \
++    LASX_SRL_W_2(in0, in1, shift);                                    \
++    LASX_SRL_W_2(in2, in3, shift);                                    \
++}
++
++/* Description : Shift right logical all double word elements of vector.
++ * Arguments   : Inputs  - in, shift
++ *               Outputs - in (in place)
++ * Details     : Each element of vector in is shifted right logical by
++ *               number of bits respective element holds in vector shift and
++ *               result is in place written to in.
++ *               Here, shift is a vector passed in.
++ * Example     : See LASX_SRL_W(in, shift)
++ */
++#define LASX_SRL_D(in, shift)                                         \
++{                                                                     \
++    in = __lasx_xvsrl_d(in, shift);                                   \
++}
++
++#define LASX_SRL_D_2(in0, in1, shift)                                 \
++{                                                                     \
++    LASX_SRL_D(in0, shift);                                           \
++    LASX_SRL_D(in1, shift);                                           \
++}
++
++#define LASX_SRL_D_4(in0, in1, in2, in3, shift)                       \
++{                                                                     \
++    LASX_SRL_D_2(in0, in1, shift);                                    \
++    LASX_SRL_D_2(in2, in3, shift);                                    \
++}
++
++
++/* Description : Shift right arithmetic rounded (immediate)
++ * Arguments   : Inputs  - in0, in1, shift
++ *               Outputs - in0, in1, (in place)
++ * Details     : Each element of vector 'in0' is shifted right arithmetic by
++ *               value in 'shift'.
++ *               The last discarded bit is added to shifted value for rounding
++ *               and the result is in place written to 'in0'
++ *               Similar for other pairs
++ * Example     : LASX_SRARI_H(in0, out0, shift)
++ *               in0:   1,2,3,4, -5,-6,-7,-8, 19,10,11,12, 13,14,15,16
++ *               shift: 2
++ *               out0:  0,1,1,1, -1,-1,-2,-2, 5,3,3,3, 3,4,4,4
++ */
++#define LASX_SRARI_H(in0, out0, shift)                              \
++{                                                                   \
++    out0 = __lasx_xvsrari_h(in0, shift);                            \
++}
++#define LASX_SRARI_H_2(in0, in1, out0, out1, shift)                 \
++{                                                                   \
++    LASX_SRARI_H(in0, out0, shift);                                 \
++    LASX_SRARI_H(in1, out1, shift);                                 \
++}
++#define LASX_SRARI_H_4(in0, in1, in2, in3, out0, out1, out2, out3, shift) \
++{                                                                         \
++    LASX_SRARI_H_2(in0, in1, out0, out1, shift);                          \
++    LASX_SRARI_H_2(in2, in3, out2, out3, shift);                          \
++}
++
++/* Description : Shift right arithmetic (immediate)
++ * Arguments   : Inputs  - in0, in1, shift
++ *               Outputs - in0, in1, (in place)
++ * Details     : Each element of vector 'in0' is shifted right arithmetic by
++ *               value in 'shift'.
++ *               Similar for other pairs
++ * Example     : see LASX_SRARI_H(in0, out0, shift)
++ */
++#define LASX_SRAI_W(in0, out0, shift)                                    \
++{                                                                        \
++    out0 = __lasx_xvsrai_w(in0, shift);                                  \
++}
++#define LASX_SRAI_W_2(in0, in1, out0, out1, shift)                       \
++{                                                                        \
++    LASX_SRAI_W(in0, out0, shift);                                       \
++    LASX_SRAI_W(in1, out1, shift);                                       \
++}
++#define LASX_SRAI_W_4(in0, in1, in2, in3, out0, out1, out2, out3, shift) \
++{                                                                        \
++    LASX_SRAI_W_2(in0, in1, out0, out1, shift);                          \
++    LASX_SRAI_W_2(in2, in3, out2, out3, shift);                          \
++}
++#define LASX_SRAI_W_8(in0, in1, in2, in3, in4, in5, in6, in7,                 \
++                      out0, out1, out2, out3, out4, out5, out6, out7, shift)  \
++{                                                                             \
++    LASX_SRAI_W_4(in0, in1, in2, in3, out0, out1, out2, out3, shift);         \
++    LASX_SRAI_W_4(in4, in5, in6, in7, out4, out5, out6, out7, shift);         \
++}
++
++/* Description : Saturate the halfword element values to the max
++ *               unsigned value of (sat_val+1 bits)
++ *               The element data width remains unchanged
++ * Arguments   : Inputs  - in0, in1, in2, in3, sat_val
++ *               Outputs - in0, in1, in2, in3 (in place)
++ *               Return Type - unsigned halfword
++ * Details     : Each unsigned halfword element from 'in0' is saturated to the
++ *               value generated with (sat_val+1) bit range
++ *               Results are in placed to original vectors
++ * Example     : LASX_SAT_H(in0, out0, sat_val)
++ *               in0:    1,2,3,4, 5,6,7,8, 19,10,11,12, 13,14,15,16
++ *               sat_val:3
++ *               out0:   1,2,3,4, 5,6,7,7, 7,7,7,7, 7,7,7,7
++ */
++#define LASX_SAT_H(in0, out0, sat_val)                                     \
++{                                                                          \
++    out0 = __lasx_xvsat_h(in0, sat_val);                                   \
++} //some error in xvsat_h built-in function
++#define LASX_SAT_H_2(in0, in1, out0, out1, sat_val)                        \
++{                                                                          \
++    LASX_SAT_H(in0, out0, sat_val);                                        \
++    LASX_SAT_H(in1, out1, sat_val);                                        \
++}
++#define LASX_SAT_H_4(in0, in1, in2, in3, out0, out1, out2, out3, sat_val)  \
++{                                                                          \
++    LASX_SAT_H_2(in0, in1, out0, out1, sat_val);                           \
++    LASX_SAT_H_2(in2, in3, out2, out3, sat_val);                           \
++}
++
++/* Description : Addition of 2 pairs of vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1
++ * Details     : Each halfwords element from 2 pairs vectors is added
++ *               and 2 results are produced
++ * Example     : LASX_ADD_H(in0, in1, out)
++ *               in0:  1,2,3,4, 5,6,7,8, 1,2,3,4, 5,6,7,8
++ *               in1:  8,7,6,5, 4,3,2,1, 8,7,6,5, 4,3,2,1
++ *               out:  9,9,9,9, 9,9,9,9, 9,9,9,9, 9,9,9,9
++ */
++#define LASX_ADD_H(in0, in1, out)             \
++{                                             \
++    out = __lasx_xvadd_h(in0, in1);           \
++}
++#define LASX_ADD_H_2(in0, in1, in2, in3, out0, out1) \
++{                                                    \
++    LASX_ADD_H(in0, in1, out0);                      \
++    LASX_ADD_H(in2, in3, out1);                      \
++}
++#define LASX_ADD_H_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3)      \
++{                                                                                         \
++    LASX_ADD_H_2(in0, in1, in2, in3, out0, out1);                                         \
++    LASX_ADD_H_2(in4, in5, in6, in7, out2, out3);                                         \
++}
++#define LASX_ADD_H_8(in0, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, \
++                     in13, in14, in15, out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                                        \
++    LASX_ADD_H_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3);        \
++    LASX_ADD_H_4(in8, in9, in10, in11, in12, in13, in14, in15, out4, out5, out6, out7);  \
++}
++
++/* Description : Horizontal subtraction of unsigned byte vector elements
++ * Arguments   : Inputs  - in0, in1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Each unsigned odd byte element from 'in0' is subtracted from
++ *               even unsigned byte element from 'in0' (pairwise) and the
++ *               halfword result is written to 'out0'
++ */
++#define LASX_HSUB_UB_2(in0, in1, out0, out1)   \
++{                                              \
++    out0 = __lasx_xvhsubw_hu_bu(in0, in0);     \
++    out1 = __lasx_xvhsubw_hu_bu(in1, in1);     \
++}
++
++#define LASX_HSUB_UB_4(in0, in1, in2, in3, out0, out1, out2, out3)    \
++{                                                                     \
++    LASX_HSUB_UB_2(in0, in1, out0, out1);                                   \
++    LASX_HSUB_UB_2(in2, in3, out2, out3);                                   \
++}
++
++/* Description : Shuffle byte vector elements as per mask vector
++ * Arguments   : Inputs  - in0, in1, in2, in3, mask0, mask1
++ *               Outputs - out0, out1
++ *               Return Type - as per RTYPE
++ * Details     : Selective byte elements from in0 & in1 are copied to out0 as
++ *               per control vector mask0
++ *               Selective byte elements from in2 & in3 are copied to out1 as
++ *               per control vector mask1
++ * Example     : LASX_SHUF_B_128SV(in0, in1,  mask0, out0)
++ *               in_h :  9,10,11,12, 13,14,15,16, 0,0,0,0, 0,0,0,0,
++ *                      17,18,19,20, 21,22,23,24, 0,0,0,0, 0,0,0,0
++ *               in_l :  1, 2, 3, 4,  5, 6, 7, 8, 0,0,0,0, 0,0,0,0,
++ *                      25,26,27,28, 29,30,31,32, 0,0,0,0, 0,0,0,0
++ *               mask0:  0, 1, 2, 3,  4, 5, 6, 7, 16,17,18,19, 20,21,22,23,
++ *                      16,17,18,19, 20,21,22,23,  0, 1, 2, 3,  4, 5, 6, 7
++ *               out0 :  1, 2, 3, 4,  5, 6, 7, 8,  9,10,11,12, 13,14,15,16,
++ *                      17,18,19,20, 21,22,23,24, 25,26,27,28, 29,30,31,32
++ */
++
++#define LASX_SHUF_B_128SV(in_h, in_l,  mask0, out0)                            \
++{                                                                              \
++    out0 = __lasx_xvshuf_b(in_h, in_l, mask0);                                 \
++}
++#define LASX_SHUF_B_2_128SV(in0_h, in0_l, in1_h, in1_l, mask0, mask1,          \
++                            out0, out1)                                        \
++{                                                                              \
++    LASX_SHUF_B_128SV(in0_h, in0_l,  mask0, out0);                             \
++    LASX_SHUF_B_128SV(in1_h, in1_l,  mask1, out1);                             \
++}
++#define LASX_SHUF_B_4_128SV(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,          \
++                            in3_h, in3_l, mask0, mask1, mask2, mask3,          \
++                            out0, out1, out2, out3)                            \
++{                                                                              \
++    LASX_SHUF_B_2_128SV(in0_h, in0_l, in1_h, in1_l, mask0, mask1, out0, out1); \
++    LASX_SHUF_B_2_128SV(in2_h, in2_l, in3_h, in3_l, mask2, mask3, out2, out3); \
++}
++
++/* Description : Addition of signed halfword elements and signed saturation
++ * Arguments   : Inputs  - in0, in1, in2, in3 ~
++ *               Outputs - out0, out1 ~
++ * Details     : Signed halfword elements from 'in0' are added to signed
++ *               halfword elements of 'in1'. The result is then signed saturated
++ *               between -32768 to +32767 (as per halfword data type)
++ *               Similar for other pairs
++ * Example     : LASX_SADD_H(in0, in1, out0)
++ *               in0:   1,2,32766,4, 5,6,7,8, 1,2,3,4, 5,6,7,8,
++ *               in1:   8,7,30586,5, 4,3,2,1, 8,7,6,5, 4,3,2,1,
++ *               out0:  9,9,32767,9, 9,9,9,9, 9,9,9,9, 9,9,9,9,
++ */
++#define LASX_SADD_H(in0, in1, out0)                            \
++{                                                              \
++    out0 = __lasx_xvsadd_h(in0, in1);                          \
++}
++#define LASX_SADD_H_2(in0, in1, in2, in3, out0, out1)          \
++{                                                              \
++    LASX_SADD_H(in0, in1, out0);                               \
++    LASX_SADD_H(in2, in3, out1);                               \
++}
++#define LASX_SADD_H_4(in0, in1, in2, in3, in4, in5, in6, in7,  \
++                      out0, out1, out2, out3)                  \
++{                                                              \
++    LASX_SADD_H_2(in0, in1, in2, in3, out0, out1);             \
++    LASX_SADD_H_2(in4, in5, in6, in7, out2, out3);             \
++}
++
++/* Description : Average with rounding (in0 + in1 + 1) / 2.
++ * Arguments   : Inputs  - in0, in1, in2, in3,
++ *               Outputs - out0, out1
++ * Details     : Each unsigned byte element from 'in0' vector is added with
++ *               each unsigned byte element from 'in1' vector.
++ *               Average with rounding is calculated and written to 'out0'
++ */
++#define LASX_AVER_BU( in0, in1, out0 )   \
++{                                        \
++    out0 = __lasx_xvavgr_bu( in0, in1 ); \
++}
++
++#define LASX_AVER_BU_2( in0, in1, in2, in3, out0, out1 )  \
++{                                                         \
++    LASX_AVER_BU( in0, in1, out0 );                       \
++    LASX_AVER_BU( in2, in3, out1 );                       \
++}
++
++#define LASX_AVER_BU_4( in0, in1, in2, in3, in4, in5, in6, in7,  \
++                        out0, out1, out2, out3 )                 \
++{                                                                \
++    LASX_AVER_BU_2( in0, in1, in2, in3, out0, out1 );            \
++    LASX_AVER_BU_2( in4, in5, in6, in7, out2, out3 );            \
++}
++
++/* Description : Butterfly of 4 input vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     : Butterfly operationuu
++ */
++#define LASX_BUTTERFLY_4(RTYPE, in0, in1, in2, in3, out0, out1, out2, out3)  \
++{                                                                            \
++    out0 = (__m256i)( (RTYPE)in0 + (RTYPE)in3 );                             \
++    out1 = (__m256i)( (RTYPE)in1 + (RTYPE)in2 );                             \
++                                                                             \
++    out2 = (__m256i)( (RTYPE)in1 - (RTYPE)in2 );                             \
++    out3 = (__m256i)( (RTYPE)in0 - (RTYPE)in3 );                             \
++}
++
++/* Description : Butterfly of 8 input vectors
++ * Arguments   : Inputs  - in0 in1 in2 ~
++ *               Outputs - out0 out1 out2 ~
++ * Details     : Butterfly operation
++ */
++#define LASX_BUTTERFLY_8(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7,    \
++                         out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                          \
++    out0 = (__m256i)( (RTYPE)in0 + (RTYPE)in7 );                           \
++    out1 = (__m256i)( (RTYPE)in1 + (RTYPE)in6 );                           \
++    out2 = (__m256i)( (RTYPE)in2 + (RTYPE)in5 );                           \
++    out3 = (__m256i)( (RTYPE)in3 + (RTYPE)in4 );                           \
++                                                                           \
++    out4 = (__m256i)( (RTYPE)in3 - (RTYPE)in4 );                           \
++    out5 = (__m256i)( (RTYPE)in2 - (RTYPE)in5 );                           \
++    out6 = (__m256i)( (RTYPE)in1 - (RTYPE)in6 );                           \
++    out7 = (__m256i)( (RTYPE)in0 - (RTYPE)in7 );                           \
++}
++
++#endif /* GENERIC_MACROS_LASX_H */
+diff --git a/simd/loongarch64/generic_macros_lsx.h b/simd/loongarch64/generic_macros_lsx.h
+new file mode 100644
+index 00000000..e8b7b884
+--- /dev/null
++++ b/simd/loongarch64/generic_macros_lsx.h
+@@ -0,0 +1,1039 @@
++/*
++ * Copyright (c) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding   <songding@loongson.cn>
++ *
++ * This file base on generic_macros_lasx.h.
++ */
++
++#ifndef GENERIC_MACROS_LSX_H
++#define GENERIC_MACROS_LSX_H
++
++#include <stdint.h>
++#include <lsxintrin.h>
++
++/* Description : Load 128-bit vector data with stride
++ * Arguments   : Inputs  - psrc    (source pointer to load from)
++ *                       - stride
++ *               Outputs - out0, out1, ~
++ * Details     : Load 128-bit data in 'out0' from (psrc)
++ *               Load 128-bit data in 'out1' from (psrc + stride)
++ */
++#define LSX_LD(psrc) *((__m128i *)(psrc))
++
++#define LSX_LD_2(psrc, stride, out0, out1)                       \
++{                                                                \
++    out0 = LSX_LD(psrc);                                         \
++    out1 = LSX_LD((psrc) + stride);                              \
++}
++
++#define LSX_LD_4(psrc, stride, out0, out1, out2, out3)           \
++{                                                                \
++    LSX_LD_2((psrc), stride, out0, out1);                        \
++    LSX_LD_2((psrc) + 2 * stride , stride, out2, out3);          \
++}
++
++#define LSX_LD_8(psrc, stride, out0, out1, out2, out3,               \
++                 out4, out5, out6, out7)                             \
++{                                                                    \
++    LSX_LD_4((psrc), stride, out0, out1, out2, out3);                \
++    LSX_LD_4((psrc) + 4 * stride, stride, out4, out5, out6, out7);   \
++}
++
++/* Description : Store 128-bit vector data with stride
++ * Arguments   : Inputs  - in0, in1, ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store 128-bit data from 'in0' to (pdst)
++ *               Store 128-bit data from 'in1' to (pdst + stride)
++ */
++#define LSX_ST(in, pdst) *((__m128i *)(pdst)) = (in)
++
++#define LSX_ST_2(in0, in1, pdst, stride)                         \
++{                                                                \
++    LSX_ST(in0, (pdst));                                         \
++    LSX_ST(in1, (pdst) + stride);                                \
++}
++
++#define LSX_ST_4(in0, in1, in2, in3, pdst, stride)               \
++{                                                                \
++    LSX_ST_2(in0, in1, (pdst), stride);                          \
++    LSX_ST_2(in2, in3, (pdst) + 2 * stride, stride);             \
++}
++
++#define LSX_ST_8(in0, in1, in2, in3, in4, in5, in6, in7, pdst, stride)      \
++{                                                                           \
++    LSX_ST_4(in0, in1, in2, in3, (pdst), stride);                           \
++    LSX_ST_4(in4, in5, in6, in7, (pdst) + 4 * stride, stride);              \
++}
++
++/* Description : Store half word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1,  ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store half word 'idx0' from 'in' to (pdst)
++ *               Store half word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : LSX_ST_H(in, idx, pdst)
++ *          in : 1, 2, 3, 4, 5, 6, 7, 8
++ *        idx0 : 0x01
++ *        out0 : 2
++ */
++#define LSX_ST_H(in, idx, pdst)                                  \
++{                                                                \
++    __lasx_xvstelm_h(in, pdst, 0, idx);                          \
++}
++
++#define LSX_ST_H_2(in, idx0, idx1, pdst, stride)                 \
++{                                                                \
++    LSX_ST_H(in, idx0, (pdst));                                  \
++    LSX_ST_H(in, idx1, (pdst) + stride);                         \
++}
++
++#define LSX_ST_H_4(in, idx0, idx1, idx2, idx3, pdst, stride)     \
++{                                                                \
++    LSX_ST_H_2(in, idx0, idx1, (pdst), stride);                  \
++    LSX_ST_H_2(in, idx2, idx3, (pdst) + 2 * stride, stride);     \
++}
++
++
++/* Description : Store word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1,  ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store word 'idx0' from 'in' to (pdst)
++ *               Store word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : LSX_ST_W(in, idx, pdst)
++ *          in : 1, 2, 3, 4
++ *        idx0 : 0x01
++ *        out0 : 2
++ */
++#define LSX_ST_W(in, idx, pdst)                                  \
++{                                                                \
++    __lasx_xvstelm_w(in, pdst, 0, idx);                          \
++}
++
++#define LSX_ST_W_2(in, idx0, idx1, pdst, stride)                 \
++{                                                                \
++    LSX_ST_W(in, idx0, (pdst));                                  \
++    LSX_ST_W(in, idx1, (pdst) + stride);                         \
++}
++
++#define LSX_ST_W_4(in, idx0, idx1, idx2, idx3, pdst, stride)     \
++{                                                                \
++    LSX_ST_W_2(in, idx0, idx1, (pdst), stride);                  \
++    LSX_ST_W_2(in, idx2, idx3, (pdst) + 2 * stride, stride);     \
++}
++
++#define LSX_ST_W_8(in, idx0, idx1, idx2, idx3, idx4, idx5,                  \
++                   idx6, idx7, pdst, stride)                                \
++{                                                                           \
++    LSX_ST_W_4(in, idx0, idx1, idx2, idx3, (pdst), stride);                 \
++    LSX_ST_W_4(in, idx4, idx5, idx6, idx7, (pdst) + 4 * stride, stride);    \
++}
++
++/* Description : Store double word elements of vector with stride
++ * Arguments   : Inputs  - in   source vector
++ *                       - idx, idx0, idx1, ~
++ *                       - pdst    (destination pointer to store to)
++ *                       - stride
++ * Details     : Store double word 'idx0' from 'in' to (pdst)
++ *               Store double word 'idx1' from 'in' to (pdst + stride)
++ *               Similar for other elements
++ * Example     : See LSX_ST_W(in, idx, pdst)
++ */
++#define LSX_ST_D(in, idx, pdst)                                  \
++{                                                                \
++    __lasx_xvstelm_d(in, pdst, 0, idx);                          \
++}
++
++#define LSX_ST_D_2(in, idx0, idx1, pdst, stride)                 \
++{                                                                \
++    LSX_ST_D(in, idx0, (pdst));                                  \
++    LSX_ST_D(in, idx1, (pdst) + stride);                         \
++}
++
++#define LSX_ST_D_4(in, idx0, idx1, idx2, idx3, pdst, stride)     \
++{                                                                \
++    LSX_ST_D_2(in, idx0, idx1, (pdst), stride);                  \
++    LSX_ST_D_2(in, idx2, idx3, (pdst) + 2 * stride, stride);     \
++}
++
++/* Description : Dot product of half word vector elements
++ * Arguments   : Inputs  - in0, in1, ~
++ *               Outputs - out0,  out1,  ~
++ *               Return Type - signed word
++ * Details     : Signed half word elements from in* are iniplied with
++ *               signed half word elements from in* producing a result
++ *               twice the size of input i.e. signed word.
++ *               Then this iniplication results of adjacent odd-even elements
++ *               are added together and stored to the out vector.
++ * Example     : LSX_DP2_W_H(in0, in1, out0)
++ *               in0:   1,2,3,4, 5,6,7,8
++ *               in0:   8,7,6,5, 4,3,2,1
++ *               out0:  22,38,38,22
++ */
++#define LSX_DP2_W_H(in0, in1, out0)                              \
++{                                                                \
++    __m128i _tmp0_m ;                                            \
++    _tmp0_m = __lsx_vmulwev_w_h( in0, in1 );                     \
++    out0 = __lsx_vmaddwod_w_h( _tmp0_m, in0, in1 );              \
++}
++
++#define LSX_DP2_W_H_2(in0, in1, in2, in3, out0, out1)            \
++{                                                                \
++    LSX_DP2_W_H(in0, in1, out0);                                 \
++    LSX_DP2_W_H(in2, in3, out1);                                 \
++}
++
++#define LSX_DP2_W_H_4(in0, in1, in2, in3, in4, in5,              \
++                      in6, in7, out0, out1, out2, out3)          \
++{                                                                \
++    LSX_DP2_W_H_2(in0, in1, in2, in3, out0, out1);               \
++    LSX_DP2_W_H_2(in4, in5, in6, in7, out2, out3);               \
++}
++
++#define LSX_DP2_W_H_8(in0, in1, in2, in3, in4, in5, in6, in7,               \
++                      in8, in9, in10, in11, in12, in13, in14, in15,         \
++                      out0, out1, out2, out3, out4, out5, out6, out7)       \
++{                                                                           \
++    LSX_DP2_W_H_4(in0, in1, in2, in3, in4, in5, in6, in7,                   \
++                  out0, out1, out2, out3);                                  \
++    LSX_DP2_W_H_4(in8, in9, in10, in11, in12, in13, in14, in15,             \
++                  out4, out5, out6, out7);                                  \
++}
++
++/* Description : Low 8-bit vector elements unsigned extension to halfword
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low 8-bit elements from in0 unsigned extension to halfword,
++ *               written to output vector out0. Similar for in1.
++ * Example     : See LSX_UNPCK_L_W_H(in0, out0)
++ */
++#define LSX_UNPCK_L_HU_BU(in0, out0)                                           \
++{                                                                              \
++    out0 = __lsx_vsllwil_hu_bu(in0, 0);                                        \
++}
++
++#define LSX_UNPCK_L_HU_BU_2(in0, in1, out0, out1)                              \
++{                                                                              \
++    LSX_UNPCK_L_HU_BU(in0, out0);                                              \
++    LSX_UNPCK_L_HU_BU(in1, out1);                                              \
++}
++
++#define LSX_UNPCK_L_HU_BU_4(in0, in1, in2, in3, out0, out1, out2, out3)        \
++{                                                                              \
++    LSX_UNPCK_L_HU_BU_2(in0, in1, out0, out1);                                 \
++    LSX_UNPCK_L_HU_BU_2(in2, in3, out2, out3);                                 \
++}
++
++#define LSX_UNPCK_L_HU_BU_8(in0, in1, in2, in3, in4, in5, in6, in7,            \
++                            out0, out1, out2, out3, out4, out5, out6, out7)    \
++{                                                                              \
++    LSX_UNPCK_L_HU_BU_4(in0, in1, in2, in3, out0, out1, out2, out3);           \
++    LSX_UNPCK_L_HU_BU_4(in4, in5, in6, in7, out4, out5, out6, out7);           \
++}
++
++
++/* Description : Low halfword vector elements signed extension to word
++ * Arguments   : Inputs  - in0,  in1,  ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low halfword elements from in0 signed extension to
++ *               word, written to output vector out0. Similar for in1.
++ *               Similar for other pairs.
++ * Example     : LSX_UNPCK_L_W_H(in0, out0)
++ *         in0 : 3, 0, 3, 0,  0, 0, 0, -1
++ *        out0 : 3, 0, 3, 0
++ */
++#define LSX_UNPCK_L_W_H(in0, out0)                                             \
++{                                                                              \
++    out0 = __lsx_vsllwil_w_h(in0, 0);                                          \
++}
++
++#define LSX_UNPCK_L_W_H_2(in0, in1, out0, out1)                                \
++{                                                                              \
++    LSX_UNPCK_L_W_H(in0, out0);                                                \
++    LSX_UNPCK_L_W_H(in1, out1);                                                \
++}
++
++#define LSX_UNPCK_L_W_H_4(in0, in1, in2, in3, out0, out1, out2, out3)          \
++{                                                                              \
++    LSX_UNPCK_L_W_H_2(in0, in1, out0, out1);                                   \
++    LSX_UNPCK_L_W_H_2(in2, in3, out2, out3);                                   \
++}
++
++#define LSX_UNPCK_L_W_H_8(in0, in1, in2, in3, in4, in5, in6, in7,              \
++                          out0, out1, out2, out3, out4, out5, out6, out7)      \
++{                                                                              \
++    LSX_UNPCK_L_W_H_4(in0, in1, in2, in3, out0, out1, out2, out3);             \
++    LSX_UNPCK_L_W_H_4(in4, in5, in6, in7, out4, out5, out6, out7);             \
++}
++
++/* Description : Interleave right half of byte elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of byte elements of in_l and high half of byte
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : See LSX_ILVL_W(in_h, in_l, out0)
++ */
++#define LSX_ILVL_B(in_h, in_l, out0)                                           \
++{                                                                              \
++    out0 = __lsx_vilvl_b(in_h, in_l);                                          \
++}
++
++#define LSX_ILVL_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                   \
++{                                                                              \
++    LSX_ILVL_B(in0_h, in0_l, out0)                                             \
++    LSX_ILVL_B(in1_h, in1_l, out1)                                             \
++}
++
++#define LSX_ILVL_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                 \
++                     in3_h, in3_l, out0, out1, out2, out3)                     \
++{                                                                              \
++    LSX_ILVL_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                       \
++    LSX_ILVL_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3)                       \
++}
++
++#define LSX_ILVL_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,   \
++                     in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,   \
++                     out0, out1, out2, out3, out4, out5, out6, out7)           \
++{                                                                              \
++    LSX_ILVL_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,       \
++                 out0, out1, out2, out3);                                      \
++    LSX_ILVL_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,       \
++                 out4, out5, out6, out7);                                      \
++}
++
++/* Description : Interleave low half of word elements from vectors
++ * Arguments   : Inputs  - in0_h, in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Low half of halfword elements of in_l and low half of word
++ *               elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs
++ * Example     : LSX_ILVL_W(in_h, in_l, out0)
++ *        in_h : 0, 1, 0, 1
++ *        in_l : 1, 2, 3, 4
++ *        out0 : 1, 0, 2, 1
++ */
++#define LSX_ILVL_W(in_h, in_l, out0)                                           \
++{                                                                              \
++    out0 = __lsx_vilvl_w(in_h, in_l);                                          \
++}
++
++#define LSX_ILVL_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                   \
++{                                                                              \
++    LSX_ILVL_W(in0_h, in0_l, out0);                                            \
++    LSX_ILVL_W(in1_h, in1_l, out1);                                            \
++}
++
++#define LSX_ILVL_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                 \
++                     in3_h, in3_l, out0, out1, out2, out3)                     \
++{                                                                              \
++    LSX_ILVL_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                      \
++    LSX_ILVL_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                      \
++}
++
++#define LSX_ILVL_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,   \
++                     in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,   \
++                     out0, out1, out2, out3, out4, out5, out6, out7)           \
++{                                                                              \
++    LSX_ILVL_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,       \
++                 out0, out1, out2, out3);                                      \
++    LSX_ILVL_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,       \
++                 out4, out5, out6, out7);                                      \
++}
++
++/* Description : Interleave high half of byte elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of  byte elements  of  in_l and high half
++ *               of byte elements of in_h are interleaved and copied
++ *               to out0.
++ *               Similar for other pairs.
++ * Example     : see LSX_ILVH_W(in_h, in_l, out0)
++ */
++#define LSX_ILVH_B(in_h, in_l, out0)                                           \
++{                                                                              \
++    out0 = __lsx_vilvh_b(in_h, in_l);                                          \
++}
++
++#define LSX_ILVH_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                   \
++{                                                                              \
++    LSX_ILVH_B(in0_h, in0_l, out0);                                            \
++    LSX_ILVH_B(in1_h, in1_l, out1);                                            \
++}
++
++#define LSX_ILVH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                 \
++                     in3_h, in3_l, out0, out1, out2, out3)                     \
++{                                                                              \
++    LSX_ILVH_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                      \
++    LSX_ILVH_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                      \
++}
++
++#define LSX_ILVH_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,   \
++                     in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,   \
++                     out0, out1, out2, out3, out4, out5, out6, out7)           \
++{                                                                              \
++    LSX_ILVH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,       \
++                 out0, out1, out2, out3);                                      \
++    LSX_ILVH_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,       \
++                 out4, out5, out6, out7);                                      \
++}
++
++/* Description : Interleave high half of word elements from vectors
++ * Arguments   : Inputs  - in0_h, in0_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : High half of word elements of in_l and high half of
++ *               word elements of in_h are interleaved and copied to out0.
++ *               Similar for other pairs.
++ * Example     : LSX_ILVH_W(in_h, in_l, out0)
++ *         in_h:-1, -2, -3, -4
++ *         in_l: 1,  2,  3,  4
++ *         out0: 3, -3,  4, -4
++ */
++#define LSX_ILVH_W(in_h, in_l, out0)                                           \
++{                                                                              \
++    out0 = __lsx_vilvh_w(in_h, in_l);                                          \
++}
++
++#define LSX_ILVH_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)                   \
++{                                                                              \
++    LSX_ILVH_W(in0_h, in0_l, out0);                                            \
++    LSX_ILVH_W(in1_h, in1_l, out1);                                            \
++}
++
++#define LSX_ILVH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                 \
++                     in3_h, in3_l, out0, out1, out2, out3)                     \
++{                                                                              \
++    LSX_ILVH_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1);                      \
++    LSX_ILVH_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3);                      \
++}
++
++#define LSX_ILVH_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,   \
++                     in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,   \
++                     out0, out1, out2, out3, out4, out5, out6, out7)           \
++{                                                                              \
++    LSX_ILVH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,       \
++                 out0, out1, out2, out3);                                      \
++    LSX_ILVH_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,       \
++                 out4, out5, out6, out7);                                      \
++}
++
++/* Description : Interleave byte elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of  byte elements  of in_l and low half of byte
++ *               elements  of in_h  are interleaved  and copied  to  out_l.
++ *               High half of byte elements of in_l and high half of byte
++ *               elements of in_h are interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LSX_ILVLH_W(in_h, in_l, out_l, out_h)
++ */
++#define LSX_ILVLH_B(in_h, in_l, out_h, out_l)                  \
++{                                                              \
++    out_l  = __lsx_vilvl_b(in_h, in_l);                        \
++    out_h  = __lsx_vilvh_b(in_h, in_l);                        \
++}
++
++#define LSX_ILVLH_B_2(in0_h, in0_l, in1_h, in1_l,              \
++                      out0_h, out0_l, out1_h, out1_l)          \
++{                                                              \
++    LSX_ILVLH_B(in0_h, in0_l, out0_h, out0_l);                 \
++    LSX_ILVLH_B(in1_h, in1_l, out1_h, out1_l);                 \
++}
++
++#define LSX_ILVLH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                      \
++    LSX_ILVLH_B_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LSX_ILVLH_B_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LSX_ILVLH_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                      out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                      out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                      \
++    LSX_ILVLH_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                  out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LSX_ILVLH_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                  out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave half word elements from vectors
++ * Arguments   : Inputs  - in_h,  in_l,  ~
++ *               Outputs - out_h, out_l, ~
++ * Details     : Low half of  half word elements  of in_l and low half of half
++ *               word elements of in_h  are  interleaved  and  copied  to out_l.
++ *               High half of half word elements of in_l and high half of half
++ *               word elements of in_h are interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : see LSX_ILVLH_W(in_h, in_l, out_h, out_l)
++ */
++#define LSX_ILVLH_H(in_h, in_l, out_h, out_l)                    \
++{                                                                \
++    out_l = __lsx_vilvl_h(in_h, in_l);                           \
++    out_h = __lsx_vilvh_h(in_h, in_l);                           \
++}
++
++#define LSX_ILVLH_H_2(in0_h, in0_l, in1_h, in1_l,                \
++                      out0_h, out0_l, out1_h, out1_l)            \
++{                                                                \
++    LSX_ILVLH_H(in0_h, in0_l, out0_h, out0_l);                   \
++    LSX_ILVLH_H(in1_h, in1_l, out1_h, out1_l);                   \
++}
++
++#define LSX_ILVLH_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                      \
++    LSX_ILVLH_H_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LSX_ILVLH_H_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LSX_ILVLH_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                      out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                      out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                      \
++    LSX_ILVLH_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                  out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LSX_ILVLH_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                  out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Interleave word elements from vectors
++ * Arguments   : Inputs  - in0_h,  in0_l,  ~
++ *               Outputs - out0_h, out0_l, ~
++ * Details     : Low half of word elements  of in_l and low half of word
++ *               elements of in_h are interleaved and copied to out_l.
++ *               High half of word elements of in_l and high half of
++ *               word elements of in_h are interleaved and copied to out_h.
++ *               Similar for other pairs.
++ * Example     : LSX_ILVLH_W(in_h, in_l, out_h, out_l)
++ *         in_h:-1, -2, -3, -4
++ *         in_l: 1,  2,  3,  4
++ *        out_h: 3, -3,  4, -4
++ *        out_l: 1, -1,  2, -2
++ */
++#define LSX_ILVLH_W(in_h, in_l, out_h, out_l)                    \
++{                                                                \
++    LSX_ILVL_W(in_h, in_l, out_l);                               \
++    LSX_ILVH_W(in_h, in_l, out_h);                               \
++}
++
++#define LSX_ILVLH_W_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l)      \
++{                                                                                      \
++    LSX_ILVLH_W(in0_h, in0_l, out0_h, out0_l);                                         \
++    LSX_ILVLH_W(in1_h, in1_l, out1_h, out1_l);                                         \
++}
++
++#define LSX_ILVLH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l)  \
++{                                                                                      \
++    LSX_ILVLH_W_2(in0_h, in0_l, in1_h, in1_l, out0_h, out0_l, out1_h, out1_l);         \
++    LSX_ILVLH_W_2(in2_h, in2_l, in3_h, in3_l, out2_h, out2_l, out3_h, out3_l);         \
++}
++
++#define LSX_ILVLH_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                      out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l,  \
++                      out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l)  \
++{                                                                                      \
++    LSX_ILVLH_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,              \
++                  out0_h, out0_l, out1_h, out1_l, out2_h, out2_l, out3_h, out3_l);     \
++    LSX_ILVLH_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,              \
++                  out4_h, out4_l, out5_h, out5_l, out6_h, out6_l, out7_h, out7_l);     \
++}
++
++/* Description : Pack even byte elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even byte elements of in_l are copied to the low half of
++ *               out0.  Even byte elements of in_h are copied to the high
++ *               half of out0.
++ *               Similar for other pairs.
++ * Example     : see LSX_PCKEV_W(in_h, in_l, out0)
++ */
++#define LSX_PCKEV_B(in_h, in_l, out0)                            \
++{                                                                \
++    out0 = __lsx_vpickev_b(in_h, in_l);                          \
++}
++
++#define LSX_PCKEV_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                \
++    LSX_PCKEV_B(in0_h, in0_l, out0);                             \
++    LSX_PCKEV_B(in1_h, in1_l, out1);                             \
++}
++
++#define LSX_PCKEV_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                      in3_h, in3_l, out0, out1, out2, out3)      \
++{                                                                \
++    LSX_PCKEV_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LSX_PCKEV_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LSX_PCKEV_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LSX_PCKEV_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                    \
++                  in3_h, in3_l, out0, out1, out2, out3);                       \
++    LSX_PCKEV_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                    \
++                  in7_h, in7_l, out4, out5, out6, out7);                       \
++}
++
++/* Description : Pack even half word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Even half word elements of in_l are copied to the  low
++ *               half of out0.  Even  half  word  elements  of in_h are
++ *               copied to the high half of out0.
++ * Example     : see LSX_PCKEV_W(in_h, in_l, out0)
++ */
++#define LSX_PCKEV_H(in_h, in_l, out0)                            \
++{                                                                \
++    out0 = __lsx_vpickev_h(in_h, in_l);                          \
++}
++
++#define LSX_PCKEV_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                \
++    LSX_PCKEV_H(in0_h, in0_l, out0);                             \
++    LSX_PCKEV_H(in1_h, in1_l, out1);                             \
++}
++
++#define LSX_PCKEV_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                      in3_h, in3_l, out0, out1, out2, out3)      \
++{                                                                \
++    LSX_PCKEV_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LSX_PCKEV_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LSX_PCKEV_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LSX_PCKEV_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                    \
++                  in3_h, in3_l, out0, out1, out2, out3);                       \
++    LSX_PCKEV_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                    \
++                  in7_h, in7_l, out4, out5, out6, out7);                       \
++}
++
++/* Description : Pack odd byte elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd byte elements of in_l are copied to the low half of
++ *               out0. Odd byte elements of in_h are copied to the high
++ *               half of out0.
++ *               Similar for other pairs.
++ * Example     : see LSX_PCKOD_W(in_h, in_l, out0)
++ */
++#define LSX_PCKOD_B(in_h, in_l, out0)                            \
++{                                                                \
++    out0 = __lsx_vpickod_b(in_h, in_l);                          \
++}
++
++#define LSX_PCKOD_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                \
++    LSX_PCKOD_B(in0_h, in0_l, out0);                             \
++    LSX_PCKOD_B(in1_h, in1_l, out1);                             \
++}
++
++#define LSX_PCKOD_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                      in3_h, in3_l, out0, out1, out2, out3)      \
++{                                                                \
++    LSX_PCKOD_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LSX_PCKOD_B_2(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LSX_PCKOD_B_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LSX_PCKOD_B_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                    \
++                  in3_h, in3_l, out0, out1, out2, out3);                       \
++    LSX_PCKOD_B_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                    \
++                  in7_h, in7_l, out4, out5, out6, out7);                       \
++}
++
++/* Description : Pack odd half word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd half word elements of in_l are copied to the low
++ *               half of out0. Odd half word elements of in_h are copied
++ *               to the high half of out0.
++ * Example     : see LSX_PCKOD_W(in_h, in_l, out0)
++ */
++#define LSX_PCKOD_H(in_h, in_l, out0)                            \
++{                                                                \
++    out0 = __lsx_vpickod_h(in_h, in_l);                          \
++}
++
++#define LSX_PCKOD_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                \
++    LSX_PCKOD_H(in0_h, in0_l, out0);                             \
++    LSX_PCKOD_H(in1_h, in1_l, out1);                             \
++}
++
++#define LSX_PCKOD_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                      in3_h, in3_l, out0, out1, out2, out3)      \
++{                                                                \
++    LSX_PCKOD_H_2(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LSX_PCKOD_H_2(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LSX_PCKOD_H_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,  \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,  \
++                      out0, out1, out2, out3, out4, out5, out6, out7)          \
++{                                                                              \
++    LSX_PCKOD_H_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                    \
++                  in3_h, in3_l, out0, out1, out2, out3);                       \
++    LSX_PCKOD_H_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                    \
++                  in7_h, in7_l, out4, out5, out6, out7);                       \
++}
++
++/* Description : Pack odd word elements of vector pairs
++ * Arguments   : Inputs  - in_h, in_l, ~
++ *               Outputs - out0, out1, ~
++ * Details     : Odd word elements of in_l are copied to the low half of out0.
++ *               Odd word elements of in_h are copied to the high half of out0.
++ * Example     : LSX_PCKOD_W(in_h, in_l, out0)
++ *         in_h: -1, -2, -3, -4
++ *         in_l:  1,  2,  3,  4
++ *         out0:  2,  4, -2, -4
++ */
++#define LSX_PCKOD_W(in_h, in_l, out0)                            \
++{                                                                \
++    out0 = __lsx_vpickod_w(in_h, in_l);                          \
++}
++
++#define LSX_PCKOD_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1)    \
++{                                                                \
++    LSX_PCKOD_W(in0_h, in0_l, out0);                             \
++    LSX_PCKOD_W(in1_h, in1_l, out1);                             \
++}
++
++#define LSX_PCKOD_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,  \
++                      in3_h, in3_l, out0, out1, out2, out3)      \
++{                                                                \
++    LSX_PCKOD_W_2(in0_h, in0_l, in1_h, in1_l, out0, out1);       \
++    LSX_PCKOD_W_2(in2_h, in2_l, in3_h, in3_l, out2, out3);       \
++}
++
++#define LSX_PCKOD_W_8(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l, in3_h, in3_l,          \
++                      in4_h, in4_l, in5_h, in5_l, in6_h, in6_l, in7_h, in7_l,          \
++                      out0, out1, out2, out3, out4, out5, out6, out7)                  \
++{                                                                                      \
++    LSX_PCKOD_W_4(in0_h, in0_l, in1_h, in1_l, in2_h, in2_l,                            \
++                  in3_h, in3_l, out0, out1, out2, out3);                               \
++    LSX_PCKOD_W_4(in4_h, in4_l, in5_h, in5_l, in6_h, in6_l,                            \
++                  in7_h, in7_l, out4, out5, out6, out7);                               \
++}
++
++/*
++ * =============================================================================
++ * Description : Transpose 4x4 block with word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     :
++ * Example     :
++ *               1, 2, 3, 4            1, 5, 9,13
++ *               5, 6, 7, 8    to      2, 6,10,14
++ *               9,10,11,12  =====>    3, 7,11,15
++ *              13,14,15,16            4, 8,12,16
++ * =============================================================================
++ */
++#define LSX_TRANSPOSE4x4_W(_in0, _in1, _in2, _in3, _out0, _out1, _out2, _out3) \
++{                                                                              \
++  __m128i _t0, _t1, _t2, _t3;                                                  \
++                                                                               \
++  _t0 = __lsx_vilvl_w(_in1, _in0);                                             \
++  _t1 = __lsx_vilvh_w(_in1, _in0);                                             \
++  _t2 = __lsx_vilvl_w(_in3, _in2);                                             \
++  _t3 = __lsx_vilvh_w(_in3, _in2);                                             \
++  _out0 = __lsx_vilvl_d(_t2, _t0);                                             \
++  _out1 = __lsx_vilvh_d(_t2, _t0);                                             \
++  _out2 = __lsx_vilvl_d(_t3, _t1);                                             \
++  _out3 = __lsx_vilvh_d(_t3, _t1);                                             \
++}
++
++/*
++ * =============================================================================
++ * Description : Transpose 8x8 block with half-word elements in vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ * Details     :
++ * Example     :
++ *              00,01,02,03,04,05,06,07           00,10,20,30,40,50,60,70
++ *              10,11,12,13,14,15,16,17           01,11,21,31,41,51,61,71
++ *              20,21,22,23,24,25,26,27           02,12,22,32,42,52,62,72
++ *              30,31,32,33,34,35,36,37    to     03,13,23,33,43,53,63,73
++ *              40,41,42,43,44,45,46,47  ======>  04,14,24,34,44,54,64,74
++ *              50,51,52,53,54,55,56,57           05,15,25,35,45,55,65,75
++ *              60,61,62,63,64,65,66,67           06,16,26,36,46,56,66,76
++ *              70,71,72,73,74,75,76,77           07,17,27,37,47,57,67,77
++ * =============================================================================
++ */
++#define LSX_TRANSPOSE8x8_H(_in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7,  \
++                           _out0, _out1, _out2, _out3, _out4, _out5, _out6, \
++                           _out7)                                           \
++{                                                                           \
++  __m128i _s0, _s1, _t0, _t1, _t2, _t3, _t4, _t5, _t6, _t7;                 \
++                                                                            \
++  _s0 = __lsx_vilvl_h(_in6, _in4);                                          \
++  _s1 = __lsx_vilvl_h(_in7, _in5);                                          \
++  _t0 = __lsx_vilvl_h(_s1, _s0);                                            \
++  _t1 = __lsx_vilvh_h(_s1, _s0);                                            \
++  _s0 = __lsx_vilvh_h(_in6, _in4);                                          \
++  _s1 = __lsx_vilvh_h(_in7, _in5);                                          \
++  _t2 = __lsx_vilvl_h(_s1, _s0);                                            \
++  _t3 = __lsx_vilvh_h(_s1, _s0);                                            \
++  _s0 = __lsx_vilvl_h(_in2, _in0);                                          \
++  _s1 = __lsx_vilvl_h(_in3, _in1);                                          \
++  _t4 = __lsx_vilvl_h(_s1, _s0);                                            \
++  _t5 = __lsx_vilvh_h(_s1, _s0);                                            \
++  _s0 = __lsx_vilvh_h(_in2, _in0);                                          \
++  _s1 = __lsx_vilvh_h(_in3, _in1);                                          \
++  _t6 = __lsx_vilvl_h(_s1, _s0);                                            \
++  _t7 = __lsx_vilvh_h(_s1, _s0);                                            \
++                                                                            \
++  _out0 = __lsx_vpickev_d(_t0, _t4);                                        \
++  _out2 = __lsx_vpickev_d(_t1, _t5);                                        \
++  _out4 = __lsx_vpickev_d(_t2, _t6);                                        \
++  _out6 = __lsx_vpickev_d(_t3, _t7);                                        \
++  _out1 = __lsx_vpickod_d(_t0, _t4);                                        \
++  _out3 = __lsx_vpickod_d(_t1, _t5);                                        \
++  _out5 = __lsx_vpickod_d(_t2, _t6);                                        \
++  _out7 = __lsx_vpickod_d(_t3, _t7);                                        \
++}
++
++/* Description : Transposes input 8x8 byte block
++ * Arguments   : Inputs  - in0, in1, in2, in3, in4, in5, in6, in7
++ *                         (input 8x8 byte block)
++ *               Outputs - out0, out1, out2, out3, out4, out5, out6, out7
++ *                         (output 8x8 byte block)
++ * Details     :
++ */
++#define LSX_TRANSPOSE8x8_B(_in0, _in1, _in2, _in3, _in4, _in5, _in6, _in7,  \
++                           _out0, _out1, _out2, _out3, _out4, _out5, _out6, \
++                           _out7)                                           \
++{                                                                           \
++  __m128i zero = { 0 };                                                     \
++  __m128i shuf8 = { 0x0F0E0D0C0B0A0908, 0x1716151413121110 };               \
++  __m128i _t0, _t1, _t2, _t3, _t4, _t5, _t6, _t7;                           \
++                                                                            \
++  _t0 = __lsx_vilvl_b(_in2, _in0);                                          \
++  _t1 = __lsx_vilvl_b(_in3, _in1);                                          \
++  _t2 = __lsx_vilvl_b(_in6, _in4);                                          \
++  _t3 = __lsx_vilvl_b(_in7, _in5);                                          \
++  _t4 = __lsx_vilvl_b(_t1, _t0);                                            \
++  _t5 = __lsx_vilvh_b(_t1, _t0);                                            \
++  _t6 = __lsx_vilvl_b(_t3, _t2);                                            \
++  _t7 = __lsx_vilvh_b(_t3, _t2);                                            \
++  _out0 = __lsx_vilvl_w(_t6, _t4);                                          \
++  _out2 = __lsx_vilvh_w(_t6, _t4);                                          \
++  _out4 = __lsx_vilvl_w(_t7, _t5);                                          \
++  _out6 = __lsx_vilvh_w(_t7, _t5);                                          \
++  _out1 = __lsx_vshuf_b(zero, _out0, shuf8);                                \
++  _out3 = __lsx_vshuf_b(zero, _out2, shuf8);                                \
++  _out5 = __lsx_vshuf_b(zero, _out4, shuf8);                                \
++  _out7 = __lsx_vshuf_b(zero, _out6, shuf8);                                \
++}
++
++/* Description : Clips all signed word elements of input vector
++ *               between 0 & 255
++ * Arguments   : Inputs  - in       (input vector)
++ *               Outputs - out_m    (output vector with clipped elements)
++ *               Return Type - signed word
++ */
++#define LSX_CLIP_W_0_255(in, out_m)       \
++{                                         \
++    out_m = __lsx_vmaxi_w(in, 0);         \
++    out_m = __lsx_vsat_wu(out_m, 7);      \
++}
++
++#define LSX_CLIP_W_0_255_2(in0, in1, out0, out1)  \
++{                                                 \
++    LSX_CLIP_W_0_255(in0, out0);                  \
++    LSX_CLIP_W_0_255(in1, out1);                  \
++}
++
++#define LSX_CLIP_W_0_255_4(in0, in1, in2, in3, out0, out1, out2, out3)  \
++{                                                                       \
++    LSX_CLIP_W_0_255_2(in0, in1, out0, out1);                           \
++    LSX_CLIP_W_0_255_2(in2, in3, out2, out3);                           \
++}
++
++/* Description : Clips all signed halfword elements of input vector
++ *               between 0 & 255
++ * Arguments   : Inputs  - in       (input vector)
++ *               Outputs - out_m    (output vector with clipped elements)
++ *               Return Type - signed halfword
++ */
++#define LSX_CLIP_H_0_255(in, out_m)       \
++{                                         \
++    out_m = __lsx_vmaxi_h(in, 0);         \
++    out_m = __lsx_vsat_hu(out_m, 7);      \
++}
++
++#define LSX_CLIP_H_0_255_2(in0, in1, out0, out1)  \
++{                                                 \
++    LSX_CLIP_H_0_255(in0, out0);                  \
++    LSX_CLIP_H_0_255(in1, out1);                  \
++}
++
++#define LSX_CLIP_H_0_255_4(in0, in1, in2, in3, out0, out1, out2, out3)  \
++{                                                                       \
++    LSX_CLIP_H_0_255_2(in0, in1, out0, out1);                           \
++    LSX_CLIP_H_0_255_2(in2, in3, out2, out3);                           \
++}
++
++/* Description : Shift right arithmetic rounded (immediate)
++ * Arguments   : Inputs  - in0, in1, shift
++ *               Outputs - in0, in1, (in place)
++ * Details     : Each element of vector 'in0' is shifted right arithmetic by
++ *               value in 'shift'.
++ *               The last discarded bit is added to shifted value for rounding
++ *               and the result is in place written to 'in0'
++ *               Similar for other pairs
++ * Example     : LSX_SRARI_H(in0, out0, shift)
++ *               in0:   1,2,3,4, 19,10,11,12
++ *               shift: 2
++ *               out0:  0,1,1,1, 5,3,3,3
++ */
++#define LSX_SRARI_H(in0, out0, shift)                                    \
++{                                                                        \
++    out0 = __lsx_vsrari_h(in0, shift);                                   \
++}
++
++#define LSX_SRARI_H_2(in0, in1, out0, out1, shift)                       \
++{                                                                        \
++    LSX_SRARI_H(in0, out0, shift);                                       \
++    LSX_SRARI_H(in1, out1, shift);                                       \
++}
++
++#define LSX_SRARI_H_4(in0, in1, in2, in3, out0, out1, out2, out3, shift) \
++{                                                                        \
++    LSX_SRARI_H_2(in0, in1, out0, out1, shift);                          \
++    LSX_SRARI_H_2(in2, in3, out2, out3, shift);                          \
++}
++
++/* Description : Addition of 2 pairs of vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1
++ * Details     : Each halfwords element from 2 pairs vectors is added
++ *               and 2 results are produced
++ * Example     : LSX_ADD_H(in0, in1, out)
++ *               in0:  1,2,3,4, 5,6,7,8
++ *               in1:  8,7,6,5, 4,3,2,1
++ *               out:  9,9,9,9, 9,9,9,9
++ */
++#define LSX_ADD_H(in0, in1, out)     \
++{                                    \
++    out = __lsx_vadd_h(in0, in1);    \
++}
++
++#define LSX_ADD_H_2(in0, in1, in2, in3, out0, out1) \
++{                                                   \
++    LSX_ADD_H(in0, in1, out0);                      \
++    LSX_ADD_H(in2, in3, out1);                      \
++}
++
++#define LSX_ADD_H_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3)     \
++{                                                                                       \
++    LSX_ADD_H_2(in0, in1, in2, in3, out0, out1);                                        \
++    LSX_ADD_H_2(in4, in5, in6, in7, out2, out3);                                        \
++}
++
++#define LSX_ADD_H_8(in0, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, \
++                    in13, in14, in15, out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                                       \
++    LSX_ADD_H_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3);        \
++    LSX_ADD_H_4(in8, in9, in10, in11, in12, in13, in14, in15, out4, out5, out6, out7);  \
++}
++
++#define LSX_ADD_W(in0, in1, out)       \
++{                                      \
++    out = __lsx_vadd_w(in0, in1);      \
++}
++
++#define LSX_ADD_W_2(in0, in1, in2, in3, out0, out1)  \
++{                                                    \
++    LSX_ADD_W(in0, in1, out0);                       \
++    LSX_ADD_W(in2, in3, out1);                       \
++}
++
++#define LSX_ADD_W_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3)  \
++{                                                                                    \
++    LSX_ADD_W_2(in0, in1, in2, in3, out0, out1);                                     \
++    LSX_ADD_W_2(in4, in5, in6, in7, out2, out3);                                     \
++}
++
++#define LSX_ADD_W_8(in0, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, \
++                    in13, in14, in15, out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                                       \
++    LSX_ADD_W_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3);        \
++    LSX_ADD_W_4(in8, in9, in10, in11, in12, in13, in14, in15, out4, out5, out6, out7);  \
++}
++
++#define LSX_SUB_W(in0, in1, out)       \
++{                                      \
++    out = __lsx_vsub_w(in0, in1);      \
++}
++
++#define LSX_SUB_W_2(in0, in1, in2, in3, out0, out1)  \
++{                                                    \
++    LSX_SUB_W(in0, in1, out0);                       \
++    LSX_SUB_W(in2, in3, out1);                       \
++}
++
++#define LSX_SUB_W_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3)     \
++{                                                                                       \
++    LSX_SUB_W_2(in0, in1, in2, in3, out0, out1);                                        \
++    LSX_SUB_W_2(in4, in5, in6, in7, out2, out3);                                        \
++}
++
++#define LSX_SUB_W_8(in0, in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, \
++                    in13, in14, in15, out0, out1, out2, out3, out4, out5, out6, out7)   \
++{                                                                                       \
++    LSX_SUB_W_4(in0, in1, in2, in3, in4, in5, in6, in7, out0, out1, out2, out3);        \
++    LSX_SUB_W_4(in8, in9, in10, in11, in12, in13, in14, in15, out4, out5, out6, out7);  \
++}
++
++/* Description : Butterfly of 4 input vectors
++ * Arguments   : Inputs  - in0, in1, in2, in3
++ *               Outputs - out0, out1, out2, out3
++ * Details     : Butterfly operationuu
++ */
++#define LSX_BUTTERFLY_4(RTYPE, in0, in1, in2, in3, out0, out1, out2, out3)  \
++{                                                                           \
++    out0 = (__m128i)( (RTYPE)in0 + (RTYPE)in3 );                            \
++    out1 = (__m128i)( (RTYPE)in1 + (RTYPE)in2 );                            \
++                                                                            \
++    out2 = (__m128i)( (RTYPE)in1 - (RTYPE)in2 );                            \
++    out3 = (__m128i)( (RTYPE)in0 - (RTYPE)in3 );                            \
++}
++
++/* Description : Butterfly of 8 input vectors
++ * Arguments   : Inputs  - in0 in1 in2 ~
++ *               Outputs - out0 out1 out2 ~
++ * Details     : Butterfly operation
++ */
++#define LSX_BUTTERFLY_8(RTYPE, in0, in1, in2, in3, in4, in5, in6, in7,      \
++                        out0, out1, out2, out3, out4, out5, out6, out7)     \
++{                                                                           \
++    out0 = (__m128i)( (RTYPE)in0 + (RTYPE)in7 );                            \
++    out1 = (__m128i)( (RTYPE)in1 + (RTYPE)in6 );                            \
++    out2 = (__m128i)( (RTYPE)in2 + (RTYPE)in5 );                            \
++    out3 = (__m128i)( (RTYPE)in3 + (RTYPE)in4 );                            \
++                                                                            \
++    out4 = (__m128i)( (RTYPE)in3 - (RTYPE)in4 );                            \
++    out5 = (__m128i)( (RTYPE)in2 - (RTYPE)in5 );                            \
++    out6 = (__m128i)( (RTYPE)in1 - (RTYPE)in6 );                            \
++    out7 = (__m128i)( (RTYPE)in0 - (RTYPE)in7 );                            \
++}
++
++#endif /* GENERIC_MACROS_LSX_H */
+diff --git a/simd/loongarch64/jccolext-lasx.c b/simd/loongarch64/jccolext-lasx.c
+new file mode 100644
+index 00000000..dfdd7a2f
+--- /dev/null
++++ b/simd/loongarch64/jccolext-lasx.c
+@@ -0,0 +1,229 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++
++GLOBAL(void)
++jsimd_rgb_ycc_convert_lasx(JDIMENSION img_width, JSAMPARRAY input_buf,
++                           JSAMPIMAGE output_buf, JDIMENSION output_row,
++                           int num_rows)
++{
++  JSAMPROW inptr;
++  JDIMENSION col, col_remainings;
++  JSAMPROW outptr0, outptr1, outptr2;
++  __m256i r, g, b;
++  __m256i src0, src1, src2;
++  __m256i const1959 = {19595};
++  __m256i const3847 = {38470};
++  __m256i const7471 = {7471};
++  __m256i const1105 = {11059};
++  __m256i const2170 = {21709};
++  __m256i const3276 = {32768};
++  __m256i const2743 = {27439};
++  __m256i const5329 = {5329};
++  __m256i constminu = {(128 << SCALEBITS) - 1};
++  int rgb_stride = RGB_PIXELSIZE << 5;
++
++#if RGB_PIXELSIZE == 3
++  v32i8 mask = {0,1,3,4,6,7,9,10,12,13,15,16,18,19,21,22,
++                8,9,11,12,14,15,17,18,20,21,23,24,26,27,29,30};
++  v32i8 mask1 = (v32i8)__lasx_xvaddi_bu((__m256i)mask, 1);
++#else
++  __m256i src3;
++#endif
++
++  const1959 = __lasx_xvreplve0_w(const1959);
++  const3847 = __lasx_xvreplve0_w(const3847);
++  const7471 = __lasx_xvreplve0_w(const7471);
++  const1105 = __lasx_xvreplve0_w(const1105);
++  const2170 = __lasx_xvreplve0_w(const2170);
++  const3276 = __lasx_xvreplve0_w(const3276);
++  const2743 = __lasx_xvreplve0_w(const2743);
++  const5329 = __lasx_xvreplve0_w(const5329);
++  constminu = __lasx_xvreplve0_w(constminu);
++
++  while (--num_rows >= 0) {
++    inptr = *input_buf++;
++    outptr0 = output_buf[0][output_row];
++    outptr1 = output_buf[1][output_row];
++    outptr2 = output_buf[2][output_row];
++    output_row++;
++    col = img_width;
++
++    LASX_LD_2(inptr, 32, src0, src1);
++
++    for (; col >= 32; col -= 32) {
++#if RGB_PIXELSIZE == 4
++
++      LASX_LD_2(inptr + 64, 32, src2, src3);
++
++#if RGB_RED == 0
++      /* rgbx */
++      {
++        __m256i rgl, rgh, bxl, bxh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, rgl, rgh);
++        LASX_PCKEV_B(rgh, rgl, r);
++        LASX_PCKOD_B(rgh, rgl, g);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, bxl, bxh);
++        LASX_PCKEV_B(bxh, bxl, b);
++      }
++#endif
++
++#if RGB_RED == 1
++      /* xrgb */
++      {
++        __m256i xrl, xrh, gbl, gbh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, xrl, xrh);
++        LASX_PCKOD_B(xrh, xrl, r);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, gbl, gbh);
++        LASX_PCKEV_B(gbh, gbl, g);
++        LASX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgrx */
++      {
++        __m256i bgl, bgh, rxl, rxh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, bgl, bgh);
++        LASX_PCKEV_B(bgh, bgl, b);
++        LASX_PCKOD_B(bgh, bgl, g);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, rxl, rxh);
++        LASX_PCKEV_B(rxh, rxl, r);
++      }
++#endif
++
++#if RGB_RED == 3
++      /* xbgr */
++      {
++        __m256i xbl, xbh, grl, grh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, xbl, xbh);
++        LASX_PCKOD_B(xbh, xbl, b);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, grl, grh);
++        LASX_PCKEV_B(grh, grl, g);
++        LASX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#else /* end RGB_PIXELSIZE == 4 */
++
++      src2 = LASX_LD(inptr + 64);
++
++#if RGB_RED == 0
++      /* rgb */
++      {
++        __m256i rgl, rgh, gbl, gbh;
++        __m256i src01, src12;
++        src01 = __lasx_xvpermi_q(src1, src0, 0x21);
++        src12 = __lasx_xvpermi_q(src2, src1, 0x21);
++        rgl = __lasx_xvshuf_b(src01, src0, (__m256i)mask);
++        rgh = __lasx_xvshuf_b(src2, src12, (__m256i)mask);
++        LASX_PCKEV_B(rgh, rgl, r);
++        LASX_PCKOD_B(rgh, rgl, g);
++        gbl = __lasx_xvshuf_b(src01, src0, (__m256i)mask1);
++        gbh = __lasx_xvshuf_b(src2, src12, (__m256i)mask1);
++        LASX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgr */
++      {
++        __m256i bgl, bgh, grl, grh;
++        __m256i src01, src12;
++        src01 = __lasx_xvpermi_q(src1, src0, 0x21);
++        src12 = __lasx_xvpermi_q(src2, src1, 0x21);
++        bgl = __lasx_xvshuf_b(src01, src0, (__m256i)mask);
++        bgh = __lasx_xvshuf_b(src2, src12, (__m256i)mask);
++        LASX_PCKEV_B(bgh, bgl, b);
++        LASX_PCKOD_B(bgh, bgl, g);
++        grl = __lasx_xvshuf_b(src01, src0, (__m256i)mask1);
++        grh = __lasx_xvshuf_b(src2, src12, (__m256i)mask1);
++        LASX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#endif /* end RGB_PIXELSIZE == 3 */
++
++      {
++        __m256i r0, r1, r2, r3, g0, g1, g2, g3, b0, b1, b2, b3;
++        __m256i y0, y1, y2, y3, cr0, cr1, cr2, cr3, cb0, cb1, cb2, cb3;
++
++        LASX_UNPCK_WU_BU_4(r, r0, r1, r2, r3);
++        LASX_UNPCK_WU_BU_4(g, g0, g1, g2, g3);
++        LASX_UNPCK_WU_BU_4(b, b0, b1, b2, b3);
++
++        /* y */
++        LASX_CALC_Y(r0, g0, b0, y0);
++        LASX_CALC_Y(r1, g1, b1, y1);
++        LASX_CALC_Y(r2, g2, b2, y2);
++        LASX_CALC_Y(r3, g3, b3, y3);
++        LASX_SRARI_W_4(y0, y1, y2, y3, SCALEBITS);
++        LASX_PCKEV_H_2(y1, y0, y3, y2, y0, y2);
++        LASX_PCKEV_B(y2, y0, y0);
++
++        /* cb */
++        LASX_CALC_CB(r0, g0, b0, cb0);
++        LASX_CALC_CB(r1, g1, b1, cb1);
++        LASX_CALC_CB(r2, g2, b2, cb2);
++        LASX_CALC_CB(r3, g3, b3, cb3);
++        LASX_SRARI_W_4(cb0, cb1, cb2, cb3, SCALEBITS);
++        LASX_PCKEV_H_2(cb1, cb0, cb3, cb2, cb0, cb2);
++        LASX_PCKEV_B(cb2, cb0, cb0);
++
++        /* cr */
++        LASX_CALC_CR(r0, g0, b0, cr0);
++        LASX_CALC_CR(r1, g1, b1, cr1);
++        LASX_CALC_CR(r2, g2, b2, cr2);
++        LASX_CALC_CR(r3, g3, b3, cr3);
++        LASX_SRARI_W_4(cr0, cr1, cr2, cr3, SCALEBITS);
++        LASX_PCKEV_H_2(cr1, cr0, cr3, cr2, cr0, cr2);
++        LASX_PCKEV_B(cr2, cr0, cr0);
++
++        LASX_ST(y0, outptr0);
++        LASX_ST(cb0, outptr1);
++        LASX_ST(cr0, outptr2);
++        inptr += rgb_stride;
++        LASX_LD_2(inptr, 32, src0, src1);
++        outptr0 += 32;
++        outptr1 += 32;
++        outptr2 += 32;
++      }
++    }/* for(; col >= 32; col -= 32) */
++
++    col_remainings = col;
++    for (col = 0; col < col_remainings; col++) {
++      JDIMENSION r = GETSAMPLE(inptr[RGB_RED]);
++      JDIMENSION g = GETSAMPLE(inptr[RGB_GREEN]);
++      JDIMENSION b = GETSAMPLE(inptr[RGB_BLUE]);
++      inptr += RGB_PIXELSIZE;
++
++      outptr0[col] = (uint8_t)((19595 * r + 38470 * g + 7471 * b +
++                               ONE_HALF) >> SCALEBITS);
++      outptr1[col] = (uint8_t)((-11059 * r + -21709 * g + 32768 * b +
++                               CBCR_OFFSET - 1 + ONE_HALF) >> SCALEBITS);
++      outptr2[col] = (uint8_t)((32768 * r + -27439 * g + -5329 * b +
++                               CBCR_OFFSET - 1 + ONE_HALF) >> SCALEBITS);
++    }
++  }
++}
+diff --git a/simd/loongarch64/jccolext-lsx.c b/simd/loongarch64/jccolext-lsx.c
+new file mode 100644
+index 00000000..fd653cf7
+--- /dev/null
++++ b/simd/loongarch64/jccolext-lsx.c
+@@ -0,0 +1,227 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++GLOBAL(void)
++jsimd_rgb_ycc_convert_lsx(JDIMENSION img_width, JSAMPARRAY input_buf,
++                          JSAMPIMAGE output_buf, JDIMENSION output_row,
++                          int num_rows)
++{
++  JSAMPROW inptr;
++  JDIMENSION col, col_remainings;
++  JSAMPROW outptr0, outptr1, outptr2;
++  __m128i r, g, b;
++  __m128i src0, src1, src2;
++  __m128i const1959 = {19595};
++  __m128i const3847 = {38470};
++  __m128i const7471 = {7471};
++  __m128i const1105 = {11059};
++  __m128i const2170 = {21709};
++  __m128i const3276 = {32768};
++  __m128i const2743 = {27439};
++  __m128i const5329 = {5329};
++  __m128i constminu = {(128 << SCALEBITS) - 1};
++  int rgb_stride = RGB_PIXELSIZE << 4;
++
++#if RGB_PIXELSIZE == 3
++  v16i8 mask = {0,1,3,4,6,7,9,10,12,13,15,24,26,27,29,30};
++  v16i8 mask1 = (v16i8)__lsx_vaddi_bu((__m128i)mask, 1);
++#else
++  __m128i src3;
++#endif
++
++  const1959 = __lsx_vreplvei_w(const1959, 0);
++  const3847 = __lsx_vreplvei_w(const3847, 0);
++  const7471 = __lsx_vreplvei_w(const7471, 0);
++  const1105 = __lsx_vreplvei_w(const1105, 0);
++  const2170 = __lsx_vreplvei_w(const2170, 0);
++  const3276 = __lsx_vreplvei_w(const3276, 0);
++  const2743 = __lsx_vreplvei_w(const2743, 0);
++  const5329 = __lsx_vreplvei_w(const5329, 0);
++  constminu = __lsx_vreplvei_w(constminu, 0);
++
++  while (--num_rows >= 0) {
++    inptr = *input_buf++;
++    outptr0 = output_buf[0][output_row];
++    outptr1 = output_buf[1][output_row];
++    outptr2 = output_buf[2][output_row];
++    output_row++;
++    col = img_width;
++
++    LSX_LD_2(inptr, 16, src0, src1);
++
++    for (; col >= 16; col -= 16) {
++#if RGB_PIXELSIZE == 4
++
++      LSX_LD_2(inptr + 32, 16, src2, src3);
++
++#if RGB_RED == 0
++      /* rgbx */
++      {
++        __m128i rgl, rgh, bxl, bxh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, rgl, rgh);
++        LSX_PCKEV_B(rgh, rgl, r);
++        LSX_PCKOD_B(rgh, rgl, g);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, bxl, bxh);
++        LSX_PCKEV_B(bxh, bxl, b);
++      }
++#endif
++
++#if RGB_RED == 1
++      /* xrgb */
++      {
++        __m128i xrl, xrh, gbl, gbh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, xrl, xrh);
++        LSX_PCKOD_B(xrh, xrl, r);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, gbl, gbh);
++        LSX_PCKEV_B(gbh, gbl, g);
++        LSX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgrx */
++      {
++        __m128i bgl, bgh, rxl, rxh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, bgl, bgh);
++        LSX_PCKEV_B(bgh, bgl, b);
++        LSX_PCKOD_B(bgh, bgl, g);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, rxl, rxh);
++        LSX_PCKEV_B(rxh, rxl, r);
++      }
++#endif
++
++#if RGB_RED == 3
++      /* xbgr */
++      {
++        __m128i xbl, xbh, grl, grh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, xbl, xbh);
++        LSX_PCKOD_B(xbh, xbl, b);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, grl, grh);
++        LSX_PCKEV_B(grh, grl, g);
++        LSX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#else /* end RGB_PIXELSIZE == 4 */
++
++      src2 = LSX_LD(inptr + 32);
++
++#if RGB_RED == 0
++      /* rgb */
++      {
++        __m128i rgl, rgh, gbl, gbh;
++        __m128i src01, src12;
++        src01 = __lsx_vpermi_w(src1, src0, 0x4E);
++        src12 = __lsx_vpermi_w(src2, src1, 0x4E);
++        rgl = __lsx_vshuf_b(src01, src0, (__m128i)mask);
++        rgh = __lsx_vshuf_b(src2, src12, (__m128i)mask);
++        r = __lsx_vpickev_b(rgh, rgl);
++        g = __lsx_vpickod_b(rgh, rgl);
++        gbl = __lsx_vshuf_b(src01, src0, (__m128i)mask1);
++        gbh = __lsx_vshuf_b(src2, src12, (__m128i)mask1);
++        b = __lsx_vpickod_b(gbh, gbl);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgr */
++      {
++        __m128i bgl, bgh, grl, grh;
++        __m128i src01, src12;
++        src01 = __lsx_vpermi_w(src1, src0, 0x4E);
++        src12 = __lsx_vpermi_w(src2, src1, 0x4E);
++        bgl = __lsx_vshuf_b(src01, src0, (__m128i)mask);
++        bgh = __lsx_vshuf_b(src2, src12, (__m128i)mask);
++        b = __lsx_vpickev_b(bgh, bgl);
++        g = __lsx_vpickod_b(bgh, bgl);
++        grl = __lsx_vshuf_b(src01, src0, (__m128i)mask1);
++        grh = __lsx_vshuf_b(src2, src12, (__m128i)mask1);
++        r = __lsx_vpickod_b(grh, grl);
++      }
++#endif
++
++#endif /* end RGB_PIXELSIZE == 3 */
++
++      {
++        __m128i r0, r1, r2, r3, g0, g1, g2, g3, b0, b1, b2, b3;
++        __m128i y0, y1, y2, y3, cr0, cr1, cr2, cr3, cb0, cb1, cb2, cb3;
++
++        LSX_UNPCK_WU_BU_4(r, r0, r1, r2, r3);
++        LSX_UNPCK_WU_BU_4(g, g0, g1, g2, g3);
++        LSX_UNPCK_WU_BU_4(b, b0, b1, b2, b3);
++
++        /* y */
++        LSX_CALC_Y(r0, g0, b0, y0);
++        LSX_CALC_Y(r1, g1, b1, y1);
++        LSX_CALC_Y(r2, g2, b2, y2);
++        LSX_CALC_Y(r3, g3, b3, y3);
++        LSX_SRARI_W_4(y0, y1, y2, y3, SCALEBITS);
++        LSX_PCKEV_H_2(y1, y0, y3, y2, y0, y2);
++        LSX_PCKEV_B(y2, y0, y0);
++
++        /* cb */
++        LSX_CALC_CB(r0, g0, b0, cb0);
++        LSX_CALC_CB(r1, g1, b1, cb1);
++        LSX_CALC_CB(r2, g2, b2, cb2);
++        LSX_CALC_CB(r3, g3, b3, cb3);
++        LSX_SRARI_W_4(cb0, cb1, cb2, cb3, SCALEBITS);
++        LSX_PCKEV_H_2(cb1, cb0, cb3, cb2, cb0, cb2);
++        LSX_PCKEV_B(cb2, cb0, cb0);
++
++        /* cr */
++        LSX_CALC_CR(r0, g0, b0, cr0);
++        LSX_CALC_CR(r1, g1, b1, cr1);
++        LSX_CALC_CR(r2, g2, b2, cr2);
++        LSX_CALC_CR(r3, g3, b3, cr3);
++        LSX_SRARI_W_4(cr0, cr1, cr2, cr3, SCALEBITS);
++        LSX_PCKEV_H_2(cr1, cr0, cr3, cr2, cr0, cr2);
++        LSX_PCKEV_B(cr2, cr0, cr0);
++
++        LSX_ST(y0, outptr0);
++        LSX_ST(cb0, outptr1);
++        LSX_ST(cr0, outptr2);
++        inptr += rgb_stride;
++        LSX_LD_2(inptr, 16, src0, src1);
++        outptr0 += 16;
++        outptr1 += 16;
++        outptr2 += 16;
++      }
++    }/* for(; col >= 16; col -= 16) */
++
++    col_remainings = col;
++    for (col = 0; col < col_remainings; col++) {
++      JDIMENSION r = GETSAMPLE(inptr[RGB_RED]);
++      JDIMENSION g = GETSAMPLE(inptr[RGB_GREEN]);
++      JDIMENSION b = GETSAMPLE(inptr[RGB_BLUE]);
++      inptr += RGB_PIXELSIZE;
++
++      outptr0[col] = (uint8_t)((19595 * r + 38470 * g + 7471 * b +
++                               ONE_HALF) >> SCALEBITS);
++      outptr1[col] = (uint8_t)((-11059 * r + -21709 * g + 32768 * b +
++                               CBCR_OFFSET - 1 + ONE_HALF) >> SCALEBITS);
++      outptr2[col] = (uint8_t)((32768 * r + -27439 * g + -5329 * b +
++                               CBCR_OFFSET - 1 + ONE_HALF) >> SCALEBITS);
++    }
++  }
++}
+diff --git a/simd/loongarch64/jccolor-lasx.c b/simd/loongarch64/jccolor-lasx.c
+new file mode 100644
+index 00000000..0e291400
+--- /dev/null
++++ b/simd/loongarch64/jccolor-lasx.c
+@@ -0,0 +1,144 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jmacros_lasx.h"
++
++/* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
++/* Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B  + 128 */
++/* Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B  + 128 */
++/*
++0.29900 * 65536 = 19595
++0.58700 * 65535 = 38470
++0.11400 * 65536 = 7471
++0.16874 * 65536 = 11059
++0.33126 * 65536 = 21709
++0.50000 * 65536 = 32768
++0.41869 * 65536 = 27439
++0.08131 * 65536 = 5329
++*/
++
++#define SCALEBITS 16
++#define ONE_HALF 32768
++#define CBCR_OFFSET (128 << SCALEBITS)
++#define GETSAMPLE(_in) ((int)(_in))
++
++#define LASX_CALC_Y(_in0, _in1, _in2, _out) { \
++  _out = __lasx_xvmul_w(_in0, const1959); \
++  _out = __lasx_xvmadd_w(_out, _in1, const3847); \
++  _out = __lasx_xvmadd_w(_out, _in2, const7471); \
++}
++
++#define LASX_CALC_CB(_in0, _in1, _in2, _out) { \
++  _out = __lasx_xvmsub_w(constminu, _in0, const1105); \
++  _out = __lasx_xvmsub_w(_out, _in1, const2170); \
++  _out = __lasx_xvmadd_w(_out, _in2, const3276); \
++}
++
++#define LASX_CALC_CR(_in0, _in1, _in2, _out) { \
++  _out = __lasx_xvmadd_w(constminu, _in0, const3276); \
++  _out = __lasx_xvmsub_w(_out, _in1, const2743); \
++  _out = __lasx_xvmsub_w(_out, _in2, const5329); \
++}
++
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lasx  jsimd_extrgb_ycc_convert_lasx
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lasx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lasx  jsimd_extbgr_ycc_convert_lasx
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lasx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lasx  jsimd_extrgbx_ycc_convert_lasx
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lasx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lasx  jsimd_extbgrx_ycc_convert_lasx
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lasx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lasx  jsimd_extxrgb_ycc_convert_lasx
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lasx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lasx  jsimd_extxbgr_ycc_convert_lasx
++#include "jccolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lasx
+diff --git a/simd/loongarch64/jccolor-lsx.c b/simd/loongarch64/jccolor-lsx.c
+new file mode 100644
+index 00000000..e747ece2
+--- /dev/null
++++ b/simd/loongarch64/jccolor-lsx.c
+@@ -0,0 +1,144 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jmacros_lsx.h"
++
++/* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
++/* Cb = -0.16874 * R - 0.33126 * G + 0.50000 * B  + 128 */
++/* Cr =  0.50000 * R - 0.41869 * G - 0.08131 * B  + 128 */
++/*
++0.29900 * 65536 = 19595
++0.58700 * 65535 = 38470
++0.11400 * 65536 = 7471
++0.16874 * 65536 = 11059
++0.33126 * 65536 = 21709
++0.50000 * 65536 = 32768
++0.41869 * 65536 = 27439
++0.08131 * 65536 = 5329
++*/
++
++#define SCALEBITS 16
++#define ONE_HALF 32768
++#define CBCR_OFFSET (128 << SCALEBITS)
++#define GETSAMPLE(_in) ((int)(_in))
++
++#define LSX_CALC_Y(_in0, _in1, _in2, _out) {   \
++  _out = __lsx_vmul_w(_in0, const1959);        \
++  _out = __lsx_vmadd_w(_out, _in1, const3847); \
++  _out = __lsx_vmadd_w(_out, _in2, const7471); \
++}
++
++#define LSX_CALC_CB(_in0, _in1, _in2, _out) {       \
++  _out = __lsx_vmsub_w(constminu, _in0, const1105); \
++  _out = __lsx_vmsub_w(_out, _in1, const2170);      \
++  _out = __lsx_vmadd_w(_out, _in2, const3276);      \
++}
++
++#define LSX_CALC_CR(_in0, _in1, _in2, _out) {       \
++  _out = __lsx_vmadd_w(constminu, _in0, const3276); \
++  _out = __lsx_vmsub_w(_out, _in1, const2743);      \
++  _out = __lsx_vmsub_w(_out, _in2, const5329);      \
++}
++
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lsx  jsimd_extrgb_ycc_convert_lsx
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lsx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lsx  jsimd_extbgr_ycc_convert_lsx
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lsx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lsx  jsimd_extrgbx_ycc_convert_lsx
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lsx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lsx  jsimd_extbgrx_ycc_convert_lsx
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lsx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lsx  jsimd_extxrgb_ycc_convert_lsx
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lsx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_rgb_ycc_convert_lsx  jsimd_extxbgr_ycc_convert_lsx
++#include "jccolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_ycc_convert_lsx
+diff --git a/simd/loongarch64/jcgray-lasx.c b/simd/loongarch64/jcgray-lasx.c
+new file mode 100644
+index 00000000..75c3f85b
+--- /dev/null
++++ b/simd/loongarch64/jcgray-lasx.c
+@@ -0,0 +1,124 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jmacros_lasx.h"
++
++/* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
++/*
++0.29900 * 65536 = 19595
++0.58700 * 65535 = 38470
++0.11400 * 65536 = 7471
++*/
++
++#define SCALEBITS 16
++#define ONE_HALF 32768
++#define GETSAMPLE(_in) ((int)(_in))
++
++#define LASX_CALC_Y(_in0, _in1, _in2, _out) { \
++  _out = __lasx_xvmul_w(_in0, const1959); \
++  _out = __lasx_xvmadd_w(_out, _in1, const3847); \
++  _out = __lasx_xvmadd_w(_out, _in2, const7471); \
++}
++
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_rgb_gray_convert_lasx  jsimd_extrgb_gray_convert_lasx
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lasx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_rgb_gray_convert_lasx  jsimd_extbgr_gray_convert_lasx
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lasx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_rgb_gray_convert_lasx  jsimd_extrgbx_gray_convert_lasx
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lasx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_rgb_gray_convert_lasx  jsimd_extbgrx_gray_convert_lasx
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lasx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_rgb_gray_convert_lasx  jsimd_extxrgb_gray_convert_lasx
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lasx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_rgb_gray_convert_lasx  jsimd_extxbgr_gray_convert_lasx
++#include "jcgryext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lasx
+diff --git a/simd/loongarch64/jcgray-lsx.c b/simd/loongarch64/jcgray-lsx.c
+new file mode 100644
+index 00000000..fd80401a
+--- /dev/null
++++ b/simd/loongarch64/jcgray-lsx.c
+@@ -0,0 +1,124 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jmacros_lsx.h"
++
++/* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
++/*
++0.29900 * 65536 = 19595
++0.58700 * 65535 = 38470
++0.11400 * 65536 = 7471
++*/
++
++#define SCALEBITS 16
++#define ONE_HALF 32768
++#define GETSAMPLE(_in) ((int)(_in))
++
++#define LSX_CALC_Y(_in0, _in1, _in2, _out) {   \
++  _out = __lsx_vmul_w(_in0, const1959);        \
++  _out = __lsx_vmadd_w(_out, _in1, const3847); \
++  _out = __lsx_vmadd_w(_out, _in2, const7471); \
++}
++
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_rgb_gray_convert_lsx  jsimd_extrgb_gray_convert_lsx
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lsx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_rgb_gray_convert_lsx  jsimd_extbgr_gray_convert_lsx
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lsx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_rgb_gray_convert_lsx  jsimd_extrgbx_gray_convert_lsx
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lsx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_rgb_gray_convert_lsx  jsimd_extbgrx_gray_convert_lsx
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lsx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_rgb_gray_convert_lsx  jsimd_extxrgb_gray_convert_lsx
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lsx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_rgb_gray_convert_lsx  jsimd_extxbgr_gray_convert_lsx
++#include "jcgryext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_rgb_gray_convert_lsx
+diff --git a/simd/loongarch64/jcgryext-lasx.c b/simd/loongarch64/jcgryext-lasx.c
+new file mode 100644
+index 00000000..1d85bc5e
+--- /dev/null
++++ b/simd/loongarch64/jcgryext-lasx.c
+@@ -0,0 +1,188 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++
++GLOBAL(void)
++jsimd_rgb_gray_convert_lasx(JDIMENSION img_width, JSAMPARRAY input_buf,
++                           JSAMPIMAGE output_buf, JDIMENSION output_row,
++                           int num_rows)
++{
++  JSAMPROW inptr, outptr0;
++  JDIMENSION col, col_remainings;
++  __m256i r, g, b;
++  __m256i src0, src1, src2;
++  __m256i const1959 = {19595};
++  __m256i const3847 = {38470};
++  __m256i const7471 = {7471};
++  int rgb_stride = RGB_PIXELSIZE << 5;
++
++#if RGB_PIXELSIZE == 3
++  v32i8 mask = {0,1,3,4,6,7,9,10,12,13,15,16,18,19,21,22,
++                8,9,11,12,14,15,17,18,20,21,23,24,26,27,29,30};
++  v32i8 mask1 = (v32i8)__lasx_xvaddi_bu((__m256i)mask, 1);
++#else
++  __m256i src3;
++#endif
++
++  const1959 = __lasx_xvreplve0_w(const1959);
++  const3847 = __lasx_xvreplve0_w(const3847);
++  const7471 = __lasx_xvreplve0_w(const7471);
++
++  while (--num_rows >= 0) {
++    inptr = *input_buf++;
++    outptr0 = output_buf[0][output_row];
++    output_row++;
++    col = img_width;
++
++    LASX_LD_2(inptr, 32, src0, src1);
++
++    for (; col >= 32; col -= 32) {
++#if RGB_PIXELSIZE == 4
++
++      LASX_LD_2(inptr + 64, 32, src2, src3);
++
++#if RGB_RED == 0
++      /* rgbx */
++      {
++        __m256i rgl, rgh, bxl, bxh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, rgl, rgh);
++        LASX_PCKEV_B(rgh, rgl, r);
++        LASX_PCKOD_B(rgh, rgl, g);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, bxl, bxh);
++        LASX_PCKEV_B(bxh, bxl, b);
++      }
++#endif
++
++#if RGB_RED == 1
++      /* xrgb */
++      {
++        __m256i xrl, xrh, gbl, gbh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, xrl, xrh);
++        LASX_PCKOD_B(xrh, xrl, r);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, gbl, gbh);
++        LASX_PCKEV_B(gbh, gbl, g);
++        LASX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgrx */
++      {
++        __m256i bgl, bgh, rxl, rxh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, bgl, bgh);
++        LASX_PCKEV_B(bgh, bgl, b);
++        LASX_PCKOD_B(bgh, bgl, g);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, rxl, rxh);
++        LASX_PCKEV_B(rxh, rxl, r);
++      }
++#endif
++
++#if RGB_RED == 3
++      /* xbgr */
++      {
++        __m256i xbl, xbh, grl, grh;
++        LASX_PCKEV_H_2(src1, src0, src3, src2, xbl, xbh);
++        LASX_PCKOD_B(xbh, xbl, b);
++        LASX_PCKOD_H_2(src1, src0, src3, src2, grl, grh);
++        LASX_PCKEV_B(grh, grl, g);
++        LASX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#else /* end RGB_PIXELSIZE == 4 */
++
++      src2 = LASX_LD(inptr + 64);
++
++#if RGB_RED == 0
++      /* rgb */
++      {
++        __m256i rgl, rgh, gbl, gbh;
++        __m256i src01, src12;
++        src01 = __lasx_xvpermi_q(src1, src0, 0x21);
++        src12 = __lasx_xvpermi_q(src2, src1, 0x21);
++        rgl = __lasx_xvshuf_b(src01, src0, (__m256i)mask);
++        rgh = __lasx_xvshuf_b(src2, src12, (__m256i)mask);
++        LASX_PCKEV_B(rgh, rgl, r);
++        LASX_PCKOD_B(rgh, rgl, g);
++        gbl = __lasx_xvshuf_b(src01, src0, (__m256i)mask1);
++        gbh = __lasx_xvshuf_b(src2, src12, (__m256i)mask1);
++        LASX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgr */
++      {
++        __m256i bgl, bgh, grl, grh;
++        __m256i src01, src12;
++        src01 = __lasx_xvpermi_q(src1, src0, 0x21);
++        src12 = __lasx_xvpermi_q(src2, src1, 0x21);
++        bgl = __lasx_xvshuf_b(src01, src0, (__m256i)mask);
++        bgh = __lasx_xvshuf_b(src2, src12, (__m256i)mask);
++        LASX_PCKEV_B(bgh, bgl, b);
++        LASX_PCKOD_B(bgh, bgl, g);
++        grl = __lasx_xvshuf_b(src01, src0, (__m256i)mask1);
++        grh = __lasx_xvshuf_b(src2, src12, (__m256i)mask1);
++        LASX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#endif /* end RGB_PIXELSIZE == 3 */
++      {
++        __m256i r0, r1, r2, r3;
++        __m256i g0, g1, g2, g3;
++        __m256i b0, b1, b2, b3;
++        __m256i y0, y1, y2, y3;
++
++        LASX_UNPCK_WU_BU_4(r, r0, r1, r2, r3);
++        LASX_UNPCK_WU_BU_4(g, g0, g1, g2, g3);
++        LASX_UNPCK_WU_BU_4(b, b0, b1, b2, b3);
++
++        /* y */
++        LASX_CALC_Y(r0, g0, b0, y0);
++        LASX_CALC_Y(r1, g1, b1, y1);
++        LASX_CALC_Y(r2, g2, b2, y2);
++        LASX_CALC_Y(r3, g3, b3, y3);
++        LASX_SRARI_W_4(y0, y1, y2, y3, SCALEBITS);
++        LASX_PCKEV_H_2(y1, y0, y3, y2, y0, y2);
++        LASX_PCKEV_B(y2, y0, y0);
++
++        LASX_ST(y0, outptr0);
++        inptr += rgb_stride;
++        LASX_LD_2(inptr, 32, src0, src1);
++        outptr0 += 32;
++      }
++    }/* for(...) */
++
++    col_remainings = col;
++    for (col = 0; col < col_remainings; col++) {
++      JDIMENSION r = GETSAMPLE(inptr[RGB_RED]);
++      JDIMENSION g = GETSAMPLE(inptr[RGB_GREEN]);
++      JDIMENSION b = GETSAMPLE(inptr[RGB_BLUE]);
++      inptr += RGB_PIXELSIZE;
++      outptr0[col] = (uint8_t)((19595 * r + 38470 * g + 7471 * b +
++                               ONE_HALF) >> SCALEBITS);
++    }
++  }
++}
+diff --git a/simd/loongarch64/jcgryext-lsx.c b/simd/loongarch64/jcgryext-lsx.c
+new file mode 100644
+index 00000000..add58d94
+--- /dev/null
++++ b/simd/loongarch64/jcgryext-lsx.c
+@@ -0,0 +1,187 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++
++GLOBAL(void)
++jsimd_rgb_gray_convert_lsx(JDIMENSION img_width, JSAMPARRAY input_buf,
++                           JSAMPIMAGE output_buf, JDIMENSION output_row,
++                           int num_rows)
++{
++  JSAMPROW inptr, outptr0;
++  JDIMENSION col, col_remainings;
++  __m128i r, g, b;
++  __m128i src0, src1, src2;
++  __m128i const1959 = {19595};
++  __m128i const3847 = {38470};
++  __m128i const7471 = {7471};
++  int rgb_stride = RGB_PIXELSIZE << 4;
++
++#if RGB_PIXELSIZE == 3
++  v16i8 mask = {0,1,3,4,6,7,9,10,12,13,15,24,26,27,29,30};
++  v16i8 mask1 = (v16i8)__lsx_vaddi_bu((__m128i)mask, 1);
++#else
++  __m128i src3;
++#endif
++
++  const1959 = __lsx_vreplvei_w(const1959, 0);
++  const3847 = __lsx_vreplvei_w(const3847, 0);
++  const7471 = __lsx_vreplvei_w(const7471, 0);
++
++  while (--num_rows >= 0) {
++    inptr = *input_buf++;
++    outptr0 = output_buf[0][output_row];
++    output_row++;
++    col = img_width;
++
++    LSX_LD_2(inptr, 16, src0, src1);
++
++    for (; col >= 16; col -= 16) {
++#if RGB_PIXELSIZE == 4
++
++      LSX_LD_2(inptr + 32, 16, src2, src3);
++
++#if RGB_RED == 0
++      /* rgbx */
++      {
++        __m128i rgl, rgh, bxl, bxh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, rgl, rgh);
++        LSX_PCKEV_B(rgh, rgl, r);
++        LSX_PCKOD_B(rgh, rgl, g);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, bxl, bxh);
++        LSX_PCKEV_B(bxh, bxl, b);
++      }
++#endif
++
++#if RGB_RED == 1
++      /* xrgb */
++      {
++        __m128i xrl, xrh, gbl, gbh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, xrl, xrh);
++        LSX_PCKOD_B(xrh, xrl, r);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, gbl, gbh);
++        LSX_PCKEV_B(gbh, gbl, g);
++        LSX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgrx */
++      {
++        __m128i bgl, bgh, rxl, rxh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, bgl, bgh);
++        LSX_PCKEV_B(bgh, bgl, b);
++        LSX_PCKOD_B(bgh, bgl, g);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, rxl, rxh);
++        LSX_PCKEV_B(rxh, rxl, r);
++      }
++#endif
++
++#if RGB_RED == 3
++      /* xbgr */
++      {
++        __m128i xbl, xbh, grl, grh;
++        LSX_PCKEV_H_2(src1, src0, src3, src2, xbl, xbh);
++        LSX_PCKOD_B(xbh, xbl, b);
++        LSX_PCKOD_H_2(src1, src0, src3, src2, grl, grh);
++        LSX_PCKEV_B(grh, grl, g);
++        LSX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#else /* end RGB_PIXELSIZE == 4 */
++
++      src2 = LSX_LD(inptr + 32);
++
++#if RGB_RED == 0
++      /* rgb */
++      {
++        __m128i rgl, rgh, gbl, gbh;
++        __m128i src01, src12;
++        src01 = __lsx_vpermi_w(src1, src0, 0x4E);
++        src12 = __lsx_vpermi_w(src2, src1, 0x4E);
++        rgl = __lsx_vshuf_b(src01, src0, (__m128i)mask);
++        rgh = __lsx_vshuf_b(src2, src12, (__m128i)mask);
++        LSX_PCKEV_B(rgh, rgl, r);
++        LSX_PCKOD_B(rgh, rgl, g);
++        gbl = __lsx_vshuf_b(src01, src0, (__m128i)mask1);
++        gbh = __lsx_vshuf_b(src2, src12, (__m128i)mask1);
++        LSX_PCKOD_B(gbh, gbl, b);
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgr */
++      {
++        __m128i bgl, bgh, grl, grh;
++        __m128i src01, src12;
++        src01 = __lsx_vpermi_w(src1, src0, 0x4E);
++        src12 = __lsx_vpermi_w(src2, src1, 0x4E);
++        bgl = __lsx_vshuf_b(src01, src0, (__m128i)mask);
++        bgh = __lsx_vshuf_b(src2, src12, (__m128i)mask);
++        LSX_PCKEV_B(bgh, bgl, b);
++        LSX_PCKOD_B(bgh, bgl, g);
++        grl = __lsx_vshuf_b(src01, src0, (__m128i)mask1);
++        grh = __lsx_vshuf_b(src2, src12, (__m128i)mask1);
++        LSX_PCKOD_B(grh, grl, r);
++      }
++#endif
++
++#endif /* end RGB_PIXELSIZE == 3 */
++      {
++        __m128i r0, r1, r2, r3;
++        __m128i g0, g1, g2, g3;
++        __m128i b0, b1, b2, b3;
++        __m128i y0, y1, y2, y3;
++
++        LSX_UNPCK_WU_BU_4(r, r0, r1, r2, r3);
++        LSX_UNPCK_WU_BU_4(g, g0, g1, g2, g3);
++        LSX_UNPCK_WU_BU_4(b, b0, b1, b2, b3);
++
++        /* y */
++        LSX_CALC_Y(r0, g0, b0, y0);
++        LSX_CALC_Y(r1, g1, b1, y1);
++        LSX_CALC_Y(r2, g2, b2, y2);
++        LSX_CALC_Y(r3, g3, b3, y3);
++        LSX_SRARI_W_4(y0, y1, y2, y3, SCALEBITS);
++        LSX_PCKEV_H_2(y1, y0, y3, y2, y0, y2);
++        LSX_PCKEV_B(y2, y0, y0);
++
++        LSX_ST(y0, outptr0);
++        inptr += rgb_stride;
++        LSX_LD_2(inptr, 16, src0, src1);
++        outptr0 += 16;
++      }
++    }/* for(...) */
++
++    col_remainings = col;
++    for (col = 0; col < col_remainings; col++) {
++      JDIMENSION r = GETSAMPLE(inptr[RGB_RED]);
++      JDIMENSION g = GETSAMPLE(inptr[RGB_GREEN]);
++      JDIMENSION b = GETSAMPLE(inptr[RGB_BLUE]);
++      inptr += RGB_PIXELSIZE;
++      outptr0[col] = (uint8_t)((19595 * r + 38470 * g + 7471 * b +
++                               ONE_HALF) >> SCALEBITS);
++    }
++  }
++}
+diff --git a/simd/loongarch64/jcsample-lasx.c b/simd/loongarch64/jcsample-lasx.c
+new file mode 100644
+index 00000000..92dd2cfa
+--- /dev/null
++++ b/simd/loongarch64/jcsample-lasx.c
+@@ -0,0 +1,183 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "jcsample.h"
++#include "jmacros_lasx.h"
++
++GLOBAL(void)
++jsimd_h2v1_downsample_lasx(JDIMENSION image_width, int max_v_samp_factor,
++                           JDIMENSION v_samp_factor, JDIMENSION width_blocks,
++                           JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++  int outrow, bias;
++  JDIMENSION outcol;
++  JDIMENSION output_cols = width_blocks << 3;
++  JSAMPROW inptr, outptr;
++  v16i16 plus01 = {0,1,0,1,0,1,0,1,0,1,0,1,0,1,0,1};
++  __m256i src0, src1;
++
++  expand_right_edge(input_data, max_v_samp_factor,
++                    image_width, output_cols << 1);
++
++  for (outrow = 0; outrow < v_samp_factor; outrow++) {
++    outptr = output_data[outrow];
++    inptr = input_data[outrow];
++    outcol = output_cols;
++
++    for (; outcol >= 32; outcol -= 32) {
++      LASX_LD_2(inptr, 32, src0, src1);
++      src0 = __lasx_xvhaddw_hu_bu(src0, src0);
++      src1 = __lasx_xvhaddw_hu_bu(src1, src1);
++      src0 = __lasx_xvadd_h(src0, (__m256i)plus01);
++      src1 = __lasx_xvadd_h(src1, (__m256i)plus01);
++      src0 = __lasx_xvsrai_h(src0, 1);
++      src1 = __lasx_xvsrai_h(src1, 1);
++      LASX_PCKEV_B(src1, src0, src0);
++      LASX_ST(src0, outptr);
++      outptr += 32;
++      inptr += 64;
++    }
++
++    if (outcol >= 16) {
++      src0 = LASX_LD(inptr);
++      src0 = __lasx_xvhaddw_hu_bu(src0, src0);
++      src0 = __lasx_xvadd_h(src0, (__m256i)plus01);
++      src0 = __lasx_xvsrai_h(src0, 1);
++      src0 = __lasx_xvpickev_b(src0, src0);
++      __lasx_xvstelm_d(src0, outptr, 0, 0);
++      __lasx_xvstelm_d(src0, outptr, 8, 2);
++      outptr += 16;
++      inptr += 32;
++      outcol -= 16;
++    }
++
++    if (outcol >= 8) {
++      src0 = LASX_LD(inptr);
++      src0 = __lasx_xvhaddw_hu_bu(src0, src0);
++      src0 = __lasx_xvadd_h(src0, (__m256i)plus01);
++      src0 = __lasx_xvsrai_h(src0, 1);
++      src0 = __lasx_xvpickev_b(src0, src0);
++      __lasx_xvstelm_d(src0, outptr, 0, 0);
++      outptr += 8;
++      inptr += 16;
++      outcol -= 8;
++    }
++
++    bias = 0;
++    for (; outcol > 0; outcol--) {
++      *outptr++ = (JSAMPLE) ((GETJSAMPLE(*inptr) + GETJSAMPLE(inptr[1])
++                              + bias) >> 1);
++      bias ^= 1;
++      inptr += 2;
++    }
++  }
++}
++
++GLOBAL(void)
++jsimd_h2v2_downsample_lasx(JDIMENSION image_width, int max_v_samp_factor,
++                           JDIMENSION v_samp_factor, JDIMENSION width_blocks,
++                           JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++  int inrow, outrow, bias;
++  JDIMENSION outcol;
++  JDIMENSION output_cols = width_blocks << 3;
++  JSAMPROW inptr0, inptr1, outptr;
++  v16i16 plus12 = {1,2,1,2,1,2,1,2,1,2,1,2,1,2,1,2};
++  __m256i src0, src1, src2, src3;
++
++  expand_right_edge(input_data, max_v_samp_factor,
++                    image_width, output_cols << 1);
++  inrow = 0;
++  for (outrow = 0; outrow < v_samp_factor; outrow++) {
++    outptr = output_data[outrow];
++    inptr0 = input_data[inrow];
++    inptr1 = input_data[inrow + 1];
++    outcol = output_cols;
++
++    for (; outcol >= 32; outcol -= 32) {
++      LASX_LD_2(inptr0, 32, src0, src1);
++      LASX_LD_2(inptr1, 32, src2, src3);
++      src0 = __lasx_xvhaddw_hu_bu(src0, src0);
++      src1 = __lasx_xvhaddw_hu_bu(src1, src1);
++      src2 = __lasx_xvhaddw_hu_bu(src2, src2);
++      src3 = __lasx_xvhaddw_hu_bu(src3, src3);
++      src0 = __lasx_xvadd_h(src0, src2);
++      src1 = __lasx_xvadd_h(src1, src3);
++      src0 = __lasx_xvadd_h(src0, (__m256i)plus12);
++      src1 = __lasx_xvadd_h(src1, (__m256i)plus12);
++      src0 = __lasx_xvsrai_h(src0, 2);
++      src1 = __lasx_xvsrai_h(src1, 2);
++      LASX_PCKEV_B(src1, src0, src0);
++      LASX_ST(src0, outptr);
++      outptr += 32;
++      inptr0 += 64;
++      inptr1 += 64;
++    }
++
++    if (outcol >= 16) {
++      src0 = LASX_LD(inptr0);
++      src1 = LASX_LD(inptr1);
++      src0 = __lasx_xvhaddw_hu_bu(src0, src0);
++      src1 = __lasx_xvhaddw_hu_bu(src1, src1);
++      src0 = __lasx_xvadd_h(src0, src1);
++      src0 = __lasx_xvadd_h(src0, (__m256i)plus12);
++      src0 = __lasx_xvsrai_h(src0, 2);
++      src0 = __lasx_xvpickev_b(src0, src0);
++      __lasx_xvstelm_d(src0, outptr, 0, 0);
++      __lasx_xvstelm_d(src0, outptr, 8, 2);
++      outptr += 16;
++      inptr0 += 32;
++      inptr1 += 32;
++      outcol -= 16;
++    }
++
++    if (outcol >= 8) {
++      src0 = LASX_LD(inptr0);
++      src1 = LASX_LD(inptr1);
++      src0 = __lasx_xvhaddw_hu_bu(src0, src0);
++      src1 = __lasx_xvhaddw_hu_bu(src1, src1);
++      src0 = __lasx_xvadd_h(src0, src1);
++      src0 = __lasx_xvadd_h(src0, (__m256i)plus12);
++      src0 = __lasx_xvsrai_h(src0, 2);
++      src0 = __lasx_xvpickev_b(src0, src0);
++      __lasx_xvstelm_d(src0, outptr, 0, 0);
++      outptr += 8;
++      inptr0 += 16;
++      inptr1 += 16;
++      outcol -= 8;
++    }
++
++    bias = 1;
++    for (; outcol > 0; outcol--) {
++      *outptr++ = (JSAMPLE) ((GETJSAMPLE(*inptr0) + GETJSAMPLE(inptr0[1]) +
++                              GETJSAMPLE(*inptr1) + GETJSAMPLE(inptr1[1])
++                              + bias) >> 2);
++      bias ^= 3;
++      inptr0 += 2; inptr1 += 2;
++    }
++    inrow += 2;
++  }
++}
+diff --git a/simd/loongarch64/jcsample-lsx.c b/simd/loongarch64/jcsample-lsx.c
+new file mode 100644
+index 00000000..1e7ff99e
+--- /dev/null
++++ b/simd/loongarch64/jcsample-lsx.c
+@@ -0,0 +1,181 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "jcsample.h"
++#include "jmacros_lsx.h"
++
++GLOBAL(void)
++jsimd_h2v1_downsample_lsx(JDIMENSION image_width, int max_v_samp_factor,
++                          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
++                          JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++  int outrow, bias;
++  JDIMENSION outcol;
++  JDIMENSION output_cols = width_blocks << 3;
++  JSAMPROW inptr, outptr;
++  v8i16 plus01 = {0,1,0,1,0,1,0,1};
++  __m128i src0, src1;
++
++  expand_right_edge(input_data, max_v_samp_factor,
++                    image_width, output_cols << 1);
++
++  for (outrow = 0; outrow < v_samp_factor; outrow++) {
++    outptr = output_data[outrow];
++    inptr = input_data[outrow];
++    outcol = output_cols;
++
++    for (; outcol >= 16; outcol -= 16) {
++      LSX_LD_2(inptr, 16, src0, src1);
++      src0 = __lsx_vhaddw_hu_bu(src0, src0);
++      src1 = __lsx_vhaddw_hu_bu(src1, src1);
++      src0 = __lsx_vadd_h(src0, (__m128i)plus01);
++      src1 = __lsx_vadd_h(src1, (__m128i)plus01);
++      src0 = __lsx_vsrai_h(src0, 1);
++      src1 = __lsx_vsrai_h(src1, 1);
++      LSX_PCKEV_B(src1, src0, src0);
++      LSX_ST(src0, outptr);
++      outptr += 16;
++      inptr += 32;
++    }
++
++    if (outcol >= 8) {
++      src0 = LSX_LD(inptr);
++      src0 = __lsx_vhaddw_hu_bu(src0, src0);
++      src0 = __lsx_vadd_h(src0, (__m128i)plus01);
++      src0 = __lsx_vsrai_h(src0, 1);
++      src0 = __lsx_vpickev_b(src0, src0);
++      __lsx_vstelm_d(src0, outptr, 0, 0);
++      outptr += 8;
++      inptr += 16;
++      outcol -= 8;
++    }
++
++    if (outcol >= 4) {
++      src0 = LSX_LD(inptr);
++      src0 = __lsx_vhaddw_hu_bu(src0, src0);
++      src0 = __lsx_vadd_h(src0, (__m128i)plus01);
++      src0 = __lsx_vsrai_h(src0, 1);
++      src0 = __lsx_vpickev_b(src0, src0);
++      __lsx_vstelm_w(src0, outptr, 0, 0);
++      outptr += 4;
++      inptr += 8;
++      outcol -= 4;
++    }
++
++    bias = 0;
++    for (; outcol > 0; outcol--) {
++      *outptr++ = (JSAMPLE) ((GETJSAMPLE(*inptr) + GETJSAMPLE(inptr[1])
++                              + bias) >> 1);
++      bias ^= 1;
++      inptr += 2;
++    }
++  }
++}
++
++GLOBAL(void)
++jsimd_h2v2_downsample_lsx(JDIMENSION image_width, int max_v_samp_factor,
++                          JDIMENSION v_samp_factor, JDIMENSION width_blocks,
++                          JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++  int inrow, outrow, bias;
++  JDIMENSION outcol;
++  JDIMENSION output_cols = width_blocks << 3;
++  JSAMPROW inptr0, inptr1, outptr;
++  v8i16 plus12 = {1,2,1,2,1,2,1,2};
++  __m128i src0, src1, src2, src3;
++
++  expand_right_edge(input_data, max_v_samp_factor,
++                    image_width, output_cols << 1);
++  inrow = 0;
++  for (outrow = 0; outrow < v_samp_factor; outrow++) {
++    outptr = output_data[outrow];
++    inptr0 = input_data[inrow];
++    inptr1 = input_data[inrow + 1];
++    outcol = output_cols;
++
++    for (; outcol >= 16; outcol -= 16) {
++      LSX_LD_2(inptr0, 16, src0, src1);
++      LSX_LD_2(inptr1, 16, src2, src3);
++      src0 = __lsx_vhaddw_hu_bu(src0, src0);
++      src1 = __lsx_vhaddw_hu_bu(src1, src1);
++      src2 = __lsx_vhaddw_hu_bu(src2, src2);
++      src3 = __lsx_vhaddw_hu_bu(src3, src3);
++      src0 = __lsx_vadd_h(src0, src2);
++      src1 = __lsx_vadd_h(src1, src3);
++      src0 = __lsx_vadd_h(src0, (__m128i)plus12);
++      src1 = __lsx_vadd_h(src1, (__m128i)plus12);
++      src0 = __lsx_vsrai_h(src0, 2);
++      src1 = __lsx_vsrai_h(src1, 2);
++      LSX_PCKEV_B(src1, src0, src0);
++      LSX_ST(src0, outptr);
++      outptr += 16;
++      inptr0 += 32;
++      inptr1 += 32;
++    }
++
++    if (outcol >= 8) {
++      src0 = LSX_LD(inptr0);
++      src1 = LSX_LD(inptr1);
++      src0 = __lsx_vhaddw_hu_bu(src0, src0);
++      src1 = __lsx_vhaddw_hu_bu(src1, src1);
++      src0 = __lsx_vadd_h(src0, src1);
++      src0 = __lsx_vadd_h(src0, (__m128i)plus12);
++      src0 = __lsx_vsrai_h(src0, 2);
++      src0 = __lsx_vpickev_b(src0, src0);
++      __lsx_vstelm_d(src0, outptr, 0, 0);
++      outptr += 8;
++      inptr0 += 16;
++      inptr1 += 16;
++      outcol -= 8;
++    }
++
++    if (outcol >= 4) {
++      src0 = LSX_LD(inptr0);
++      src1 = LSX_LD(inptr1);
++      src0 = __lsx_vhaddw_hu_bu(src0, src0);
++      src1 = __lsx_vhaddw_hu_bu(src1, src1);
++      src0 = __lsx_vadd_h(src0, src1);
++      src0 = __lsx_vadd_h(src0, (__m128i)plus12);
++      src0 = __lsx_vsrai_h(src0, 2);
++      src0 = __lsx_vpickev_b(src0, src0);
++      __lsx_vstelm_w(src0, outptr, 0, 0);
++      outptr += 4;
++      inptr0 += 8;
++      inptr1 += 8;
++      outcol -= 4;
++    }
++
++    bias = 1;
++    for (; outcol > 0; outcol--) {
++      *outptr++ = (JSAMPLE) ((GETJSAMPLE(*inptr0) + GETJSAMPLE(inptr0[1]) +
++                              GETJSAMPLE(*inptr1) + GETJSAMPLE(inptr1[1])
++                              + bias) >> 2);
++      bias ^= 3;
++      inptr0 += 2; inptr1 += 2;
++    }
++    inrow += 2;
++  }
++}
+diff --git a/simd/loongarch64/jcsample.h b/simd/loongarch64/jcsample.h
+new file mode 100644
+index 00000000..bd07fcc4
+--- /dev/null
++++ b/simd/loongarch64/jcsample.h
+@@ -0,0 +1,28 @@
++/*
++ * jcsample.h
++ *
++ * This file was part of the Independent JPEG Group's software:
++ * Copyright (C) 1991-1996, Thomas G. Lane.
++ * For conditions of distribution and use, see the accompanying README.ijg
++ * file.
++ */
++
++LOCAL(void)
++expand_right_edge(JSAMPARRAY image_data, int num_rows, JDIMENSION input_cols,
++                  JDIMENSION output_cols)
++{
++  register JSAMPROW ptr;
++  register JSAMPLE pixval;
++  register int count;
++  int row;
++  int numcols = (int)(output_cols - input_cols);
++
++  if (numcols > 0) {
++    for (row = 0; row < num_rows; row++) {
++      ptr = image_data[row] + input_cols;
++      pixval = ptr[-1];
++      for (count = numcols; count > 0; count--)
++        *ptr++ = pixval;
++    }
++  }
++}
+diff --git a/simd/loongarch64/jdcolext-lasx.c b/simd/loongarch64/jdcolext-lasx.c
+new file mode 100644
+index 00000000..69a96829
+--- /dev/null
++++ b/simd/loongarch64/jdcolext-lasx.c
+@@ -0,0 +1,312 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++GLOBAL(void)
++jsimd_ycc_rgb_convert_lasx(JDIMENSION out_width,
++                           JSAMPIMAGE input_buf, JDIMENSION input_row,
++                           JSAMPARRAY output_buf, int num_rows)
++{
++  register JSAMPROW ptr_y, ptr_cb, ptr_cr;
++  register JSAMPROW ptr_rgb;
++  int y, cb, cr;
++  JDIMENSION cols;
++  __m256i vec_y, vec_cb, vec_cr;
++  __m256i out_r0, out_g0, out_b0;
++  __m256i vec_yh_l, vec_yh_h;
++  __m256i vec_cbh_l, vec_cbh_h;
++  __m256i vec_crh_l, vec_crh_h;
++  __m256i const128 = {128};
++  __m256i alpha = {0xFF};
++
++  v8i32 const1402 = {FIX_140200, FIX_140200, FIX_140200, FIX_140200, FIX_140200,
++                     FIX_140200, FIX_140200, FIX_140200};
++  v16i16 const_34414_28586 = {-FIX_34414, FIX_28586, -FIX_34414, FIX_28586,
++                    -FIX_34414, FIX_28586, -FIX_34414, FIX_28586, -FIX_34414,
++                     FIX_28586, -FIX_34414, FIX_28586, -FIX_34414, FIX_28586,
++                    -FIX_34414, FIX_28586};
++  v8i32 const1772 = {FIX_177200, FIX_177200, FIX_177200, FIX_177200, FIX_177200,
++                     FIX_177200, FIX_177200, FIX_177200};
++
++  alpha    = __lasx_xvreplve0_b(alpha);
++  const128 = __lasx_xvreplve0_b(const128);
++
++  while (--num_rows >= 0) {
++    ptr_y   = input_buf[0][input_row];
++    ptr_cb  = input_buf[1][input_row];
++    ptr_cr  = input_buf[2][input_row];
++    ptr_rgb = *output_buf++;
++    input_row++;
++
++    for (cols = out_width; cols >= 32; cols -= 32) {
++      vec_y  = LASX_LD(ptr_y);
++      vec_cb = LASX_LD(ptr_cb);
++      vec_cr = LASX_LD(ptr_cr);
++      ptr_y  += 32;
++      ptr_cb += 32;
++      ptr_cr += 32;
++
++      /* Cb = Cb - 128, Cr = Cr - 128 */
++      vec_cb = __lasx_xvsub_b(vec_cb, const128);
++      vec_cr = __lasx_xvsub_b(vec_cr, const128);
++
++      LASX_UNPCKLH_HU_BU(vec_y, vec_yh_h, vec_yh_l);
++      LASX_UNPCKLH_H_B(vec_cb, vec_cbh_h, vec_cbh_l);
++      LASX_UNPCKLH_H_B(vec_cr, vec_crh_h, vec_crh_l);
++
++      /* R: Y + 1.40200 * Cr */
++      {
++        __m256i tmp0_m, tmp1_m;
++        __m256i out0_m, out1_m, out2_m, out3_m;
++
++        LASX_UNPCKLH_W_H(vec_crh_l, out1_m, out0_m);
++        LASX_UNPCKLH_W_H(vec_crh_h, out3_m, out2_m);
++        out0_m = __lasx_xvmul_w(out0_m, (__m256i)const1402);
++        out1_m = __lasx_xvmul_w(out1_m, (__m256i)const1402);
++        out2_m = __lasx_xvmul_w(out2_m, (__m256i)const1402);
++        out3_m = __lasx_xvmul_w(out3_m, (__m256i)const1402);
++
++        out0_m = __lasx_xvsrari_w(out0_m, 16);
++        out1_m = __lasx_xvsrari_w(out1_m, 16);
++        out2_m = __lasx_xvsrari_w(out2_m, 16);
++        out3_m = __lasx_xvsrari_w(out3_m, 16);
++
++        LASX_PCKEV_H_2(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m);
++        tmp0_m = __lasx_xvadd_h(tmp0_m, vec_yh_l);
++        tmp1_m = __lasx_xvadd_h(tmp1_m, vec_yh_h);
++        LASX_CLIP_H_0_255_2(tmp0_m, tmp1_m, tmp0_m, tmp1_m);
++        out_r0 = __lasx_xvpickev_b(tmp1_m, tmp0_m);
++        out_r0 = __lasx_xvpermi_d(out_r0, 0xd8);
++      }
++
++      /* G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
++      {
++        __m256i tmp0_m, tmp1_m;
++        __m256i out0_m, out1_m, out2_m, out3_m;
++
++        LASX_ILVLH_H(vec_crh_l, vec_cbh_l, tmp1_m, tmp0_m);
++        LASX_DOTP2_W_H(tmp0_m, (__m256i)const_34414_28586, out0_m);
++        LASX_DOTP2_W_H(tmp1_m, (__m256i)const_34414_28586, out1_m);
++        out0_m = __lasx_xvsrari_w(out0_m, 16);
++        out1_m = __lasx_xvsrari_w(out1_m, 16);
++
++        LASX_ILVLH_H(vec_crh_h, vec_cbh_h, tmp1_m, tmp0_m);
++        LASX_DOTP2_W_H(tmp0_m, (__m256i)const_34414_28586, out2_m);
++        LASX_DOTP2_W_H(tmp1_m, (__m256i)const_34414_28586, out3_m);
++        out2_m = __lasx_xvsrari_w(out2_m, 16);
++        out3_m = __lasx_xvsrari_w(out3_m, 16);
++
++        LASX_PCKEV_H_2(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m);
++        tmp0_m = __lasx_xvadd_h(tmp0_m, vec_yh_l);
++        tmp1_m = __lasx_xvadd_h(tmp1_m, vec_yh_h);
++        tmp0_m = __lasx_xvsub_h(tmp0_m, vec_crh_l);
++        tmp1_m = __lasx_xvsub_h(tmp1_m, vec_crh_h);
++        LASX_CLIP_H_0_255_2(tmp0_m, tmp1_m, tmp0_m, tmp1_m);
++        out_g0 = __lasx_xvpickev_b(tmp1_m, tmp0_m);
++        out_g0 = __lasx_xvpermi_d(out_g0, 0xd8);
++      }
++
++      /* B: Y + 1.77200 * Cb */
++      {
++        __m256i tmp0_m, tmp1_m;
++        __m256i out0_m, out1_m, out2_m, out3_m;
++
++        LASX_UNPCKLH_W_H(vec_cbh_l, out1_m, out0_m);
++        LASX_UNPCKLH_W_H(vec_cbh_h, out3_m, out2_m);
++        out0_m = __lasx_xvmul_w(out0_m, (__m256i)const1772);
++        out1_m = __lasx_xvmul_w(out1_m, (__m256i)const1772);
++        out2_m = __lasx_xvmul_w(out2_m, (__m256i)const1772);
++        out3_m = __lasx_xvmul_w(out3_m, (__m256i)const1772);
++
++        out0_m = __lasx_xvsrari_w(out0_m, 16);
++        out1_m = __lasx_xvsrari_w(out1_m, 16);
++        out2_m = __lasx_xvsrari_w(out2_m, 16);
++        out3_m = __lasx_xvsrari_w(out3_m, 16);
++
++        LASX_PCKEV_H_2(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m);
++        tmp0_m = __lasx_xvadd_h(tmp0_m, vec_yh_l);
++        tmp1_m = __lasx_xvadd_h(tmp1_m, vec_yh_h);
++        LASX_CLIP_H_0_255_2(tmp0_m, tmp1_m, tmp0_m, tmp1_m);
++        out_b0 = __lasx_xvpickev_b(tmp1_m, tmp0_m);
++        out_b0 = __lasx_xvpermi_d(out_b0, 0xd8);
++      }
++
++      /* Store to memory */
++
++#if RGB_PIXELSIZE == 4
++
++#if RGB_RED == 0
++      /* rgbx */
++      {
++        __m256i out_rg_l, out_rg_h, out_bx_l, out_bx_h;
++        __m256i out_rgbx_l_l, out_rgbx_l_h, out_rgbx_h_l, out_rgbx_h_h;
++        LASX_ILVLH_B(out_g0, out_r0, out_rg_h, out_rg_l);
++        LASX_ILVLH_B(alpha, out_b0, out_bx_h, out_bx_l);
++        LASX_ILVLH_H(out_bx_l, out_rg_l, out_rgbx_l_h, out_rgbx_l_l);
++        LASX_ILVLH_H(out_bx_h, out_rg_h, out_rgbx_h_h, out_rgbx_h_l);
++        LASX_ST_4(out_rgbx_l_l, out_rgbx_l_h, out_rgbx_h_l, out_rgbx_h_h, ptr_rgb, 32);
++        ptr_rgb += 128;
++      }
++#endif
++
++#if RGB_RED == 1
++      /* xrgb */
++      {
++        __m256i out_xr_l, out_xr_h, out_gb_l, out_gb_h;
++        __m256i out_xrgb_l_l, out_xrgb_l_h, out_xrgb_h_l, out_xrgb_h_h;
++        LASX_ILVLH_B(out_r0, alpha, out_xr_h, out_xr_l);
++        LASX_ILVLH_B(out_b0, out_g0, out_gb_h, out_gb_l);
++        LASX_ILVLH_H(out_gb_l, out_xr_l, out_xrgb_l_h, out_xrgb_l_l);
++        LASX_ILVLH_H(out_gb_h, out_xr_h, out_xrgb_h_h, out_xrgb_h_l);
++        LASX_ST_4(out_xrgb_l_l, out_xrgb_l_h, out_xrgb_h_l, out_xrgb_h_h, ptr_rgb, 32);
++        ptr_rgb += 128;
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgrx */
++      {
++        __m256i out_bg_l, out_bg_h, out_rx_l, out_rx_h;
++        __m256i out_bgrx_l_l, out_bgrx_l_h, out_bgrx_h_l, out_bgrx_h_h;
++        LASX_ILVLH_B(out_g0, out_b0, out_bg_h, out_bg_l);
++        LASX_ILVLH_B(alpha, out_r0, out_rx_h, out_rx_l);
++        LASX_ILVLH_H(out_rx_l, out_bg_l, out_bgrx_l_h, out_bgrx_l_l);
++        LASX_ILVLH_H(out_rx_h, out_bg_h, out_bgrx_h_h, out_bgrx_h_l);
++        LASX_ST_4(out_bgrx_l_l, out_bgrx_l_h, out_bgrx_h_l, out_bgrx_h_h, ptr_rgb, 32);
++        ptr_rgb += 128;
++      }
++#endif
++
++#if RGB_RED == 3
++      /* xbgr */
++      {
++        __m256i out_xb_l, out_xb_h, out_gr_l, out_gr_h;
++        __m256i out_xbgr_l_l, out_xbgr_l_h, out_xbgr_h_l, out_xbgr_h_h;
++        LASX_ILVLH_B(out_b0, alpha, out_xb_h, out_xb_l);
++        LASX_ILVLH_B(out_r0, out_g0, out_gr_h, out_gr_l);
++        LASX_ILVLH_H(out_gr_l, out_xb_l, out_xbgr_l_h, out_xbgr_l_l);
++        LASX_ILVLH_H(out_gr_h, out_xb_h, out_xbgr_h_h, out_xbgr_h_l);
++        LASX_ST_4(out_xbgr_l_l, out_xbgr_l_h, out_xbgr_h_l, out_xbgr_h_h, ptr_rgb, 32);
++        ptr_rgb += 128;
++      }
++#endif
++
++#else /* RGB_PIXELSIZE == 3 */
++
++#if RGB_RED == 0
++      /* rgb */
++      {
++        __m256i out_rg_l, out_rg_h, out_bx_l, out_bx_h;
++        __m256i out_rgb_l_l, out_rgb_l_h, out_rgb_h_l;
++        __m256i tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
++        v32i8 mask0 = {0,1,16,2,3,18,4,5,20,6,7,22,8,9,24,10,0,
++                       1,16,2,3,18,4,5,20,6,7,22,8,9,24,10};
++        v32i8 mask1 = {11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0,
++                       11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0};
++        LASX_ILVLH_B(out_g0, out_r0, out_rg_h, out_rg_l);
++        LASX_ILVLH_B(alpha, out_b0, out_bx_h, out_bx_l);
++
++        tmp0 = __lasx_xvshuf_b(out_bx_l, out_rg_l, (__m256i)mask0);
++        tmp1 = __lasx_xvshuf_b(out_bx_l, out_rg_l, (__m256i)mask1);
++        tmp1 = __lasx_xvpermi_d(tmp1, 0xd8);
++        tmp2 = __lasx_xvpermi_q(tmp0, tmp1, 0x12);
++        tmp3 = __lasx_xvpermi_q(tmp0, tmp1, 0x03);
++        tmp3 = __lasx_xvpermi_d(tmp3, 0xd2);
++        out_rgb_l_l = __lasx_xvpermi_q(tmp2, tmp3, 0x02);
++        tmp4 = __lasx_xvpermi_q(tmp2, tmp3, 0x31);
++
++        tmp0 = __lasx_xvshuf_b(out_bx_h, out_rg_h, (__m256i)mask0);
++        tmp1 = __lasx_xvshuf_b(out_bx_h, out_rg_h, (__m256i)mask1);
++        tmp1 = __lasx_xvpermi_d(tmp1, 0xd8);
++        tmp2 = __lasx_xvpermi_q(tmp0, tmp1, 0x12);
++        tmp3 = __lasx_xvpermi_q(tmp0, tmp1, 0x03);
++        tmp3 = __lasx_xvpermi_d(tmp3, 0xd2);
++        tmp5 = __lasx_xvpermi_q(tmp2, tmp3, 0x02);
++        tmp6 = __lasx_xvpermi_q(tmp2, tmp3, 0x31);
++
++        out_rgb_l_h = __lasx_xvpermi_q(tmp4, tmp5, 0x02);
++        tmp7 = __lasx_xvpermi_q(tmp4, tmp5, 0x13);
++        out_rgb_h_l = __lasx_xvpermi_q(tmp6, tmp7, 0x21);
++        LASX_ST_2(out_rgb_l_l, out_rgb_l_h, ptr_rgb, 32);
++        LASX_ST(out_rgb_h_l, ptr_rgb + 64);
++        ptr_rgb += 96;
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgr */
++      {
++        __m256i out_bg_l, out_bg_h, out_rx_l, out_rx_h;
++        __m256i out_bgr_l_l, out_bgr_l_h, out_bgr_h_l;
++        __m256i tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
++        v32i8 mask0 = {0,1,16,2,3,18,4,5,20,6,7,22,8,9,24,10,0,
++                       1,16,2,3,18,4,5,20,6,7,22,8,9,24,10};
++        v32i8 mask1 = {11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0,
++                       11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0};
++        LASX_ILVLH_B(out_g0, out_b0, out_bg_h, out_bg_l);
++        LASX_ILVLH_B(alpha, out_r0, out_rx_h, out_rx_l);
++
++        tmp0 = __lasx_xvshuf_b(out_rx_l, out_bg_l, (__m256i)mask0);
++        tmp1 = __lasx_xvshuf_b(out_rx_l, out_bg_l, (__m256i)mask1);
++        tmp1 = __lasx_xvpermi_d(tmp1, 0xd8);
++        tmp2 = __lasx_xvpermi_q(tmp0, tmp1, 0x12);
++        tmp3 = __lasx_xvpermi_q(tmp0, tmp1, 0x03);
++        tmp3 = __lasx_xvpermi_d(tmp3, 0xd2);
++        out_bgr_l_l = __lasx_xvpermi_q(tmp2, tmp3, 0x02);
++        tmp4 = __lasx_xvpermi_q(tmp2, tmp3, 0x31);
++
++        tmp0 = __lasx_xvshuf_b(out_rx_h, out_bg_h, (__m256i)mask0);
++        tmp1 = __lasx_xvshuf_b(out_rx_h, out_bg_h, (__m256i)mask1);
++        tmp1 = __lasx_xvpermi_d(tmp1, 0xd8);
++        tmp2 = __lasx_xvpermi_q(tmp0, tmp1, 0x12);
++        tmp3 = __lasx_xvpermi_q(tmp0, tmp1, 0x03);
++        tmp3 = __lasx_xvpermi_d(tmp3, 0xd2);
++        tmp5 = __lasx_xvpermi_q(tmp2, tmp3, 0x02);
++        tmp6 = __lasx_xvpermi_q(tmp2, tmp3, 0x31);
++
++        out_bgr_l_h = __lasx_xvpermi_q(tmp4, tmp5, 0x02);
++        tmp7 = __lasx_xvpermi_q(tmp4, tmp5, 0x13);
++        out_bgr_h_l = __lasx_xvpermi_q(tmp6, tmp7, 0x21);
++        LASX_ST_2(out_bgr_l_l, out_bgr_l_h, ptr_rgb, 32);
++        LASX_ST(out_bgr_h_l, ptr_rgb + 64);
++        ptr_rgb += 96;
++      }
++#endif
++
++#endif /* RGB_PIXELSIZE == 3 */
++    } /* for (cols = out_width; cols >= 32; cols -= 32) */
++
++    for (int i = 0; i < cols; i++) {
++      y  = (int)(ptr_y[i]);
++      cb = (int)(ptr_cb[i]) - 128;
++      cr = (int)(ptr_cr[i]) - 128;
++      ptr_rgb[RGB_RED]   = clip_pixel(y + DESCALE(FIX_140200 * cr, 16));
++      ptr_rgb[RGB_GREEN] = clip_pixel(y + DESCALE(((-FIX_34414) * cb - FIX_71414 * cr), 16));
++      ptr_rgb[RGB_BLUE]  = clip_pixel(y + DESCALE(FIX_177200 * cb, 16));
++#ifdef RGB_ALPHA
++      ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++      ptr_rgb += RGB_PIXELSIZE;
++    }
++  }
++}
+diff --git a/simd/loongarch64/jdcolext-lsx.c b/simd/loongarch64/jdcolext-lsx.c
+new file mode 100644
+index 00000000..61704ebc
+--- /dev/null
++++ b/simd/loongarch64/jdcolext-lsx.c
+@@ -0,0 +1,279 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++GLOBAL(void)
++jsimd_ycc_rgb_convert_lsx(JDIMENSION out_width,
++                          JSAMPIMAGE input_buf, JDIMENSION input_row,
++                          JSAMPARRAY output_buf, int num_rows)
++{
++  register JSAMPROW ptr_y, ptr_cb, ptr_cr;
++  register JSAMPROW ptr_rgb;
++  int y, cb, cr;
++  JDIMENSION cols;
++  __m128i vec_y, vec_cb, vec_cr;
++  __m128i out_r0, out_g0, out_b0;
++  __m128i vec_yh_l, vec_yh_h;
++  __m128i vec_cbh_l, vec_cbh_h;
++  __m128i vec_crh_l, vec_crh_h;
++  __m128i const128 = {128};
++  __m128i alpha = {0xFF};
++
++  v4i32 const1402 = {FIX_140200, FIX_140200, FIX_140200, FIX_140200};
++  v8i16 const_34414_28586 = {-FIX_34414, FIX_28586, -FIX_34414, FIX_28586,
++                             -FIX_34414, FIX_28586, -FIX_34414, FIX_28586};
++  v4i32 const1772 = {FIX_177200, FIX_177200, FIX_177200, FIX_177200};
++
++  alpha    = __lsx_vreplvei_b(alpha, 0);
++  const128 = __lsx_vreplvei_b(const128, 0);
++
++  while (--num_rows >= 0) {
++    ptr_y   = input_buf[0][input_row];
++    ptr_cb  = input_buf[1][input_row];
++    ptr_cr  = input_buf[2][input_row];
++    ptr_rgb = *output_buf++;
++    input_row++;
++
++    for (cols = out_width; cols >= 16; cols -= 16) {
++      vec_y  = LSX_LD(ptr_y);
++      vec_cb = LSX_LD(ptr_cb);
++      vec_cr = LSX_LD(ptr_cr);
++      ptr_y  += 16;
++      ptr_cb += 16;
++      ptr_cr += 16;
++
++      /* Cb = Cb - 128, Cr = Cr - 128 */
++      vec_cb = __lsx_vsub_b(vec_cb, const128);
++      vec_cr = __lsx_vsub_b(vec_cr, const128);
++
++      LSX_UNPCKLH_HU_BU(vec_y, vec_yh_h, vec_yh_l);
++      LSX_UNPCKLH_H_B(vec_cb, vec_cbh_h, vec_cbh_l);
++      LSX_UNPCKLH_H_B(vec_cr, vec_crh_h, vec_crh_l);
++
++      /* R: Y + 1.40200 * Cr */
++      {
++        __m128i tmp0_m, tmp1_m;
++        __m128i out0_m, out1_m, out2_m, out3_m;
++
++        LSX_UNPCKLH_W_H(vec_crh_l, out1_m, out0_m);
++        LSX_UNPCKLH_W_H(vec_crh_h, out3_m, out2_m);
++        out0_m = __lsx_vmul_w(out0_m, (__m128i)const1402);
++        out1_m = __lsx_vmul_w(out1_m, (__m128i)const1402);
++        out2_m = __lsx_vmul_w(out2_m, (__m128i)const1402);
++        out3_m = __lsx_vmul_w(out3_m, (__m128i)const1402);
++
++        out0_m = __lsx_vsrari_w(out0_m, 16);
++        out1_m = __lsx_vsrari_w(out1_m, 16);
++        out2_m = __lsx_vsrari_w(out2_m, 16);
++        out3_m = __lsx_vsrari_w(out3_m, 16);
++
++        LSX_PCKEV_H_2(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m);
++        tmp0_m = __lsx_vadd_h(tmp0_m, vec_yh_l);
++        tmp1_m = __lsx_vadd_h(tmp1_m, vec_yh_h);
++        LSX_CLIP_H_0_255_2(tmp0_m, tmp1_m, tmp0_m, tmp1_m);
++        out_r0 = __lsx_vpickev_b(tmp1_m, tmp0_m);
++      }
++
++      /* G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
++      {
++        __m128i tmp0_m, tmp1_m;
++        __m128i out0_m, out1_m, out2_m, out3_m;
++
++        LSX_ILVLH_H(vec_crh_l, vec_cbh_l, tmp1_m, tmp0_m);
++        LSX_DP2_W_H(tmp0_m, (__m128i)const_34414_28586, out0_m);
++        LSX_DP2_W_H(tmp1_m, (__m128i)const_34414_28586, out1_m);
++        out0_m = __lsx_vsrari_w(out0_m, 16);
++        out1_m = __lsx_vsrari_w(out1_m, 16);
++
++        LSX_ILVLH_H(vec_crh_h, vec_cbh_h, tmp1_m, tmp0_m);
++        LSX_DP2_W_H(tmp0_m, (__m128i)const_34414_28586, out2_m);
++        LSX_DP2_W_H(tmp1_m, (__m128i)const_34414_28586, out3_m);
++        out2_m = __lsx_vsrari_w(out2_m, 16);
++        out3_m = __lsx_vsrari_w(out3_m, 16);
++
++        LSX_PCKEV_H_2(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m);
++        tmp0_m = __lsx_vadd_h(tmp0_m, vec_yh_l);
++        tmp1_m = __lsx_vadd_h(tmp1_m, vec_yh_h);
++        tmp0_m = __lsx_vsub_h(tmp0_m, vec_crh_l);
++        tmp1_m = __lsx_vsub_h(tmp1_m, vec_crh_h);
++        LSX_CLIP_H_0_255_2(tmp0_m, tmp1_m, tmp0_m, tmp1_m);
++        out_g0 = __lsx_vpickev_b(tmp1_m, tmp0_m);
++      }
++
++      /* B: Y + 1.77200 * Cb */
++      {
++        __m128i tmp0_m, tmp1_m;
++        __m128i out0_m, out1_m, out2_m, out3_m;
++
++        LSX_UNPCKLH_W_H(vec_cbh_l, out1_m, out0_m);
++        LSX_UNPCKLH_W_H(vec_cbh_h, out3_m, out2_m);
++        out0_m = __lsx_vmul_w(out0_m, (__m128i)const1772);
++        out1_m = __lsx_vmul_w(out1_m, (__m128i)const1772);
++        out2_m = __lsx_vmul_w(out2_m, (__m128i)const1772);
++        out3_m = __lsx_vmul_w(out3_m, (__m128i)const1772);
++
++        out0_m = __lsx_vsrari_w(out0_m, 16);
++        out1_m = __lsx_vsrari_w(out1_m, 16);
++        out2_m = __lsx_vsrari_w(out2_m, 16);
++        out3_m = __lsx_vsrari_w(out3_m, 16);
++
++        LSX_PCKEV_H_2(out1_m, out0_m, out3_m, out2_m, tmp0_m, tmp1_m);
++        tmp0_m = __lsx_vadd_h(tmp0_m, vec_yh_l);
++        tmp1_m = __lsx_vadd_h(tmp1_m, vec_yh_h);
++        LSX_CLIP_H_0_255_2(tmp0_m, tmp1_m, tmp0_m, tmp1_m);
++        out_b0 = __lsx_vpickev_b(tmp1_m, tmp0_m);
++      }
++
++      /* Store to memory */
++
++#if RGB_PIXELSIZE == 4
++
++#if RGB_RED == 0
++      /* rgbx */
++      {
++        __m128i out_rg_l, out_rg_h, out_bx_l, out_bx_h;
++        __m128i out_rgbx_l_l, out_rgbx_l_h, out_rgbx_h_l, out_rgbx_h_h;
++        LSX_ILVLH_B(out_g0, out_r0, out_rg_h, out_rg_l);
++        LSX_ILVLH_B(alpha, out_b0, out_bx_h, out_bx_l);
++        LSX_ILVLH_H(out_bx_l, out_rg_l, out_rgbx_l_h, out_rgbx_l_l);
++        LSX_ILVLH_H(out_bx_h, out_rg_h, out_rgbx_h_h, out_rgbx_h_l);
++        LSX_ST_4(out_rgbx_l_l, out_rgbx_l_h, out_rgbx_h_l, out_rgbx_h_h, ptr_rgb, 16);
++        ptr_rgb += 64;
++      }
++#endif
++
++#if RGB_RED == 1
++      /* xrgb */
++      {
++        __m128i out_xr_l, out_xr_h, out_gb_l, out_gb_h;
++        __m128i out_xrgb_l_l, out_xrgb_l_h, out_xrgb_h_l, out_xrgb_h_h;
++        LSX_ILVLH_B(out_r0, alpha, out_xr_h, out_xr_l);
++        LSX_ILVLH_B(out_b0, out_g0, out_gb_h, out_gb_l);
++        LSX_ILVLH_H(out_gb_l, out_xr_l, out_xrgb_l_h, out_xrgb_l_l);
++        LSX_ILVLH_H(out_gb_h, out_xr_h, out_xrgb_h_h, out_xrgb_h_l);
++        LSX_ST_4(out_xrgb_l_l, out_xrgb_l_h, out_xrgb_h_l, out_xrgb_h_h, ptr_rgb, 16);
++        ptr_rgb += 64;
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgrx */
++      {
++        __m128i out_bg_l, out_bg_h, out_rx_l, out_rx_h;
++        __m128i out_bgrx_l_l, out_bgrx_l_h, out_bgrx_h_l, out_bgrx_h_h;
++        LSX_ILVLH_B(out_g0, out_b0, out_bg_h, out_bg_l);
++        LSX_ILVLH_B(alpha, out_r0, out_rx_h, out_rx_l);
++        LSX_ILVLH_H(out_rx_l, out_bg_l, out_bgrx_l_h, out_bgrx_l_l);
++        LSX_ILVLH_H(out_rx_h, out_bg_h, out_bgrx_h_h, out_bgrx_h_l);
++        LSX_ST_4(out_bgrx_l_l, out_bgrx_l_h, out_bgrx_h_l, out_bgrx_h_h, ptr_rgb, 16);
++        ptr_rgb += 64;
++      }
++#endif
++
++#if RGB_RED == 3
++      /* xbgr */
++      {
++        __m128i out_xb_l, out_xb_h, out_gr_l, out_gr_h;
++        __m128i out_xbgr_l_l, out_xbgr_l_h, out_xbgr_h_l, out_xbgr_h_h;
++        LSX_ILVLH_B(out_b0, alpha, out_xb_h, out_xb_l);
++        LSX_ILVLH_B(out_r0, out_g0, out_gr_h, out_gr_l);
++        LSX_ILVLH_H(out_gr_l, out_xb_l, out_xbgr_l_h, out_xbgr_l_l);
++        LSX_ILVLH_H(out_gr_h, out_xb_h, out_xbgr_h_h, out_xbgr_h_l);
++        LSX_ST_4(out_xbgr_l_l, out_xbgr_l_h, out_xbgr_h_l, out_xbgr_h_h, ptr_rgb, 16);
++        ptr_rgb += 64;
++      }
++#endif
++
++#else /* RGB_PIXELSIZE == 3 */
++
++#if RGB_RED == 0
++      /* rgb */
++      {
++        __m128i out_rgb_l_l, out_rgb_l_h, out_rgb_h_l;
++        __m128i tmp0, tmp1, tmp2;
++        v16i8 mask0 = {0,16,1,17,2,18,3,19,4,20,5,21,6,22,7,23};
++        v16i8 mask1 = {0,1,16,2,3,17,4,5,18,6,7,19,8,9,20,10};
++        v16i8 mask2 = {21,6,22,7,23,8,24,9,25,10,26,11,27,12,28,13};
++        v16i8 mask3 = {0,21,1,2,22,3,4,23,5,6,24,7,8,25,9,10};
++        v16i8 mask4 = {11,27,12,28,13,29,14,30,15,31,0,0,0,0,0,0};
++        v16i8 mask5 = {26,0,1,27,2,3,28,4,5,29,6,7,30,8,9,31};
++
++	tmp0 = __lsx_vshuf_b(out_g0, out_r0, (__m128i)mask0);
++        out_rgb_l_l = __lsx_vshuf_b(out_b0, tmp0, (__m128i)mask1);
++
++        tmp1 = __lsx_vshuf_b(out_g0, out_r0, (__m128i)mask2);
++        out_rgb_l_h = __lsx_vshuf_b(out_b0, tmp1, (__m128i)mask3);
++
++        tmp2 = __lsx_vshuf_b(out_g0, out_r0, (__m128i)mask4);
++        out_rgb_h_l = __lsx_vshuf_b(out_b0, tmp2, (__m128i)mask5);
++
++        LSX_ST_2(out_rgb_l_l, out_rgb_l_h, ptr_rgb, 16);
++        LSX_ST(out_rgb_h_l, ptr_rgb + 32);
++        ptr_rgb += 48;
++      }
++#endif
++
++#if RGB_RED == 2
++      /* bgr */
++      {
++        __m128i out_bgr_l_l, out_bgr_l_h, out_bgr_h_l;
++        __m128i tmp0, tmp1, tmp2;
++        v16i8 mask0 = {0,16,1,17,2,18,3,19,4,20,5,21,6,22,7,23};
++        v16i8 mask1 = {0,1,16,2,3,17,4,5,18,6,7,19,8,9,20,10};
++        v16i8 mask2 = {21,6,22,7,23,8,24,9,25,10,26,11,27,12,28,13};
++        v16i8 mask3 = {0,21,1,2,22,3,4,23,5,6,24,7,8,25,9,10};
++        v16i8 mask4 = {11,27,12,28,13,29,14,30,15,31,0,0,0,0,0,0};
++        v16i8 mask5 = {26,0,1,27,2,3,28,4,5,29,6,7,30,8,9,31};
++
++	tmp0 = __lsx_vshuf_b(out_g0, out_b0, (__m128i)mask0);
++        out_bgr_l_l = __lsx_vshuf_b(out_r0, tmp0, (__m128i)mask1);
++
++        tmp1 = __lsx_vshuf_b(out_g0, out_b0, (__m128i)mask2);
++        out_bgr_l_h = __lsx_vshuf_b(out_r0, tmp1, (__m128i)mask3);
++
++        tmp2 = __lsx_vshuf_b(out_g0, out_b0, (__m128i)mask4);
++        out_bgr_h_l = __lsx_vshuf_b(out_r0, tmp2, (__m128i)mask5);
++
++        LSX_ST_2(out_bgr_l_l, out_bgr_l_h, ptr_rgb, 16);
++        LSX_ST(out_bgr_h_l, ptr_rgb + 32);
++        ptr_rgb += 48;
++      }
++#endif
++
++#endif /* RGB_PIXELSIZE == 3 */
++    } /* for (cols = out_width; cols >= 32; cols -= 32) */
++
++    for (int i = 0; i < cols; i++) {
++      y  = (int)(ptr_y[i]);
++      cb = (int)(ptr_cb[i]) - 128;
++      cr = (int)(ptr_cr[i]) - 128;
++      ptr_rgb[RGB_RED]   = clip_pixel(y + DESCALE(FIX_140200 * cr, 16));
++      ptr_rgb[RGB_GREEN] = clip_pixel(y + DESCALE(((-FIX_34414) * cb - FIX_71414 * cr), 16));
++      ptr_rgb[RGB_BLUE]  = clip_pixel(y + DESCALE(FIX_177200 * cb, 16));
++#ifdef RGB_ALPHA
++      ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++      ptr_rgb += RGB_PIXELSIZE;
++    }
++  }
++}
+diff --git a/simd/loongarch64/jdcolor-lasx.c b/simd/loongarch64/jdcolor-lasx.c
+new file mode 100644
+index 00000000..a87fa625
+--- /dev/null
++++ b/simd/loongarch64/jdcolor-lasx.c
+@@ -0,0 +1,144 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jconfigint.h"
++#include "jmacros_lasx.h"
++
++
++#define FIX_140200  91881
++#define FIX_34414   22554
++#define FIX_71414   46802
++#define FIX_177200  116130
++#define FIX_28586   18734
++
++#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
++
++#define LASX_DOTP2_W_H(_in0, _in1, _out0) \
++{ \
++  __m256i _tmp0, _tmp1, _tmp2, _tmp3; \
++  _tmp0 = __lasx_xvsrai_h(_in0, 15); \
++  _tmp1 = __lasx_xvsrai_h(_in1, 15); \
++  _tmp2 = __lasx_xvpackev_h(_tmp0, _in0); \
++  _tmp3 = __lasx_xvpackev_h(_tmp1, _in1); \
++  _out0 = __lasx_xvmul_w(_tmp2, _tmp3); \
++  _tmp2 = __lasx_xvpackod_h(_tmp0, _in0); \
++  _tmp3 = __lasx_xvpackod_h(_tmp1, _in1); \
++  _tmp0 = __lasx_xvmul_w(_tmp2, _tmp3); \
++  _out0 = __lasx_xvadd_w(_out0, _tmp0); \
++}
++
++static INLINE unsigned char clip_pixel(int val)
++{
++  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
++}
++
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lasx  jsimd_ycc_extrgb_convert_lasx
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lasx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lasx  jsimd_ycc_extbgr_convert_lasx
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lasx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lasx  jsimd_ycc_extrgbx_convert_lasx
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lasx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lasx  jsimd_ycc_extbgrx_convert_lasx
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lasx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lasx  jsimd_ycc_extxrgb_convert_lasx
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lasx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lasx  jsimd_ycc_extxbgr_convert_lasx
++#include "jdcolext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lasx
+diff --git a/simd/loongarch64/jdcolor-lsx.c b/simd/loongarch64/jdcolor-lsx.c
+new file mode 100644
+index 00000000..137d53e2
+--- /dev/null
++++ b/simd/loongarch64/jdcolor-lsx.c
+@@ -0,0 +1,129 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jconfigint.h"
++#include "jmacros_lsx.h"
++
++#define FIX_140200  91881
++#define FIX_34414   22554
++#define FIX_71414   46802
++#define FIX_177200  116130
++#define FIX_28586   18734
++
++#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
++
++static INLINE unsigned char clip_pixel(int val)
++{
++  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
++}
++
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lsx  jsimd_ycc_extrgb_convert_lsx
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lsx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lsx  jsimd_ycc_extbgr_convert_lsx
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lsx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lsx  jsimd_ycc_extrgbx_convert_lsx
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lsx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lsx  jsimd_ycc_extbgrx_convert_lsx
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lsx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lsx  jsimd_ycc_extxrgb_convert_lsx
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lsx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_ycc_rgb_convert_lsx  jsimd_ycc_extxbgr_convert_lsx
++#include "jdcolext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_ycc_rgb_convert_lsx
+diff --git a/simd/loongarch64/jdmerge-lasx.c b/simd/loongarch64/jdmerge-lasx.c
+new file mode 100644
+index 00000000..fa0945ad
+--- /dev/null
++++ b/simd/loongarch64/jdmerge-lasx.c
+@@ -0,0 +1,141 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jconfigint.h"
++#include "jmacros_lasx.h"
++
++#define FIX_140200  91881
++#define FIX_34414   22554
++#define FIX_71414   46802
++#define FIX_177200  116130
++#define FIX_28586   18734
++
++#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
++
++static INLINE unsigned char clip_pixel(int val)
++{
++  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
++}
++
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lasx  jsimd_h2v1_extrgb_merged_upsample_lasx
++#define jsimd_h2v2_merged_upsample_lasx  jsimd_h2v2_extrgb_merged_upsample_lasx
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lasx
++#undef jsimd_h2v2_merged_upsample_lasx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lasx  jsimd_h2v1_extbgr_merged_upsample_lasx
++#define jsimd_h2v2_merged_upsample_lasx  jsimd_h2v2_extbgr_merged_upsample_lasx
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lasx
++#undef jsimd_h2v2_merged_upsample_lasx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lasx  jsimd_h2v1_extrgbx_merged_upsample_lasx
++#define jsimd_h2v2_merged_upsample_lasx  jsimd_h2v2_extrgbx_merged_upsample_lasx
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lasx
++#undef jsimd_h2v2_merged_upsample_lasx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lasx  jsimd_h2v1_extbgrx_merged_upsample_lasx
++#define jsimd_h2v2_merged_upsample_lasx  jsimd_h2v2_extbgrx_merged_upsample_lasx
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lasx
++#undef jsimd_h2v2_merged_upsample_lasx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lasx  jsimd_h2v1_extxrgb_merged_upsample_lasx
++#define jsimd_h2v2_merged_upsample_lasx  jsimd_h2v2_extxrgb_merged_upsample_lasx
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lasx
++#undef jsimd_h2v2_merged_upsample_lasx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lasx  jsimd_h2v1_extxbgr_merged_upsample_lasx
++#define jsimd_h2v2_merged_upsample_lasx  jsimd_h2v2_extxbgr_merged_upsample_lasx
++#include "jdmrgext-lasx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lasx
++#undef jsimd_h2v2_merged_upsample_lasx
+diff --git a/simd/loongarch64/jdmerge-lsx.c b/simd/loongarch64/jdmerge-lsx.c
+new file mode 100644
+index 00000000..57f30ba8
+--- /dev/null
++++ b/simd/loongarch64/jdmerge-lsx.c
+@@ -0,0 +1,141 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jconfigint.h"
++#include "jmacros_lsx.h"
++
++#define FIX_140200  91881
++#define FIX_34414   22554
++#define FIX_71414   46802
++#define FIX_177200  116130
++#define FIX_28586   18734
++
++#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
++
++static INLINE unsigned char clip_pixel(int val)
++{
++  return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
++}
++
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++
++#define RGB_RED        EXT_RGB_RED
++#define RGB_GREEN      EXT_RGB_GREEN
++#define RGB_BLUE       EXT_RGB_BLUE
++#define RGB_PIXELSIZE  EXT_RGB_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lsx  jsimd_h2v1_extrgb_merged_upsample_lsx
++#define jsimd_h2v2_merged_upsample_lsx  jsimd_h2v2_extrgb_merged_upsample_lsx
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lsx
++#undef jsimd_h2v2_merged_upsample_lsx
++
++#define RGB_RED        EXT_BGR_RED
++#define RGB_GREEN      EXT_BGR_GREEN
++#define RGB_BLUE       EXT_BGR_BLUE
++#define RGB_PIXELSIZE  EXT_BGR_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lsx  jsimd_h2v1_extbgr_merged_upsample_lsx
++#define jsimd_h2v2_merged_upsample_lsx  jsimd_h2v2_extbgr_merged_upsample_lsx
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lsx
++#undef jsimd_h2v2_merged_upsample_lsx
++
++#define RGB_RED        EXT_RGBX_RED
++#define RGB_GREEN      EXT_RGBX_GREEN
++#define RGB_BLUE       EXT_RGBX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_RGBX_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lsx  jsimd_h2v1_extrgbx_merged_upsample_lsx
++#define jsimd_h2v2_merged_upsample_lsx  jsimd_h2v2_extrgbx_merged_upsample_lsx
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lsx
++#undef jsimd_h2v2_merged_upsample_lsx
++
++#define RGB_RED        EXT_BGRX_RED
++#define RGB_GREEN      EXT_BGRX_GREEN
++#define RGB_BLUE       EXT_BGRX_BLUE
++#define RGB_ALPHA      3
++#define RGB_PIXELSIZE  EXT_BGRX_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lsx  jsimd_h2v1_extbgrx_merged_upsample_lsx
++#define jsimd_h2v2_merged_upsample_lsx  jsimd_h2v2_extbgrx_merged_upsample_lsx
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lsx
++#undef jsimd_h2v2_merged_upsample_lsx
++
++#define RGB_RED        EXT_XRGB_RED
++#define RGB_GREEN      EXT_XRGB_GREEN
++#define RGB_BLUE       EXT_XRGB_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XRGB_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lsx  jsimd_h2v1_extxrgb_merged_upsample_lsx
++#define jsimd_h2v2_merged_upsample_lsx  jsimd_h2v2_extxrgb_merged_upsample_lsx
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lsx
++#undef jsimd_h2v2_merged_upsample_lsx
++
++#define RGB_RED        EXT_XBGR_RED
++#define RGB_GREEN      EXT_XBGR_GREEN
++#define RGB_BLUE       EXT_XBGR_BLUE
++#define RGB_ALPHA      0
++#define RGB_PIXELSIZE  EXT_XBGR_PIXELSIZE
++#define jsimd_h2v1_merged_upsample_lsx  jsimd_h2v1_extxbgr_merged_upsample_lsx
++#define jsimd_h2v2_merged_upsample_lsx  jsimd_h2v2_extxbgr_merged_upsample_lsx
++#include "jdmrgext-lsx.c"
++#undef RGB_RED
++#undef RGB_GREEN
++#undef RGB_BLUE
++#undef RGB_ALPHA
++#undef RGB_PIXELSIZE
++#undef jsimd_h2v1_merged_upsample_lsx
++#undef jsimd_h2v2_merged_upsample_lsx
+diff --git a/simd/loongarch64/jdmrgext-lasx.c b/simd/loongarch64/jdmrgext-lasx.c
+new file mode 100644
+index 00000000..28765c64
+--- /dev/null
++++ b/simd/loongarch64/jdmrgext-lasx.c
+@@ -0,0 +1,335 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++GLOBAL(void)
++jsimd_h2v1_merged_upsample_lasx(JDIMENSION output_width, JSAMPIMAGE input_buf,
++                                JDIMENSION in_row_group_ctr,
++                                JSAMPARRAY output_buf)
++{
++  register JSAMPROW ptr_y, ptr_cb, ptr_cr;
++  register JSAMPROW ptr_rgb;
++  register int y, cb, cr, cred, cgreen, cblue;
++  JDIMENSION cols;
++  __m256i out_r0, out_g0, out_b0;
++  __m256i vec_y0, vec_cb, vec_cr, vec_yo, vec_ye;
++  __m256i vec_cbh_l, vec_crh_l;
++
++  __m256i const128 = {128};
++  __m256i alpha = {0xFF};
++  __m256i zero = {0};
++
++  v8i32 const1402 = {FIX_140200, FIX_140200, FIX_140200, FIX_140200, FIX_140200,
++                     FIX_140200, FIX_140200, FIX_140200};
++  v16i16 const_34414_28586 = {-FIX_34414, FIX_28586, -FIX_34414, FIX_28586,
++                    -FIX_34414, FIX_28586, -FIX_34414, FIX_28586, -FIX_34414,
++                     FIX_28586, -FIX_34414, FIX_28586, -FIX_34414, FIX_28586,
++                    -FIX_34414, FIX_28586};
++  v8i32 const1772 = {FIX_177200, FIX_177200, FIX_177200, FIX_177200, FIX_177200,
++                     FIX_177200, FIX_177200, FIX_177200};
++
++  alpha = __lasx_xvreplve0_b(alpha);
++  const128 = __lasx_xvreplve0_b(const128);
++
++  ptr_y = input_buf[0][in_row_group_ctr];
++  ptr_cb = input_buf[1][in_row_group_ctr];
++  ptr_cr = input_buf[2][in_row_group_ctr];
++  ptr_rgb = output_buf[0];
++
++  for (cols = output_width; cols >= 32; cols -= 32) {
++    vec_y0 = LASX_LD(ptr_y);
++    vec_cb = LASX_LD(ptr_cb);
++    vec_cr = LASX_LD(ptr_cr);
++
++    ptr_y += 32;
++    ptr_cb += 16;
++    ptr_cr += 16;
++
++    /* Cb = Cb - 128, Cr = Cr - 128 */
++    vec_cb = __lasx_xvsub_b(vec_cb, const128);
++    vec_cr = __lasx_xvsub_b(vec_cr, const128);
++
++    vec_ye = __lasx_xvpackev_b(zero, vec_y0);
++    vec_yo = __lasx_xvpackod_b(zero, vec_y0);
++    LASX_UNPCKL_H_B(vec_cb, vec_cbh_l);
++    LASX_UNPCKL_H_B(vec_cr, vec_crh_l);
++
++    /* R = Y + 1.40200 * Cr */
++    {
++      __m256i temp0, out0, out1;
++
++      LASX_UNPCKLH_W_H(vec_crh_l, out1, out0);
++      out0 = __lasx_xvmul_w(out0, (__m256i)const1402);
++      out1 = __lasx_xvmul_w(out1, (__m256i)const1402);
++      out0 = __lasx_xvsrari_w(out0, 16);
++      out1 = __lasx_xvsrari_w(out1, 16);
++      LASX_PCKEV_H(out1, out0, temp0);
++      out0 = __lasx_xvadd_h(temp0, vec_ye);
++      out1 = __lasx_xvadd_h(temp0, vec_yo);
++      LASX_CLIP_H_0_255_2(out0, out1, out0, out1);
++      out_r0 = __lasx_xvpackev_b(out1, out0);
++    }
++
++    /* G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
++    {
++      __m256i temp0, temp1, out0, out1;
++
++      LASX_ILVLH_H(vec_crh_l, vec_cbh_l, temp1, temp0);
++      LASX_DP2_W_H(temp0, (__m256i)const_34414_28586, out0);
++      LASX_DP2_W_H(temp1, (__m256i)const_34414_28586, out1);
++      out0 = __lasx_xvsrari_w(out0, 16);
++      out1 = __lasx_xvsrari_w(out1, 16);
++      LASX_PCKEV_H(out1, out0, temp0);
++      temp0 = __lasx_xvsub_h(temp0, vec_crh_l);
++      out0 = __lasx_xvadd_h(temp0, vec_ye);
++      out1 = __lasx_xvadd_h(temp0, vec_yo);
++      LASX_CLIP_H_0_255_2(out0, out1, out0, out1);
++      out_g0 = __lasx_xvpackev_b(out1, out0);
++    }
++
++    /* B = Y + 1.77200 * Cb */
++    {
++      __m256i temp0, out0, out1;
++
++      LASX_UNPCKLH_W_H(vec_cbh_l, out1, out0);
++      out0 = __lasx_xvmul_w(out0, (__m256i)const1772);
++      out1 = __lasx_xvmul_w(out1, (__m256i)const1772);
++      out0 = __lasx_xvsrari_w(out0, 16);
++      out1 = __lasx_xvsrari_w(out1, 16);
++      LASX_PCKEV_H(out1, out0, temp0);
++      out0 = __lasx_xvadd_h(temp0, vec_ye);
++      out1 = __lasx_xvadd_h(temp0, vec_yo);
++      LASX_CLIP_H_0_255_2(out0, out1, out0, out1);
++      out_b0 = __lasx_xvpackev_b(out1, out0);
++    }
++
++    /* Store to memory */
++#if RGB_PIXELSIZE == 4
++
++#if RGB_RED == 0
++    /* rgbx */
++    {
++      __m256i out_rg_l, out_rg_h, out_bx_l, out_bx_h;
++      __m256i out_rgbx0_l_l, out_rgbx0_l_h, out_rgbx0_h_l, out_rgbx0_h_h;
++
++      LASX_ILVLH_B(out_g0, out_r0, out_rg_h, out_rg_l);
++      LASX_ILVLH_B(alpha, out_b0, out_bx_h, out_bx_l);
++      LASX_ILVLH_H(out_bx_l, out_rg_l, out_rgbx0_l_h, out_rgbx0_l_l);
++      LASX_ILVLH_H(out_bx_h, out_rg_h, out_rgbx0_h_h, out_rgbx0_h_l);
++
++      LASX_ST_4(out_rgbx0_l_l, out_rgbx0_l_h, out_rgbx0_h_l, out_rgbx0_h_h,
++                ptr_rgb, 32);
++      ptr_rgb += 128;
++    }
++#endif
++
++#if RGB_RED == 1
++    /* xrgb */
++    {
++      __m256i out_xr_l, out_xr_h, out_gb_l, out_gb_h;
++      __m256i out_xrgb0_l_l, out_xrgb0_l_h, out_xrgb0_h_l, out_xrgb0_h_h;
++
++      LASX_ILVLH_B(out_r0, alpha, out_xr_h, out_xr_l);
++      LASX_ILVLH_B(out_b0, out_g0, out_gb_h, out_gb_l);
++      LASX_ILVLH_H(out_gb_l, out_xr_l, out_xrgb0_l_h, out_xrgb0_l_l);
++      LASX_ILVLH_H(out_gb_h, out_xr_h, out_xrgb0_h_h, out_xrgb0_h_l);
++
++      LASX_ST_4(out_xrgb0_l_l, out_xrgb0_l_h, out_xrgb0_h_l, out_xrgb0_h_h,
++                ptr_rgb, 32);
++      ptr_rgb += 128;
++    }
++#endif
++
++#if RGB_RED == 2
++    /* bgrx */
++    {
++      __m256i out_bg_l, out_bg_h, out_rx_l, out_rx_h;
++      __m256i out_bgrx0_l_l, out_bgrx0_l_h, out_bgrx0_h_l, out_bgrx0_h_h;
++
++      LASX_ILVLH_B(out_g0, out_b0, out_bg_h, out_bg_l);
++      LASX_ILVLH_B(alpha, out_r0, out_rx_h, out_rx_l);
++      LASX_ILVLH_H(out_rx_l, out_bg_l, out_bgrx0_l_h, out_bgrx0_l_l);
++      LASX_ILVLH_H(out_rx_h, out_bg_h, out_bgrx0_h_h, out_bgrx0_h_l);
++
++      LASX_ST_4(out_bgrx0_l_l, out_bgrx0_l_h, out_bgrx0_h_l, out_bgrx0_h_h,
++                ptr_rgb, 32);
++      ptr_rgb += 128;
++    }
++#endif
++
++#if RGB_RED == 3
++    /* xbgr */
++    {
++      __m256i out_xb_l, out_xb_h, out_gr_l, out_gr_h;
++      __m256i out_xbgr0_l_l, out_xbgr0_l_h, out_xbgr0_h_l, out_xbgr0_h_h;
++
++      LASX_ILVLH_B(out_b0, alpha, out_xb_h, out_xb_l);
++      LASX_ILVLH_B(out_r0, out_g0, out_gr_h, out_gr_l);
++      LASX_ILVLH_H(out_gr_l, out_xb_l, out_xbgr0_l_h, out_xbgr0_l_l);
++      LASX_ILVLH_H(out_gr_h, out_xb_h, out_xbgr0_h_h, out_xbgr0_h_l);
++
++      LASX_ST_4(out_xbgr0_l_l, out_xbgr0_l_h, out_xbgr0_h_l, out_xbgr0_h_h,
++                ptr_rgb, 32);
++      ptr_rgb += 128;
++    }
++#endif
++
++#else /* end RGB_PIXELSIZE == 4 */
++
++#if RGB_RED == 0
++    /* rgb */
++    {
++      __m256i out_rg_l, out_rg_h, out_bx_l, out_bx_h;
++      __m256i temp0, temp1, temp2, temp3;
++      v32i8 mask0 = {0,1,16,2,3,18,4,5,20,6,7,22,8,9,24,10,0,
++                     1,16,2,3,18,4,5,20,6,7,22,8,9,24,10};
++      v32i8 mask1 = {11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0,
++                     11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0};
++
++      LASX_ILVLH_B(out_g0, out_r0, out_rg_h, out_rg_l);
++      LASX_ILVLH_B(alpha, out_b0, out_bx_h, out_bx_l);
++
++      temp0 = __lasx_xvshuf_b(out_bx_l, out_rg_l, (__m256i)mask0);
++      temp1 = __lasx_xvshuf_b(out_bx_l, out_rg_l, (__m256i)mask1);
++      temp2 = __lasx_xvshuf_b(out_bx_h, out_rg_h, (__m256i)mask0);
++      temp3 = __lasx_xvshuf_b(out_bx_h, out_rg_h, (__m256i)mask1);
++
++      __lasx_xvstelm_d(temp0, ptr_rgb, 0, 0);
++      __lasx_xvstelm_d(temp0, ptr_rgb, 8, 1);
++      __lasx_xvstelm_d(temp1, ptr_rgb, 16, 0);
++      __lasx_xvstelm_d(temp0, ptr_rgb, 24, 2);
++      __lasx_xvstelm_d(temp0, ptr_rgb, 32, 3);
++      __lasx_xvstelm_d(temp1, ptr_rgb, 40, 2);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 48, 0);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 56, 1);
++      __lasx_xvstelm_d(temp3, ptr_rgb, 64, 0);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 72, 2);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 80, 3);
++      __lasx_xvstelm_d(temp3, ptr_rgb, 88, 2);
++      ptr_rgb += 96;
++    }
++#endif
++
++#if RGB_RED == 2
++    /* bgr */
++    {
++      __m256i out_bg_l, out_bg_h, out_rx_l, out_rx_h;
++      __m256i temp0, temp1, temp2, temp3;
++      v32i8 mask0 = {0,1,16,2,3,18,4,5,20,6,7,22,8,9,24,10,0,
++                     1,16,2,3,18,4,5,20,6,7,22,8,9,24,10};
++      v32i8 mask1 = {11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0,
++                     11,26,12,13,28,14,15,30,0,0,0,0,0,0,0,0};
++
++      LASX_ILVLH_B(out_g0, out_b0, out_bg_h, out_bg_l);
++      LASX_ILVLH_B(alpha, out_r0, out_rx_h, out_rx_l);
++
++      temp0 = __lasx_xvshuf_b(out_rx_l, out_bg_l, (__m256i)mask0);
++      temp1 = __lasx_xvshuf_b(out_rx_l, out_bg_l, (__m256i)mask1);
++      temp2 = __lasx_xvshuf_b(out_rx_h, out_bg_h, (__m256i)mask0);
++      temp3 = __lasx_xvshuf_b(out_rx_h, out_bg_h, (__m256i)mask1);
++
++      __lasx_xvstelm_d(temp0, ptr_rgb, 0, 0);
++      __lasx_xvstelm_d(temp0, ptr_rgb, 8, 1);
++      __lasx_xvstelm_d(temp1, ptr_rgb, 16, 0);
++      __lasx_xvstelm_d(temp0, ptr_rgb, 24, 2);
++      __lasx_xvstelm_d(temp0, ptr_rgb, 32, 3);
++      __lasx_xvstelm_d(temp1, ptr_rgb, 40, 2);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 48, 0);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 56, 1);
++      __lasx_xvstelm_d(temp3, ptr_rgb, 64, 0);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 72, 2);
++      __lasx_xvstelm_d(temp2, ptr_rgb, 80, 3);
++      __lasx_xvstelm_d(temp3, ptr_rgb, 88, 2);
++      ptr_rgb += 96;
++    }
++#endif
++
++#endif
++  }
++
++  for (int i = 0; i < (cols & ~1); i += 2) {
++    cb = (int)(*ptr_cb++) - 128;
++    cr = (int)(*ptr_cr++) - 128;
++    cred = DESCALE(FIX_140200 * cr, 16);
++    cgreen = DESCALE(((-FIX_34414) * cb - FIX_71414 * cr), 16);
++    cblue = DESCALE(FIX_177200 * cb, 16);
++
++    y = (int)(*ptr_y++);
++    ptr_rgb[RGB_RED] = clip_pixel(y + cred);
++    ptr_rgb[RGB_GREEN] = clip_pixel(y + cgreen);
++    ptr_rgb[RGB_BLUE] = clip_pixel(y + cblue);
++#ifdef RGB_ALPHA
++    ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++    ptr_rgb += RGB_PIXELSIZE;
++
++    y = (int)(*ptr_y++);
++    ptr_rgb[RGB_RED] = clip_pixel(y + cred);
++    ptr_rgb[RGB_GREEN] = clip_pixel(y + cgreen);
++    ptr_rgb[RGB_BLUE] = clip_pixel(y + cblue);
++#ifdef RGB_ALPHA
++    ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++    ptr_rgb += RGB_PIXELSIZE;
++  }
++
++  if (output_width & 1) {
++    cb = (int)(*ptr_cb) - 128;
++    cr = (int)(*ptr_cr) - 128;
++    cred = DESCALE(FIX_140200 * cr, 16);
++    cgreen = DESCALE(((-FIX_34414) * cb - FIX_71414 * cr), 16);
++    cblue = DESCALE(FIX_177200 * cb, 16);
++
++    y = (int)(*ptr_y);
++    ptr_rgb[RGB_RED] = clip_pixel(y + cred);
++    ptr_rgb[RGB_GREEN] = clip_pixel(y + cgreen);
++    ptr_rgb[RGB_BLUE] = clip_pixel(y + cblue);
++#ifdef RGB_ALPHA
++    ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++  }
++}
++
++GLOBAL(void)
++jsimd_h2v2_merged_upsample_lasx(JDIMENSION output_width,
++                                JSAMPIMAGE input_buf,
++                                JDIMENSION in_row_group_ctr,
++                                JSAMPARRAY output_buf)
++{
++  JSAMPROW inptr, outptr;
++
++  inptr = input_buf[0][in_row_group_ctr];
++  outptr = output_buf[0];
++
++  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2];
++  jsimd_h2v1_merged_upsample_lasx(output_width, input_buf, in_row_group_ctr,
++                                  output_buf);
++
++  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2 + 1];
++  output_buf[0] = output_buf[1];
++  jsimd_h2v1_merged_upsample_lasx(output_width, input_buf, in_row_group_ctr,
++                                  output_buf);
++
++  input_buf[0][in_row_group_ctr] = inptr;
++  output_buf[0] = outptr;
++}
+diff --git a/simd/loongarch64/jdmrgext-lsx.c b/simd/loongarch64/jdmrgext-lsx.c
+new file mode 100644
+index 00000000..5648e94e
+--- /dev/null
++++ b/simd/loongarch64/jdmrgext-lsx.c
+@@ -0,0 +1,317 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++GLOBAL(void)
++jsimd_h2v1_merged_upsample_lsx(JDIMENSION output_width, JSAMPIMAGE input_buf,
++                               JDIMENSION in_row_group_ctr,
++                               JSAMPARRAY output_buf)
++{
++  register JSAMPROW ptr_y, ptr_cb, ptr_cr;
++  register JSAMPROW ptr_rgb;
++  register int y, cb, cr, cred, cgreen, cblue;
++  JDIMENSION cols;
++  __m128i out_r0, out_g0, out_b0;
++  __m128i vec_y0, vec_cb, vec_cr, vec_yo, vec_ye;
++  __m128i vec_cbh_l, vec_crh_l;
++
++  __m128i const128 = {128};
++  __m128i alpha = {0xFF};
++  __m128i zero = {0};
++
++  v4i32 const1402 = {FIX_140200, FIX_140200, FIX_140200, FIX_140200};
++  v8i16 const_34414_28586 = {-FIX_34414, FIX_28586, -FIX_34414, FIX_28586,
++                             -FIX_34414, FIX_28586, -FIX_34414, FIX_28586};
++  v4i32 const1772 = {FIX_177200, FIX_177200, FIX_177200, FIX_177200};
++
++  alpha = __lsx_vreplvei_b(alpha, 0);
++  const128 = __lsx_vreplvei_b(const128, 0);
++
++  ptr_y = input_buf[0][in_row_group_ctr];
++  ptr_cb = input_buf[1][in_row_group_ctr];
++  ptr_cr = input_buf[2][in_row_group_ctr];
++  ptr_rgb = output_buf[0];
++
++  for (cols = output_width; cols >= 16; cols -= 16) {
++    vec_y0 = LSX_LD(ptr_y);
++    vec_cb = LSX_LD(ptr_cb);
++    vec_cr = LSX_LD(ptr_cr);
++
++    ptr_y += 16;
++    ptr_cb += 8;
++    ptr_cr += 8;
++
++    /* Cb = Cb - 128, Cr = Cr - 128 */
++    vec_cb = __lsx_vsub_b(vec_cb, const128);
++    vec_cr = __lsx_vsub_b(vec_cr, const128);
++
++    vec_ye = __lsx_vpackev_b(zero, vec_y0);
++    vec_yo = __lsx_vpackod_b(zero, vec_y0);
++    LSX_UNPCKL_H_B(vec_cb, vec_cbh_l);
++    LSX_UNPCKL_H_B(vec_cr, vec_crh_l);
++
++    /* R = Y + 1.40200 * Cr */
++    {
++      __m128i temp0, out0, out1;
++
++      LSX_UNPCKLH_W_H(vec_crh_l, out1, out0);
++      out0 = __lsx_vmul_w(out0, (__m128i)const1402);
++      out1 = __lsx_vmul_w(out1, (__m128i)const1402);
++      out0 = __lsx_vsrari_w(out0, 16);
++      out1 = __lsx_vsrari_w(out1, 16);
++      LSX_PCKEV_H(out1, out0, temp0);
++      out0 = __lsx_vadd_h(temp0, vec_ye);
++      out1 = __lsx_vadd_h(temp0, vec_yo);
++      LSX_CLIP_H_0_255_2(out0, out1, out0, out1);
++      out_r0 = __lsx_vpackev_b(out1, out0);
++    }
++
++    /* G = Y - 0.34414 * Cb + 0.28586 * Cr - Cr */
++    {
++      __m128i temp0, temp1, out0, out1;
++
++      LSX_ILVLH_H(vec_crh_l, vec_cbh_l, temp1, temp0);
++      LSX_DP2_W_H(temp0, (__m128i)const_34414_28586, out0);
++      LSX_DP2_W_H(temp1, (__m128i)const_34414_28586, out1);
++      out0 = __lsx_vsrari_w(out0, 16);
++      out1 = __lsx_vsrari_w(out1, 16);
++      LSX_PCKEV_H(out1, out0, temp0);
++      temp0 = __lsx_vsub_h(temp0, vec_crh_l);
++      out0 = __lsx_vadd_h(temp0, vec_ye);
++      out1 = __lsx_vadd_h(temp0, vec_yo);
++      LSX_CLIP_H_0_255_2(out0, out1, out0, out1);
++      out_g0 = __lsx_vpackev_b(out1, out0);
++    }
++
++    /* B = Y + 1.77200 * Cb */
++    {
++      __m128i temp0, out0, out1;
++
++      LSX_UNPCKLH_W_H(vec_cbh_l, out1, out0);
++      out0 = __lsx_vmul_w(out0, (__m128i)const1772);
++      out1 = __lsx_vmul_w(out1, (__m128i)const1772);
++      out0 = __lsx_vsrari_w(out0, 16);
++      out1 = __lsx_vsrari_w(out1, 16);
++      LSX_PCKEV_H(out1, out0, temp0);
++      out0 = __lsx_vadd_h(temp0, vec_ye);
++      out1 = __lsx_vadd_h(temp0, vec_yo);
++      LSX_CLIP_H_0_255_2(out0, out1, out0, out1);
++      out_b0 = __lsx_vpackev_b(out1, out0);
++    }
++
++    /* Store to memory */
++#if RGB_PIXELSIZE == 4
++
++#if RGB_RED == 0
++    /* rgbx */
++    {
++      __m128i out_rg_l, out_rg_h, out_bx_l, out_bx_h;
++      __m128i out_rgbx0_l_l, out_rgbx0_l_h, out_rgbx0_h_l, out_rgbx0_h_h;
++
++      LSX_ILVLH_B(out_g0, out_r0, out_rg_h, out_rg_l);
++      LSX_ILVLH_B(alpha, out_b0, out_bx_h, out_bx_l);
++      LSX_ILVLH_H(out_bx_l, out_rg_l, out_rgbx0_l_h, out_rgbx0_l_l);
++      LSX_ILVLH_H(out_bx_h, out_rg_h, out_rgbx0_h_h, out_rgbx0_h_l);
++
++      LSX_ST_4(out_rgbx0_l_l, out_rgbx0_l_h, out_rgbx0_h_l, out_rgbx0_h_h,
++               ptr_rgb, 16);
++      ptr_rgb += 64;
++    }
++#endif
++
++#if RGB_RED == 1
++    /* xrgb */
++    {
++      __m128i out_xr_l, out_xr_h, out_gb_l, out_gb_h;
++      __m128i out_xrgb0_l_l, out_xrgb0_l_h, out_xrgb0_h_l, out_xrgb0_h_h;
++
++      LSX_ILVLH_B(out_r0, alpha, out_xr_h, out_xr_l);
++      LSX_ILVLH_B(out_b0, out_g0, out_gb_h, out_gb_l);
++      LSX_ILVLH_H(out_gb_l, out_xr_l, out_xrgb0_l_h, out_xrgb0_l_l);
++      LSX_ILVLH_H(out_gb_h, out_xr_h, out_xrgb0_h_h, out_xrgb0_h_l);
++
++      LSX_ST_4(out_xrgb0_l_l, out_xrgb0_l_h, out_xrgb0_h_l, out_xrgb0_h_h,
++               ptr_rgb, 16);
++      ptr_rgb += 64;
++    }
++#endif
++
++#if RGB_RED == 2
++    /* bgrx */
++    {
++      __m128i out_bg_l, out_bg_h, out_rx_l, out_rx_h;
++      __m128i out_bgrx0_l_l, out_bgrx0_l_h, out_bgrx0_h_l, out_bgrx0_h_h;
++
++      LSX_ILVLH_B(out_g0, out_b0, out_bg_h, out_bg_l);
++      LSX_ILVLH_B(alpha, out_r0, out_rx_h, out_rx_l);
++      LSX_ILVLH_H(out_rx_l, out_bg_l, out_bgrx0_l_h, out_bgrx0_l_l);
++      LSX_ILVLH_H(out_rx_h, out_bg_h, out_bgrx0_h_h, out_bgrx0_h_l);
++
++      LSX_ST_4(out_bgrx0_l_l, out_bgrx0_l_h, out_bgrx0_h_l, out_bgrx0_h_h,
++               ptr_rgb, 16);
++      ptr_rgb += 64;
++    }
++#endif
++
++#if RGB_RED == 3
++    /* xbgr */
++    {
++      __m128i out_xb_l, out_xb_h, out_gr_l, out_gr_h;
++      __m128i out_xbgr0_l_l, out_xbgr0_l_h, out_xbgr0_h_l, out_xbgr0_h_h;
++
++      LSX_ILVLH_B(out_b0, alpha, out_xb_h, out_xb_l);
++      LSX_ILVLH_B(out_r0, out_g0, out_gr_h, out_gr_l);
++      LSX_ILVLH_H(out_gr_l, out_xb_l, out_xbgr0_l_h, out_xbgr0_l_l);
++      LSX_ILVLH_H(out_gr_h, out_xb_h, out_xbgr0_h_h, out_xbgr0_h_l);
++
++      LSX_ST_4(out_xbgr0_l_l, out_xbgr0_l_h, out_xbgr0_h_l, out_xbgr0_h_h,
++               ptr_rgb, 16);
++      ptr_rgb += 64;
++    }
++#endif
++
++#else /* end RGB_PIXELSIZE == 4 */
++
++#if RGB_RED == 0
++    /* rgb */
++    {
++      __m128i out_rgb_l_l, out_rgb_l_h, out_rgb_h_l;
++      __m128i tmp0, tmp1, tmp2;
++      v16i8 mask0 = {0,16,1,17,2,18,3,19,4,20,5,21,6,22,7,23};
++      v16i8 mask1 = {0,1,16,2,3,17,4,5,18,6,7,19,8,9,20,10};
++      v16i8 mask2 = {21,6,22,7,23,8,24,9,25,10,26,11,27,12,28,13};
++      v16i8 mask3 = {0,21,1,2,22,3,4,23,5,6,24,7,8,25,9,10};
++      v16i8 mask4 = {11,27,12,28,13,29,14,30,15,31,0,0,0,0,0,0};
++      v16i8 mask5 = {26,0,1,27,2,3,28,4,5,29,6,7,30,8,9,31};
++
++      tmp0 = __lsx_vshuf_b(out_g0, out_r0, (__m128i)mask0);
++      out_rgb_l_l = __lsx_vshuf_b(out_b0, tmp0, (__m128i)mask1);
++
++      tmp1 = __lsx_vshuf_b(out_g0, out_r0, (__m128i)mask2);
++      out_rgb_l_h = __lsx_vshuf_b(out_b0, tmp1, (__m128i)mask3);
++
++      tmp2 = __lsx_vshuf_b(out_g0, out_r0, (__m128i)mask4);
++      out_rgb_h_l = __lsx_vshuf_b(out_b0, tmp2, (__m128i)mask5);
++
++      LSX_ST_2(out_rgb_l_l, out_rgb_l_h, ptr_rgb, 16);
++      LSX_ST(out_rgb_h_l, ptr_rgb + 32);
++      ptr_rgb += 48;
++    }
++#endif
++
++#if RGB_RED == 2
++    /* bgr */
++    {
++      __m128i out_bgr_l_l, out_bgr_l_h, out_bgr_h_l;
++      __m128i tmp0, tmp1, tmp2;
++      v16i8 mask0 = {0,16,1,17,2,18,3,19,4,20,5,21,6,22,7,23};
++      v16i8 mask1 = {0,1,16,2,3,17,4,5,18,6,7,19,8,9,20,10};
++      v16i8 mask2 = {21,6,22,7,23,8,24,9,25,10,26,11,27,12,28,13};
++      v16i8 mask3 = {0,21,1,2,22,3,4,23,5,6,24,7,8,25,9,10};
++      v16i8 mask4 = {11,27,12,28,13,29,14,30,15,31,0,0,0,0,0,0};
++      v16i8 mask5 = {26,0,1,27,2,3,28,4,5,29,6,7,30,8,9,31};
++
++      tmp0 = __lsx_vshuf_b(out_g0, out_b0, (__m128i)mask0);
++      out_bgr_l_l = __lsx_vshuf_b(out_r0, tmp0, (__m128i)mask1);
++
++      tmp1 = __lsx_vshuf_b(out_g0, out_b0, (__m128i)mask2);
++      out_bgr_l_h = __lsx_vshuf_b(out_r0, tmp1, (__m128i)mask3);
++
++      tmp2 = __lsx_vshuf_b(out_g0, out_b0, (__m128i)mask4);
++      out_bgr_h_l = __lsx_vshuf_b(out_r0, tmp2, (__m128i)mask5);
++
++      LSX_ST_2(out_bgr_l_l, out_bgr_l_h, ptr_rgb, 16);
++      LSX_ST(out_bgr_h_l, ptr_rgb + 32);
++      ptr_rgb += 48;
++    }
++#endif
++
++#endif
++  }
++
++  for (int i = 0; i < (cols & ~1); i += 2) {
++    cb = (int)(*ptr_cb++) - 128;
++    cr = (int)(*ptr_cr++) - 128;
++    cred = DESCALE(FIX_140200 * cr, 16);
++    cgreen = DESCALE(((-FIX_34414) * cb - FIX_71414 * cr), 16);
++    cblue = DESCALE(FIX_177200 * cb, 16);
++
++    y = (int)(*ptr_y++);
++    ptr_rgb[RGB_RED] = clip_pixel(y + cred);
++    ptr_rgb[RGB_GREEN] = clip_pixel(y + cgreen);
++    ptr_rgb[RGB_BLUE] = clip_pixel(y + cblue);
++#ifdef RGB_ALPHA
++    ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++    ptr_rgb += RGB_PIXELSIZE;
++
++    y = (int)(*ptr_y++);
++    ptr_rgb[RGB_RED] = clip_pixel(y + cred);
++    ptr_rgb[RGB_GREEN] = clip_pixel(y + cgreen);
++    ptr_rgb[RGB_BLUE] = clip_pixel(y + cblue);
++#ifdef RGB_ALPHA
++    ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++    ptr_rgb += RGB_PIXELSIZE;
++  }
++
++  if (output_width & 1) {
++    cb = (int)(*ptr_cb) - 128;
++    cr = (int)(*ptr_cr) - 128;
++    cred = DESCALE(FIX_140200 * cr, 16);
++    cgreen = DESCALE(((-FIX_34414) * cb - FIX_71414 * cr), 16);
++    cblue = DESCALE(FIX_177200 * cb, 16);
++
++    y = (int)(*ptr_y);
++    ptr_rgb[RGB_RED] = clip_pixel(y + cred);
++    ptr_rgb[RGB_GREEN] = clip_pixel(y + cgreen);
++    ptr_rgb[RGB_BLUE] = clip_pixel(y + cblue);
++#ifdef RGB_ALPHA
++    ptr_rgb[RGB_ALPHA] = 0xFF;
++#endif
++  }
++}
++
++GLOBAL(void)
++jsimd_h2v2_merged_upsample_lsx(JDIMENSION output_width,
++                               JSAMPIMAGE input_buf,
++                               JDIMENSION in_row_group_ctr,
++                               JSAMPARRAY output_buf)
++{
++  JSAMPROW inptr, outptr;
++
++  inptr = input_buf[0][in_row_group_ctr];
++  outptr = output_buf[0];
++
++  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2];
++  jsimd_h2v1_merged_upsample_lsx(output_width, input_buf, in_row_group_ctr,
++                                 output_buf);
++
++  input_buf[0][in_row_group_ctr] = input_buf[0][in_row_group_ctr * 2 + 1];
++  output_buf[0] = output_buf[1];
++  jsimd_h2v1_merged_upsample_lsx(output_width, input_buf, in_row_group_ctr,
++                                 output_buf);
++
++  input_buf[0][in_row_group_ctr] = inptr;
++  output_buf[0] = outptr;
++}
+diff --git a/simd/loongarch64/jdsample-lasx.c b/simd/loongarch64/jdsample-lasx.c
+new file mode 100644
+index 00000000..d1af0d57
+--- /dev/null
++++ b/simd/loongarch64/jdsample-lasx.c
+@@ -0,0 +1,424 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jmacros_lasx.h"
++
++/*
++ * Fancy processing for the common case of 2:1 horizontal and 1:1 vertical.
++ * The centers of the output pixels are 1/4 and 3/4 of the way between input
++ * pixel centers.
++*/
++GLOBAL(void)
++jsimd_h2v1_fancy_upsample_lasx(int max_v_samp_factor,
++                               JDIMENSION downsampled_width,
++                               JSAMPARRAY input_data,
++                               JSAMPARRAY *output_data_ptr)
++{
++  int invalue, row, col;
++  JSAMPROW srcptr, outptr;
++  JSAMPARRAY output_data = *output_data_ptr;
++  __m256i src0, src1, src2, out0, out1, tmp0, tmp1;
++  __m256i src0_l, src0_h, src1_l, src1_h, src2_l, src2_h;
++
++  for (row = 0; row < max_v_samp_factor; row++) {
++    srcptr = input_data[row];
++    outptr = output_data[row];
++    col = downsampled_width;
++
++    for (; col >= 32; col -= 32) {
++      src0 = LASX_LD(srcptr - 1);
++      src1 = LASX_LD(srcptr);
++      src2 = LASX_LD(srcptr + 1);
++
++      srcptr += 32;
++
++      LASX_UNPCKLH_HU_BU(src0, src0_h, src0_l);
++      LASX_UNPCKLH_HU_BU(src1, src1_h, src1_l);
++      LASX_UNPCKLH_HU_BU(src2, src2_h, src2_l);
++
++      tmp0 = __lasx_xvslli_h(src1_l, 1);
++      tmp1 = __lasx_xvslli_h(src1_h, 1);
++      src1_l = __lasx_xvadd_h(src1_l, tmp0);
++      src1_h = __lasx_xvadd_h(src1_h, tmp1);
++
++      src0_l = __lasx_xvadd_h(src0_l, src1_l);
++      src0_h = __lasx_xvadd_h(src0_h, src1_h);
++      src0_l = __lasx_xvaddi_hu(src0_l, 1);
++      src0_h = __lasx_xvaddi_hu(src0_h, 1);
++
++      src2_l = __lasx_xvadd_h(src2_l, src1_l);
++      src2_h = __lasx_xvadd_h(src2_h, src1_h);
++      src2_l = __lasx_xvaddi_hu(src2_l, 2);
++      src2_h = __lasx_xvaddi_hu(src2_h, 2);
++
++      src0_l = __lasx_xvsrai_h(src0_l, 2);
++      src0_h = __lasx_xvsrai_h(src0_h, 2);
++      src2_l = __lasx_xvsrai_h(src2_l, 2);
++      src2_h = __lasx_xvsrai_h(src2_h, 2);
++
++      out0 = __lasx_xvpackev_b(src2_l, src0_l);
++      out1 = __lasx_xvpackev_b(src2_h, src0_h);
++
++      LASX_ST_2(out0, out1, outptr, 32);
++      outptr += 64;
++    }
++    if (col >= 16) {
++      src0 = LASX_LD(srcptr - 1);
++      src1 = LASX_LD(srcptr);
++      src2 = LASX_LD(srcptr + 1);
++
++      srcptr += 16;
++      col -= 16;
++
++      LASX_UNPCKL_HU_BU(src0, src0_l);
++      LASX_UNPCKL_HU_BU(src1, src1_l);
++      LASX_UNPCKL_HU_BU(src2, src2_l);
++
++      tmp0 = __lasx_xvslli_h(src1_l, 1);
++      src1_l = __lasx_xvadd_h(src1_l, tmp0);
++
++      src0_l = __lasx_xvadd_h(src0_l, src1_l);
++      src0_l = __lasx_xvaddi_hu(src0_l, 1);
++
++      src2_l = __lasx_xvadd_h(src2_l, src1_l);
++      src2_l = __lasx_xvaddi_hu(src2_l, 2);
++
++      src0_l = __lasx_xvsrai_h(src0_l, 2);
++      src2_l = __lasx_xvsrai_h(src2_l, 2);
++
++      out0 = __lasx_xvpackev_b(src2_l, src0_l);
++      LASX_ST(out0, outptr);
++      outptr += 32;
++    }
++
++    for(; col > 0; col--) {
++      invalue = GETJSAMPLE(*srcptr++) * 3;
++      *outptr++ = (JSAMPLE) ((invalue + GETJSAMPLE(srcptr[-2]) + 1) >> 2);
++      *outptr++ = (JSAMPLE) ((invalue + GETJSAMPLE(*srcptr) + 2) >> 2);
++    }
++
++    /* update fisrt col */
++    *(output_data[row]) = *(input_data[row]);
++    /* update last col */
++    *(output_data[row] + (downsampled_width << 1) - 1) = *(input_data[row] + downsampled_width - 1);
++  }
++}
++
++/*
++ * Fancy processing for the common case of 2:1 horizontal and 2:1 vertical.
++ * Again a triangle filter; see comments for h2v1 case, above.
++ *
++ * It is OK for us to reference the adjacent input rows because we demanded
++ * context from the main buffer controller (see initialization code).
++ */
++GLOBAL(void)
++jsimd_h2v2_fancy_upsample_lasx(int max_v_samp_factor,
++                               JDIMENSION downsampled_width,
++                               JSAMPARRAY input_data,
++                               JSAMPARRAY *output_data_ptr)
++{
++  JSAMPARRAY output_data = *output_data_ptr;
++  JSAMPROW srcptr0, srcptr1, srcptr2, outptr0, outptr1;
++  int thissum0, lastsum0, nextsum0, thissum1, lastsum1, nextsum1;
++  int col, srcrow = 0, outrow = 0, tmp0, tmp1, tmp2;
++  __m256i tmp0_l, tmp1_l, tmp2_l, tmp0_h, tmp1_h, tmp2_h;
++  __m256i pre0, pre1, pre2, cur0, cur1, cur2, nxt0, nxt1, nxt2;
++  __m256i presum0_l, presum1_l, cursum0_l, cursum1_l, nxtsum0_l, nxtsum1_l;
++  __m256i presum0_h, presum1_h, cursum0_h, cursum1_h, nxtsum0_h, nxtsum1_h;
++  __m256i out00_l, out01_l, out10_l, out11_l;
++  __m256i out00_h, out01_h, out10_h, out11_h;
++  __m256i const3 = {3};
++
++  const3 = __lasx_xvreplve0_h(const3);
++  while (outrow < max_v_samp_factor) {
++    srcptr0 = input_data[srcrow];
++    srcptr1 = input_data[srcrow - 1];
++    srcptr2 = input_data[srcrow + 1];
++
++    outptr0 = output_data[outrow];
++    outptr1 = output_data[outrow + 1];
++    col = downsampled_width;
++
++    for (; col >= 32; col -= 32) {
++      pre0 = LASX_LD(srcptr0 - 1);
++      pre1 = LASX_LD(srcptr1 - 1);
++      pre2 = LASX_LD(srcptr2 - 1);
++
++      cur0 = LASX_LD(srcptr0);
++      cur1 = LASX_LD(srcptr1);
++      cur2 = LASX_LD(srcptr2);
++
++      nxt0 = LASX_LD(srcptr0 + 1);
++      nxt1 = LASX_LD(srcptr1 + 1);
++      nxt2 = LASX_LD(srcptr2 + 1);
++
++      srcptr0 += 32;
++      srcptr1 += 32;
++      srcptr2 += 32;
++
++      LASX_UNPCKLH_HU_BU(pre0, tmp0_h, tmp0_l);
++      LASX_UNPCKLH_HU_BU(pre1, tmp1_h, tmp1_l);
++      LASX_UNPCKLH_HU_BU(pre2, tmp2_h, tmp2_l);
++
++      presum0_l = __lasx_xvmadd_h(tmp1_l, tmp0_l, const3);
++      presum0_h = __lasx_xvmadd_h(tmp1_h, tmp0_h, const3);
++      presum1_l = __lasx_xvmadd_h(tmp2_l, tmp0_l, const3);
++      presum1_h = __lasx_xvmadd_h(tmp2_h, tmp0_h, const3);
++
++      LASX_UNPCKLH_HU_BU(cur0, tmp0_h, tmp0_l);
++      LASX_UNPCKLH_HU_BU(cur1, tmp1_h, tmp1_l);
++      LASX_UNPCKLH_HU_BU(cur2, tmp2_h, tmp2_l);
++
++      cursum0_l = __lasx_xvmadd_h(tmp1_l, tmp0_l, const3);
++      cursum0_h = __lasx_xvmadd_h(tmp1_h, tmp0_h, const3);
++      cursum1_l = __lasx_xvmadd_h(tmp2_l, tmp0_l, const3);
++      cursum1_h = __lasx_xvmadd_h(tmp2_h, tmp0_h, const3);
++
++      LASX_UNPCKLH_HU_BU(nxt0, tmp0_h, tmp0_l);
++      LASX_UNPCKLH_HU_BU(nxt1, tmp1_h, tmp1_l);
++      LASX_UNPCKLH_HU_BU(nxt2, tmp2_h, tmp2_l);
++
++      nxtsum0_l = __lasx_xvmadd_h(tmp1_l, tmp0_l, const3);
++      nxtsum0_h = __lasx_xvmadd_h(tmp1_h, tmp0_h, const3);
++      nxtsum1_l = __lasx_xvmadd_h(tmp2_l, tmp0_l, const3);
++      nxtsum1_h = __lasx_xvmadd_h(tmp2_h, tmp0_h, const3);
++
++      /* outptr0 */
++      out00_l = __lasx_xvmadd_h(presum0_l, cursum0_l, const3);
++      out00_l = __lasx_xvaddi_hu(out00_l, 8);
++      out00_l = __lasx_xvsrai_h(out00_l, 4);
++      out01_l = __lasx_xvmadd_h(nxtsum0_l, cursum0_l, const3);
++      out01_l = __lasx_xvaddi_hu(out01_l, 7);
++      out01_l = __lasx_xvsrai_h(out01_l, 4);
++      out00_h = __lasx_xvmadd_h(presum0_h, cursum0_h, const3);
++      out00_h = __lasx_xvaddi_hu(out00_h, 8);
++      out00_h = __lasx_xvsrai_h(out00_h, 4);
++      out01_h = __lasx_xvmadd_h(nxtsum0_h, cursum0_h, const3);
++      out01_h = __lasx_xvaddi_hu(out01_h, 7);
++      out01_h = __lasx_xvsrai_h(out01_h, 4);
++
++      /* outptr1 */
++      out10_l = __lasx_xvmadd_h(presum1_l, cursum1_l, const3);
++      out10_l = __lasx_xvaddi_hu(out10_l, 8);
++      out10_l = __lasx_xvsrai_h(out10_l, 4);
++      out11_l = __lasx_xvmadd_h(nxtsum1_l, cursum1_l, const3);
++      out11_l = __lasx_xvaddi_hu(out11_l, 7);
++      out11_l = __lasx_xvsrai_h(out11_l, 4);
++      out10_h = __lasx_xvmadd_h(presum1_h, cursum1_h, const3);
++      out10_h = __lasx_xvaddi_hu(out10_h, 8);
++      out10_h = __lasx_xvsrai_h(out10_h, 4);
++      out11_h = __lasx_xvmadd_h(nxtsum1_h, cursum1_h, const3);
++      out11_h = __lasx_xvaddi_hu(out11_h, 7);
++      out11_h = __lasx_xvsrai_h(out11_h, 4);
++
++      out00_l = __lasx_xvpackev_b(out01_l, out00_l);
++      out10_l = __lasx_xvpackev_b(out11_l, out10_l);
++      out00_h = __lasx_xvpackev_b(out01_h, out00_h);
++      out10_h = __lasx_xvpackev_b(out11_h, out10_h);
++
++      LASX_ST_2(out00_l, out00_h, outptr0, 32);
++      LASX_ST_2(out10_l, out10_h, outptr1, 32);
++      outptr0 += 64;
++      outptr1 += 64;
++    }
++
++    if (col >= 16) {
++      pre0 = LASX_LD(srcptr0 - 1);
++      pre1 = LASX_LD(srcptr1 - 1);
++      pre2 = LASX_LD(srcptr2 - 1);
++
++      cur0 = LASX_LD(srcptr0);
++      cur1 = LASX_LD(srcptr1);
++      cur2 = LASX_LD(srcptr2);
++
++      nxt0 = LASX_LD(srcptr0 + 1);
++      nxt1 = LASX_LD(srcptr1 + 1);
++      nxt2 = LASX_LD(srcptr2 + 1);
++
++      srcptr0 += 16;
++      srcptr1 += 16;
++      srcptr2 += 16;
++      col -= 16;
++
++      LASX_UNPCKL_HU_BU(pre0, tmp0_l);
++      LASX_UNPCKL_HU_BU(pre1, tmp1_l);
++      LASX_UNPCKL_HU_BU(pre2, tmp2_l);
++
++      presum0_l = __lasx_xvmadd_h(tmp1_l, tmp0_l, const3);
++      presum1_l = __lasx_xvmadd_h(tmp2_l, tmp0_l, const3);
++
++      LASX_UNPCKL_HU_BU(cur0, tmp0_l);
++      LASX_UNPCKL_HU_BU(cur1, tmp1_l);
++      LASX_UNPCKL_HU_BU(cur2, tmp2_l);
++
++      cursum0_l = __lasx_xvmadd_h(tmp1_l, tmp0_l, const3);
++      cursum1_l = __lasx_xvmadd_h(tmp2_l, tmp0_l, const3);
++
++      LASX_UNPCKL_HU_BU(nxt0, tmp0_l);
++      LASX_UNPCKL_HU_BU(nxt1, tmp1_l);
++      LASX_UNPCKL_HU_BU(nxt2, tmp2_l);
++
++      nxtsum0_l = __lasx_xvmadd_h(tmp1_l, tmp0_l, const3);
++      nxtsum1_l = __lasx_xvmadd_h(tmp2_l, tmp0_l, const3);
++
++      /* outptr0 */
++      out00_l = __lasx_xvmadd_h(presum0_l, cursum0_l, const3);
++      out00_l = __lasx_xvaddi_hu(out00_l, 8);
++      out00_l = __lasx_xvsrai_h(out00_l, 4);
++      out01_l = __lasx_xvmadd_h(nxtsum0_l, cursum0_l, const3);
++      out01_l = __lasx_xvaddi_hu(out01_l, 7);
++      out01_l = __lasx_xvsrai_h(out01_l, 4);
++
++      /* outptr1 */
++      out10_l = __lasx_xvmadd_h(presum1_l, cursum1_l, const3);
++      out10_l = __lasx_xvaddi_hu(out10_l, 8);
++      out10_l = __lasx_xvsrai_h(out10_l, 4);
++      out11_l = __lasx_xvmadd_h(nxtsum1_l, cursum1_l, const3);
++      out11_l = __lasx_xvaddi_hu(out11_l, 7);
++      out11_l = __lasx_xvsrai_h(out11_l, 4);
++
++      out00_l = __lasx_xvpackev_b(out01_l, out00_l);
++      out10_l = __lasx_xvpackev_b(out11_l, out10_l);
++
++      LASX_ST(out00_l, outptr0);
++      LASX_ST(out10_l, outptr1);
++      outptr0 += 32;
++      outptr1 += 32;
++    }
++
++    for (; col > 0; col--) {
++      tmp0 = (*srcptr0++) * 3;
++      tmp1 = (*(srcptr0 - 2)) * 3;
++      tmp2 = (*(srcptr0)) * 3;
++
++      thissum0 = tmp0 + GETJSAMPLE(*srcptr1++);
++      lastsum0 = tmp1 + GETJSAMPLE(*(srcptr1 - 2));
++      nextsum0 = tmp2 + GETJSAMPLE(*(srcptr1));
++      *outptr0++ = (JSAMPLE) ((thissum0 * 3 + lastsum0 + 8) >> 4);
++      *outptr0++ = (JSAMPLE) ((thissum0 * 3 + nextsum0 + 7) >> 4);
++
++      thissum1 = tmp0 + GETJSAMPLE(*srcptr2++);
++      lastsum1 = tmp1 + GETJSAMPLE(*(srcptr2 - 2));
++      nextsum1 = tmp2 + GETJSAMPLE(*(srcptr2));
++      *outptr1++ = (JSAMPLE) ((thissum1 * 3 + lastsum1 + 8) >> 4);
++      *outptr1++ = (JSAMPLE) ((thissum1 * 3 + nextsum1 + 7) >> 4);
++    }
++
++    /* update fisrt col for v = 0 */
++    thissum0 = GETJSAMPLE(*input_data[srcrow]) * 3 + GETJSAMPLE(*input_data[srcrow - 1]);
++    *(output_data[outrow]) = (JSAMPLE) ((thissum0 * 4 + 8) >> 4);
++
++    /* update last col for v = 0 */
++    thissum0 = GETJSAMPLE(*(input_data[srcrow] + downsampled_width - 1)) * 3 +
++               GETJSAMPLE(*(input_data[srcrow - 1] + downsampled_width - 1));
++    *(output_data[outrow] + (downsampled_width << 1) - 1) = (JSAMPLE) ((thissum0 * 4 + 7) >> 4);
++
++    /* update fisrt col for v = 1 */
++    thissum0 = GETJSAMPLE(*input_data[srcrow]) * 3 + GETJSAMPLE(*input_data[srcrow + 1]);
++    *(output_data[outrow + 1]) = (JSAMPLE) ((thissum0 * 4 + 8) >> 4);
++
++    /* update last col for v = 1 */
++    thissum0 = GETJSAMPLE(*(input_data[srcrow] + downsampled_width - 1)) * 3 +
++               GETJSAMPLE(*(input_data[srcrow + 1] + downsampled_width - 1));
++    *(output_data[outrow + 1] + (downsampled_width << 1) - 1) = (JSAMPLE) ((thissum0 * 4 + 7) >> 4);
++
++    srcrow++;
++    outrow += 2;
++  }
++}
++
++/*
++ * Fast processing for the common case of 2:1 horizontal and 1:1 vertical.
++ * It's still a box filter.
++ */
++
++GLOBAL(void)
++jsimd_h2v1_upsample_lasx(int max_v_samp_factor,
++                         JDIMENSION output_width,
++                         JSAMPARRAY input_data,
++                         JSAMPARRAY *output_data_ptr)
++{
++  JSAMPARRAY output_data = *output_data_ptr;
++  int col, loop, srcrow;
++  JSAMPROW srcptr, outptr;
++  __m256i src0, src0_l, src0_h;
++
++  loop = output_width & ~63;
++  for (srcrow = 0; srcrow < max_v_samp_factor; srcrow++) {
++    srcptr = input_data[srcrow];
++    outptr = output_data[srcrow];
++    col = 0;
++
++    for (; (col << 1) < loop; col += 32) {
++      src0 = LASX_LD(srcptr + col);
++      LASX_ILVLH_B(src0, src0, src0_h, src0_l);
++      LASX_ST_2(src0_l, src0_h, outptr + (col << 1), 32);
++    }
++
++    for (; (col << 1) < output_width; col += 16) {
++      src0 = LASX_LD(srcptr + col);
++      LASX_ILVL_B(src0, src0, src0_l);
++      LASX_ST(src0_l, outptr + (col << 1));
++    }
++  }
++}
++
++
++GLOBAL(void)
++jsimd_h2v2_upsample_lasx(int max_v_samp_factor,
++                         JDIMENSION output_width,
++                         JSAMPARRAY input_data,
++                         JSAMPARRAY *output_data_ptr)
++{
++  JSAMPARRAY output_data = *output_data_ptr;
++  int col, loop, srcrow, outrow;
++  JSAMPROW srcptr, outptr0, outptr1;
++  __m256i src0, src0_l, src0_h;
++
++  loop = output_width & ~63;
++  for (srcrow = 0, outrow = 0; outrow < max_v_samp_factor; srcrow++) {
++    srcptr = input_data[srcrow];
++    outptr0 = output_data[outrow++];
++    outptr1 = output_data[outrow++];
++    col = 0;
++
++    for (; (col << 1) < loop; col += 32) {
++      src0 = LASX_LD(srcptr + col);
++      LASX_ILVLH_B(src0, src0, src0_h, src0_l);
++      LASX_ST_2(src0_l, src0_h, outptr0 + (col << 1), 32);
++      LASX_ST_2(src0_l, src0_h, outptr1 + (col << 1), 32);
++    }
++
++    for (; (col << 1) < output_width; col += 16) {
++      src0 = LASX_LD(srcptr + col);
++      LASX_ILVL_B(src0, src0, src0_l);
++      LASX_ST(src0_l, outptr0 + (col << 1));
++      LASX_ST(src0_l, outptr1 + (col << 1));
++    }
++  }
++}
+diff --git a/simd/loongarch64/jdsample-lsx.c b/simd/loongarch64/jdsample-lsx.c
+new file mode 100644
+index 00000000..89c7016f
+--- /dev/null
++++ b/simd/loongarch64/jdsample-lsx.c
+@@ -0,0 +1,425 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "jmacros_lsx.h"
++
++/*
++ * Fancy processing for the common case of 2:1 horizontal and 1:1 vertical.
++ * The centers of the output pixels are 1/4 and 3/4 of the way between input
++ * pixel centers.
++*/
++GLOBAL(void)
++jsimd_h2v1_fancy_upsample_lsx(int max_v_samp_factor,
++                              JDIMENSION downsampled_width,
++                              JSAMPARRAY input_data,
++                              JSAMPARRAY *output_data_ptr)
++{
++  int invalue, row, col;
++  JSAMPROW srcptr, outptr;
++  JSAMPARRAY output_data = *output_data_ptr;
++  __m128i src0, src1, src2, out0, out1, tmp0, tmp1;
++  __m128i src0_l, src0_h, src1_l, src1_h, src2_l, src2_h;
++
++  for (row = 0; row < max_v_samp_factor; row++) {
++    srcptr = input_data[row];
++    outptr = output_data[row];
++    col = downsampled_width;
++
++    for (; col >= 16; col -= 16) {
++      src0 = LSX_LD(srcptr - 1);
++      src1 = LSX_LD(srcptr);
++      src2 = LSX_LD(srcptr + 1);
++
++      srcptr += 16;
++
++      LSX_UNPCKLH_HU_BU(src0, src0_h, src0_l);
++      LSX_UNPCKLH_HU_BU(src1, src1_h, src1_l);
++      LSX_UNPCKLH_HU_BU(src2, src2_h, src2_l);
++
++      tmp0 = __lsx_vslli_h(src1_l, 1);
++      tmp1 = __lsx_vslli_h(src1_h, 1);
++      src1_l = __lsx_vadd_h(src1_l, tmp0);
++      src1_h = __lsx_vadd_h(src1_h, tmp1);
++
++      src0_l = __lsx_vadd_h(src0_l, src1_l);
++      src0_h = __lsx_vadd_h(src0_h, src1_h);
++      src0_l = __lsx_vaddi_hu(src0_l, 1);
++      src0_h = __lsx_vaddi_hu(src0_h, 1);
++
++      src2_l = __lsx_vadd_h(src2_l, src1_l);
++      src2_h = __lsx_vadd_h(src2_h, src1_h);
++      src2_l = __lsx_vaddi_hu(src2_l, 2);
++      src2_h = __lsx_vaddi_hu(src2_h, 2);
++
++      src0_l = __lsx_vsrai_h(src0_l, 2);
++      src0_h = __lsx_vsrai_h(src0_h, 2);
++      src2_l = __lsx_vsrai_h(src2_l, 2);
++      src2_h = __lsx_vsrai_h(src2_h, 2);
++
++      out0 = __lsx_vpackev_b(src2_l, src0_l);
++      out1 = __lsx_vpackev_b(src2_h, src0_h);
++
++      LSX_ST_2(out0, out1, outptr, 16);
++      outptr += 32;
++    }
++
++    if (col >= 8) {
++      src0 = LSX_LD(srcptr - 1);
++      src1 = LSX_LD(srcptr);
++      src2 = LSX_LD(srcptr + 1);
++
++      srcptr += 8;
++      col -= 8;
++
++      LSX_UNPCKL_HU_BU(src0, src0_l);
++      LSX_UNPCKL_HU_BU(src1, src1_l);
++      LSX_UNPCKL_HU_BU(src2, src2_l);
++
++      tmp0 = __lsx_vslli_h(src1_l, 1);
++      src1_l = __lsx_vadd_h(src1_l, tmp0);
++
++      src0_l = __lsx_vadd_h(src0_l, src1_l);
++      src0_l = __lsx_vaddi_hu(src0_l, 1);
++
++      src2_l = __lsx_vadd_h(src2_l, src1_l);
++      src2_l = __lsx_vaddi_hu(src2_l, 2);
++
++      src0_l = __lsx_vsrai_h(src0_l, 2);
++      src2_l = __lsx_vsrai_h(src2_l, 2);
++
++      out0 = __lsx_vpackev_b(src2_l, src0_l);
++      LSX_ST(out0, outptr);
++      outptr += 16;
++    }
++
++    for(; col > 0; col--) {
++      invalue = GETJSAMPLE(*srcptr++) * 3;
++      *outptr++ = (JSAMPLE) ((invalue + GETJSAMPLE(srcptr[-2]) + 1) >> 2);
++      *outptr++ = (JSAMPLE) ((invalue + GETJSAMPLE(*srcptr) + 2) >> 2);
++    }
++
++    /* update fisrt col */
++    *(output_data[row]) = *(input_data[row]);
++    /* update last col */
++    *(output_data[row] + (downsampled_width << 1) - 1) = *(input_data[row] + downsampled_width - 1);
++  }
++}
++
++/*
++ * Fancy processing for the common case of 2:1 horizontal and 2:1 vertical.
++ * Again a triangle filter; see comments for h2v1 case, above.
++ *
++ * It is OK for us to reference the adjacent input rows because we demanded
++ * context from the main buffer controller (see initialization code).
++ */
++GLOBAL(void)
++jsimd_h2v2_fancy_upsample_lsx(int max_v_samp_factor,
++                               JDIMENSION downsampled_width,
++                               JSAMPARRAY input_data,
++                               JSAMPARRAY *output_data_ptr)
++{
++  JSAMPARRAY output_data = *output_data_ptr;
++  JSAMPROW srcptr0, srcptr1, srcptr2, outptr0, outptr1;
++  int thissum0, lastsum0, nextsum0, thissum1, lastsum1, nextsum1;
++  int col, srcrow = 0, outrow = 0, tmp0, tmp1, tmp2;
++  __m128i tmp0_l, tmp1_l, tmp2_l, tmp0_h, tmp1_h, tmp2_h;
++  __m128i pre0, pre1, pre2, cur0, cur1, cur2, nxt0, nxt1, nxt2;
++  __m128i presum0_l, presum1_l, cursum0_l, cursum1_l, nxtsum0_l, nxtsum1_l;
++  __m128i presum0_h, presum1_h, cursum0_h, cursum1_h, nxtsum0_h, nxtsum1_h;
++  __m128i out00_l, out01_l, out10_l, out11_l;
++  __m128i out00_h, out01_h, out10_h, out11_h;
++  __m128i const3 = {3};
++
++  const3 = __lsx_vreplvei_h(const3, 0);
++  while (outrow < max_v_samp_factor) {
++    srcptr0 = input_data[srcrow];
++    srcptr1 = input_data[srcrow - 1];
++    srcptr2 = input_data[srcrow + 1];
++
++    outptr0 = output_data[outrow];
++    outptr1 = output_data[outrow + 1];
++    col = downsampled_width;
++
++    for (; col >= 16; col -= 16) {
++      pre0 = LSX_LD(srcptr0 - 1);
++      pre1 = LSX_LD(srcptr1 - 1);
++      pre2 = LSX_LD(srcptr2 - 1);
++
++      cur0 = LSX_LD(srcptr0);
++      cur1 = LSX_LD(srcptr1);
++      cur2 = LSX_LD(srcptr2);
++
++      nxt0 = LSX_LD(srcptr0 + 1);
++      nxt1 = LSX_LD(srcptr1 + 1);
++      nxt2 = LSX_LD(srcptr2 + 1);
++
++      srcptr0 += 16;
++      srcptr1 += 16;
++      srcptr2 += 16;
++
++      LSX_UNPCKLH_HU_BU(pre0, tmp0_h, tmp0_l);
++      LSX_UNPCKLH_HU_BU(pre1, tmp1_h, tmp1_l);
++      LSX_UNPCKLH_HU_BU(pre2, tmp2_h, tmp2_l);
++
++      presum0_l = __lsx_vmadd_h(tmp1_l, tmp0_l, const3);
++      presum0_h = __lsx_vmadd_h(tmp1_h, tmp0_h, const3);
++      presum1_l = __lsx_vmadd_h(tmp2_l, tmp0_l, const3);
++      presum1_h = __lsx_vmadd_h(tmp2_h, tmp0_h, const3);
++
++      LSX_UNPCKLH_HU_BU(cur0, tmp0_h, tmp0_l);
++      LSX_UNPCKLH_HU_BU(cur1, tmp1_h, tmp1_l);
++      LSX_UNPCKLH_HU_BU(cur2, tmp2_h, tmp2_l);
++
++      cursum0_l = __lsx_vmadd_h(tmp1_l, tmp0_l, const3);
++      cursum0_h = __lsx_vmadd_h(tmp1_h, tmp0_h, const3);
++      cursum1_l = __lsx_vmadd_h(tmp2_l, tmp0_l, const3);
++      cursum1_h = __lsx_vmadd_h(tmp2_h, tmp0_h, const3);
++
++      LSX_UNPCKLH_HU_BU(nxt0, tmp0_h, tmp0_l);
++      LSX_UNPCKLH_HU_BU(nxt1, tmp1_h, tmp1_l);
++      LSX_UNPCKLH_HU_BU(nxt2, tmp2_h, tmp2_l);
++
++      nxtsum0_l = __lsx_vmadd_h(tmp1_l, tmp0_l, const3);
++      nxtsum0_h = __lsx_vmadd_h(tmp1_h, tmp0_h, const3);
++      nxtsum1_l = __lsx_vmadd_h(tmp2_l, tmp0_l, const3);
++      nxtsum1_h = __lsx_vmadd_h(tmp2_h, tmp0_h, const3);
++
++      /* outptr0 */
++      out00_l = __lsx_vmadd_h(presum0_l, cursum0_l, const3);
++      out00_l = __lsx_vaddi_hu(out00_l, 8);
++      out00_l = __lsx_vsrai_h(out00_l, 4);
++      out01_l = __lsx_vmadd_h(nxtsum0_l, cursum0_l, const3);
++      out01_l = __lsx_vaddi_hu(out01_l, 7);
++      out01_l = __lsx_vsrai_h(out01_l, 4);
++      out00_h = __lsx_vmadd_h(presum0_h, cursum0_h, const3);
++      out00_h = __lsx_vaddi_hu(out00_h, 8);
++      out00_h = __lsx_vsrai_h(out00_h, 4);
++      out01_h = __lsx_vmadd_h(nxtsum0_h, cursum0_h, const3);
++      out01_h = __lsx_vaddi_hu(out01_h, 7);
++      out01_h = __lsx_vsrai_h(out01_h, 4);
++
++      /* outptr1 */
++      out10_l = __lsx_vmadd_h(presum1_l, cursum1_l, const3);
++      out10_l = __lsx_vaddi_hu(out10_l, 8);
++      out10_l = __lsx_vsrai_h(out10_l, 4);
++      out11_l = __lsx_vmadd_h(nxtsum1_l, cursum1_l, const3);
++      out11_l = __lsx_vaddi_hu(out11_l, 7);
++      out11_l = __lsx_vsrai_h(out11_l, 4);
++      out10_h = __lsx_vmadd_h(presum1_h, cursum1_h, const3);
++      out10_h = __lsx_vaddi_hu(out10_h, 8);
++      out10_h = __lsx_vsrai_h(out10_h, 4);
++      out11_h = __lsx_vmadd_h(nxtsum1_h, cursum1_h, const3);
++      out11_h = __lsx_vaddi_hu(out11_h, 7);
++      out11_h = __lsx_vsrai_h(out11_h, 4);
++
++      out00_l = __lsx_vpackev_b(out01_l, out00_l);
++      out10_l = __lsx_vpackev_b(out11_l, out10_l);
++      out00_h = __lsx_vpackev_b(out01_h, out00_h);
++      out10_h = __lsx_vpackev_b(out11_h, out10_h);
++
++      LSX_ST_2(out00_l, out00_h, outptr0, 16);
++      LSX_ST_2(out10_l, out10_h, outptr1, 16);
++      outptr0 += 32;
++      outptr1 += 32;
++    }
++
++    if (col >= 8) {
++      pre0 = LSX_LD(srcptr0 - 1);
++      pre1 = LSX_LD(srcptr1 - 1);
++      pre2 = LSX_LD(srcptr2 - 1);
++
++      cur0 = LSX_LD(srcptr0);
++      cur1 = LSX_LD(srcptr1);
++      cur2 = LSX_LD(srcptr2);
++
++      nxt0 = LSX_LD(srcptr0 + 1);
++      nxt1 = LSX_LD(srcptr1 + 1);
++      nxt2 = LSX_LD(srcptr2 + 1);
++
++      srcptr0 += 8;
++      srcptr1 += 8;
++      srcptr2 += 8;
++      col -= 8;
++
++      LSX_UNPCKL_HU_BU(pre0, tmp0_l);
++      LSX_UNPCKL_HU_BU(pre1, tmp1_l);
++      LSX_UNPCKL_HU_BU(pre2, tmp2_l);
++
++      presum0_l = __lsx_vmadd_h(tmp1_l, tmp0_l, const3);
++      presum1_l = __lsx_vmadd_h(tmp2_l, tmp0_l, const3);
++
++      LSX_UNPCKL_HU_BU(cur0, tmp0_l);
++      LSX_UNPCKL_HU_BU(cur1, tmp1_l);
++      LSX_UNPCKL_HU_BU(cur2, tmp2_l);
++
++      cursum0_l = __lsx_vmadd_h(tmp1_l, tmp0_l, const3);
++      cursum1_l = __lsx_vmadd_h(tmp2_l, tmp0_l, const3);
++
++      LSX_UNPCKL_HU_BU(nxt0, tmp0_l);
++      LSX_UNPCKL_HU_BU(nxt1, tmp1_l);
++      LSX_UNPCKL_HU_BU(nxt2, tmp2_l);
++
++      nxtsum0_l = __lsx_vmadd_h(tmp1_l, tmp0_l, const3);
++      nxtsum1_l = __lsx_vmadd_h(tmp2_l, tmp0_l, const3);
++
++      /* outptr0 */
++      out00_l = __lsx_vmadd_h(presum0_l, cursum0_l, const3);
++      out00_l = __lsx_vaddi_hu(out00_l, 8);
++      out00_l = __lsx_vsrai_h(out00_l, 4);
++      out01_l = __lsx_vmadd_h(nxtsum0_l, cursum0_l, const3);
++      out01_l = __lsx_vaddi_hu(out01_l, 7);
++      out01_l = __lsx_vsrai_h(out01_l, 4);
++
++      /* outptr1 */
++      out10_l = __lsx_vmadd_h(presum1_l, cursum1_l, const3);
++      out10_l = __lsx_vaddi_hu(out10_l, 8);
++      out10_l = __lsx_vsrai_h(out10_l, 4);
++      out11_l = __lsx_vmadd_h(nxtsum1_l, cursum1_l, const3);
++      out11_l = __lsx_vaddi_hu(out11_l, 7);
++      out11_l = __lsx_vsrai_h(out11_l, 4);
++
++      out00_l = __lsx_vpackev_b(out01_l, out00_l);
++      out10_l = __lsx_vpackev_b(out11_l, out10_l);
++
++      LSX_ST(out00_l, outptr0);
++      LSX_ST(out10_l, outptr1);
++      outptr0 += 16;
++      outptr1 += 16;
++    }
++
++    for (; col > 0; col--) {
++      tmp0 = (*srcptr0++) * 3;
++      tmp1 = (*(srcptr0 - 2)) * 3;
++      tmp2 = (*(srcptr0)) * 3;
++
++      thissum0 = tmp0 + GETJSAMPLE(*srcptr1++);
++      lastsum0 = tmp1 + GETJSAMPLE(*(srcptr1 - 2));
++      nextsum0 = tmp2 + GETJSAMPLE(*(srcptr1));
++      *outptr0++ = (JSAMPLE) ((thissum0 * 3 + lastsum0 + 8) >> 4);
++      *outptr0++ = (JSAMPLE) ((thissum0 * 3 + nextsum0 + 7) >> 4);
++
++      thissum1 = tmp0 + GETJSAMPLE(*srcptr2++);
++      lastsum1 = tmp1 + GETJSAMPLE(*(srcptr2 - 2));
++      nextsum1 = tmp2 + GETJSAMPLE(*(srcptr2));
++      *outptr1++ = (JSAMPLE) ((thissum1 * 3 + lastsum1 + 8) >> 4);
++      *outptr1++ = (JSAMPLE) ((thissum1 * 3 + nextsum1 + 7) >> 4);
++    }
++
++    /* update fisrt col for v = 0 */
++    thissum0 = GETJSAMPLE(*input_data[srcrow]) * 3 + GETJSAMPLE(*input_data[srcrow - 1]);
++    *(output_data[outrow]) = (JSAMPLE) ((thissum0 * 4 + 8) >> 4);
++
++    /* update last col for v = 0 */
++    thissum0 = GETJSAMPLE(*(input_data[srcrow] + downsampled_width - 1)) * 3 +
++               GETJSAMPLE(*(input_data[srcrow - 1] + downsampled_width - 1));
++    *(output_data[outrow] + (downsampled_width << 1) - 1) = (JSAMPLE) ((thissum0 * 4 + 7) >> 4);
++
++    /* update fisrt col for v = 1 */
++    thissum0 = GETJSAMPLE(*input_data[srcrow]) * 3 + GETJSAMPLE(*input_data[srcrow + 1]);
++    *(output_data[outrow + 1]) = (JSAMPLE) ((thissum0 * 4 + 8) >> 4);
++
++    /* update last col for v = 1 */
++    thissum0 = GETJSAMPLE(*(input_data[srcrow] + downsampled_width - 1)) * 3 +
++               GETJSAMPLE(*(input_data[srcrow + 1] + downsampled_width - 1));
++    *(output_data[outrow + 1] + (downsampled_width << 1) - 1) = (JSAMPLE) ((thissum0 * 4 + 7) >> 4);
++
++    srcrow++;
++    outrow += 2;
++  }
++}
++
++/*
++ * Fast processing for the common case of 2:1 horizontal and 1:1 vertical.
++ * It's still a box filter.
++ */
++
++GLOBAL(void)
++jsimd_h2v1_upsample_lsx(int max_v_samp_factor,
++                         JDIMENSION output_width,
++                         JSAMPARRAY input_data,
++                         JSAMPARRAY *output_data_ptr)
++{
++  JSAMPARRAY output_data = *output_data_ptr;
++  int col, loop, srcrow;
++  JSAMPROW srcptr, outptr;
++  __m128i src0, src0_l, src0_h;
++
++  loop = output_width & ~31;
++  for (srcrow = 0; srcrow < max_v_samp_factor; srcrow++) {
++    srcptr = input_data[srcrow];
++    outptr = output_data[srcrow];
++    col = 0;
++
++    for (; (col << 1) < loop; col += 16) {
++      src0 = LSX_LD(srcptr + col);
++      LSX_ILVLH_B(src0, src0, src0_h, src0_l);
++      LSX_ST_2(src0_l, src0_h, outptr + (col << 1), 16);
++    }
++
++    for (; (col << 1) < output_width; col += 8) {
++      src0 = LSX_LD(srcptr + col);
++      LSX_ILVL_B(src0, src0, src0_l);
++      LSX_ST(src0_l, outptr + (col << 1));
++    }
++  }
++}
++
++
++GLOBAL(void)
++jsimd_h2v2_upsample_lsx(int max_v_samp_factor,
++                         JDIMENSION output_width,
++                         JSAMPARRAY input_data,
++                         JSAMPARRAY *output_data_ptr)
++{
++  JSAMPARRAY output_data = *output_data_ptr;
++  int col, loop, srcrow, outrow;
++  JSAMPROW srcptr, outptr0, outptr1;
++  __m128i src0, src0_l, src0_h;
++
++  loop = output_width & ~31;
++  for (srcrow = 0, outrow = 0; outrow < max_v_samp_factor; srcrow++) {
++    srcptr = input_data[srcrow];
++    outptr0 = output_data[outrow++];
++    outptr1 = output_data[outrow++];
++    col = 0;
++
++    for (; (col << 1) < loop; col += 16) {
++      src0 = LSX_LD(srcptr + col);
++      LSX_ILVLH_B(src0, src0, src0_h, src0_l);
++      LSX_ST_2(src0_l, src0_h, outptr0 + (col << 1), 16);
++      LSX_ST_2(src0_l, src0_h, outptr1 + (col << 1), 16);
++    }
++
++    for (; (col << 1) < output_width; col += 8) {
++      src0 = LSX_LD(srcptr + col);
++      LSX_ILVL_B(src0, src0, src0_l);
++      LSX_ST(src0_l, outptr0 + (col << 1));
++      LSX_ST(src0_l, outptr1 + (col << 1));
++    }
++  }
++}
+diff --git a/simd/loongarch64/jfdctfst-lasx.c b/simd/loongarch64/jfdctfst-lasx.c
+new file mode 100644
+index 00000000..5ad5da61
+--- /dev/null
++++ b/simd/loongarch64/jfdctfst-lasx.c
+@@ -0,0 +1,123 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "jmacros_lasx.h"
++
++
++#define FIX_0_382683433       ((int32_t)( 98 << 8))  /* FIX(0.382683433) */
++#define FIX_0_541196100       ((int32_t)(139 << 8))  /* FIX(0.541196100) */
++#define FIX_0_707106781       ((int32_t)(181 << 8))  /* FIX(0.707106781) */
++#define FIX_1_306562965       ((int32_t)(334 << 8))  /* FIX(1.306562965) */
++
++#define DO_FDCT_IFAST(src0, src1, src2, src3, src4, src5, src6, src7, \
++                      dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7) { \
++  __m256i tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7; \
++  __m256i tmp10, tmp11, tmp12, tmp13; \
++  __m256i z1, z2, z3, z4, z5, z11, z13; \
++\
++  LASX_BUTTERFLY_8(v16i16, src0, src1, src2, src3, src4, src5, src6, src7, \
++                   tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7); \
++\
++  LASX_BUTTERFLY_4(v16i16, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13); \
++\
++  dst0 = __lasx_xvadd_h(tmp10, tmp11); \
++  dst4 = __lasx_xvsub_h(tmp10, tmp11); \
++\
++  tmp12 = __lasx_xvadd_h(tmp12, tmp13); \
++  LASX_UNPCK_L_W_H(tmp12, tmp12); \
++  z1 = __lasx_xvmul_w(tmp12, const7071); \
++  LASX_PCKOD_H(zero, z1, z1); \
++\
++  dst2 = __lasx_xvadd_h(tmp13, z1); \
++  dst6 = __lasx_xvsub_h(tmp13, z1); \
++\
++  tmp10 = __lasx_xvadd_h(tmp4, tmp5); \
++  tmp11 = __lasx_xvadd_h(tmp5, tmp6); \
++  tmp12 = __lasx_xvadd_h(tmp6, tmp7); \
++  z5 = __lasx_xvsub_h(tmp10, tmp12); \
++\
++  LASX_UNPCK_L_W_H_4(z5, tmp10, tmp11, tmp12, z5, tmp10, tmp11, tmp12); \
++  z5 = __lasx_xvmul_w(z5, const3826); \
++  z2 = __lasx_xvmul_w(tmp10, const5411); \
++  z4 = __lasx_xvmul_w(tmp12, const3065); \
++  z3 = __lasx_xvmul_w(tmp11, const7071); \
++\
++  LASX_PCKOD_H_4(zero, z5, zero, z2, zero, z4, zero, z3, z5, z2, z4, z3); \
++  z2 = __lasx_xvadd_h(z2, z5); \
++  z4 = __lasx_xvadd_h(z4, z5); \
++\
++  z11 = __lasx_xvadd_h(tmp7, z3); \
++  z13 = __lasx_xvsub_h(tmp7, z3); \
++\
++  LASX_BUTTERFLY_4(v16i16, z11, z13, z2, z4, dst1, dst5, dst3, dst7); \
++}
++
++GLOBAL(void)
++jsimd_fdct_ifast_lasx(DCTELEM *data)
++{
++  __m256i zero = __lasx_xvldi(0);
++  __m256i src0, src1, src2, src3, src4, src5, src6, src7;
++  __m256i dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++
++  __m256i const7071 = {FIX_0_707106781};
++  __m256i const3826 = {FIX_0_382683433};
++  __m256i const5411 = {FIX_0_541196100};
++  __m256i const3065 = {FIX_1_306562965};
++
++  const7071 = __lasx_xvreplve0_w(const7071);
++  const3826 = __lasx_xvreplve0_w(const3826);
++  const5411 = __lasx_xvreplve0_w(const5411);
++  const3065 = __lasx_xvreplve0_w(const3065);
++
++  LASX_LD_4(data, 16, src0, src2, src4, src6);
++
++  src1 = __lasx_xvpermi_q(zero, src0, 0x31);
++  src3 = __lasx_xvpermi_q(zero, src2, 0x31);
++  src5 = __lasx_xvpermi_q(zero, src4, 0x31);
++  src7 = __lasx_xvpermi_q(zero, src6, 0x31);
++
++  LASX_TRANSPOSE8x8_H_128SV(src0, src1, src2, src3, src4, src5, src6, src7,
++                            src0, src1, src2, src3, src4, src5, src6, src7);
++
++  DO_FDCT_IFAST(src0, src1, src2, src3, src4, src5, src6, src7,
++                dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  LASX_TRANSPOSE8x8_H_128SV(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                            src0, src1, src2, src3, src4, src5, src6, src7);
++
++  DO_FDCT_IFAST(src0, src1, src2, src3, src4, src5, src6, src7,
++                dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  dst0 = __lasx_xvpermi_q(dst1, dst0, 0x20);
++  dst2 = __lasx_xvpermi_q(dst3, dst2, 0x20);
++  dst4 = __lasx_xvpermi_q(dst5, dst4, 0x20);
++  dst6 = __lasx_xvpermi_q(dst7, dst6, 0x20);
++
++  LASX_ST_4(dst0, dst2, dst4, dst6, data, 16);
++}
+diff --git a/simd/loongarch64/jfdctfst-lsx.c b/simd/loongarch64/jfdctfst-lsx.c
+new file mode 100644
+index 00000000..ae39d32d
+--- /dev/null
++++ b/simd/loongarch64/jfdctfst-lsx.c
+@@ -0,0 +1,119 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "jmacros_lsx.h"
++
++#define FIX_0_382683433       ((int32_t)( 98 << 8))  /* FIX(0.382683433) */
++#define FIX_0_541196100       ((int32_t)(139 << 8))  /* FIX(0.541196100) */
++#define FIX_0_707106781       ((int32_t)(181 << 8))  /* FIX(0.707106781) */
++#define FIX_1_306562965       ((int32_t)(334 << 8))  /* FIX(1.306562965) */
++
++#define DO_FDCT_IFAST(src0, src1, src2, src3, src4, src5, src6, src7,         \
++                      dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7) {       \
++  __m128i tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;                     \
++  __m128i tmp10, tmp11, tmp12, tmp13;                                         \
++  __m128i z1, z2, z3, z4, z5, z11, z13;                                       \
++  __m128i z1_h, z1_l, z2_h, z2_l, z3_h, z3_l, z4_h, z4_l, z5_h, z5_l;         \
++                                                                              \
++  LSX_BUTTERFLY_8(v8i16, src0, src1, src2, src3, src4, src5, src6, src7,      \
++                  tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);            \
++                                                                              \
++  LSX_BUTTERFLY_4(v8i16, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13); \
++                                                                              \
++  dst0 = __lsx_vadd_h(tmp10, tmp11);                                          \
++  dst4 = __lsx_vsub_h(tmp10, tmp11);                                          \
++                                                                              \
++  tmp12 = __lsx_vadd_h(tmp12, tmp13);                                         \
++  LSX_UNPCKLH_W_H(tmp12, z1_h, z1_l);                                         \
++  z1_h = __lsx_vmul_w(z1_h, const7071);                                       \
++  z1_l = __lsx_vmul_w(z1_l, const7071);                                       \
++  LSX_PCKOD_H(z1_h, z1_l, z1);                                                \
++                                                                              \
++  dst2 = __lsx_vadd_h(tmp13, z1);                                             \
++  dst6 = __lsx_vsub_h(tmp13, z1);                                             \
++                                                                              \
++  tmp10 = __lsx_vadd_h(tmp4, tmp5);                                           \
++  tmp11 = __lsx_vadd_h(tmp5, tmp6);                                           \
++  tmp12 = __lsx_vadd_h(tmp6, tmp7);                                           \
++  z5 = __lsx_vsub_h(tmp10, tmp12);                                            \
++                                                                              \
++  LSX_UNPCKLH_W_H_4(z5, tmp10, tmp12, tmp11, z5_h, z5_l, z2_h, z2_l,          \
++                    z4_h, z4_l, z3_h, z3_l);                                  \
++  z2_l = __lsx_vmul_w(z2_l, const5411);                                       \
++  z2_h = __lsx_vmul_w(z2_h, const5411);                                       \
++  z3_l = __lsx_vmul_w(z3_l, const7071);                                       \
++  z3_h = __lsx_vmul_w(z3_h, const7071);                                       \
++  z4_l = __lsx_vmul_w(z4_l, const3065);                                       \
++  z4_h = __lsx_vmul_w(z4_h, const3065);                                       \
++  z5_l = __lsx_vmul_w(z5_l, const3826);                                       \
++  z5_h = __lsx_vmul_w(z5_h, const3826);                                       \
++                                                                              \
++  LSX_PCKOD_H_4(z2_h, z2_l, z3_h, z3_l, z4_h, z4_l, z5_h, z5_l,               \
++		z2, z3, z4, z5);                                              \
++  z2 = __lsx_vadd_h(z2, z5);                                                  \
++  z4 = __lsx_vadd_h(z4, z5);                                                  \
++                                                                              \
++  z11 = __lsx_vadd_h(tmp7, z3);                                               \
++  z13 = __lsx_vsub_h(tmp7, z3);                                               \
++                                                                              \
++  LSX_BUTTERFLY_4(v8i16, z11, z13, z2, z4, dst1, dst5, dst3, dst7);           \
++}
++
++GLOBAL(void)
++jsimd_fdct_ifast_lsx(DCTELEM *data)
++{
++  __m128i src0, src1, src2, src3, src4, src5, src6, src7;
++  __m128i dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++
++  __m128i const7071 = {FIX_0_707106781};
++  __m128i const3826 = {FIX_0_382683433};
++  __m128i const5411 = {FIX_0_541196100};
++  __m128i const3065 = {FIX_1_306562965};
++
++  const7071 = __lsx_vreplvei_w(const7071, 0);
++  const3826 = __lsx_vreplvei_w(const3826, 0);
++  const5411 = __lsx_vreplvei_w(const5411, 0);
++  const3065 = __lsx_vreplvei_w(const3065, 0);
++
++  LSX_LD_8(data, 8, src0, src1, src2, src3, src4, src5, src6, src7);
++
++  LSX_TRANSPOSE8x8_H(src0, src1, src2, src3, src4, src5, src6, src7,
++                     src0, src1, src2, src3, src4, src5, src6, src7);
++
++  DO_FDCT_IFAST(src0, src1, src2, src3, src4, src5, src6, src7,
++                dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  LSX_TRANSPOSE8x8_H(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                     src0, src1, src2, src3, src4, src5, src6, src7);
++
++  DO_FDCT_IFAST(src0, src1, src2, src3, src4, src5, src6, src7,
++                dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  LSX_ST_8(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, data, 8);
++}
+diff --git a/simd/loongarch64/jfdctint-lasx.c b/simd/loongarch64/jfdctint-lasx.c
+new file mode 100644
+index 00000000..8418416e
+--- /dev/null
++++ b/simd/loongarch64/jfdctint-lasx.c
+@@ -0,0 +1,221 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "jmacros_lasx.h"
++
++#define CONST_BITS  13
++#define PASS1_BITS  2
++
++#define FIX_0_298631336  ((int32_t)2446)   /* FIX(0.298631336) */
++#define FIX_0_390180644  ((int32_t)3196)   /* FIX(0.390180644) */
++#define FIX_0_541196100  ((int32_t)4433)   /* FIX(0.541196100) */
++#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
++#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
++#define FIX_1_175875602  ((int32_t)9633)   /* FIX(1.175875602) */
++#define FIX_1_501321110  ((int32_t)12299)  /* FIX(1.501321110) */
++#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
++#define FIX_1_961570560  ((int32_t)16069)  /* FIX(1.961570560) */
++#define FIX_2_053119869  ((int32_t)16819)  /* FIX(2.053119869) */
++#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
++#define FIX_3_072711026  ((int32_t)25172)  /* FIX(3.072711026) */
++
++GLOBAL(void)
++jsimd_fdct_islow_lasx(DCTELEM *data)
++{
++  __m256i temp;
++  __m256i val0, val1, val2, val3, val4, val5, val6, val7;
++  __m256i tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
++  __m256i tmp10, tmp11, tmp12, tmp13;
++  __m256i tmp4_l, tmp5_l, tmp6_l, tmp7_l;
++  __m256i dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++  __m256i z1_l, z2_l, z3_l, z4_l, z5_l, z12_l, z13_l;
++  __m256i zero = __lasx_xvldi(0);
++
++  __m256i const5411 = {FIX_0_541196100};
++  __m256i const7653 = {FIX_0_765366865};
++  __m256i const8477 = {-FIX_1_847759065};
++  __m256i const1758 = {FIX_1_175875602};
++  __m256i const8999 = {-FIX_0_899976223};
++  __m256i const5629 = {-FIX_2_562915447};
++  __m256i const9615 = {-FIX_1_961570560};
++  __m256i const3901 = {-FIX_0_390180644};
++  __m256i const2986 = {FIX_0_298631336};
++  __m256i const0531 = {FIX_2_053119869};
++  __m256i const0727 = {FIX_3_072711026};
++  __m256i const5013 = {FIX_1_501321110};
++
++  const5411 = __lasx_xvreplve0_w(const5411);
++  const7653 = __lasx_xvreplve0_w(const7653);
++  const8477 = __lasx_xvreplve0_w(const8477);
++  const1758 = __lasx_xvreplve0_w(const1758);
++  const8999 = __lasx_xvreplve0_w(const8999);
++  const5629 = __lasx_xvreplve0_w(const5629);
++  const9615 = __lasx_xvreplve0_w(const9615);
++  const3901 = __lasx_xvreplve0_w(const3901);
++  const2986 = __lasx_xvreplve0_w(const2986);
++  const0531 = __lasx_xvreplve0_w(const0531);
++  const0727 = __lasx_xvreplve0_w(const0727);
++  const5013 = __lasx_xvreplve0_w(const5013);
++
++  LASX_LD_4(data, 16, val0, val2, val4, val6);
++  val1 = __lasx_xvpermi_q(zero, val0, 0x31);
++  val3 = __lasx_xvpermi_q(zero, val2, 0x31);
++  val5 = __lasx_xvpermi_q(zero, val4, 0x31);
++  val7 = __lasx_xvpermi_q(zero, val6, 0x31);
++
++  /* Pass1 */
++
++  LASX_TRANSPOSE8x8_H_128SV(val0, val1, val2, val3, val4, val5, val6, val7,
++                            val0, val1, val2, val3, val4, val5, val6, val7);
++
++  LASX_BUTTERFLY_8(v16i16, val0, val1, val2, val3, val4, val5, val6, val7,
++                   tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
++
++  LASX_BUTTERFLY_4(v16i16, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
++
++  temp = __lasx_xvadd_h(tmp10, tmp11);
++  dst0 = __lasx_xvslli_h(temp, PASS1_BITS);
++  temp = __lasx_xvsub_h(tmp10, tmp11);
++  dst4 = __lasx_xvslli_h(temp, PASS1_BITS);
++
++  LASX_UNPCK_L_W_H_2(tmp12, tmp13, z12_l, z13_l);
++  tmp12 = __lasx_xvadd_h(tmp12, tmp13);
++  LASX_UNPCK_L_W_H(tmp12, z1_l);
++
++  z1_l = __lasx_xvmul_w(z1_l, const5411);
++  z12_l = __lasx_xvmadd_w(z1_l, z12_l, const8477);
++  z13_l = __lasx_xvmadd_w(z1_l, z13_l, const7653);
++
++  z12_l = __lasx_xvsrari_w(z12_l, (CONST_BITS - PASS1_BITS));
++  z13_l = __lasx_xvsrari_w(z13_l, (CONST_BITS - PASS1_BITS));
++  LASX_PCKEV_H_2(zero, z12_l, zero, z13_l, dst6, dst2);
++
++  tmp10 = __lasx_xvadd_h(tmp4, tmp7);
++  tmp11 = __lasx_xvadd_h(tmp5, tmp6);
++  tmp12 = __lasx_xvadd_h(tmp4, tmp6);
++  tmp13 = __lasx_xvadd_h(tmp5, tmp7);
++
++  LASX_UNPCK_L_W_H_4(tmp10, tmp11, tmp12, tmp13, z1_l, z2_l, z3_l, z4_l);
++
++  z5_l = __lasx_xvadd_w(z3_l, z4_l);
++  z5_l = __lasx_xvmul_w(z5_l, const1758);
++
++  LASX_UNPCK_L_W_H_4(tmp4, tmp5, tmp6, tmp7, tmp4_l, tmp5_l, tmp6_l, tmp7_l);
++
++  z1_l = __lasx_xvmul_w(z1_l, const8999);
++  z2_l = __lasx_xvmul_w(z2_l, const5629);
++  z3_l = __lasx_xvmadd_w(z5_l, z3_l, const9615);
++  z4_l = __lasx_xvmadd_w(z5_l, z4_l, const3901);
++
++  tmp4_l = __lasx_xvmadd_w(z1_l, tmp4_l, const2986);
++  tmp5_l = __lasx_xvmadd_w(z2_l, tmp5_l, const0531);
++  tmp6_l = __lasx_xvmadd_w(z2_l, tmp6_l, const0727);
++  tmp7_l = __lasx_xvmadd_w(z1_l, tmp7_l, const5013);
++
++  tmp4_l = __lasx_xvadd_w(tmp4_l, z3_l);
++  tmp5_l = __lasx_xvadd_w(tmp5_l, z4_l);
++  tmp6_l = __lasx_xvadd_w(tmp6_l, z3_l);
++  tmp7_l = __lasx_xvadd_w(tmp7_l, z4_l);
++
++  tmp4_l = __lasx_xvsrari_w(tmp4_l, (CONST_BITS - PASS1_BITS));
++  tmp5_l = __lasx_xvsrari_w(tmp5_l, (CONST_BITS - PASS1_BITS));
++  tmp6_l = __lasx_xvsrari_w(tmp6_l, (CONST_BITS - PASS1_BITS));
++  tmp7_l = __lasx_xvsrari_w(tmp7_l, (CONST_BITS - PASS1_BITS));
++
++  LASX_PCKEV_H_2(zero, tmp4_l, zero, tmp5_l, dst7, dst5);
++  LASX_PCKEV_H_2(zero, tmp6_l, zero, tmp7_l, dst3, dst1);
++
++  /* Pass 2 */
++
++  LASX_TRANSPOSE8x8_H_128SV(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                            val0, val1, val2, val3, val4, val5, val6, val7);
++
++  LASX_BUTTERFLY_8(v16i16, val0, val1, val2, val3, val4, val5, val6, val7,
++                   tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
++
++  LASX_BUTTERFLY_4(v16i16, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
++
++  dst0 = __lasx_xvadd_h(tmp10, tmp11);
++  dst4 = __lasx_xvsub_h(tmp10, tmp11);
++  LASX_SRARI_H_2(dst0, dst4, dst0, dst4, PASS1_BITS);
++
++  LASX_UNPCK_L_W_H_2(tmp12, tmp13, z12_l, z13_l);
++  tmp12 = __lasx_xvadd_h(tmp12, tmp13);
++  LASX_UNPCK_L_W_H(tmp12, z1_l);
++
++  z1_l = __lasx_xvmul_w(z1_l, const5411);
++  z12_l = __lasx_xvmadd_w(z1_l, z12_l, const8477);
++  z13_l = __lasx_xvmadd_w(z1_l, z13_l, const7653);
++
++  z12_l = __lasx_xvsrari_w(z12_l, (CONST_BITS + PASS1_BITS));
++  z13_l = __lasx_xvsrari_w(z13_l, (CONST_BITS + PASS1_BITS));
++  LASX_PCKEV_H_2(zero, z12_l, zero, z13_l, dst6, dst2);
++
++  tmp10 = __lasx_xvadd_h(tmp4, tmp7);
++  tmp11 = __lasx_xvadd_h(tmp5, tmp6);
++  tmp12 = __lasx_xvadd_h(tmp4, tmp6);
++  tmp13 = __lasx_xvadd_h(tmp5, tmp7);
++
++  LASX_UNPCK_L_W_H_4(tmp10, tmp11, tmp12, tmp13, z1_l, z2_l, z3_l, z4_l);
++
++  z5_l = __lasx_xvadd_w(z3_l, z4_l);
++  z5_l = __lasx_xvmul_w(z5_l, const1758);
++
++  LASX_UNPCK_L_W_H_4(tmp4, tmp5, tmp6, tmp7, tmp4_l, tmp5_l, tmp6_l, tmp7_l);
++
++  z1_l = __lasx_xvmul_w(z1_l, const8999);
++  z2_l = __lasx_xvmul_w(z2_l, const5629);
++  z3_l = __lasx_xvmadd_w(z5_l, z3_l, const9615);
++  z4_l = __lasx_xvmadd_w(z5_l, z4_l, const3901);
++
++  tmp4_l = __lasx_xvmadd_w(z1_l, tmp4_l, const2986);
++  tmp5_l = __lasx_xvmadd_w(z2_l, tmp5_l, const0531);
++  tmp6_l = __lasx_xvmadd_w(z2_l, tmp6_l, const0727);
++  tmp7_l = __lasx_xvmadd_w(z1_l, tmp7_l, const5013);
++
++  tmp4_l = __lasx_xvadd_w(tmp4_l, z3_l);
++  tmp5_l = __lasx_xvadd_w(tmp5_l, z4_l);
++  tmp6_l = __lasx_xvadd_w(tmp6_l, z3_l);
++  tmp7_l = __lasx_xvadd_w(tmp7_l, z4_l);
++
++  tmp4_l = __lasx_xvsrari_w(tmp4_l, (CONST_BITS + PASS1_BITS));
++  tmp5_l = __lasx_xvsrari_w(tmp5_l, (CONST_BITS + PASS1_BITS));
++  tmp6_l = __lasx_xvsrari_w(tmp6_l, (CONST_BITS + PASS1_BITS));
++  tmp7_l = __lasx_xvsrari_w(tmp7_l, (CONST_BITS + PASS1_BITS));
++
++  LASX_PCKEV_H_2(zero, tmp4_l, zero, tmp5_l, dst7, dst5);
++  LASX_PCKEV_H_2(zero, tmp6_l, zero, tmp7_l, dst3, dst1);
++
++  dst0 = __lasx_xvpermi_q(dst1, dst0, 0x20);
++  dst2 = __lasx_xvpermi_q(dst3, dst2, 0x20);
++  dst4 = __lasx_xvpermi_q(dst5, dst4, 0x20);
++  dst6 = __lasx_xvpermi_q(dst7, dst6, 0x20);
++
++  LASX_ST_4(dst0, dst2, dst4, dst6, data, 16);
++}
+diff --git a/simd/loongarch64/jfdctint-lsx.c b/simd/loongarch64/jfdctint-lsx.c
+new file mode 100644
+index 00000000..aa105f9f
+--- /dev/null
++++ b/simd/loongarch64/jfdctint-lsx.c
+@@ -0,0 +1,247 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "jmacros_lsx.h"
++
++#define CONST_BITS  13
++#define PASS1_BITS  2
++
++#define FIX_0_298631336  ((int32_t)2446)   /* FIX(0.298631336) */
++#define FIX_0_390180644  ((int32_t)3196)   /* FIX(0.390180644) */
++#define FIX_0_541196100  ((int32_t)4433)   /* FIX(0.541196100) */
++#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
++#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
++#define FIX_1_175875602  ((int32_t)9633)   /* FIX(1.175875602) */
++#define FIX_1_501321110  ((int32_t)12299)  /* FIX(1.501321110) */
++#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
++#define FIX_1_961570560  ((int32_t)16069)  /* FIX(1.961570560) */
++#define FIX_2_053119869  ((int32_t)16819)  /* FIX(2.053119869) */
++#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
++#define FIX_3_072711026  ((int32_t)25172)  /* FIX(3.072711026) */
++
++GLOBAL(void)
++jsimd_fdct_islow_lsx(DCTELEM *data)
++{
++  __m128i temp;
++  __m128i val0, val1, val2, val3, val4, val5, val6, val7;
++  __m128i tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
++  __m128i tmp10, tmp11, tmp12, tmp13;
++  __m128i tmp4_h, tmp4_l, tmp5_h, tmp5_l, tmp6_h, tmp6_l, tmp7_h, tmp7_l;
++  __m128i dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++  __m128i z1_h, z1_l, z2_h, z2_l, z3_h, z3_l, z4_h, z4_l, z5_h, z5_l;
++  __m128i z12_h, z12_l, z13_h, z13_l;
++
++  __m128i const5411 = {FIX_0_541196100};
++  __m128i const7653 = {FIX_0_765366865};
++  __m128i const8477 = {-FIX_1_847759065};
++  __m128i const1758 = {FIX_1_175875602};
++  __m128i const8999 = {-FIX_0_899976223};
++  __m128i const5629 = {-FIX_2_562915447};
++  __m128i const9615 = {-FIX_1_961570560};
++  __m128i const3901 = {-FIX_0_390180644};
++  __m128i const2986 = {FIX_0_298631336};
++  __m128i const0531 = {FIX_2_053119869};
++  __m128i const0727 = {FIX_3_072711026};
++  __m128i const5013 = {FIX_1_501321110};
++
++  const5411 = __lsx_vreplvei_w(const5411, 0);
++  const7653 = __lsx_vreplvei_w(const7653, 0);
++  const8477 = __lsx_vreplvei_w(const8477, 0);
++  const1758 = __lsx_vreplvei_w(const1758, 0);
++  const8999 = __lsx_vreplvei_w(const8999, 0);
++  const5629 = __lsx_vreplvei_w(const5629, 0);
++  const9615 = __lsx_vreplvei_w(const9615, 0);
++  const3901 = __lsx_vreplvei_w(const3901, 0);
++  const2986 = __lsx_vreplvei_w(const2986, 0);
++  const0531 = __lsx_vreplvei_w(const0531, 0);
++  const0727 = __lsx_vreplvei_w(const0727, 0);
++  const5013 = __lsx_vreplvei_w(const5013, 0);
++
++  LSX_LD_8(data, 8, val0, val1, val2, val3, val4, val5, val6, val7);
++
++  /* Pass1 */
++
++  LSX_TRANSPOSE8x8_H(val0, val1, val2, val3, val4, val5, val6, val7,
++                     val0, val1, val2, val3, val4, val5, val6, val7);
++
++  LSX_BUTTERFLY_8(v8i16, val0, val1, val2, val3, val4, val5, val6, val7,
++                  tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
++
++  LSX_BUTTERFLY_4(v8i16, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
++
++  temp = __lsx_vadd_h(tmp10, tmp11);
++  dst0 = __lsx_vslli_h(temp, PASS1_BITS);
++  temp = __lsx_vsub_h(tmp10, tmp11);
++  dst4 = __lsx_vslli_h(temp, PASS1_BITS);
++
++  LSX_UNPCKLH_W_H_2(tmp12, tmp13, z12_h, z12_l, z13_h, z13_l);
++  tmp12 = __lsx_vadd_h(tmp12, tmp13);
++  LSX_UNPCKLH_W_H(tmp12, z1_h, z1_l);
++
++  z1_h = __lsx_vmul_w(z1_h, const5411);
++  z1_l = __lsx_vmul_w(z1_l, const5411);
++
++  z12_h = __lsx_vmadd_w(z1_h, z12_h, const8477);
++  z12_l = __lsx_vmadd_w(z1_l, z12_l, const8477);
++  z13_h = __lsx_vmadd_w(z1_h, z13_h, const7653);
++  z13_l = __lsx_vmadd_w(z1_l, z13_l, const7653);
++
++  LSX_SRARI_W_4(z12_l, z12_h, z13_l, z13_h, (CONST_BITS - PASS1_BITS));
++  LSX_PCKEV_H_2(z12_h, z12_l, z13_h, z13_l, dst6, dst2);
++
++  tmp10 = __lsx_vadd_h(tmp4, tmp7);
++  tmp11 = __lsx_vadd_h(tmp5, tmp6);
++  tmp12 = __lsx_vadd_h(tmp4, tmp6);
++  tmp13 = __lsx_vadd_h(tmp5, tmp7);
++
++  LSX_UNPCKLH_W_H_4(tmp10, tmp11, tmp12, tmp13, z1_h, z1_l, z2_h, z2_l, z3_h,
++		    z3_l, z4_h, z4_l);
++  LSX_ADD_W_2(z3_h, z4_h, z3_l, z4_l, z5_h, z5_l);
++
++  z5_h = __lsx_vmul_w(z5_h, const1758);
++  z5_l = __lsx_vmul_w(z5_l, const1758);
++
++  LSX_UNPCKLH_W_H_4(tmp4, tmp5, tmp6, tmp7, tmp4_h, tmp4_l, tmp5_h, tmp5_l,
++		    tmp6_h, tmp6_l, tmp7_h, tmp7_l);
++
++  z1_h = __lsx_vmul_w(z1_h, const8999);
++  z1_l = __lsx_vmul_w(z1_l, const8999);
++  z2_h = __lsx_vmul_w(z2_h, const5629);
++  z2_l = __lsx_vmul_w(z2_l, const5629);
++  z3_h = __lsx_vmadd_w(z5_h, z3_h, const9615);
++  z3_l = __lsx_vmadd_w(z5_l, z3_l, const9615);
++  z4_h = __lsx_vmadd_w(z5_h, z4_h, const3901);
++  z4_l = __lsx_vmadd_w(z5_l, z4_l, const3901);
++
++  tmp4_h = __lsx_vmadd_w(z1_h, tmp4_h, const2986);
++  tmp5_h = __lsx_vmadd_w(z2_h, tmp5_h, const0531);
++  tmp6_h = __lsx_vmadd_w(z2_h, tmp6_h, const0727);
++  tmp7_h = __lsx_vmadd_w(z1_h, tmp7_h, const5013);
++  tmp4_l = __lsx_vmadd_w(z1_l, tmp4_l, const2986);
++  tmp5_l = __lsx_vmadd_w(z2_l, tmp5_l, const0531);
++  tmp6_l = __lsx_vmadd_w(z2_l, tmp6_l, const0727);
++  tmp7_l = __lsx_vmadd_w(z1_l, tmp7_l, const5013);
++
++  tmp4_h = __lsx_vadd_w(tmp4_h, z3_h);
++  tmp5_h = __lsx_vadd_w(tmp5_h, z4_h);
++  tmp6_h = __lsx_vadd_w(tmp6_h, z3_h);
++  tmp7_h = __lsx_vadd_w(tmp7_h, z4_h);
++  tmp4_l = __lsx_vadd_w(tmp4_l, z3_l);
++  tmp5_l = __lsx_vadd_w(tmp5_l, z4_l);
++  tmp6_l = __lsx_vadd_w(tmp6_l, z3_l);
++  tmp7_l = __lsx_vadd_w(tmp7_l, z4_l);
++
++  LSX_SRARI_W_4(tmp4_h, tmp5_h, tmp6_h, tmp7_h, (CONST_BITS - PASS1_BITS));
++  LSX_SRARI_W_4(tmp4_l, tmp5_l, tmp6_l, tmp7_l, (CONST_BITS - PASS1_BITS));
++
++  LSX_PCKEV_H_2(tmp4_h, tmp4_l, tmp5_h, tmp5_l, dst7, dst5);
++  LSX_PCKEV_H_2(tmp6_h, tmp6_l, tmp7_h, tmp7_l, dst3, dst1);
++
++  /* Pass 2 */
++
++  LSX_TRANSPOSE8x8_H(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                     val0, val1, val2, val3, val4, val5, val6, val7);
++
++  LSX_BUTTERFLY_8(v8i16, val0, val1, val2, val3, val4, val5, val6, val7,
++                  tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
++
++  LSX_BUTTERFLY_4(v8i16, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
++
++  dst0 = __lsx_vadd_h(tmp10, tmp11);
++  dst4 = __lsx_vsub_h(tmp10, tmp11);
++  LSX_SRARI_H_2(dst0, dst4, dst0, dst4, PASS1_BITS);
++
++  LSX_UNPCKLH_W_H_2(tmp12, tmp13, z12_h, z12_l, z13_h, z13_l);
++
++  tmp10 = __lsx_vadd_h(tmp12, tmp13);
++  LSX_UNPCKLH_W_H(tmp10, z1_h, z1_l);
++
++  z1_h = __lsx_vmul_w(z1_h, const5411);
++  z1_l = __lsx_vmul_w(z1_l, const5411);
++
++  z12_h = __lsx_vmadd_w(z1_h, z12_h, const8477);
++  z12_l = __lsx_vmadd_w(z1_l, z12_l, const8477);
++  z13_h = __lsx_vmadd_w(z1_h, z13_h, const7653);
++  z13_l = __lsx_vmadd_w(z1_l, z13_l, const7653);
++
++  z12_h = __lsx_vsrari_w(z12_h, (CONST_BITS + PASS1_BITS));
++  z12_l = __lsx_vsrari_w(z12_l, (CONST_BITS + PASS1_BITS));
++  z13_h = __lsx_vsrari_w(z13_h, (CONST_BITS + PASS1_BITS));
++  z13_l = __lsx_vsrari_w(z13_l, (CONST_BITS + PASS1_BITS));
++  LSX_PCKEV_H_2(z12_h, z12_l, z13_h, z13_l, dst6, dst2);
++
++  LSX_ADD_H_4(tmp4, tmp7, tmp5, tmp6, tmp4, tmp6, tmp5, tmp7,
++	      tmp10, tmp11, tmp12, tmp13);
++
++  LSX_UNPCKLH_W_H_4(tmp10, tmp11, tmp12, tmp13, z1_h, z1_l, z2_h, z2_l,
++		    z3_h, z3_l, z4_h, z4_l);
++
++  LSX_ADD_W_2(z3_h, z4_h, z3_l, z4_l, z5_h, z5_l);
++
++  z5_h = __lsx_vmul_w(z5_h, const1758);
++  z5_l = __lsx_vmul_w(z5_l, const1758);
++
++  LSX_UNPCKLH_W_H_4(tmp4, tmp5, tmp6, tmp7, tmp4_h, tmp4_l, tmp5_h, tmp5_l,
++		    tmp6_h, tmp6_l, tmp7_h, tmp7_l);
++
++  z1_h = __lsx_vmul_w(z1_h, const8999);
++  z1_l = __lsx_vmul_w(z1_l, const8999);
++  z2_h = __lsx_vmul_w(z2_h, const5629);
++  z2_l = __lsx_vmul_w(z2_l, const5629);
++  z3_h = __lsx_vmadd_w(z5_h, z3_h, const9615);
++  z3_l = __lsx_vmadd_w(z5_l, z3_l, const9615);
++  z4_h = __lsx_vmadd_w(z5_h, z4_h, const3901);
++  z4_l = __lsx_vmadd_w(z5_l, z4_l, const3901);
++
++  tmp4_h = __lsx_vmadd_w(z1_h, tmp4_h, const2986);
++  tmp5_h = __lsx_vmadd_w(z2_h, tmp5_h, const0531);
++  tmp6_h = __lsx_vmadd_w(z2_h, tmp6_h, const0727);
++  tmp7_h = __lsx_vmadd_w(z1_h, tmp7_h, const5013);
++  tmp4_l = __lsx_vmadd_w(z1_l, tmp4_l, const2986);
++  tmp5_l = __lsx_vmadd_w(z2_l, tmp5_l, const0531);
++  tmp6_l = __lsx_vmadd_w(z2_l, tmp6_l, const0727);
++  tmp7_l = __lsx_vmadd_w(z1_l, tmp7_l, const5013);
++
++  tmp4_h = __lsx_vadd_w(tmp4_h, z3_h);
++  tmp5_h = __lsx_vadd_w(tmp5_h, z4_h);
++  tmp6_h = __lsx_vadd_w(tmp6_h, z3_h);
++  tmp7_h = __lsx_vadd_w(tmp7_h, z4_h);
++  tmp4_l = __lsx_vadd_w(tmp4_l, z3_l);
++  tmp5_l = __lsx_vadd_w(tmp5_l, z4_l);
++  tmp6_l = __lsx_vadd_w(tmp6_l, z3_l);
++  tmp7_l = __lsx_vadd_w(tmp7_l, z4_l);
++
++  LSX_SRARI_W_4(tmp4_h, tmp5_h, tmp6_h, tmp7_h, (CONST_BITS + PASS1_BITS));
++  LSX_SRARI_W_4(tmp4_l, tmp5_l, tmp6_l, tmp7_l, (CONST_BITS + PASS1_BITS));
++
++  LSX_PCKEV_H_2(tmp4_h, tmp4_l, tmp5_h, tmp5_l, dst7, dst5);
++  LSX_PCKEV_H_2(tmp6_h, tmp6_l, tmp7_h, tmp7_l, dst3, dst1);
++
++  LSX_ST_8(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, data, 8);
++}
+diff --git a/simd/loongarch64/jidctfst-lasx.c b/simd/loongarch64/jidctfst-lasx.c
+new file mode 100644
+index 00000000..e22d439d
+--- /dev/null
++++ b/simd/loongarch64/jidctfst-lasx.c
+@@ -0,0 +1,246 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "jmacros_lasx.h"
++
++#define DCTSIZE 8
++#define PASS1_BITS 2
++#define CONST_BITS_FAST 8
++
++#define FIX_1_082392200 ((int32_t)277)  /* FIX(1.082392200) */
++#define FIX_1_414213562 ((int32_t)362)  /* FIX(1.414213562) */
++#define FIX_1_847759065 ((int32_t)473)  /* FIX(1.847759065) */
++#define FIX_2_613125930 ((int32_t)669)  /* FIX(2.613125930) */
++
++GLOBAL(void)
++jsimd_idct_ifast_lasx(void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                      JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = (JCOEFPTR)dct_table;
++  __m256i coef01, coef23, coef45, coef67;
++  __m256i quant01, quant23, quant45, quant67;
++  __m256i zero = __lasx_xvldi(0);
++  __m256i tmp0, tmp1, tmp2, tmp3;
++  __m256i tmp4, tmp5, tmp6, tmp7;
++  __m256i tmp10, tmp11, tmp12, tmp13;
++  __m256i dst0, dst1, dst2, dst3;
++  __m256i dst4, dst5, dst6, dst7;
++  __m256i z5, z10, z11, z12, z13;
++  __m256i const128 = { 128 };
++  __m256i const1414 = { FIX_1_414213562 };
++  __m256i const1847 = { FIX_1_847759065 };
++  __m256i const1082 = { FIX_1_082392200 };
++  __m256i const2613 = { -FIX_2_613125930 };
++
++  const2613 = __lasx_xvreplve0_w(const2613);
++  const1082 = __lasx_xvreplve0_w(const1082);
++  const1847 = __lasx_xvreplve0_w(const1847);
++  const1414 = __lasx_xvreplve0_w(const1414);
++  const128 = __lasx_xvreplve0_h(const128);
++
++  LASX_LD_4(coef_block, 16, coef01, coef23, coef45, coef67);
++
++  tmp0 = __lasx_xvpermi_q(zero, coef01, 0x31);
++  tmp0 = __lasx_xvor_v(tmp0, coef23);
++  tmp0 = __lasx_xvor_v(tmp0, coef45);
++  tmp0 = __lasx_xvor_v(tmp0, coef67);
++
++  if (__lasx_xbz_v(tmp0)) {
++    /* AC terms all zero */
++    quant01 = LASX_LD(quantptr);
++    dst0 = __lasx_xvmul_h(coef01, quant01);
++    tmp1  = __lasx_xvpermi_q(dst0, dst0, 0x20);
++    dst0 = __lasx_xvrepl128vei_h(tmp1, 0);
++    dst1 = __lasx_xvrepl128vei_h(tmp1, 1);
++    dst2 = __lasx_xvrepl128vei_h(tmp1, 2);
++    dst3 = __lasx_xvrepl128vei_h(tmp1, 3);
++    dst4 = __lasx_xvrepl128vei_h(tmp1, 4);
++    dst5 = __lasx_xvrepl128vei_h(tmp1, 5);
++    dst6 = __lasx_xvrepl128vei_h(tmp1, 6);
++    dst7 = __lasx_xvrepl128vei_h(tmp1, 7);
++  } else {
++    LASX_LD_4(quantptr, 16, quant01, quant23, quant45, quant67);
++
++    dst0 = __lasx_xvmul_h(coef01, quant01);
++    dst2 = __lasx_xvmul_h(coef23, quant23);
++    dst4 = __lasx_xvmul_h(coef45, quant45);
++    dst6 = __lasx_xvmul_h(coef67, quant67);
++    dst1 = __lasx_xvpermi_q(zero, dst0, 0x31);
++    dst0 = __lasx_xvpermi_q(zero, dst0, 0x20);
++    dst3 = __lasx_xvpermi_q(zero, dst2, 0x31);
++    dst2 = __lasx_xvpermi_q(zero, dst2, 0x20);
++    dst5 = __lasx_xvpermi_q(zero, dst4, 0x31);
++    dst4 = __lasx_xvpermi_q(zero, dst4, 0x20);
++    dst7 = __lasx_xvpermi_q(zero, dst6, 0x31);
++    dst6 = __lasx_xvpermi_q(zero, dst6, 0x20);
++
++    /* Even part */
++    LASX_BUTTERFLY_4(v16i16, dst0, dst2, dst6, dst4,
++                     tmp10, tmp13, tmp12, tmp11);
++
++    LASX_UNPCK_L_W_H(tmp12, tmp12);
++    tmp12 = __lasx_xvmul_w(tmp12, const1414);
++    tmp12 = __lasx_xvsrai_w(tmp12, CONST_BITS_FAST);
++    LASX_PCKEV_H(zero, tmp12, tmp12);
++    tmp12 = __lasx_xvsub_h(tmp12, tmp13);
++
++    LASX_BUTTERFLY_4(v16i16, tmp10, tmp11, tmp12, tmp13,
++                     tmp0, tmp1, tmp2, tmp3);
++
++    /* Odd part */
++    LASX_BUTTERFLY_4(v16i16, dst5, dst1, dst7, dst3,
++                     z13, z11, z12, z10);
++
++    tmp7 = __lasx_xvadd_h(z11, z13);
++
++    tmp11 = __lasx_xvsub_h(z11, z13);
++    LASX_UNPCK_L_W_H(tmp11, tmp11);
++    tmp11 = __lasx_xvmul_w(tmp11, const1414);
++    tmp11 = __lasx_xvsrai_w(tmp11, CONST_BITS_FAST);
++    LASX_PCKEV_H(zero, tmp11, tmp11);
++
++    z5 = __lasx_xvadd_h(z10, z12);
++    LASX_UNPCK_L_W_H(z5, z5);
++    z5 = __lasx_xvmul_w(z5, const1847);
++    z5 = __lasx_xvsrai_w(z5, CONST_BITS_FAST);
++    LASX_PCKEV_H(zero, z5, z5);
++
++    LASX_UNPCK_L_W_H(z12, tmp10);
++    tmp10 = __lasx_xvmul_w(tmp10, const1082);
++    tmp10 = __lasx_xvsrai_w(tmp10, CONST_BITS_FAST);
++    LASX_PCKEV_H(zero, tmp10, tmp10);
++    tmp10 = __lasx_xvsub_h(tmp10, z5);
++
++    LASX_UNPCK_L_W_H(z10, tmp12);
++    tmp12 = __lasx_xvmul_w(tmp12, const2613);
++    tmp12 = __lasx_xvsrai_w(tmp12, CONST_BITS_FAST);
++    LASX_PCKEV_H(zero, tmp12, tmp12);
++    tmp12 = __lasx_xvadd_h(tmp12, z5);
++
++    tmp6 = __lasx_xvsub_h(tmp12, tmp7);
++    tmp5 = __lasx_xvsub_h(tmp11, tmp6);
++    tmp4 = __lasx_xvadd_h(tmp10, tmp5);
++
++    LASX_BUTTERFLY_8(v16i16, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
++                     dst0, dst1, dst2, dst4, dst3, dst5, dst6, dst7);
++
++    LASX_TRANSPOSE8x8_H_128SV(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                              dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++  }
++
++  /* Even part */
++  LASX_BUTTERFLY_4(v16i16, dst0, dst2, dst6, dst4,
++                   tmp10, tmp13, tmp12, tmp11);
++
++  LASX_UNPCK_L_W_H(tmp12, tmp12);
++  tmp12 = __lasx_xvmul_w(tmp12, const1414);
++  tmp12 = __lasx_xvsrai_w(tmp12, CONST_BITS_FAST);
++  LASX_PCKEV_H(zero, tmp12, tmp12);
++  tmp12 = __lasx_xvsub_h(tmp12, tmp13);
++
++  LASX_BUTTERFLY_4(v16i16, tmp10, tmp11, tmp12, tmp13,
++                   tmp0, tmp1, tmp2, tmp3);
++
++  /* Odd part */
++  LASX_BUTTERFLY_4(v16i16, dst5, dst1, dst7, dst3,
++                   z13, z11, z12, z10);
++
++  tmp7 = __lasx_xvadd_h(z11, z13);
++
++  tmp11 = __lasx_xvsub_h(z11, z13);
++  LASX_UNPCK_L_W_H(tmp11, tmp11);
++  tmp11 = __lasx_xvmul_w(tmp11, const1414);
++  tmp11 = __lasx_xvsrai_w(tmp11, CONST_BITS_FAST);
++  LASX_PCKEV_H(zero, tmp11, tmp11);
++
++  z5 = __lasx_xvadd_h(z10, z12);
++  LASX_UNPCK_L_W_H(z5, z5);
++  z5 = __lasx_xvmul_w(z5, const1847);
++  z5 = __lasx_xvsrai_w(z5, CONST_BITS_FAST);
++  LASX_PCKEV_H(zero, z5, z5);
++
++  LASX_UNPCK_L_W_H(z12, tmp10);
++  tmp10 = __lasx_xvmul_w(tmp10, const1082);
++  tmp10 = __lasx_xvsrai_w(tmp10, CONST_BITS_FAST);
++  LASX_PCKEV_H(zero, tmp10, tmp10);
++  tmp10 = __lasx_xvsub_h(tmp10, z5);
++
++  LASX_UNPCK_L_W_H(z10, tmp12);
++  tmp12 = __lasx_xvmul_w(tmp12, const2613);
++  tmp12 = __lasx_xvsrai_w(tmp12, CONST_BITS_FAST);
++  LASX_PCKEV_H(zero, tmp12, tmp12);
++  tmp12 = __lasx_xvadd_h(tmp12, z5);
++
++  tmp6 = __lasx_xvsub_h(tmp12, tmp7);
++  tmp5 = __lasx_xvsub_h(tmp11, tmp6);
++  tmp4 = __lasx_xvadd_h(tmp10, tmp5);
++
++  LASX_BUTTERFLY_8(v16i16, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
++                   dst0, dst1, dst2, dst4, dst3, dst5, dst6, dst7);
++
++  dst0 = __lasx_xvsrai_h(dst0, PASS1_BITS + 3);
++  dst1 = __lasx_xvsrai_h(dst1, PASS1_BITS + 3);
++  dst2 = __lasx_xvsrai_h(dst2, PASS1_BITS + 3);
++  dst3 = __lasx_xvsrai_h(dst3, PASS1_BITS + 3);
++  dst4 = __lasx_xvsrai_h(dst4, PASS1_BITS + 3);
++  dst5 = __lasx_xvsrai_h(dst5, PASS1_BITS + 3);
++  dst6 = __lasx_xvsrai_h(dst6, PASS1_BITS + 3);
++  dst7 = __lasx_xvsrai_h(dst7, PASS1_BITS + 3);
++
++  dst0 = __lasx_xvadd_h(dst0, const128);
++  dst1 = __lasx_xvadd_h(dst1, const128);
++  dst2 = __lasx_xvadd_h(dst2, const128);
++  dst3 = __lasx_xvadd_h(dst3, const128);
++  dst4 = __lasx_xvadd_h(dst4, const128);
++  dst5 = __lasx_xvadd_h(dst5, const128);
++  dst6 = __lasx_xvadd_h(dst6, const128);
++  dst7 = __lasx_xvadd_h(dst7, const128);
++
++  LASX_CLIP_H_0_255_4(dst0, dst1, dst2, dst3,
++                      dst0, dst1, dst2, dst3);
++  LASX_CLIP_H_0_255_4(dst4, dst5, dst6, dst7,
++                      dst4, dst5, dst6, dst7);
++
++  LASX_PCKEV_B_8(zero, dst0, zero, dst1, zero, dst2, zero, dst3,
++                 zero, dst4, zero, dst5, zero, dst6, zero, dst7,
++                 dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  LASX_TRANSPOSE8x8_B(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                      dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  __lasx_xvstelm_d(dst0, output_buf[0] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst1, output_buf[1] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst2, output_buf[2] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst3, output_buf[3] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst4, output_buf[4] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst5, output_buf[5] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst6, output_buf[6] + output_col, 0, 0);
++  __lasx_xvstelm_d(dst7, output_buf[7] + output_col, 0, 0);
++}
+diff --git a/simd/loongarch64/jidctfst-lsx.c b/simd/loongarch64/jidctfst-lsx.c
+new file mode 100644
+index 00000000..9263d090
+--- /dev/null
++++ b/simd/loongarch64/jidctfst-lsx.c
+@@ -0,0 +1,264 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "jmacros_lsx.h"
++
++#define DCTSIZE 8
++#define PASS1_BITS 2
++#define CONST_BITS_FAST 8
++
++#define FIX_1_082392200 ((int32_t)277)  /* FIX(1.082392200) */
++#define FIX_1_414213562 ((int32_t)362)  /* FIX(1.414213562) */
++#define FIX_1_847759065 ((int32_t)473)  /* FIX(1.847759065) */
++#define FIX_2_613125930 ((int32_t)669)  /* FIX(2.613125930) */
++
++GLOBAL(void)
++jsimd_idct_ifast_lsx(void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                     JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = (JCOEFPTR)dct_table;
++  __m128i coef0, coef1, coef2, coef3, coef4, coef5, coef6, coef7;
++  __m128i quant0, quant1, quant2, quant3, quant4, quant5, quant6, quant7;
++  __m128i tmp0, tmp1, tmp2, tmp3;
++  __m128i tmp4, tmp5, tmp6, tmp7;
++  __m128i tmp10, tmp11, tmp12, tmp13;
++  __m128i tmp11_h, tmp11_l, tmp12_h, tmp12_l;
++  __m128i dst0, dst1, dst2, dst3;
++  __m128i dst4, dst5, dst6, dst7;
++  __m128i z5, z10, z11, z12, z13;
++  __m128i z5_h, z5_l, z10_h, z10_l, z12_h, z12_l;
++  __m128i const128 = { 128 };
++  __m128i const1414 = { FIX_1_414213562 };
++  __m128i const1847 = { FIX_1_847759065 };
++  __m128i const1082 = { FIX_1_082392200 };
++  __m128i const2613 = { -FIX_2_613125930 };
++
++  const2613 = __lsx_vreplvei_w(const2613, 0);
++  const1082 = __lsx_vreplvei_w(const1082, 0);
++  const1847 = __lsx_vreplvei_w(const1847, 0);
++  const1414 = __lsx_vreplvei_w(const1414, 0);
++  const128 = __lsx_vreplvei_h(const128, 0);
++
++  LSX_LD_4(coef_block, 8, coef0, coef1, coef2, coef3);
++  LSX_LD_4(coef_block + 32, 8, coef4, coef5, coef6, coef7);
++
++  tmp0 = coef1 | coef2 | coef3 | coef4 | coef5 | coef6 | coef7;
++
++  if (__lsx_bz_v(tmp0)) {
++    /* AC terms all zero */
++    quant0 = LSX_LD(quantptr);
++    tmp0 = __lsx_vmul_h(coef0, quant0);
++
++    dst0 = __lsx_vreplvei_h(tmp0, 0);
++    dst1 = __lsx_vreplvei_h(tmp0, 1);
++    dst2 = __lsx_vreplvei_h(tmp0, 2);
++    dst3 = __lsx_vreplvei_h(tmp0, 3);
++    dst4 = __lsx_vreplvei_h(tmp0, 4);
++    dst5 = __lsx_vreplvei_h(tmp0, 5);
++    dst6 = __lsx_vreplvei_h(tmp0, 6);
++    dst7 = __lsx_vreplvei_h(tmp0, 7);
++  } else {
++    LSX_LD_4(quantptr, 8, quant0, quant1, quant2, quant3);
++    LSX_LD_4(quantptr + 32, 8, quant4, quant5, quant6, quant7);
++
++    dst0 = __lsx_vmul_h(coef0, quant0);
++    dst1 = __lsx_vmul_h(coef1, quant1);
++    dst2 = __lsx_vmul_h(coef2, quant2);
++    dst3 = __lsx_vmul_h(coef3, quant3);
++    dst4 = __lsx_vmul_h(coef4, quant4);
++    dst5 = __lsx_vmul_h(coef5, quant5);
++    dst6 = __lsx_vmul_h(coef6, quant6);
++    dst7 = __lsx_vmul_h(coef7, quant7);
++
++    /* Even part */
++    LSX_BUTTERFLY_4(v8i16, dst0, dst2, dst6, dst4,
++                    tmp10, tmp13, tmp12, tmp11);
++
++    LSX_UNPCKLH_W_H(tmp12, tmp12_l, tmp12_h);
++    tmp12_h = __lsx_vmul_w(tmp12_h, const1414);
++    tmp12_l = __lsx_vmul_w(tmp12_l, const1414);
++
++    tmp12_h = __lsx_vsrai_w(tmp12_h, CONST_BITS_FAST);
++    tmp12_l = __lsx_vsrai_w(tmp12_l, CONST_BITS_FAST);
++
++    LSX_PCKEV_H(tmp12_l, tmp12_h, tmp12);
++    tmp12 = __lsx_vsub_h(tmp12, tmp13);
++
++    LSX_BUTTERFLY_4(v8i16, tmp10, tmp11, tmp12, tmp13,
++                    tmp0, tmp1, tmp2, tmp3);
++
++    /* Odd part */
++    LSX_BUTTERFLY_4(v8i16, dst5, dst1, dst7, dst3,
++                    z13, z11, z12, z10);
++
++    tmp7 = __lsx_vadd_h(z11, z13);
++
++    tmp11 = __lsx_vsub_h(z11, z13);
++    LSX_UNPCKLH_W_H(tmp11, tmp11_l, tmp11_h);
++    tmp11_h = __lsx_vmul_w(tmp11_h, const1414);
++    tmp11_l = __lsx_vmul_w(tmp11_l, const1414);
++    tmp11_h = __lsx_vsrai_w(tmp11_h, CONST_BITS_FAST);
++    tmp11_l = __lsx_vsrai_w(tmp11_l, CONST_BITS_FAST);
++    LSX_PCKEV_H(tmp11_l, tmp11_h, tmp11);
++
++    z5 = __lsx_vadd_h(z10, z12);
++    LSX_UNPCKLH_W_H(z5, z5_l, z5_h);
++    z5_h = __lsx_vmul_w(z5_h, const1847);
++    z5_l = __lsx_vmul_w(z5_l, const1847);
++    z5_h = __lsx_vsrai_w(z5_h, CONST_BITS_FAST);
++    z5_l = __lsx_vsrai_w(z5_l, CONST_BITS_FAST);
++    LSX_PCKEV_H(z5_l, z5_h, z5);
++
++    LSX_UNPCKLH_W_H(z12, z12_l, z12_h);
++    z12_h = __lsx_vmul_w(z12_h, const1082);
++    z12_l = __lsx_vmul_w(z12_l, const1082);
++    z12_h = __lsx_vsrai_w(z12_h, CONST_BITS_FAST);
++    z12_l = __lsx_vsrai_w(z12_l, CONST_BITS_FAST);
++    LSX_PCKEV_H(z12_l, z12_h, tmp10);
++    tmp10 = __lsx_vsub_h(tmp10, z5);
++
++    LSX_UNPCKLH_W_H(z10, z10_l, z10_h);
++    z10_h = __lsx_vmul_w(z10_h, const2613);
++    z10_l = __lsx_vmul_w(z10_l, const2613);
++    z10_h = __lsx_vsrai_w(z10_h, CONST_BITS_FAST);
++    z10_l = __lsx_vsrai_w(z10_l, CONST_BITS_FAST);
++    LSX_PCKEV_H(z10_l, z10_h, tmp12);
++    tmp12 = __lsx_vadd_h(tmp12, z5);
++
++    tmp6 = __lsx_vsub_h(tmp12, tmp7);
++    tmp5 = __lsx_vsub_h(tmp11, tmp6);
++    tmp4 = __lsx_vadd_h(tmp10, tmp5);
++
++    LSX_BUTTERFLY_8(v8i16, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
++                    dst0, dst1, dst2, dst4, dst3, dst5, dst6, dst7);
++
++    LSX_TRANSPOSE8x8_H(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                       dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++  }
++
++  /* Even part */
++  LSX_BUTTERFLY_4(v8i16, dst0, dst2, dst6, dst4,
++                  tmp10, tmp13, tmp12, tmp11);
++
++  LSX_UNPCKLH_W_H(tmp12, tmp12_l, tmp12_h);
++  tmp12_h = __lsx_vmul_w(tmp12_h, const1414);
++  tmp12_l = __lsx_vmul_w(tmp12_l, const1414);
++  tmp12_h = __lsx_vsrai_w(tmp12_h, CONST_BITS_FAST);
++  tmp12_l = __lsx_vsrai_w(tmp12_l, CONST_BITS_FAST);
++  LSX_PCKEV_H(tmp12_l, tmp12_h, tmp12);
++  tmp12 = __lsx_vsub_h(tmp12, tmp13);
++
++  LSX_BUTTERFLY_4(v8i16, tmp10, tmp11, tmp12, tmp13,
++                  tmp0, tmp1, tmp2, tmp3);
++
++  /* Odd part */
++  LSX_BUTTERFLY_4(v8i16, dst5, dst1, dst7, dst3,
++                  z13, z11, z12, z10);
++
++  tmp7 = __lsx_vadd_h(z11, z13);
++
++  tmp11 = __lsx_vsub_h(z11, z13);
++  LSX_UNPCKLH_W_H(tmp11, tmp11_l, tmp11_h);
++  tmp11_h = __lsx_vmul_w(tmp11_h, const1414);
++  tmp11_l = __lsx_vmul_w(tmp11_l, const1414);
++  tmp11_h = __lsx_vsrai_w(tmp11_h, CONST_BITS_FAST);
++  tmp11_l = __lsx_vsrai_w(tmp11_l, CONST_BITS_FAST);
++  LSX_PCKEV_H(tmp11_l, tmp11_h, tmp11);
++
++  z5 = __lsx_vadd_h(z10, z12);
++  LSX_UNPCKLH_W_H(z5, z5_l, z5_h);
++  z5_h = __lsx_vmul_w(z5_h, const1847);
++  z5_l = __lsx_vmul_w(z5_l, const1847);
++  z5_h = __lsx_vsrai_w(z5_h, CONST_BITS_FAST);
++  z5_l = __lsx_vsrai_w(z5_l, CONST_BITS_FAST);
++  LSX_PCKEV_H(z5_l, z5_h, z5);
++
++  LSX_UNPCKLH_W_H(z12, z12_l, z12_h);
++  z12_h = __lsx_vmul_w(z12_h, const1082);
++  z12_l = __lsx_vmul_w(z12_l, const1082);
++  z12_h = __lsx_vsrai_w(z12_h, CONST_BITS_FAST);
++  z12_l = __lsx_vsrai_w(z12_l, CONST_BITS_FAST);
++  LSX_PCKEV_H(z12_l, z12_h, tmp10);
++  tmp10 = __lsx_vsub_h(tmp10, z5);
++
++  LSX_UNPCKLH_W_H(z10, z10_l, z10_h);
++  z10_h = __lsx_vmul_w(z10_h, const2613);
++  z10_l = __lsx_vmul_w(z10_l, const2613);
++  z10_h = __lsx_vsrai_w(z10_h, CONST_BITS_FAST);
++  z10_l = __lsx_vsrai_w(z10_l, CONST_BITS_FAST);
++  LSX_PCKEV_H(z10_l, z10_h, tmp12);
++  tmp12 = __lsx_vadd_h(tmp12, z5);
++
++  tmp6 = __lsx_vsub_h(tmp12, tmp7);
++  tmp5 = __lsx_vsub_h(tmp11, tmp6);
++  tmp4 = __lsx_vadd_h(tmp10, tmp5);
++
++  LSX_BUTTERFLY_8(v8i16, tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7,
++                  dst0, dst1, dst2, dst4, dst3, dst5, dst6, dst7);
++
++  dst0 = __lsx_vsrai_h(dst0, PASS1_BITS + 3);
++  dst1 = __lsx_vsrai_h(dst1, PASS1_BITS + 3);
++  dst2 = __lsx_vsrai_h(dst2, PASS1_BITS + 3);
++  dst3 = __lsx_vsrai_h(dst3, PASS1_BITS + 3);
++  dst4 = __lsx_vsrai_h(dst4, PASS1_BITS + 3);
++  dst5 = __lsx_vsrai_h(dst5, PASS1_BITS + 3);
++  dst6 = __lsx_vsrai_h(dst6, PASS1_BITS + 3);
++  dst7 = __lsx_vsrai_h(dst7, PASS1_BITS + 3);
++
++  dst0 = __lsx_vadd_h(dst0, const128);
++  dst1 = __lsx_vadd_h(dst1, const128);
++  dst2 = __lsx_vadd_h(dst2, const128);
++  dst3 = __lsx_vadd_h(dst3, const128);
++  dst4 = __lsx_vadd_h(dst4, const128);
++  dst5 = __lsx_vadd_h(dst5, const128);
++  dst6 = __lsx_vadd_h(dst6, const128);
++  dst7 = __lsx_vadd_h(dst7, const128);
++
++  LSX_CLIP_H_0_255_4(dst0, dst1, dst2, dst3,
++                     dst0, dst1, dst2, dst3);
++  LSX_CLIP_H_0_255_4(dst4, dst5, dst6, dst7,
++                     dst4, dst5, dst6, dst7);
++
++  LSX_PCKEV_B_8(dst0, dst0, dst1, dst1, dst2, dst2, dst3, dst3,
++                dst4, dst4, dst5, dst5, dst6, dst6, dst7, dst7,
++                dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  LSX_TRANSPOSE8x8_B(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7,
++                     dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7);
++
++  __lsx_vstelm_d(dst0, output_buf[0] + output_col, 0, 0);
++  __lsx_vstelm_d(dst1, output_buf[1] + output_col, 0, 0);
++  __lsx_vstelm_d(dst2, output_buf[2] + output_col, 0, 0);
++  __lsx_vstelm_d(dst3, output_buf[3] + output_col, 0, 0);
++  __lsx_vstelm_d(dst4, output_buf[4] + output_col, 0, 0);
++  __lsx_vstelm_d(dst5, output_buf[5] + output_col, 0, 0);
++  __lsx_vstelm_d(dst6, output_buf[6] + output_col, 0, 0);
++  __lsx_vstelm_d(dst7, output_buf[7] + output_col, 0, 0);
++}
+diff --git a/simd/loongarch64/jidctint-lasx.c b/simd/loongarch64/jidctint-lasx.c
+new file mode 100644
+index 00000000..bb65f2ce
+--- /dev/null
++++ b/simd/loongarch64/jidctint-lasx.c
+@@ -0,0 +1,309 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "jmacros_lasx.h"
++
++#define DCTSIZE     8
++#define CONST_BITS  13
++#define PASS1_BITS  2
++#define SHIFT_11 (CONST_BITS-PASS1_BITS)
++#define SHIFT_18 (CONST_BITS+PASS1_BITS+3)
++
++#define FIX_0_298631336  ((int32_t)2446)   /* FIX(0.298631336) */
++#define FIX_0_390180644  ((int32_t)3196)   /* FIX(0.390180644) */
++#define FIX_0_541196100  ((int32_t)4433)   /* FIX(0.541196100) */
++#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
++#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
++#define FIX_1_175875602  ((int32_t)9633)   /* FIX(1.175875602) */
++#define FIX_1_501321110  ((int32_t)12299)  /* FIX(1.501321110) */
++#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
++#define FIX_1_961570560  ((int32_t)16069)  /* FIX(1.961570560) */
++#define FIX_2_053119869  ((int32_t)16819)  /* FIX(2.053119869) */
++#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
++#define FIX_3_072711026  ((int32_t)25172)  /* FIX(3.072711026) */
++
++#define LASX_RANGE_PACK(_in1, _in2, _out1, _out2) \
++{ \
++  __m256i _pack_1_2; \
++  _pack_1_2 = __lasx_xvpickev_h(_in2, _in1); \
++  _pack_1_2 = __lasx_xvpermi_d(_pack_1_2, 0xd8); \
++  _pack_1_2 = __lasx_xvadd_h(_pack_1_2, const128); \
++  LASX_CLIP_H_0_255(_pack_1_2, _pack_1_2); \
++  _pack_1_2 = __lasx_xvpickev_b(zero, _pack_1_2); \
++  _out1 = __lasx_xvpermi_q(_pack_1_2, zero, 0x02); \
++  _out2 = __lasx_xvpermi_q(_pack_1_2, zero, 0x13); \
++}
++
++#define LASX_MUL_W_H(_in0, _in1, _out0, _out1) \
++{ \
++  __m256i _tmp0, _tmp1, _tmp2, _tmp3; \
++  LASX_UNPCKLH_W_H(_in0, _tmp1, _tmp0); \
++  LASX_UNPCKLH_W_H(_in1, _tmp3, _tmp2); \
++  _out0 = __lasx_xvmul_w(_tmp0, _tmp2); \
++  _out1 = __lasx_xvmul_w(_tmp1, _tmp3); \
++}
++
++GLOBAL(void)
++jsimd_idct_islow_lasx(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                      JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                      JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = compptr->dct_table;
++  __m256i coef01, coef23, coef45, coef67;
++  __m256i quant01, quant23, quant45, quant67;
++  __m256i zero = __lasx_xvldi(0);
++  __m256i tmp0, tmp1, tmp2, tmp3;
++  __m256i tmp10, tmp11, tmp12, tmp13;
++
++  __m256i dcval0, dcval1, dcval2, dcval3;
++  __m256i dcval4, dcval5, dcval6, dcval7;
++
++  __m256i z1, z2, z3, z4, z5;
++
++  __m256i const100 = { FIX_0_541196100 };
++  __m256i const065 = {-FIX_1_847759065 };
++  __m256i const865 = { FIX_0_765366865 };
++  __m256i const602 = { FIX_1_175875602 };
++  __m256i const223 = {-FIX_0_899976223 };
++  __m256i const447 = {-FIX_2_562915447 };
++  __m256i const560 = {-FIX_1_961570560 };
++  __m256i const644 = {-FIX_0_390180644 };
++  __m256i const336 = { FIX_0_298631336 };
++  __m256i const869 = { FIX_2_053119869 };
++  __m256i const026 = { FIX_3_072711026 };
++  __m256i const110 = { FIX_1_501321110 };
++
++  __m256i const128 = {128};
++
++  const100 = __lasx_xvreplve0_w(const100);
++  const065 = __lasx_xvreplve0_w(const065);
++  const865 = __lasx_xvreplve0_w(const865);
++  const602 = __lasx_xvreplve0_w(const602);
++
++  const223 = __lasx_xvreplve0_w(const223);
++  const447 = __lasx_xvreplve0_w(const447);
++  const560 = __lasx_xvreplve0_w(const560);
++  const644 = __lasx_xvreplve0_w(const644);
++
++  const336 = __lasx_xvreplve0_w(const336);
++  const869 = __lasx_xvreplve0_w(const869);
++  const026 = __lasx_xvreplve0_w(const026);
++  const110 = __lasx_xvreplve0_w(const110);
++
++  const128 = __lasx_xvreplve0_h(const128);
++
++  LASX_LD_4(coef_block, 16, coef01, coef23, coef45, coef67);
++  quant01 = LASX_LD(quantptr);
++
++  tmp0 = __lasx_xvpermi_q(coef01, zero, 0x13);
++  tmp0 = __lasx_xvor_v(tmp0, coef23);
++  tmp0 = __lasx_xvor_v(tmp0, coef45);
++  tmp0 = __lasx_xvor_v(tmp0, coef67);
++
++  if (__lasx_xbz_v(tmp0)) {
++    /* AC terms all zero */
++    __m256i coef0, quant0;
++    LASX_UNPCKL_W_H(coef01, coef0);
++    LASX_UNPCKL_W_H(quant01, quant0);
++    dcval0 = __lasx_xvmul_w(coef0, quant0);
++    dcval0 = __lasx_xvslli_w(dcval0, PASS1_BITS);
++    tmp1  = __lasx_xvpermi_q(dcval0, dcval0, 0x02);/* low */
++    tmp2  = __lasx_xvpermi_q(dcval0, dcval0, 0x13);/* high */
++    dcval0 = __lasx_xvrepl128vei_w(tmp1, 0);
++    dcval1 = __lasx_xvrepl128vei_w(tmp1, 1);
++    dcval2 = __lasx_xvrepl128vei_w(tmp1, 2);
++    dcval3 = __lasx_xvrepl128vei_w(tmp1, 3);
++    dcval4 = __lasx_xvrepl128vei_w(tmp2, 0);
++    dcval5 = __lasx_xvrepl128vei_w(tmp2, 1);
++    dcval6 = __lasx_xvrepl128vei_w(tmp2, 2);
++    dcval7 = __lasx_xvrepl128vei_w(tmp2, 3);
++  } else {
++    LASX_LD_4(quantptr, 16, quant01, quant23, quant45, quant67);
++
++    LASX_MUL_W_H(coef01, quant01, dcval0, dcval1);
++    LASX_MUL_W_H(coef23, quant23, dcval2, dcval3);
++    LASX_MUL_W_H(coef45, quant45, dcval4, dcval5);
++    LASX_MUL_W_H(coef67, quant67, dcval6, dcval7);
++
++    /* Even part */
++
++    z1   = __lasx_xvadd_w(dcval2, dcval6);
++    z1   = __lasx_xvmul_w(z1, const100);
++    tmp2 = __lasx_xvmadd_w(z1, dcval6, const065);
++    tmp3 = __lasx_xvmadd_w(z1, dcval2, const865);
++
++    tmp0 = __lasx_xvadd_w(dcval0, dcval4);
++    tmp1 = __lasx_xvsub_w(dcval0, dcval4);
++    tmp0 = __lasx_xvslli_w(tmp0, CONST_BITS);
++    tmp1 = __lasx_xvslli_w(tmp1, CONST_BITS);
++
++    LASX_BUTTERFLY_4(v8i32, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
++
++    /* Odd part */
++
++    z1   = __lasx_xvadd_w(dcval1, dcval7);
++    z2   = __lasx_xvadd_w(dcval3, dcval5);
++    z3   = __lasx_xvadd_w(dcval3, dcval7);
++    z4   = __lasx_xvadd_w(dcval1, dcval5);
++
++    z5   = __lasx_xvadd_w(z3, z4);
++    z5   = __lasx_xvmul_w(z5, const602);
++
++    z1   = __lasx_xvmul_w(z1, const223);
++    z2   = __lasx_xvmul_w(z2, const447);
++    z3   = __lasx_xvmadd_w(z5, z3, const560);
++    z4   = __lasx_xvmadd_w(z5, z4, const644);
++
++    tmp0 = __lasx_xvadd_w(z1, z3);
++    tmp1 = __lasx_xvadd_w(z2, z4);
++    tmp2 = __lasx_xvadd_w(z2, z3);
++    tmp3 = __lasx_xvadd_w(z1, z4);
++
++    tmp0 = __lasx_xvmadd_w(tmp0, dcval7, const336);
++    tmp1 = __lasx_xvmadd_w(tmp1, dcval5, const869);
++    tmp2 = __lasx_xvmadd_w(tmp2, dcval3, const026);
++    tmp3 = __lasx_xvmadd_w(tmp3, dcval1, const110);
++
++    dcval0 = __lasx_xvadd_w(tmp10, tmp3);
++    dcval0 = __lasx_xvsrari_w(dcval0, SHIFT_11);
++
++    dcval1 = __lasx_xvadd_w(tmp11, tmp2);
++    dcval1 = __lasx_xvsrari_w(dcval1, SHIFT_11);
++
++    dcval2 = __lasx_xvadd_w(tmp12, tmp1);
++    dcval2 = __lasx_xvsrari_w(dcval2, SHIFT_11);
++
++    dcval3 = __lasx_xvadd_w(tmp13, tmp0);
++    dcval3 = __lasx_xvsrari_w(dcval3, SHIFT_11);
++
++    dcval4 = __lasx_xvsub_w(tmp13, tmp0);
++    dcval4 = __lasx_xvsrari_w(dcval4, SHIFT_11);
++
++    dcval5 = __lasx_xvsub_w(tmp12, tmp1);
++    dcval5 = __lasx_xvsrari_w(dcval5, SHIFT_11);
++
++    dcval6 = __lasx_xvsub_w(tmp11, tmp2);
++    dcval6 = __lasx_xvsrari_w(dcval6, SHIFT_11);
++
++    dcval7 = __lasx_xvsub_w(tmp10, tmp3);
++    dcval7 = __lasx_xvsrari_w(dcval7, SHIFT_11);
++
++    LASX_TRANSPOSE8x8_W(dcval0, dcval1, dcval2, dcval3, dcval4, dcval5, dcval6, dcval7,
++                        dcval0, dcval1, dcval2, dcval3, dcval4, dcval5, dcval6, dcval7);
++
++  }
++
++  /* Even part */
++
++  z1   = __lasx_xvadd_w(dcval2, dcval6);
++  z1   = __lasx_xvmul_w(z1, const100);
++  tmp2 = __lasx_xvmadd_w(z1, dcval6, const065);
++  tmp3 = __lasx_xvmadd_w(z1, dcval2, const865);
++
++  tmp0 = __lasx_xvadd_w(dcval0, dcval4);
++  tmp1 = __lasx_xvsub_w(dcval0, dcval4);
++  tmp0 = __lasx_xvslli_w(tmp0, CONST_BITS);
++  tmp1 = __lasx_xvslli_w(tmp1, CONST_BITS);
++
++  LASX_BUTTERFLY_4(v8i32, tmp0, tmp1, tmp2, tmp3, tmp10, tmp11, tmp12, tmp13);
++
++  /* Odd part */
++
++  z1   = __lasx_xvadd_w(dcval1, dcval7);
++  z2   = __lasx_xvadd_w(dcval3, dcval5);
++  z3   = __lasx_xvadd_w(dcval3, dcval7);
++  z4   = __lasx_xvadd_w(dcval1, dcval5);
++
++  z5   = __lasx_xvadd_w(z3, z4);
++  z5   = __lasx_xvmul_w(z5, const602);
++
++  z1   = __lasx_xvmul_w(z1, const223);
++  z2   = __lasx_xvmul_w(z2, const447);
++  z3   = __lasx_xvmadd_w(z5, z3, const560);
++  z4   = __lasx_xvmadd_w(z5, z4, const644);
++
++  tmp0 = __lasx_xvadd_w(z1, z3);
++  tmp1 = __lasx_xvadd_w(z2, z4);
++  tmp2 = __lasx_xvadd_w(z2, z3);
++  tmp3 = __lasx_xvadd_w(z1, z4);
++
++  tmp0 = __lasx_xvmadd_w(tmp0, dcval7, const336);
++  tmp1 = __lasx_xvmadd_w(tmp1, dcval5, const869);
++  tmp2 = __lasx_xvmadd_w(tmp2, dcval3, const026);
++  tmp3 = __lasx_xvmadd_w(tmp3, dcval1, const110);
++
++  /*
++   * outptr[0], outptr[1]
++   */
++  dcval0 = __lasx_xvadd_w(tmp10, tmp3);
++  dcval0 = __lasx_xvsrari_w(dcval0, SHIFT_18);
++  dcval1 = __lasx_xvadd_w(tmp11, tmp2);
++  dcval1 = __lasx_xvsrari_w(dcval1, SHIFT_18);
++  LASX_RANGE_PACK(dcval0, dcval1, dcval0, dcval1);
++
++  /*
++   * outptr[2], outptr[3]
++   */
++  dcval2 = __lasx_xvadd_w(tmp12, tmp1);
++  dcval2 = __lasx_xvsrari_w(dcval2, SHIFT_18);
++  dcval3 = __lasx_xvadd_w(tmp13, tmp0);
++  dcval3 = __lasx_xvsrari_w(dcval3, SHIFT_18);
++  LASX_RANGE_PACK(dcval2, dcval3, dcval2, dcval3);
++
++  /*
++   * outptr[4], outptr[5]
++   */
++  dcval4 = __lasx_xvsub_w(tmp13, tmp0);
++  dcval4 = __lasx_xvsrari_w(dcval4, SHIFT_18);
++  dcval5 = __lasx_xvsub_w(tmp12, tmp1);
++  dcval5 = __lasx_xvsrari_w(dcval5, SHIFT_18);
++  LASX_RANGE_PACK(dcval4, dcval5, dcval4, dcval5);
++
++  /*
++   * outptr[6], outptr[7]
++   */
++  dcval6 = __lasx_xvsub_w(tmp11, tmp2);
++  dcval6 = __lasx_xvsrari_w(dcval6, SHIFT_18);
++  dcval7 = __lasx_xvsub_w(tmp10, tmp3);
++  dcval7 = __lasx_xvsrari_w(dcval7, SHIFT_18);
++  LASX_RANGE_PACK(dcval6, dcval7, dcval6, dcval7);
++
++  LASX_TRANSPOSE8x8_B(dcval0, dcval1, dcval2, dcval3, dcval4, dcval5, dcval6, dcval7,
++                      dcval0, dcval1, dcval2, dcval3, dcval4, dcval5, dcval6, dcval7);
++
++  __lasx_xvstelm_d(dcval0, output_buf[0], 0, 0);
++  __lasx_xvstelm_d(dcval1, output_buf[1], 0, 0);
++  __lasx_xvstelm_d(dcval2, output_buf[2], 0, 0);
++  __lasx_xvstelm_d(dcval3, output_buf[3], 0, 0);
++  __lasx_xvstelm_d(dcval4, output_buf[4], 0, 0);
++  __lasx_xvstelm_d(dcval5, output_buf[5], 0, 0);
++  __lasx_xvstelm_d(dcval6, output_buf[6], 0, 0);
++  __lasx_xvstelm_d(dcval7, output_buf[7], 0, 0);
++}
+diff --git a/simd/loongarch64/jidctint-lsx.c b/simd/loongarch64/jidctint-lsx.c
+new file mode 100644
+index 00000000..d3fc4305
+--- /dev/null
++++ b/simd/loongarch64/jidctint-lsx.c
+@@ -0,0 +1,413 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "jmacros_lsx.h"
++
++#define DCTSIZE     8
++#define CONST_BITS  13
++#define PASS1_BITS  2
++#define SHIFT_11 (CONST_BITS-PASS1_BITS)
++#define SHIFT_18 (CONST_BITS+PASS1_BITS+3)
++
++#define FIX_0_298631336  ((int32_t)2446)   /* FIX(0.298631336) */
++#define FIX_0_390180644  ((int32_t)3196)   /* FIX(0.390180644) */
++#define FIX_0_541196100  ((int32_t)4433)   /* FIX(0.541196100) */
++#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
++#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
++#define FIX_1_175875602  ((int32_t)9633)   /* FIX(1.175875602) */
++#define FIX_1_501321110  ((int32_t)12299)  /* FIX(1.501321110) */
++#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
++#define FIX_1_961570560  ((int32_t)16069)  /* FIX(1.961570560) */
++#define FIX_2_053119869  ((int32_t)16819)  /* FIX(2.053119869) */
++#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
++#define FIX_3_072711026  ((int32_t)25172)  /* FIX(3.072711026) */
++
++#define LSX_RANGE_PACK(_in1, _in2, _out)         \
++{                                                \
++  __m128i _pack_1_2;                             \
++  _pack_1_2 = __lsx_vpickev_h(_in1, _in2);       \
++  _pack_1_2 = __lsx_vadd_h(_pack_1_2, const128); \
++  LSX_CLIP_H_0_255(_pack_1_2, _pack_1_2);        \
++  _out = __lsx_vpickev_b(_in2, _pack_1_2);       \
++}
++
++#define LSX_MUL_W_H(_in0, _in1, _out0, _out1)   \
++{                                               \
++  __m128i _tmp0, _tmp1, _tmp2, _tmp3;           \
++  LSX_UNPCKLH_W_H(_in0, _tmp1, _tmp0);          \
++  LSX_UNPCKLH_W_H(_in1, _tmp3, _tmp2);          \
++  _out0 = __lsx_vmul_w(_tmp0, _tmp2);           \
++  _out1 = __lsx_vmul_w(_tmp1, _tmp3);           \
++}
++
++GLOBAL(void)
++jsimd_idct_islow_lsx(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                     JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                     JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = compptr->dct_table;
++  __m128i coef0, coef1, coef2, coef3, coef4, coef5, coef6, coef7;
++  __m128i tmp0, tmp1, tmp2;
++
++  __m128i dcval0, dcval1, dcval2, dcval3;
++  __m128i dcval4, dcval5, dcval6, dcval7;
++
++  __m128i res0, res1, res2, res3, res4, res5, res6, res7;
++  __m128i quant0, quant1, quant2, quant3, quant4, quant5, quant6, quant7;
++  __m128i d0_h, d1_h, d2_h, d3_h, d4_h, d5_h, d6_h, d7_h;
++  __m128i d0_l, d1_l, d2_l, d3_l, d4_l, d5_l, d6_l, d7_l;
++  __m128i tmp_h, tmp_l, tmp2_h, tmp2_l, tmp3_h, tmp3_l, tmp0_h, tmp0_l, tmp1_h;
++  __m128i tmp1_l, tmp10_h, tmp10_l, tmp11_h, tmp11_l, tmp12_h, tmp12_l;
++  __m128i tmp13_h, tmp13_l;
++  __m128i z1_h, z1_l, z2_h, z2_l, z3_h, z3_l, z4_h, z4_l, z5_h, z5_l;
++  __m128i dst0_h, dst1_h, dst2_h, dst3_h, dst4_h, dst5_h, dst6_h, dst7_h;
++  __m128i dst0_l, dst1_l, dst2_l, dst3_l, dst4_l, dst5_l, dst6_l, dst7_l;
++
++  __m128i const100 = { FIX_0_541196100 };
++  __m128i const065 = {-FIX_1_847759065 };
++  __m128i const865 = { FIX_0_765366865 };
++  __m128i const602 = { FIX_1_175875602 };
++  __m128i const223 = {-FIX_0_899976223 };
++  __m128i const447 = {-FIX_2_562915447 };
++  __m128i const560 = {-FIX_1_961570560 };
++  __m128i const644 = {-FIX_0_390180644 };
++  __m128i const336 = { FIX_0_298631336 };
++  __m128i const869 = { FIX_2_053119869 };
++  __m128i const026 = { FIX_3_072711026 };
++  __m128i const110 = { FIX_1_501321110 };
++
++  __m128i const128 = {128};
++
++  const100 = __lsx_vreplvei_w(const100, 0);
++  const065 = __lsx_vreplvei_w(const065, 0);
++  const865 = __lsx_vreplvei_w(const865, 0);
++  const602 = __lsx_vreplvei_w(const602, 0);
++
++  const223 = __lsx_vreplvei_w(const223, 0);
++  const447 = __lsx_vreplvei_w(const447, 0);
++  const560 = __lsx_vreplvei_w(const560, 0);
++  const644 = __lsx_vreplvei_w(const644, 0);
++
++  const336 = __lsx_vreplvei_w(const336, 0);
++  const869 = __lsx_vreplvei_w(const869, 0);
++  const026 = __lsx_vreplvei_w(const026, 0);
++  const110 = __lsx_vreplvei_w(const110, 0);
++
++  const128 = __lsx_vreplvei_h(const128, 0);
++
++  LSX_LD_8(coef_block, 8, coef0, coef1, coef2, coef3,
++           coef4, coef5, coef6, coef7 );
++
++  tmp0 = __lsx_vor_v(coef1, coef2);
++  tmp1 = __lsx_vor_v(coef3, coef4);
++  tmp0 = __lsx_vor_v(tmp0, tmp1);
++  tmp2 = __lsx_vor_v(coef5, coef6);
++  tmp2 = __lsx_vor_v(tmp2, coef7);
++  tmp0 = __lsx_vor_v(tmp0, tmp2);
++
++  if (__lsx_bz_v(tmp0)) {
++    /* AC terms all zero */
++    quant0 = LSX_LD(quantptr);
++    LSX_MUL_W_H(coef0, quant0, tmp1, tmp2);
++    tmp1 = __lsx_vslli_w(tmp1, PASS1_BITS);
++    tmp2 = __lsx_vslli_w(tmp2, PASS1_BITS);
++
++    d0_l = __lsx_vreplvei_w(tmp1, 0);
++    d1_l = __lsx_vreplvei_w(tmp1, 1);
++    d2_l = __lsx_vreplvei_w(tmp1, 2);
++    d3_l = __lsx_vreplvei_w(tmp1, 3);
++    d4_l = __lsx_vreplvei_w(tmp2, 0);
++    d5_l = __lsx_vreplvei_w(tmp2, 1);
++    d6_l = __lsx_vreplvei_w(tmp2, 2);
++    d7_l = __lsx_vreplvei_w(tmp2, 3);
++
++    d0_h = d0_l;
++    d1_h = d1_l;
++    d2_h = d2_l;
++    d3_h = d3_l;
++    d4_h = d4_l;
++    d5_h = d5_l;
++    d6_h = d6_l;
++    d7_h = d7_l;
++  } else {
++    LSX_LD_8(quantptr, 8, quant0, quant1, quant2, quant3,
++             quant4, quant5, quant6, quant7);
++
++    dcval0 = __lsx_vmul_h(coef0, quant0);
++    dcval1 = __lsx_vmul_h(coef1, quant1);
++    dcval2 = __lsx_vmul_h(coef2, quant2);
++    dcval3 = __lsx_vmul_h(coef3, quant3);
++    dcval4 = __lsx_vmul_h(coef4, quant4);
++    dcval5 = __lsx_vmul_h(coef5, quant5);
++    dcval6 = __lsx_vmul_h(coef6, quant6);
++    dcval7 = __lsx_vmul_h(coef7, quant7);
++
++    LSX_UNPCKLH_W_H(dcval0, d0_l, d0_h);
++    LSX_UNPCKLH_W_H(dcval2, d2_l, d2_h);
++    LSX_UNPCKLH_W_H(dcval4, d4_l, d4_h);
++    LSX_UNPCKLH_W_H(dcval6, d6_l, d6_h);
++
++    /* Even part */
++
++    LSX_ADD_W_2(d2_h, d6_h, d2_l, d6_l, tmp_h, tmp_l);
++    z1_h = __lsx_vmul_w(tmp_h, const100);
++    z1_l = __lsx_vmul_w(tmp_l, const100);
++
++    tmp2_h = __lsx_vmadd_w(z1_h, d6_h, const065);
++    tmp2_l = __lsx_vmadd_w(z1_l, d6_l, const065);
++
++    tmp3_h = __lsx_vmadd_w(z1_h, d2_h, const865);
++    tmp3_l = __lsx_vmadd_w(z1_l, d2_l, const865);
++
++    LSX_BUTTERFLY_4(v4i32, d0_h, d0_l, d4_l, d4_h, tmp0_h, tmp0_l, tmp1_l, tmp1_h);
++
++    tmp0_h = __lsx_vslli_w(tmp0_h, CONST_BITS);
++    tmp0_l = __lsx_vslli_w(tmp0_l, CONST_BITS);
++    tmp1_h = __lsx_vslli_w(tmp1_h, CONST_BITS);
++    tmp1_l = __lsx_vslli_w(tmp1_l, CONST_BITS);
++
++    LSX_BUTTERFLY_8(v4i32, tmp0_h, tmp0_l, tmp1_h, tmp1_l, tmp2_l, tmp2_h, tmp3_l, tmp3_h,
++                    tmp10_h, tmp10_l, tmp11_h, tmp11_l, tmp12_l, tmp12_h, tmp13_l, tmp13_h);
++
++    /* Odd part */
++
++    LSX_UNPCKLH_W_H(dcval1, d1_l, d1_h);
++    LSX_UNPCKLH_W_H(dcval3, d3_l, d3_h);
++    LSX_UNPCKLH_W_H(dcval5, d5_l, d5_h);
++    LSX_UNPCKLH_W_H(dcval7, d7_l, d7_h);
++
++    LSX_ADD_W_4(d7_h, d1_h, d7_l, d1_l, d5_h, d3_h, d5_l, d3_l,
++		z1_h, z1_l, z2_h, z2_l);
++    LSX_ADD_W_4(d7_h, d3_h, d7_l, d3_l, d5_h, d1_h, d5_l, d1_l,
++		z3_h, z3_l, z4_h, z4_l);
++
++    LSX_ADD_W_2(z3_h, z4_h, z3_l, z4_l, z5_h, z5_l);
++    z5_h = __lsx_vmul_w(z5_h, const602);
++    z5_l = __lsx_vmul_w(z5_l, const602);
++
++    z1_h = __lsx_vmul_w(z1_h, const223);
++    z1_l = __lsx_vmul_w(z1_l, const223);
++
++    z2_h = __lsx_vmul_w(z2_h, const447);
++    z2_l = __lsx_vmul_w(z2_l, const447);
++
++    z3_h = __lsx_vmul_w(z3_h, const560);
++    z3_l = __lsx_vmul_w(z3_l, const560);
++
++    z4_h = __lsx_vmul_w(z4_h, const644);
++    z4_l = __lsx_vmul_w(z4_l, const644);
++
++    LSX_ADD_W_4(z3_h, z5_h, z3_l, z5_l, z4_h, z5_h, z4_l, z5_l,
++		z3_h, z3_l, z4_h, z4_l);
++
++    LSX_ADD_W_2(z1_h, z3_h, z1_l, z3_l, tmp0_h, tmp0_l);
++    tmp0_h = __lsx_vmadd_w(tmp0_h, d7_h, const336);
++    tmp0_l = __lsx_vmadd_w(tmp0_l, d7_l, const336);
++
++    LSX_ADD_W_2(tmp13_h, tmp0_h, tmp13_l, tmp0_l, dst3_h, dst3_l);
++    dst3_h = __lsx_vsrari_w(dst3_h, SHIFT_11);
++    dst3_l = __lsx_vsrari_w(dst3_l, SHIFT_11);
++
++    LSX_SUB_W_2(tmp13_h, tmp0_h, tmp13_l, tmp0_l, dst4_h, dst4_l);
++    dst4_h = __lsx_vsrari_w(dst4_h, SHIFT_11);
++    dst4_l = __lsx_vsrari_w(dst4_l, SHIFT_11);
++
++
++    LSX_ADD_W_2(z2_h, z4_h, z2_l, z4_l, tmp1_h, tmp1_l);
++    tmp1_h = __lsx_vmadd_w(tmp1_h, d5_h, const869);
++    tmp1_l = __lsx_vmadd_w(tmp1_l, d5_l, const869);
++
++    LSX_ADD_W_2(tmp12_h, tmp1_h, tmp12_l, tmp1_l, dst2_h, dst2_l);
++    dst2_h = __lsx_vsrari_w(dst2_h, SHIFT_11);
++    dst2_l = __lsx_vsrari_w(dst2_l, SHIFT_11);
++
++    LSX_SUB_W_2(tmp12_h, tmp1_h, tmp12_l, tmp1_l, dst5_h, dst5_l);
++    dst5_h = __lsx_vsrari_w(dst5_h, SHIFT_11);
++    dst5_l = __lsx_vsrari_w(dst5_l, SHIFT_11);
++
++
++    LSX_ADD_W_2(z2_h, z3_h, z2_l, z3_l, tmp2_h, tmp2_l);
++    tmp2_h = __lsx_vmadd_w(tmp2_h, d3_h, const026);
++    tmp2_l = __lsx_vmadd_w(tmp2_l, d3_l, const026);
++
++    LSX_ADD_W_2(tmp11_h, tmp2_h, tmp11_l, tmp2_l, dst1_h, dst1_l);
++    dst1_h = __lsx_vsrari_w(dst1_h, SHIFT_11);
++    dst1_l = __lsx_vsrari_w(dst1_l, SHIFT_11);
++
++    LSX_SUB_W_2(tmp11_h, tmp2_h, tmp11_l, tmp2_l, dst6_h, dst6_l);
++    dst6_h = __lsx_vsrari_w(dst6_h, SHIFT_11);
++    dst6_l = __lsx_vsrari_w(dst6_l, SHIFT_11);
++
++
++    LSX_ADD_W_2(z1_h, z4_h, z1_l, z4_l, tmp3_h, tmp3_l);
++    tmp3_h = __lsx_vmadd_w(tmp3_h, d1_h, const110);
++    tmp3_l = __lsx_vmadd_w(tmp3_l, d1_l, const110);
++
++    LSX_ADD_W_2(tmp10_h, tmp3_h, tmp10_l, tmp3_l, dst0_h, dst0_l);
++    dst0_h = __lsx_vsrari_w(dst0_h, SHIFT_11);
++    dst0_l = __lsx_vsrari_w(dst0_l, SHIFT_11);
++
++    LSX_SUB_W_2(tmp10_h, tmp3_h, tmp10_l, tmp3_l, dst7_h, dst7_l);
++    dst7_h = __lsx_vsrari_w(dst7_h, SHIFT_11);
++    dst7_l = __lsx_vsrari_w(dst7_l, SHIFT_11);
++
++    LSX_TRANSPOSE4x4_W(dst0_h, dst1_h, dst2_h, dst3_h, d0_h, d1_h, d2_h, d3_h);
++    LSX_TRANSPOSE4x4_W(dst4_h, dst5_h, dst6_h, dst7_h, d0_l, d1_l, d2_l, d3_l);
++    LSX_TRANSPOSE4x4_W(dst0_l, dst1_l, dst2_l, dst3_l, d4_h, d5_h, d6_h, d7_h);
++    LSX_TRANSPOSE4x4_W(dst4_l, dst5_l, dst6_l, dst7_l, d4_l, d5_l, d6_l, d7_l);
++  }
++
++  LSX_ADD_W_2(d2_h, d6_h, d2_l, d6_l, tmp_h, tmp_l);
++  z1_h = __lsx_vmul_w(tmp_h, const100);
++  z1_l = __lsx_vmul_w(tmp_l, const100);
++
++  tmp2_h = __lsx_vmul_w(d6_h, const065);
++  tmp2_l = __lsx_vmul_w(d6_l, const065);
++  LSX_ADD_W_2(tmp2_h, z1_h, tmp2_l, z1_l, tmp2_h, tmp2_l);
++
++  tmp3_h = __lsx_vmul_w(d2_h, const865);
++  tmp3_l = __lsx_vmul_w(d2_l, const865);
++  LSX_ADD_W_2(tmp3_h, z1_h, tmp3_l, z1_l, tmp3_h, tmp3_l);
++
++  LSX_BUTTERFLY_4(v4i32, d0_h, d0_l, d4_l, d4_h, tmp0_h, tmp0_l, tmp1_l, tmp1_h);
++  tmp0_h = __lsx_vslli_w(tmp0_h, CONST_BITS);
++  tmp0_l = __lsx_vslli_w(tmp0_l, CONST_BITS);
++  tmp1_h = __lsx_vslli_w(tmp1_h, CONST_BITS);
++  tmp1_l = __lsx_vslli_w(tmp1_l, CONST_BITS);
++
++  LSX_BUTTERFLY_8(v4i32, tmp0_h, tmp0_l, tmp1_h, tmp1_l, tmp2_l, tmp2_h, tmp3_l, tmp3_h,
++                  tmp10_h, tmp10_l, tmp11_h, tmp11_l, tmp12_l, tmp12_h, tmp13_l, tmp13_h);
++
++  LSX_ADD_W_4(d7_h, d1_h, d7_l, d1_l, d5_h, d3_h, d5_l, d3_l,
++              z1_h, z1_l, z2_h, z2_l);
++  LSX_ADD_W_4(d7_h, d3_h, d7_l, d3_l, d5_h, d1_h, d5_l, d1_l,
++              z3_h, z3_l, z4_h, z4_l);
++
++  /* z5 = MULTIPLY(z3 + z4, FIX_1_175875602) */
++  LSX_ADD_W_2(z3_h, z4_h, z3_l, z4_l, z5_h, z5_l);
++  z5_h = __lsx_vmul_w(z5_h, const602);
++  z5_l = __lsx_vmul_w(z5_l, const602);
++  /* z1 = MULTIPLY(-z1, FIX_0_899976223) */
++  z1_h = __lsx_vmul_w(z1_h, const223);
++  z1_l = __lsx_vmul_w(z1_l, const223);
++  /* z2 = MULTIPLY(-z2, FIX_2_562915447) */
++  z2_h = __lsx_vmul_w(z2_h, const447);
++  z2_l = __lsx_vmul_w(z2_l, const447);
++  /* z3 = MULTIPLY(-z3, FIX_1_961570560) */
++  z3_h = __lsx_vmul_w(z3_h, const560);
++  z3_l = __lsx_vmul_w(z3_l, const560);
++  /* z4 = MULTIPLY(-z4, FIX_0_390180644) */
++  z4_h = __lsx_vmul_w(z4_h, const644);
++  z4_l = __lsx_vmul_w(z4_l, const644);
++
++  LSX_ADD_W_4(z3_h, z5_h, z3_l, z5_l, z4_h, z5_h, z4_l, z5_l, z3_h, z3_l, z4_h, z4_l);
++
++  LSX_ADD_W_2(z1_h, z3_h, z1_l, z3_l, tmp0_h, tmp0_l);
++  tmp0_h = __lsx_vmadd_w(tmp0_h, d7_h, const336);
++  tmp0_l = __lsx_vmadd_w(tmp0_l, d7_l, const336);
++
++  /* dataptr[3] = DESCALE(tmp13 + tmp0, CONST_BITS+PASS1_BITS+3) */
++  LSX_ADD_W_2(tmp13_h, tmp0_h, tmp13_l, tmp0_l, dst3_h, dst3_l);
++  dst3_h = __lsx_vsrari_w(dst3_h, SHIFT_18);
++  dst3_l = __lsx_vsrari_w(dst3_l, SHIFT_18);
++  LSX_RANGE_PACK(dst3_l, dst3_h, res3);
++
++  /* dataptr[4] = DESCALE(tmp13 - tmp0, CONST_BITS+PASS1_BITS+3) */
++  LSX_SUB_W_2(tmp13_h, tmp0_h, tmp13_l, tmp0_l, dst4_h, dst4_l);
++  dst4_h = __lsx_vsrari_w(dst4_h, SHIFT_18);
++  dst4_l = __lsx_vsrari_w(dst4_l, SHIFT_18);
++  LSX_RANGE_PACK(dst4_l, dst4_h, res4);
++
++  /* tmp1 = MULTIPLY(d5, FIX_2_053119869) */
++  /* tmp1 += z2 + z4 */
++  LSX_ADD_W_2(z2_h, z4_h, z2_l, z4_l, tmp1_h, tmp1_l);
++  tmp1_h = __lsx_vmadd_w(tmp1_h, d5_h, const869);
++  tmp1_l = __lsx_vmadd_w(tmp1_l, d5_l, const869);
++
++  /* dataptr[2] = DESCALE(tmp12 + tmp1, CONST_BITS+PASS1_BITS+3) */
++  LSX_ADD_W_2(tmp12_h, tmp1_h, tmp12_l, tmp1_l, dst2_h, dst2_l);
++  dst2_h = __lsx_vsrari_w(dst2_h, SHIFT_18);
++  dst2_l = __lsx_vsrari_w(dst2_l, SHIFT_18);
++  LSX_RANGE_PACK(dst2_l, dst2_h, res2);
++
++  /* dataptr[5] = DESCALE(tmp12 - tmp1, CONST_BITS+PASS1_BITS+3) */
++  LSX_SUB_W_2(tmp12_h, tmp1_h, tmp12_l, tmp1_l, dst5_h, dst5_l);
++  dst5_h = __lsx_vsrari_w(dst5_h, SHIFT_18);
++  dst5_l = __lsx_vsrari_w(dst5_l, SHIFT_18);
++  LSX_RANGE_PACK(dst5_l, dst5_h, res5);
++
++  /* tmp2 = MULTIPLY(d3, FIX_3_072711026) */
++  /* tmp2 += z2 + z3 */
++  LSX_ADD_W_2(z2_h, z3_h, z2_l, z3_l, tmp2_h, tmp2_l);
++  tmp2_h = __lsx_vmadd_w(tmp2_h, d3_h, const026);
++  tmp2_l = __lsx_vmadd_w(tmp2_l, d3_l, const026);
++
++  /* dataptr[1] = DESCALE(tmp11 + tmp2, CONST_BITS+PASS1_BITS+3) */
++  LSX_ADD_W_2(tmp11_h, tmp2_h, tmp11_l, tmp2_l, dst1_h, dst1_l);
++  dst1_h = __lsx_vsrari_w(dst1_h, SHIFT_18);
++  dst1_l = __lsx_vsrari_w(dst1_l, SHIFT_18);
++  LSX_RANGE_PACK(dst1_l, dst1_h, res1);
++
++  /* dataptr[6] = DESCALE(tmp11 - tmp2, CONST_BITS+PASS1_BITS+3) */
++  LSX_SUB_W_2(tmp11_h, tmp2_h, tmp11_l, tmp2_l, dst6_h, dst6_l);
++  dst6_h = __lsx_vsrari_w(dst6_h, SHIFT_18);
++  dst6_l = __lsx_vsrari_w(dst6_l, SHIFT_18);
++  LSX_RANGE_PACK(dst6_l, dst6_h, res6);
++
++  /* tmp3 = MULTIPLY(d1, FIX_1_501321110) */
++  /* tmp3 += z1 + z4 */
++  LSX_ADD_W_2(z1_h, z4_h, z1_l, z4_l, tmp3_h, tmp3_l);
++  tmp3_h = __lsx_vmadd_w(tmp3_h, d1_h, const110);
++  tmp3_l = __lsx_vmadd_w(tmp3_l, d1_l, const110);
++
++  /* dataptr[0] = DESCALE(tmp10 + tmp3, CONST_BITS+PASS1_BITS+3) */
++  LSX_ADD_W_2(tmp10_h, tmp3_h, tmp10_l, tmp3_l, dst0_h, dst0_l);
++  dst0_h = __lsx_vsrari_w(dst0_h, SHIFT_18);
++  dst0_l = __lsx_vsrari_w(dst0_l, SHIFT_18);
++  LSX_RANGE_PACK(dst0_l, dst0_h, res0);
++
++  /* dataptr[7] = DESCALE(tmp10 - tmp3, CONST_BITS+PASS1_BITS+3) */
++  LSX_SUB_W_2(tmp10_h, tmp3_h, tmp10_l, tmp3_l, dst7_h, dst7_l);
++  dst7_h = __lsx_vsrari_w(dst7_h, SHIFT_18);
++  dst7_l = __lsx_vsrari_w(dst7_l, SHIFT_18);
++  LSX_RANGE_PACK(dst7_l, dst7_h, res7);
++
++  LSX_TRANSPOSE8x8_B(res0, res1, res2, res3, res4, res5, res6, res7,
++                     res0, res1, res2, res3, res4, res5, res6, res7);
++
++  __lsx_vstelm_d(res0, output_buf[0], 0, 0);
++  __lsx_vstelm_d(res1, output_buf[1], 0, 0);
++  __lsx_vstelm_d(res2, output_buf[2], 0, 0);
++  __lsx_vstelm_d(res3, output_buf[3], 0, 0);
++  __lsx_vstelm_d(res4, output_buf[4], 0, 0);
++  __lsx_vstelm_d(res5, output_buf[5], 0, 0);
++  __lsx_vstelm_d(res6, output_buf[6], 0, 0);
++  __lsx_vstelm_d(res7, output_buf[7], 0, 0);
++}
+diff --git a/simd/loongarch64/jidctred-lasx.c b/simd/loongarch64/jidctred-lasx.c
+new file mode 100644
+index 00000000..5ba48817
+--- /dev/null
++++ b/simd/loongarch64/jidctred-lasx.c
+@@ -0,0 +1,308 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "jmacros_lasx.h"
++
++#define DCTSIZE 8
++#define PASS1_BITS 2
++#define CONST_BITS 13
++
++#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
++#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
++#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
++#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
++#define FIX_0_211164243  ((int32_t)1730)   /* FIX(0.211164243) */
++#define FIX_0_509795579  ((int32_t)4176)   /* FIX(0.509795579) */
++#define FIX_0_601344887  ((int32_t)4926)   /* FIX(0.601344887) */
++#define FIX_0_720959822  ((int32_t)5906)   /* FIX(0.720959822) */
++#define FIX_0_850430095  ((int32_t)6967)   /* FIX(0.850430095) */
++#define FIX_1_061594337  ((int32_t)8697)   /* FIX(1.061594337) */
++#define FIX_1_272758580  ((int32_t)10426)  /* FIX(1.272758580) */
++#define FIX_1_451774981  ((int32_t)11893)  /* FIX(1.451774981) */
++#define FIX_2_172734803  ((int32_t)17799)  /* FIX(2.172734803) */
++#define FIX_3_624509785  ((int32_t)29692)  /* FIX(3.624509785) */
++
++GLOBAL(void)
++jsimd_idct_2x2_lasx(void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                    JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = (JCOEFPTR)dct_table;
++  __m256i coef01, coef23, coef45, coef67;
++  __m256i quant01, quant23, quant45, quant67;
++  __m256i tmp0, tmp1, tmp10;
++  __m256i zero = __lasx_xvldi(0);
++  __m256i const128 = { 128 };
++  __m256i dcval0, dcval1, dcval2, dcval3;
++  __m256i dcval4, dcval5, dcval6, dcval7;
++
++  v8i32 const072 =
++    {-FIX_0_720959822,-FIX_0_720959822,-FIX_0_720959822,-FIX_0_720959822,
++     -FIX_0_720959822,-FIX_0_720959822,-FIX_0_720959822,-FIX_0_720959822 };
++  v8i32 const085 =
++    { FIX_0_850430095, FIX_0_850430095, FIX_0_850430095, FIX_0_850430095,
++      FIX_0_850430095, FIX_0_850430095, FIX_0_850430095, FIX_0_850430095 };
++  v8i32 const127 =
++    { FIX_1_272758580, FIX_1_272758580, FIX_1_272758580, FIX_1_272758580,
++      FIX_1_272758580, FIX_1_272758580, FIX_1_272758580, FIX_1_272758580 };
++  v8i32 const362 =
++    { FIX_3_624509785, FIX_3_624509785, FIX_3_624509785, FIX_3_624509785,
++      FIX_3_624509785, FIX_3_624509785, FIX_3_624509785, FIX_3_624509785 };
++  v8i32 constall =
++    { FIX_3_624509785,-FIX_1_272758580, FIX_0_850430095,-FIX_0_720959822,
++      FIX_3_624509785,-FIX_1_272758580, FIX_0_850430095,-FIX_0_720959822};
++
++  LASX_LD_4(coef_block, 16, coef01, coef23, coef45, coef67);
++  quant01 = LASX_LD(quantptr);
++
++  const128 = __lasx_xvreplve0_h(const128);
++
++  dcval1 = __lasx_xvpermi_q(zero, coef01, 0x31);
++  dcval3 = __lasx_xvpermi_q(zero, coef23, 0x31);
++  dcval5 = __lasx_xvpermi_q(zero, coef45, 0x31);
++  dcval7 = __lasx_xvpermi_q(zero, coef67, 0x31);
++  tmp0 = dcval1 | dcval3 | dcval5 | dcval7;
++
++  if (__lasx_xbz_v(tmp0)) {
++    /* AC terms all zero */
++    dcval0 = __lasx_xvmul_h(coef01, quant01);
++    LASX_UNPCK_L_W_H(dcval0, dcval0);
++    dcval0 = __lasx_xvslli_w(dcval0, PASS1_BITS);
++    dcval1 = dcval0;
++  } else {
++    quant23 = LASX_LD(quantptr + 16);
++    LASX_LD_2(quantptr + 32, 16, quant45, quant67);
++
++    dcval0 = __lasx_xvmul_h(coef01, quant01);
++    dcval2 = __lasx_xvmul_h(coef23, quant23);
++    dcval4 = __lasx_xvmul_h(coef45, quant45);
++    dcval6 = __lasx_xvmul_h(coef67, quant67);
++    dcval1 = __lasx_xvpermi_q(zero, dcval0, 0x31);
++    dcval3 = __lasx_xvpermi_q(zero, dcval2, 0x31);
++    dcval5 = __lasx_xvpermi_q(zero, dcval4, 0x31);
++    dcval7 = __lasx_xvpermi_q(zero, dcval6, 0x31);
++
++    /* Even part */
++    LASX_UNPCK_L_W_H(dcval0, tmp10);
++    tmp10 = __lasx_xvslli_w(tmp10, CONST_BITS + 2);
++
++    /* Odd part */
++    LASX_UNPCK_L_W_H_4(dcval1, dcval3, dcval5, dcval7,
++                       dcval1, dcval3, dcval5, dcval7);
++    tmp0 = __lasx_xvmul_w(dcval7, (__m256i)const072);
++    tmp0 += __lasx_xvmul_w(dcval5, (__m256i)const085);
++    tmp0 -= __lasx_xvmul_w(dcval3, (__m256i)const127);
++    tmp0 += __lasx_xvmul_w(dcval1, (__m256i)const362);
++
++    dcval0 = __lasx_xvadd_w(tmp10, tmp0);
++    dcval1 = __lasx_xvsub_w(tmp10, tmp0);
++    dcval0 = __lasx_xvsrari_w(dcval0, CONST_BITS - PASS1_BITS + 2);
++    dcval1 = __lasx_xvsrari_w(dcval1, CONST_BITS - PASS1_BITS + 2);
++  }
++
++  /* Even part */
++  tmp10 = __lasx_xvpackev_w(dcval1, dcval0);
++  tmp10 = __lasx_xvslli_w(tmp10, CONST_BITS + 2);
++
++  /* Odd part */
++  LASX_PCKOD_W(dcval1, dcval0, tmp0);// 1 3 5 7 1 3 5 7
++  tmp0 = __lasx_xvmul_w(tmp0, (__m256i)constall);
++  tmp0 = __lasx_xvhaddw_d_w(tmp0, tmp0);// 1+3 5+7 1+3 5+7
++  tmp0 = __lasx_xvhaddw_q_d(tmp0, tmp0);// 1+3+5+7 1+3+5+7
++  tmp1 = __lasx_xvpermi_q(zero, tmp0, 0x31);
++  tmp0 = __lasx_xvpackev_w(tmp1, tmp0);
++
++  dcval0 = __lasx_xvadd_w(tmp10, tmp0);
++  dcval1 = __lasx_xvsub_w(tmp10, tmp0);
++
++  dcval0 = __lasx_xvpackev_d(dcval1, dcval0);
++  dcval0 = __lasx_xvsrari_w(dcval0, CONST_BITS + PASS1_BITS + 3 + 2);
++  dcval0 = __lasx_xvadd_h(dcval0, const128);
++  LASX_CLIP_H_0_255(dcval0, dcval0);
++
++  __lasx_xvstelm_b(dcval0, output_buf[0] + output_col, 0, 0);
++  __lasx_xvstelm_b(dcval0, output_buf[1] + output_col, 0, 4);
++  __lasx_xvstelm_b(dcval0, output_buf[0] + output_col + 1, 0, 8);
++  __lasx_xvstelm_b(dcval0, output_buf[1] + output_col + 1, 0, 12);
++}
++
++GLOBAL(void)
++jsimd_idct_4x4_lasx(void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                    JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = (JCOEFPTR)dct_table;
++  __m256i coef01, coef23, coef45, coef67;
++  __m256i quant01, quant23, quant45, quant67;
++  __m256i tmp0, tmp2, tmp10, tmp12;
++  __m256i zero = __lasx_xvldi(0);
++  __m256i const128 = { 128 };
++  __m256i dcval0, dcval1, dcval2, dcval3;
++  __m256i dcval4, dcval5, dcval6, dcval7;
++
++  v8i32 const184 =
++    { FIX_1_847759065, FIX_1_847759065, FIX_1_847759065, FIX_1_847759065,
++      FIX_1_847759065, FIX_1_847759065, FIX_1_847759065, FIX_1_847759065 };
++  v8i32 const076 =
++    {-FIX_0_765366865,-FIX_0_765366865,-FIX_0_765366865,-FIX_0_765366865,
++     -FIX_0_765366865,-FIX_0_765366865,-FIX_0_765366865,-FIX_0_765366865 };
++  v8i32 const021 =
++    {-FIX_0_211164243,-FIX_0_211164243,-FIX_0_211164243,-FIX_0_211164243,
++     -FIX_0_211164243,-FIX_0_211164243,-FIX_0_211164243,-FIX_0_211164243 };
++  v8i32 const145 =
++    { FIX_1_451774981, FIX_1_451774981, FIX_1_451774981, FIX_1_451774981,
++      FIX_1_451774981, FIX_1_451774981, FIX_1_451774981, FIX_1_451774981 };
++  v8i32 const217 =
++    { FIX_2_172734803, FIX_2_172734803, FIX_2_172734803, FIX_2_172734803,
++      FIX_2_172734803, FIX_2_172734803, FIX_2_172734803, FIX_2_172734803 };
++  v8i32 const106 =
++    { FIX_1_061594337, FIX_1_061594337, FIX_1_061594337, FIX_1_061594337,
++      FIX_1_061594337, FIX_1_061594337, FIX_1_061594337, FIX_1_061594337 };
++  v8i32 const050 =
++    {-FIX_0_509795579,-FIX_0_509795579,-FIX_0_509795579,-FIX_0_509795579,
++     -FIX_0_509795579,-FIX_0_509795579,-FIX_0_509795579,-FIX_0_509795579 };
++  v8i32 const060 =
++    { FIX_0_601344887, FIX_0_601344887, FIX_0_601344887, FIX_0_601344887,
++      FIX_0_601344887, FIX_0_601344887, FIX_0_601344887, FIX_0_601344887 };
++  v8i32 const089 =
++    { FIX_0_899976223, FIX_0_899976223, FIX_0_899976223, FIX_0_899976223,
++      FIX_0_899976223, FIX_0_899976223, FIX_0_899976223, FIX_0_899976223 };
++  v8i32 const256 =
++    { FIX_2_562915447, FIX_2_562915447, FIX_2_562915447, FIX_2_562915447,
++      FIX_2_562915447, FIX_2_562915447, FIX_2_562915447, FIX_2_562915447 };
++
++  LASX_LD_4(coef_block, 16, coef01, coef23, coef45, coef67);
++  quant01 = LASX_LD(quantptr);
++  dcval1 = __lasx_xvpermi_q(zero, coef01, 0x31);
++  dcval5 = __lasx_xvpermi_q(zero, coef45, 0x31);
++
++  const128 = __lasx_xvreplve0_h(const128);
++  tmp0 = dcval1 | coef23 | dcval5 | coef67;
++  if (__lasx_xbz_v(tmp0)) {
++    tmp0 = __lasx_xvmul_h(coef01, quant01);
++    LASX_UNPCK_L_W_H(tmp0, tmp0);
++    tmp0 = __lasx_xvslli_w(tmp0, PASS1_BITS);
++    dcval0 = __lasx_xvrepl128vei_w(tmp0, 0);
++    dcval1 = __lasx_xvrepl128vei_w(tmp0, 1);
++    dcval2 = __lasx_xvrepl128vei_w(tmp0, 2);
++    dcval3 = __lasx_xvrepl128vei_w(tmp0, 3);
++    dcval5 = __lasx_xvpermi_q(zero, dcval1, 0x31);
++    dcval6 = __lasx_xvpermi_q(zero, dcval2, 0x31);
++    dcval7 = __lasx_xvpermi_q(zero, dcval3, 0x31);
++  } else {
++    quant23 = LASX_LD(quantptr + 16);
++    LASX_LD_2(quantptr + 32, 16, quant45, quant67);
++
++    dcval0 = __lasx_xvmul_h(coef01, quant01);
++    dcval2 = __lasx_xvmul_h(coef23, quant23);
++    dcval4 = __lasx_xvmul_h(coef45, quant45);
++    dcval6 = __lasx_xvmul_h(coef67, quant67);
++    dcval1 = __lasx_xvpermi_q(zero, dcval0, 0x31);
++    dcval3 = __lasx_xvpermi_q(zero, dcval2, 0x31);
++    dcval5 = __lasx_xvpermi_q(zero, dcval4, 0x31);
++    dcval7 = __lasx_xvpermi_q(zero, dcval6, 0x31);
++
++    /* Even part */
++    LASX_UNPCK_L_W_H(dcval0, dcval0);
++    LASX_UNPCK_L_W_H(dcval2, dcval2);
++    LASX_UNPCK_L_W_H(dcval6, dcval6);
++    tmp0 = __lasx_xvslli_w(dcval0, CONST_BITS + 1);
++    tmp2 = __lasx_xvmul_w(dcval2, (__m256i)const184);
++    tmp2 = __lasx_xvmadd_w(tmp2, dcval6, (__m256i)const076);
++    tmp10 = __lasx_xvadd_w(tmp0, tmp2);
++    tmp12 = __lasx_xvsub_w(tmp0, tmp2);
++
++    /* Odd part */
++    LASX_UNPCK_L_W_H(dcval1, dcval1);
++    LASX_UNPCK_L_W_H(dcval3, dcval3);
++    LASX_UNPCK_L_W_H(dcval5, dcval5);
++    LASX_UNPCK_L_W_H(dcval7, dcval7);
++
++    tmp0 = __lasx_xvmul_w(dcval7, (__m256i)const021);
++    tmp0 = __lasx_xvmadd_w(tmp0, dcval5, (__m256i)const145);
++    tmp0 = __lasx_xvmsub_w(tmp0, dcval3, (__m256i)const217);
++    tmp0 = __lasx_xvmadd_w(tmp0, dcval1, (__m256i)const106);
++
++    tmp2 = __lasx_xvmul_w(dcval7, (__m256i)const050);
++    tmp2 = __lasx_xvmsub_w(tmp2, dcval5, (__m256i)const060);
++    tmp2 = __lasx_xvmadd_w(tmp2, dcval3, (__m256i)const089);
++    tmp2 = __lasx_xvmadd_w(tmp2, dcval1, (__m256i)const256);
++
++    LASX_BUTTERFLY_4(v8i32, tmp10, tmp12, tmp0, tmp2,
++                     dcval0, dcval1, dcval2, dcval3);
++
++    LASX_SRARI_W_4(dcval0, dcval1, dcval2, dcval3,
++                   CONST_BITS - PASS1_BITS + 1);
++
++    LASX_TRANSPOSE4x4_W_128SV(dcval0, dcval1, dcval2, dcval3,
++                              dcval0, dcval1, dcval2, dcval3);
++
++    dcval5 = __lasx_xvpermi_q(zero, dcval1, 0x31);
++    dcval6 = __lasx_xvpermi_q(zero, dcval2, 0x31);
++    dcval7 = __lasx_xvpermi_q(zero, dcval3, 0x31);
++  }
++
++  /* Even part */
++  tmp0 = __lasx_xvslli_w(dcval0, CONST_BITS + 1);
++
++  tmp2 = __lasx_xvmul_w(dcval2, (__m256i)const184);
++  tmp2 = __lasx_xvmadd_w(tmp2, dcval6, (__m256i)const076);
++  tmp10 = __lasx_xvadd_w(tmp0, tmp2);
++  tmp12 = __lasx_xvsub_w(tmp0, tmp2);
++
++  /* Odd part */
++  tmp0 = __lasx_xvmul_w(dcval7, (__m256i)const021);
++  tmp0 = __lasx_xvmadd_w(tmp0, dcval5, (__m256i)const145);
++  tmp0 = __lasx_xvmsub_w(tmp0, dcval3, (__m256i)const217);
++  tmp0 = __lasx_xvmadd_w(tmp0, dcval1, (__m256i)const106);
++
++  tmp2 = __lasx_xvmul_w(dcval7, (__m256i)const050);
++  tmp2 = __lasx_xvmsub_w(tmp2, dcval5, (__m256i)const060);
++  tmp2 = __lasx_xvmadd_w(tmp2, dcval3, (__m256i)const089);
++  tmp2 = __lasx_xvmadd_w(tmp2, dcval1, (__m256i)const256);
++
++  LASX_BUTTERFLY_4(v8i32, tmp10, tmp12, tmp0, tmp2,
++                   dcval0, dcval1, dcval2, dcval3);
++
++  LASX_SRARI_W_4(dcval0, dcval1, dcval2, dcval3,
++                 CONST_BITS + PASS1_BITS + 3 + 1);
++
++  LASX_TRANSPOSE4x4_W_128SV(dcval0, dcval1, dcval2, dcval3,
++                            dcval0, dcval1, dcval2, dcval3);
++
++  LASX_PCKEV_Q_2(dcval1, dcval0, dcval3, dcval2, dcval0, dcval1);
++  LASX_PCKEV_H(dcval1, dcval0, dcval0);
++  dcval0 = __lasx_xvadd_h(dcval0, const128);
++  LASX_CLIP_H_0_255(dcval0, dcval0);
++  LASX_PCKEV_B_128SV(zero, dcval0, dcval0);
++
++  __lasx_xvstelm_w(dcval0, output_buf[0] + output_col, 0, 0);
++  __lasx_xvstelm_w(dcval0, output_buf[1] + output_col, 0, 1);
++  __lasx_xvstelm_w(dcval0, output_buf[2] + output_col, 0, 4);
++  __lasx_xvstelm_w(dcval0, output_buf[3] + output_col, 0, 5);
++}
+diff --git a/simd/loongarch64/jidctred-lsx.c b/simd/loongarch64/jidctred-lsx.c
+new file mode 100644
+index 00000000..b5990cca
+--- /dev/null
++++ b/simd/loongarch64/jidctred-lsx.c
+@@ -0,0 +1,323 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "jmacros_lsx.h"
++
++#define DCTSIZE 8
++#define PASS1_BITS 2
++#define CONST_BITS 13
++
++#define FIX_0_765366865  ((int32_t)6270)   /* FIX(0.765366865) */
++#define FIX_0_899976223  ((int32_t)7373)   /* FIX(0.899976223) */
++#define FIX_1_847759065  ((int32_t)15137)  /* FIX(1.847759065) */
++#define FIX_2_562915447  ((int32_t)20995)  /* FIX(2.562915447) */
++#define FIX_0_211164243  ((int32_t)1730)   /* FIX(0.211164243) */
++#define FIX_0_509795579  ((int32_t)4176)   /* FIX(0.509795579) */
++#define FIX_0_601344887  ((int32_t)4926)   /* FIX(0.601344887) */
++#define FIX_0_720959822  ((int32_t)5906)   /* FIX(0.720959822) */
++#define FIX_0_850430095  ((int32_t)6967)   /* FIX(0.850430095) */
++#define FIX_1_061594337  ((int32_t)8697)   /* FIX(1.061594337) */
++#define FIX_1_272758580  ((int32_t)10426)  /* FIX(1.272758580) */
++#define FIX_1_451774981  ((int32_t)11893)  /* FIX(1.451774981) */
++#define FIX_2_172734803  ((int32_t)17799)  /* FIX(2.172734803) */
++#define FIX_3_624509785  ((int32_t)29692)  /* FIX(3.624509785) */
++
++GLOBAL(void)
++jsimd_idct_2x2_lsx(void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                   JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = (JCOEFPTR)dct_table;
++  __m128i coef0, coef1, coef3, coef5, coef7;
++  __m128i quant0, quant1, quant3, quant5, quant7;
++  __m128i tmp0, tmp10;
++  __m128i tmp0_h, tmp0_l, tmp10_h, tmp10_l;
++  __m128i const128 = { 128 };
++  __m128i dcval0, dcval1, dcval3, dcval5, dcval7;
++  __m128i dst0_h, dst1_h, dst3_h, dst5_h, dst7_h, dst0_l, dst1_l, dst3_l, dst5_l, dst7_l;
++
++  v4i32 const072 = {-FIX_0_720959822,-FIX_0_720959822,-FIX_0_720959822,-FIX_0_720959822};
++  v4i32 const085 = { FIX_0_850430095, FIX_0_850430095, FIX_0_850430095, FIX_0_850430095};
++  v4i32 const127 = { FIX_1_272758580, FIX_1_272758580, FIX_1_272758580, FIX_1_272758580};
++  v4i32 const362 = { FIX_3_624509785, FIX_3_624509785, FIX_3_624509785, FIX_3_624509785};
++  v4i32 const0 = { FIX_0_850430095, -FIX_0_720959822, FIX_0_850430095, -FIX_0_720959822};
++  v4i32 const1 = { FIX_3_624509785, -FIX_1_272758580, FIX_3_624509785, -FIX_1_272758580};
++
++  coef0 = LSX_LD(coef_block);
++  LSX_LD_4(coef_block + DCTSIZE, 16, coef1, coef3, coef5, coef7);
++  quant0 = LSX_LD(quantptr);
++
++  const128 = __lsx_vreplvei_h(const128, 0);
++
++  tmp0 = coef1 | coef3 | coef5 | coef7;
++
++  if (__lsx_bz_v(tmp0)) {
++    /* AC terms all zero */
++    dcval0 = __lsx_vmul_h(coef0, quant0);
++    LSX_UNPCKLH_W_H(dcval0, dst0_l, dst0_h);
++    dst0_h = __lsx_vslli_w(dst0_h, PASS1_BITS);
++    dst0_l = __lsx_vslli_w(dst0_l, PASS1_BITS);
++
++    dst1_h = dst0_h;
++    dst1_l = dst0_l;
++  } else {
++    LSX_LD_4(quantptr + 8, 16, quant1, quant3, quant5, quant7);
++
++    dcval0 = __lsx_vmul_h(coef0, quant0);
++    dcval1 = __lsx_vmul_h(coef1, quant1);
++    dcval3 = __lsx_vmul_h(coef3, quant3);
++    dcval5 = __lsx_vmul_h(coef5, quant5);
++    dcval7 = __lsx_vmul_h(coef7, quant7);
++
++    /* Even part */
++    LSX_UNPCKLH_W_H(dcval0, dst0_l, dst0_h);
++    dst0_h = __lsx_vslli_w(dst0_h, CONST_BITS + 2);
++    dst0_l = __lsx_vslli_w(dst0_l, CONST_BITS + 2);
++    tmp10_h = dst0_h;
++    tmp10_l = dst0_l;
++
++    /* Odd part */
++    LSX_UNPCKLH_W_H_4(dcval1, dcval3, dcval5, dcval7, dst1_l, dst1_h,
++                      dst3_l, dst3_h, dst5_l, dst5_h, dst7_l, dst7_h);
++
++    tmp0_h = __lsx_vmul_w(dst7_h, (__m128i)const072);
++    tmp0_h += __lsx_vmul_w(dst5_h, (__m128i)const085);
++    tmp0_h -= __lsx_vmul_w(dst3_h, (__m128i)const127);
++    tmp0_h += __lsx_vmul_w(dst1_h, (__m128i)const362);
++
++    tmp0_l = __lsx_vmul_w(dst7_l, (__m128i)const072);
++    tmp0_l += __lsx_vmul_w(dst5_l, (__m128i)const085);
++    tmp0_l -= __lsx_vmul_w(dst3_l, (__m128i)const127);
++    tmp0_l += __lsx_vmul_w(dst1_l, (__m128i)const362);
++
++    LSX_BUTTERFLY_4(v4i32, tmp10_h, tmp10_l, tmp0_l, tmp0_h,
++                    dst0_h, dst0_l, dst1_l, dst1_h);
++
++    LSX_SRARI_W_4(dst0_h, dst0_l, dst1_h, dst1_l, CONST_BITS - PASS1_BITS +2);
++  }
++
++  /* Even part */
++  tmp10 = __lsx_vilvl_w(dst1_h, dst0_h);
++  tmp10 = __lsx_vslli_w(tmp10, CONST_BITS + 2);
++
++  /* Odd part */
++  LSX_PCKOD_W(dst1_l, dst0_l, dst0_l); // 1 3 1 3
++  LSX_PCKOD_W(dst1_h, dst0_h, dst0_h); // 5 7 5 7
++
++  tmp0 = __lsx_vmulwev_d_w(dst0_l, (__m128i)const0);
++  dst0_l = __lsx_vmaddwod_d_w(tmp0, dst0_l, (__m128i)const0);
++
++  tmp0 = __lsx_vmulwev_d_w(dst0_h, (__m128i)const1);
++  dst0_h = __lsx_vmaddwod_d_w(tmp0, dst0_h, (__m128i)const1);
++
++  tmp0 = __lsx_vadd_w(dst0_l, dst0_h);
++  tmp0 = __lsx_vpickev_w(tmp0, tmp0);
++
++  dst0_h = __lsx_vadd_w(tmp10, tmp0);
++  dst1_h = __lsx_vsub_w(tmp10, tmp0);
++
++  dst0_h = __lsx_vsrari_w(dst0_h, CONST_BITS + PASS1_BITS + 3 + 2);
++  dst1_h = __lsx_vsrari_w(dst1_h, CONST_BITS + PASS1_BITS + 3 + 2);
++
++  dcval0 = __lsx_vpickev_d(dst1_h, dst0_h);
++  dcval0 = __lsx_vadd_h(dcval0, const128);
++  LSX_CLIP_H_0_255(dcval0, dcval0);
++
++  __lsx_vstelm_b(dcval0, output_buf[0] + output_col, 0, 0);
++  __lsx_vstelm_b(dcval0, output_buf[1] + output_col, 0, 4);
++  __lsx_vstelm_b(dcval0, output_buf[0] + output_col + 1, 0, 8);
++  __lsx_vstelm_b(dcval0, output_buf[1] + output_col + 1, 0, 12);
++}
++
++GLOBAL(void)
++jsimd_idct_4x4_lsx(void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                   JDIMENSION output_col)
++{
++  JCOEFPTR quantptr = (JCOEFPTR)dct_table;
++  __m128i coef0, coef1, coef2, coef3, coef5, coef6, coef7;
++  __m128i quant0, quant1, quant2, quant3, quant5, quant6, quant7;
++  __m128i tmp0, res;
++  __m128i tmp0_h, tmp0_l, tmp2_h, tmp2_l, tmp10_h, tmp10_l, tmp12_h, tmp12_l;
++  __m128i const128 = { 128 };
++  __m128i dst0_h, dst1_h, dst2_h, dst3_h;
++  __m128i dst0_l, dst1_l, dst2_l, dst3_l;
++  __m128i d0_h, d1_h, d2_h, d3_h, d5_h, d6_h, d7_h;
++  __m128i d0_l, d1_l, d2_l, d3_l, d5_l, d6_l, d7_l;
++  __m128i dcval0, dcval1, dcval2, dcval3;
++  __m128i dcval5, dcval6, dcval7;
++
++  v4i32 const184 = { FIX_1_847759065, FIX_1_847759065, FIX_1_847759065, FIX_1_847759065};
++  v4i32 const076 = {-FIX_0_765366865,-FIX_0_765366865,-FIX_0_765366865,-FIX_0_765366865};
++  v4i32 const021 = {-FIX_0_211164243,-FIX_0_211164243,-FIX_0_211164243,-FIX_0_211164243};
++  v4i32 const145 = { FIX_1_451774981, FIX_1_451774981, FIX_1_451774981, FIX_1_451774981};
++  v4i32 const217 = { FIX_2_172734803, FIX_2_172734803, FIX_2_172734803, FIX_2_172734803};
++  v4i32 const106 = { FIX_1_061594337, FIX_1_061594337, FIX_1_061594337, FIX_1_061594337};
++  v4i32 const050 = {-FIX_0_509795579,-FIX_0_509795579,-FIX_0_509795579,-FIX_0_509795579};
++  v4i32 const060 = { FIX_0_601344887, FIX_0_601344887, FIX_0_601344887, FIX_0_601344887};
++  v4i32 const089 = { FIX_0_899976223, FIX_0_899976223, FIX_0_899976223, FIX_0_899976223};
++  v4i32 const256 = { FIX_2_562915447, FIX_2_562915447, FIX_2_562915447, FIX_2_562915447};
++
++  LSX_LD_4(coef_block, 8, coef0, coef1, coef2, coef3);
++  LSX_LD_2(coef_block + 5 * DCTSIZE, 8, coef5, coef6);
++  coef7 = LSX_LD(coef_block + 7 * DCTSIZE);
++  quant0 = LSX_LD(quantptr);
++
++  const128 = __lsx_vreplvei_h(const128, 0);
++  tmp0 = coef1 | coef2 | coef3 | coef5 | coef6 | coef7;
++  if (__lsx_bz_v(tmp0)) {
++    dcval0 = __lsx_vmul_h(coef0, quant0);
++    LSX_UNPCKLH_W_H(dcval0, dst0_l, dst0_h);
++    dst0_h = __lsx_vslli_w(dst0_h, PASS1_BITS);
++    dst0_l = __lsx_vslli_w(dst0_l, PASS1_BITS);
++
++    d0_h = __lsx_vreplvei_w(dst0_h, 0);
++    d1_h = __lsx_vreplvei_w(dst0_h, 1);
++    d2_h = __lsx_vreplvei_w(dst0_h, 2);
++    d3_h = __lsx_vreplvei_w(dst0_h, 3);
++
++    d5_h = __lsx_vreplvei_w(dst0_l, 1);
++    d6_h = __lsx_vreplvei_w(dst0_l, 2);
++    d7_h = __lsx_vreplvei_w(dst0_l, 3);
++  } else {
++    LSX_LD_4(quantptr, 8, quant0, quant1, quant2, quant3);
++    LSX_LD_2(quantptr + 5 * DCTSIZE, 8, quant5, quant6);
++    quant7 = LSX_LD(quantptr + 7 * DCTSIZE);
++
++    dcval0 = __lsx_vmul_h(coef0, quant0);
++    dcval1 = __lsx_vmul_h(coef1, quant1);
++    dcval2 = __lsx_vmul_h(coef2, quant2);
++    dcval3 = __lsx_vmul_h(coef3, quant3);
++
++    dcval5 = __lsx_vmul_h(coef5, quant5);
++    dcval6 = __lsx_vmul_h(coef6, quant6);
++    dcval7 = __lsx_vmul_h(coef7, quant7);
++
++    /* Even part */
++    LSX_UNPCKLH_W_H(dcval0, d0_l, d0_h);
++    LSX_UNPCKLH_W_H(dcval2, d2_l, d2_h);
++    LSX_UNPCKLH_W_H(dcval6, d6_l, d6_h);
++
++    d0_h = __lsx_vslli_w(d0_h, CONST_BITS + 1);
++    d0_l = __lsx_vslli_w(d0_l, CONST_BITS + 1);
++
++    d2_h = __lsx_vmul_w(d2_h, (__m128i)const184);
++    d2_h = __lsx_vmadd_w(d2_h, d6_h, (__m128i)const076);
++
++    d2_l = __lsx_vmul_w(d2_l, (__m128i)const184);
++    d2_l = __lsx_vmadd_w(d2_l, d6_l, (__m128i)const076);
++
++    LSX_BUTTERFLY_4(v4i32, d0_h, d0_l, d2_l, d2_h,
++                    tmp10_h, tmp10_l, tmp12_l, tmp12_h);
++
++    /* Odd part */
++    LSX_UNPCKLH_W_H(dcval1, d1_l, d1_h);
++    LSX_UNPCKLH_W_H(dcval3, d3_l, d3_h);
++    LSX_UNPCKLH_W_H(dcval5, d5_l, d5_h);
++    LSX_UNPCKLH_W_H(dcval7, d7_l, d7_h);
++
++    tmp0_h = __lsx_vmul_w(d7_h, (__m128i)const021);
++    tmp0_h = __lsx_vmadd_w(tmp0_h, d5_h, (__m128i)const145);
++    tmp0_h = __lsx_vmsub_w(tmp0_h, d3_h, (__m128i)const217);
++    tmp0_h = __lsx_vmadd_w(tmp0_h, d1_h, (__m128i)const106);
++
++    tmp0_l = __lsx_vmul_w(d7_l, (__m128i)const021);
++    tmp0_l = __lsx_vmadd_w(tmp0_l, d5_l, (__m128i)const145);
++    tmp0_l = __lsx_vmsub_w(tmp0_l, d3_l, (__m128i)const217);
++    tmp0_l = __lsx_vmadd_w(tmp0_l, d1_l, (__m128i)const106);
++
++    tmp2_h = __lsx_vmul_w(d7_h, (__m128i)const050);
++    tmp2_h = __lsx_vmsub_w(tmp2_h, d5_h, (__m128i)const060);
++    tmp2_h = __lsx_vmadd_w(tmp2_h, d3_h, (__m128i)const089);
++    tmp2_h = __lsx_vmadd_w(tmp2_h, d1_h, (__m128i)const256);
++
++    tmp2_l = __lsx_vmul_w(d7_l, (__m128i)const050);
++    tmp2_l = __lsx_vmsub_w(tmp2_l, d5_l, (__m128i)const060);
++    tmp2_l = __lsx_vmadd_w(tmp2_l, d3_l, (__m128i)const089);
++    tmp2_l = __lsx_vmadd_w(tmp2_l, d1_l, (__m128i)const256);
++
++    LSX_BUTTERFLY_4(v4i32, tmp10_h, tmp12_h, tmp0_h, tmp2_h,
++                    dst0_h, dst1_h, dst2_h, dst3_h);
++
++    LSX_BUTTERFLY_4(v4i32, tmp10_l, tmp12_l, tmp0_l, tmp2_l,
++                    dst0_l, dst1_l, dst2_l, dst3_l);
++
++    LSX_SRARI_W_4(dst0_h, dst1_h, dst2_h, dst3_h, CONST_BITS - PASS1_BITS + 1);
++    LSX_SRARI_W_4(dst0_l, dst1_l, dst2_l, dst3_l, CONST_BITS - PASS1_BITS + 1);
++
++    LSX_TRANSPOSE4x4_W(dst0_h, dst1_h, dst2_h, dst3_h, d0_h, d1_h, d2_h, d3_h);
++
++    dcval0 = __lsx_vilvl_w(dst1_l, dst0_l);
++    dcval1 = __lsx_vilvh_w(dst1_l, dst0_l);
++    dcval2 = __lsx_vilvl_w(dst3_l, dst2_l);
++    dcval3 = __lsx_vilvh_w(dst3_l, dst2_l);
++
++    d5_h = __lsx_vilvh_d(dcval2, dcval0);
++    d6_h = __lsx_vilvl_d(dcval3, dcval1);
++    d7_h = __lsx_vilvh_d(dcval3, dcval1);
++  }
++
++  /* Even part */
++  d0_h = __lsx_vslli_w(d0_h, CONST_BITS + 1);
++
++  d2_h = __lsx_vmul_w(d2_h, (__m128i)const184);
++  d2_h = __lsx_vmadd_w(d2_h, d6_h, (__m128i)const076);
++  tmp10_h = __lsx_vadd_w(d0_h, d2_h);
++  tmp12_h = __lsx_vsub_w(d0_h, d2_h);
++
++  /* Odd part */
++  tmp0_h = __lsx_vmul_w(d7_h, (__m128i)const021);
++  tmp0_h = __lsx_vmadd_w(tmp0_h, d5_h, (__m128i)const145);
++  tmp0_h = __lsx_vmsub_w(tmp0_h, d3_h, (__m128i)const217);
++  tmp0_h = __lsx_vmadd_w(tmp0_h, d1_h, (__m128i)const106);
++
++  tmp2_h = __lsx_vmul_w(d7_h, (__m128i)const050);
++  tmp2_h = __lsx_vmsub_w(tmp2_h, d5_h, (__m128i)const060);
++  tmp2_h = __lsx_vmadd_w(tmp2_h, d3_h, (__m128i)const089);
++  tmp2_h = __lsx_vmadd_w(tmp2_h, d1_h, (__m128i)const256);
++
++  LSX_BUTTERFLY_4(v4i32, tmp10_h, tmp12_h, tmp0_h, tmp2_h,
++                  dst0_h, dst1_h, dst2_h, dst3_h);
++
++  LSX_SRARI_W_4(dst0_h, dst1_h, dst2_h, dst3_h, CONST_BITS + PASS1_BITS + 3 + 1);
++
++  LSX_TRANSPOSE4x4_W(dst0_h, dst1_h, dst2_h, dst3_h, dst0_h, dst1_h, dst2_h, dst3_h);
++
++  dcval0 = __lsx_vpickev_h(dst1_h, dst0_h);
++  dcval1 = __lsx_vpickev_h(dst3_h, dst2_h);
++  dcval0 = __lsx_vadd_h(dcval0, const128);
++  dcval1 = __lsx_vadd_h(dcval1, const128);
++  LSX_CLIP_H_0_255(dcval0, dcval0);
++  LSX_CLIP_H_0_255(dcval1, dcval1);
++  res = __lsx_vpickev_b(dcval1, dcval0);
++
++  __lsx_vstelm_w(res, output_buf[0] + output_col, 0, 0);
++  __lsx_vstelm_w(res, output_buf[1] + output_col, 0, 1);
++  __lsx_vstelm_w(res, output_buf[2] + output_col, 0, 2);
++  __lsx_vstelm_w(res, output_buf[3] + output_col, 0, 3);
++}
+diff --git a/simd/loongarch64/jmacros_lasx.h b/simd/loongarch64/jmacros_lasx.h
+new file mode 100644
+index 00000000..cd6bff70
+--- /dev/null
++++ b/simd/loongarch64/jmacros_lasx.h
+@@ -0,0 +1,111 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#ifndef __JMACROS_LASX_H__
++#define __JMACROS_LASX_H__
++
++#include <stdint.h>
++#include "generic_macros_lasx.h"
++
++#define LASX_UNPCKL_HU_BU(_in, _out) { \
++  _out = __lasx_vext2xv_hu_bu(_in); \
++}
++
++#define LASX_UNPCKL_H_B(_in, _out) { \
++  _out = __lasx_vext2xv_h_b(_in); \
++}
++
++#define LASX_UNPCKLH_HU_BU(_in, _out_h, _out_l) { \
++  __m256i _tmp_h; \
++  _tmp_h = __lasx_xvpermi_q(_in, _in, 0x33); \
++  _out_l = __lasx_vext2xv_hu_bu(_in); \
++  _out_h = __lasx_vext2xv_hu_bu(_tmp_h); \
++}
++
++#define LASX_UNPCKLH_H_B(_in, _out_h, _out_l) { \
++  __m256i _tmp_h; \
++  _tmp_h = __lasx_xvpermi_q(_in, _in, 0x33); \
++  _out_l = __lasx_vext2xv_h_b(_in); \
++  _out_h = __lasx_vext2xv_h_b(_tmp_h); \
++}
++
++#define LASX_UNPCKL_WU_HU(_in, _out) { \
++  _out = __lasx_vext2xv_wu_hu(_in); \
++}
++
++#define LASX_UNPCKL_W_H(_in, _out) { \
++  _out = __lasx_vext2xv_w_h(_in); \
++}
++
++#define LASX_UNPCKLH_WU_HU(_in, _out_h, _out_l) { \
++  __m256i _tmp_h; \
++  _tmp_h = __lasx_xvpermi_q(_in, _in, 0x33); \
++  _out_l = __lasx_vext2xv_wu_hu(_in); \
++  _out_h = __lasx_vext2xv_wu_hu(_tmp_h); \
++}
++
++#define LASX_UNPCKLH_W_H(_in, _out_h, _out_l) { \
++  __m256i _tmp_h; \
++  _tmp_h = __lasx_xvpermi_q(_in, _in, 0x33); \
++  _out_l = __lasx_vext2xv_w_h(_in); \
++  _out_h = __lasx_vext2xv_w_h(_tmp_h); \
++}
++
++#define LASX_UNPCK_WU_BU_4(_in, _out0, _out1, _out2, _out3) {\
++\
++  _out0 = __lasx_vext2xv_wu_bu(_in); \
++  _out1 = __lasx_xvpermi_d(_in, 0xe1); \
++  _out1 = __lasx_vext2xv_wu_bu(_out1); \
++  _out2 = __lasx_xvpermi_d(_in, 0xc6); \
++  _out2 = __lasx_vext2xv_wu_bu(_out2); \
++  _out3 = __lasx_xvpermi_d(_in, 0x27); \
++  _out3 = __lasx_vext2xv_wu_bu(_out3); \
++}
++
++#define LASX_SRARI_W_4(_in0, _in1, _in2, _in3, shift_value) { \
++  _in0 = __lasx_xvsrari_w(_in0, shift_value); \
++  _in1 = __lasx_xvsrari_w(_in1, shift_value); \
++  _in2 = __lasx_xvsrari_w(_in2, shift_value); \
++  _in3 = __lasx_xvsrari_w(_in3, shift_value); \
++}
++
++/*
++ * 1,2,3,4,5,6,7,8     1 1 1 1 5 5 5 5
++ * 1,2,3,4,5,6,7,8 --> 2 2 2 2 6 6 6 6
++ * 1,2,3,4,5,6,7,8     3 3 3 3 7 7 7 7
++ * 1,2,3,4,5,6,7,8     4 4 4 4 8 8 8 8
++ */
++#define LASX_TRANSPOSE4x4_W_128SV(_in0, _in1, _in2, _in3, \
++                                  _out0, _out1, _out2, _out3) \
++{ \
++  __m256i _tmp0,_tmp1,_tmp2,_tmp3; \
++  LASX_ILVLH_W_128SV(_in1, _in0, _tmp1, _tmp0); \
++  LASX_ILVLH_W_128SV(_in3, _in2, _tmp3, _tmp2); \
++  LASX_PCKEV_D_128SV(_tmp2, _tmp0, _out0); \
++  LASX_PCKOD_D_128SV(_tmp2, _tmp0, _out1); \
++  LASX_PCKEV_D_128SV(_tmp3, _tmp1, _out2); \
++  LASX_PCKOD_D_128SV(_tmp3, _tmp1, _out3); \
++}
++
++#endif /* __JMACROS_LASX_H__ */
+diff --git a/simd/loongarch64/jmacros_lsx.h b/simd/loongarch64/jmacros_lsx.h
+new file mode 100644
+index 00000000..7a61a676
+--- /dev/null
++++ b/simd/loongarch64/jmacros_lsx.h
+@@ -0,0 +1,114 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++#ifndef __JMACROS_LSX_H__
++#define __JMACROS_LSX_H__
++
++#include <stdint.h>
++#include "generic_macros_lsx.h"
++
++#define LSX_UNPCKL_HU_BU(_in, _out)   \
++{                                     \
++  _out = __lsx_vsllwil_hu_bu(_in, 0); \
++}
++
++#define LSX_UNPCKL_H_B(_in, _out)     \
++{                                     \
++  _out = __lsx_vsllwil_h_b(_in, 0);   \
++}
++
++#define LSX_UNPCKLH_HU_BU(_in, _out_h, _out_l) \
++{                                              \
++  _out_l = __lsx_vsllwil_hu_bu(_in, 0);        \
++  _out_h = __lsx_vexth_hu_bu(_in);             \
++}
++
++#define LSX_UNPCKLH_H_B(_in, _out_h, _out_l)   \
++{                                              \
++  _out_l = __lsx_vsllwil_h_b(_in, 0);          \
++  _out_h = __lsx_vexth_h_b(_in);               \
++}
++
++#define LSX_UNPCKL_WU_HU(_in, _out)            \
++{                                              \
++  _out = __lsx_vsllwil_wu_hu(_in, 0);          \
++}
++
++#define LSX_UNPCKL_W_H(_in, _out)              \
++{                                              \
++  _out = __lsx_vsllwil_w_h(_in, 0);            \
++}
++
++#define LSX_UNPCKL_W_H_2(_in0, _in1, _out0, _out1)  \
++{                                                   \
++  LSX_UNPCKL_W_H(_in0, _out0);                      \
++  LSX_UNPCKL_W_H(_in1, _out1);                      \
++}
++
++#define LSX_UNPCKLH_WU_HU(_in, _out_h, _out_l) \
++{                                              \
++  _out_l = __lsx_vsllwil_wu_hu(_in, 0);        \
++  _out_h = __lsx_vexth_wu_hu(_in);             \
++}
++
++#define LSX_UNPCKLH_W_H(_in, _out_h, _out_l)   \
++{                                              \
++  _out_l = __lsx_vsllwil_w_h(_in, 0);          \
++  _out_h = __lsx_vexth_w_h(_in);               \
++}
++
++#define LSX_UNPCKLH_W_H_2(_in0, _in1, _out0_h, _out0_l, _out1_h, _out1_l)    \
++{                                                                            \
++  LSX_UNPCKLH_W_H(_in0, _out0_h, _out0_l);                                   \
++  LSX_UNPCKLH_W_H(_in1, _out1_h, _out1_l);                                   \
++}
++
++#define LSX_UNPCKLH_W_H_4(_in0, _in1, _in2, _in3, _out0_h, _out0_l, _out1_h, \
++                          _out1_l, _out2_h, _out2_l, _out3_h, _out3_l)       \
++{                                                                            \
++  LSX_UNPCKLH_W_H_2(_in0, _in1, _out0_h, _out0_l, _out1_h, _out1_l);         \
++  LSX_UNPCKLH_W_H_2(_in2, _in3, _out2_h, _out2_l, _out3_h, _out3_l);         \
++}
++
++#define LSX_UNPCK_WU_BU_4(_in, _out0, _out1, _out2, _out3)                   \
++{                                                                            \
++  __m128i zero = __lsx_vldi(0);                                              \
++  v16u8 mask0 = {0,16,16,16,1,16,16,16,2,16,16,16,3,16,16,16};               \
++  v16u8 mask1 = {4,16,16,16,5,16,16,16,6,16,16,16,7,16,16,16};               \
++  v16u8 mask2 = {8,16,16,16,9,16,16,16,10,16,16,16,11,16,16,16};             \
++  v16u8 mask3 = {12,16,16,16,13,16,16,16,14,16,16,16,15,16,16,16};           \
++  _out0 = __lsx_vshuf_b(zero, _in, (__m128i)mask0);                          \
++  _out1 = __lsx_vshuf_b(zero, _in, (__m128i)mask1);                          \
++  _out2 = __lsx_vshuf_b(zero, _in, (__m128i)mask2);                          \
++  _out3 = __lsx_vshuf_b(zero, _in, (__m128i)mask3);                          \
++}
++
++#define LSX_SRARI_W_4(_in0, _in1, _in2, _in3, shift_value) {                 \
++  _in0 = __lsx_vsrari_w(_in0, shift_value);                                  \
++  _in1 = __lsx_vsrari_w(_in1, shift_value);                                  \
++  _in2 = __lsx_vsrari_w(_in2, shift_value);                                  \
++  _in3 = __lsx_vsrari_w(_in3, shift_value);                                  \
++}
++
++#endif /* __JMACROS_LSX_H__ */
+diff --git a/simd/loongarch64/jquanti-lasx.c b/simd/loongarch64/jquanti-lasx.c
+new file mode 100644
+index 00000000..487f897f
+--- /dev/null
++++ b/simd/loongarch64/jquanti-lasx.c
+@@ -0,0 +1,152 @@
++/*
++ * LOONGARCH LASX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++/* INTEGER QUANTIZATION AND SAMPLE CONVERSION */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "jmacros_lasx.h"
++
++#define LASX_MUL_WU_HU(_in0, _in1, _out0, _out1) \
++{ \
++  __m256i _tmp0, _tmp1, _tmp2, _tmp3; \
++  LASX_UNPCKLH_WU_HU(_in0, _tmp1, _tmp0); \
++  LASX_UNPCKLH_WU_HU(_in1, _tmp3, _tmp2); \
++  _out0 = __lasx_xvmul_w(_tmp0, _tmp2); \
++  _out1 = __lasx_xvmul_w(_tmp1, _tmp3); \
++}
++
++GLOBAL(void)
++jsimd_convsamp_lasx(JSAMPARRAY sample_data, JDIMENSION start_col,
++                    DCTELEM *workspace)
++{
++  __m256i src0, src1, src2, src3, src4, src5, src6, src7;
++  __m256i dst0, dst1, dst2, dst3;
++  __m256i const128 = {128};
++
++  const128 = __lasx_xvreplve0_h(const128);
++
++  src0 = LASX_LD(sample_data[0] + start_col);
++  src1 = LASX_LD(sample_data[1] + start_col);
++  src2 = LASX_LD(sample_data[2] + start_col);
++  src3 = LASX_LD(sample_data[3] + start_col);
++  src4 = LASX_LD(sample_data[4] + start_col);
++  src5 = LASX_LD(sample_data[5] + start_col);
++  src6 = LASX_LD(sample_data[6] + start_col);
++  src7 = LASX_LD(sample_data[7] + start_col);
++
++  src0 = __lasx_xvpackev_d(src1, src0);
++  src2 = __lasx_xvpackev_d(src3, src2);
++  src4 = __lasx_xvpackev_d(src5, src4);
++  src6 = __lasx_xvpackev_d(src7, src6);
++
++  LASX_UNPCK_L_HU_BU_4(src0, src2, src4, src6, src0, src2, src4, src6);
++
++  dst0 = __lasx_xvsub_h(src0, const128);
++  dst1 = __lasx_xvsub_h(src2, const128);
++  dst2 = __lasx_xvsub_h(src4, const128);
++  dst3 = __lasx_xvsub_h(src6, const128);
++
++  LASX_ST_4(dst0, dst1, dst2, dst3, workspace, 16);
++}
++
++GLOBAL(void)
++jsimd_quantize_lasx(JCOEFPTR coef_block, DCTELEM *divisors,
++                    DCTELEM *workspace)
++{
++  DCTELEM *recip, *corr, *shift;
++  __m256i src0, src1, src2, src3, rec0, rec1, rec2, rec3;
++  __m256i cor0, cor1, cor2, cor3, shi0, shi1, shi2, shi3;
++  __m256i src0_l, src0_h, src1_l, src1_h, src2_l, src2_h;
++  __m256i src3_l, src3_h, shi0_l, shi0_h, shi1_l, shi1_h;
++  __m256i shi2_l, shi2_h, shi3_l, shi3_h;
++  __m256i sin0, sin1, sin2, sin3;
++  __m256i zero = __lasx_xvldi(0);
++
++  recip = divisors;
++  corr  = divisors + 64;
++  shift = divisors + 192;
++
++  LASX_LD_4(workspace, 16, src0, src1 ,src2, src3);
++  LASX_LD_4(recip, 16, rec0, rec1, rec2, rec3);
++  LASX_LD_4(corr, 16, cor0, cor1, cor2, cor3);
++  LASX_LD_4(shift, 16, shi0, shi1, shi2, shi3);
++
++  /* Get signs */
++  sin0 = __lasx_xvsrai_h(src0, 15);
++  sin1 = __lasx_xvsrai_h(src1, 15);
++  sin2 = __lasx_xvsrai_h(src2, 15);
++  sin3 = __lasx_xvsrai_h(src3, 15);
++
++  /* Abs */
++  src0 = __lasx_xvadda_h(src0, zero);
++  src1 = __lasx_xvadda_h(src1, zero);
++  src2 = __lasx_xvadda_h(src2, zero);
++  src3 = __lasx_xvadda_h(src3, zero);
++
++  src0 = __lasx_xvadd_h(src0, cor0);
++  src1 = __lasx_xvadd_h(src1, cor1);
++  src2 = __lasx_xvadd_h(src2, cor2);
++  src3 = __lasx_xvadd_h(src3, cor3);
++
++  /* Multiply */
++  LASX_MUL_WU_HU(src0, rec0, src0_l, src0_h);
++  LASX_MUL_WU_HU(src1, rec1, src1_l, src1_h);
++  LASX_MUL_WU_HU(src2, rec2, src2_l, src2_h);
++  LASX_MUL_WU_HU(src3, rec3, src3_l, src3_h);
++
++  /* Shift */
++  LASX_UNPCKLH_W_H(shi0, shi0_h, shi0_l);
++  LASX_UNPCKLH_W_H(shi1, shi1_h, shi1_l);
++  LASX_UNPCKLH_W_H(shi2, shi2_h, shi2_l);
++  LASX_UNPCKLH_W_H(shi3, shi3_h, shi3_l);
++
++  src0_l = __lasx_xvsrl_w(src0_l, shi0_l);
++  src0_h = __lasx_xvsrl_w(src0_h, shi0_h);
++  src1_l = __lasx_xvsrl_w(src1_l, shi1_l);
++  src1_h = __lasx_xvsrl_w(src1_h, shi1_h);
++  src2_l = __lasx_xvsrl_w(src2_l, shi2_l);
++  src2_h = __lasx_xvsrl_w(src2_h, shi2_h);
++  src3_l = __lasx_xvsrl_w(src3_l, shi3_l);
++  src3_h = __lasx_xvsrl_w(src3_h, shi3_h);
++
++  LASX_PCKOD_H_4(src0_h, src0_l, src1_h, src1_l, src2_h, src2_l,
++                 src3_h, src3_l, src0, src1, src2, src3);
++
++  /* Apply back signs */
++  src0 = __lasx_xvxor_v(src0, sin0);
++  src1 = __lasx_xvxor_v(src1, sin1);
++  src2 = __lasx_xvxor_v(src2, sin2);
++  src3 = __lasx_xvxor_v(src3, sin3);
++
++  src0 = __lasx_xvsub_h(src0, sin0);
++  src1 = __lasx_xvsub_h(src1, sin1);
++  src2 = __lasx_xvsub_h(src2, sin2);
++  src3 = __lasx_xvsub_h(src3, sin3);
++
++  LASX_ST_4(src0, src1, src2, src3, coef_block, 16);
++}
+diff --git a/simd/loongarch64/jquanti-lsx.c b/simd/loongarch64/jquanti-lsx.c
+new file mode 100644
+index 00000000..8e2c71e1
+--- /dev/null
++++ b/simd/loongarch64/jquanti-lsx.c
+@@ -0,0 +1,155 @@
++/*
++ * LOONGARCH LSX optimizations for libjpeg-turbo
++ *
++ * Copyright (C) 2023 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Song Ding (songding@loongson.cn)
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ */
++
++/* INTEGER QUANTIZATION AND SAMPLE CONVERSION */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "jmacros_lsx.h"
++
++#define LSX_MUL_WU_HU(_in0, _in1, _out0, _out1) \
++{                                               \
++  __m128i _tmp0, _tmp1, _tmp2, _tmp3;           \
++  LSX_UNPCKLH_WU_HU(_in0, _tmp1, _tmp0);        \
++  LSX_UNPCKLH_WU_HU(_in1, _tmp3, _tmp2);        \
++  _out0 = __lsx_vmul_w(_tmp0, _tmp2);           \
++  _out1 = __lsx_vmul_w(_tmp1, _tmp3);           \
++}
++
++GLOBAL(void)
++jsimd_convsamp_lsx(JSAMPARRAY sample_data, JDIMENSION start_col,
++                   DCTELEM *workspace)
++{
++  __m128i src0, src1, src2, src3, src4, src5, src6, src7;
++  __m128i dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7;
++  __m128i const128 = {128};
++
++  const128 = __lsx_vreplvei_h(const128, 0);
++
++  src0 = LSX_LD(sample_data[0] + start_col);
++  src1 = LSX_LD(sample_data[1] + start_col);
++  src2 = LSX_LD(sample_data[2] + start_col);
++  src3 = LSX_LD(sample_data[3] + start_col);
++  src4 = LSX_LD(sample_data[4] + start_col);
++  src5 = LSX_LD(sample_data[5] + start_col);
++  src6 = LSX_LD(sample_data[6] + start_col);
++  src7 = LSX_LD(sample_data[7] + start_col);
++
++  LSX_UNPCK_L_HU_BU_8(src0, src1, src2, src3, src4, src5, src6, src7,
++                      src0, src1, src2, src3, src4, src5, src6, src7);
++
++  dst0 = __lsx_vsub_h(src0, const128);
++  dst1 = __lsx_vsub_h(src1, const128);
++  dst2 = __lsx_vsub_h(src2, const128);
++  dst3 = __lsx_vsub_h(src3, const128);
++  dst4 = __lsx_vsub_h(src4, const128);
++  dst5 = __lsx_vsub_h(src5, const128);
++  dst6 = __lsx_vsub_h(src6, const128);
++  dst7 = __lsx_vsub_h(src7, const128);
++
++  LSX_ST_8(dst0, dst1, dst2, dst3, dst4, dst5, dst6, dst7, workspace, 8);
++}
++
++GLOBAL(void)
++jsimd_quantize_lsx(JCOEFPTR coef_block, DCTELEM *divisors,
++                   DCTELEM *workspace)
++{
++  DCTELEM *recip, *corr, *shift;
++  JDIMENSION cnt;
++  __m128i src0, src1, src2, src3, rec0, rec1, rec2, rec3;
++  __m128i cor0, cor1, cor2, cor3, shi0, shi1, shi2, shi3;
++  __m128i src0_l, src0_h, src1_l, src1_h, src2_l, src2_h;
++  __m128i src3_l, src3_h, shi0_l, shi0_h, shi1_l, shi1_h;
++  __m128i shi2_l, shi2_h, shi3_l, shi3_h;
++  __m128i sin0, sin1, sin2, sin3;
++  __m128i zero = __lsx_vldi(0);
++
++  recip = divisors;
++  corr  = divisors + 64;
++  shift = divisors + 192;
++
++  for (cnt = 0; cnt < 2; cnt++) {
++    LSX_LD_4(workspace + cnt * 32, 8, src0, src1 ,src2, src3);
++    LSX_LD_4(recip + cnt * 32, 8, rec0, rec1, rec2, rec3);
++    LSX_LD_4(corr + cnt * 32, 8, cor0, cor1, cor2, cor3);
++    LSX_LD_4(shift + cnt * 32, 8, shi0, shi1, shi2, shi3);
++
++    /* Get signs */
++    sin0 = __lsx_vsrai_h(src0, 15);
++    sin1 = __lsx_vsrai_h(src1, 15);
++    sin2 = __lsx_vsrai_h(src2, 15);
++    sin3 = __lsx_vsrai_h(src3, 15);
++
++    /* Abs */
++    src0 = __lsx_vadda_h(src0, zero);
++    src1 = __lsx_vadda_h(src1, zero);
++    src2 = __lsx_vadda_h(src2, zero);
++    src3 = __lsx_vadda_h(src3, zero);
++
++    src0 = __lsx_vadd_h(src0, cor0);
++    src1 = __lsx_vadd_h(src1, cor1);
++    src2 = __lsx_vadd_h(src2, cor2);
++    src3 = __lsx_vadd_h(src3, cor3);
++
++    /* Multiply */
++    LSX_MUL_WU_HU(src0, rec0, src0_l, src0_h);
++    LSX_MUL_WU_HU(src1, rec1, src1_l, src1_h);
++    LSX_MUL_WU_HU(src2, rec2, src2_l, src2_h);
++    LSX_MUL_WU_HU(src3, rec3, src3_l, src3_h);
++
++    /* Shift */
++    LSX_UNPCKLH_W_H(shi0, shi0_h, shi0_l);
++    LSX_UNPCKLH_W_H(shi1, shi1_h, shi1_l);
++    LSX_UNPCKLH_W_H(shi2, shi2_h, shi2_l);
++    LSX_UNPCKLH_W_H(shi3, shi3_h, shi3_l);
++
++    src0_l = __lsx_vsrl_w(src0_l, shi0_l);
++    src0_h = __lsx_vsrl_w(src0_h, shi0_h);
++    src1_l = __lsx_vsrl_w(src1_l, shi1_l);
++    src1_h = __lsx_vsrl_w(src1_h, shi1_h);
++    src2_l = __lsx_vsrl_w(src2_l, shi2_l);
++    src2_h = __lsx_vsrl_w(src2_h, shi2_h);
++    src3_l = __lsx_vsrl_w(src3_l, shi3_l);
++    src3_h = __lsx_vsrl_w(src3_h, shi3_h);
++
++    LSX_PCKOD_H_4(src0_h, src0_l, src1_h, src1_l, src2_h, src2_l,
++                  src3_h, src3_l, src0, src1, src2, src3);
++
++    /* Apply back signs */
++    src0 = __lsx_vxor_v(src0, sin0);
++    src1 = __lsx_vxor_v(src1, sin1);
++    src2 = __lsx_vxor_v(src2, sin2);
++    src3 = __lsx_vxor_v(src3, sin3);
++
++    src0 = __lsx_vsub_h(src0, sin0);
++    src1 = __lsx_vsub_h(src1, sin1);
++    src2 = __lsx_vsub_h(src2, sin2);
++    src3 = __lsx_vsub_h(src3, sin3);
++
++    LSX_ST_4(src0, src1, src2, src3, (coef_block + cnt * 32), 8);
++  }
++}
+diff --git a/simd/loongarch64/jsimd.c b/simd/loongarch64/jsimd.c
+new file mode 100644
+index 00000000..ec145bdc
+--- /dev/null
++++ b/simd/loongarch64/jsimd.c
+@@ -0,0 +1,1060 @@
++/*
++ * jsimd_loongarch64.c
++ *
++ * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
++ * Copyright (C) 2009-2011, 2014, 2016, 2018, D. R. Commander.
++ * Copyright (C) 2013-2014, MIPS Technologies, Inc., California.
++ * Copyright (C) 2015, 2018, Matthieu Darbois.
++ * Copyright (C) 2021, 2023, Loongson Technology Corporation Limited, BeiJing.
++ *
++ * Based on the x86 SIMD extension for IJG JPEG library,
++ * Copyright (C) 1999-2006, MIYASAKA Masaru.
++ * For conditions of distribution and use, see copyright notice in jsimdext.inc
++ *
++ * This file contains the interface between the "normal" portions
++ * of the library and the SIMD implementations when running on a
++ * 64-bit LOONGARCH architecture.
++ */
++
++#define JPEG_INTERNALS
++#include "../../src/jinclude.h"
++#include "../../src/jpeglib.h"
++#include "../../src/jsimd.h"
++#include "../../src/jdct.h"
++#include "../../src/jsimddct.h"
++#include "../jsimd.h"
++
++#include <ctype.h>
++#include <sys/auxv.h>
++#include <asm/hwcap.h>
++
++static THREAD_LOCAL unsigned int simd_support = ~0;
++
++LOCAL(void)
++check_loongarch_feature(void)
++{
++  simd_support = 0;
++
++  uint64_t hwcaps = getauxval(AT_HWCAP);
++
++  if (hwcaps & HWCAP_LOONGARCH_LSX)
++      simd_support |= JSIMD_LSX;
++  if (hwcaps & HWCAP_LOONGARCH_LASX)
++      simd_support |= JSIMD_LASX;
++}
++
++/*
++ * Check what SIMD accelerations are supported.
++ */
++LOCAL(void)
++init_simd(void)
++{
++#ifndef NO_GETENV
++  char env[2] = { 0 };
++#endif
++
++  if (simd_support != ~0U)
++    return;
++
++  check_loongarch_feature();
++
++#ifndef NO_GETENV
++  /* Force different settings through environment variables */
++  if (!GETENV_S(env, 2, "JSIMD_FORCELSX") && !strcmp(env, "1"))
++    simd_support &= JSIMD_LSX;
++  if (!GETENV_S(env, 2, "JSIMD_FORCELASX") && !strcmp(env, "1"))
++    simd_support &= JSIMD_LASX;
++  if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
++    simd_support = 0;
++#endif
++}
++
++GLOBAL(int)
++jsimd_can_rgb_ycc(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_rgb_gray(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_ycc_rgb(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_ycc_rgb565(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_c_can_null_convert(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_rgb_ycc_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
++                      JSAMPIMAGE output_buf, JDIMENSION output_row,
++                      int num_rows)
++{
++  void (*lasxfct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
++  void (*lsxfct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
++
++  switch (cinfo->in_color_space) {
++  case JCS_EXT_RGB:
++    lasxfct = jsimd_extrgb_ycc_convert_lasx;
++    lsxfct = jsimd_extrgb_ycc_convert_lsx;
++    break;
++  case JCS_EXT_RGBX:
++  case JCS_EXT_RGBA:
++    lasxfct = jsimd_extrgbx_ycc_convert_lasx;
++    lsxfct = jsimd_extrgbx_ycc_convert_lsx;
++    break;
++  case JCS_EXT_BGR:
++    lasxfct = jsimd_extbgr_ycc_convert_lasx;
++    lsxfct = jsimd_extbgr_ycc_convert_lsx;
++    break;
++  case JCS_EXT_BGRX:
++  case JCS_EXT_BGRA:
++    lasxfct = jsimd_extbgrx_ycc_convert_lasx;
++    lsxfct = jsimd_extbgrx_ycc_convert_lsx;
++    break;
++  case JCS_EXT_XBGR:
++  case JCS_EXT_ABGR:
++    lasxfct = jsimd_extxbgr_ycc_convert_lasx;
++    lsxfct = jsimd_extxbgr_ycc_convert_lsx;
++    break;
++  case JCS_EXT_XRGB:
++  case JCS_EXT_ARGB:
++    lasxfct = jsimd_extxrgb_ycc_convert_lasx;
++    lsxfct = jsimd_extxrgb_ycc_convert_lsx;
++    break;
++  default:
++    lasxfct = jsimd_rgb_ycc_convert_lasx;
++    lsxfct = jsimd_rgb_ycc_convert_lsx;
++    break;
++  }
++
++  if (simd_support & JSIMD_LASX)
++    lasxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
++  else if (simd_support & JSIMD_LSX)
++    lsxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
++}
++
++GLOBAL(void)
++jsimd_rgb_gray_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
++                       JSAMPIMAGE output_buf, JDIMENSION output_row,
++                       int num_rows)
++{
++  void (*lasxfct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
++  void (*lsxfct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
++
++  switch (cinfo->in_color_space) {
++  case JCS_EXT_RGB:
++    lasxfct = jsimd_extrgb_gray_convert_lasx;
++    lsxfct = jsimd_extrgb_gray_convert_lsx;
++    break;
++  case JCS_EXT_RGBX:
++  case JCS_EXT_RGBA:
++    lasxfct = jsimd_extrgbx_gray_convert_lasx;
++    lsxfct = jsimd_extrgbx_gray_convert_lsx;
++    break;
++  case JCS_EXT_BGR:
++    lasxfct = jsimd_extbgr_gray_convert_lasx;
++    lsxfct = jsimd_extbgr_gray_convert_lsx;
++    break;
++  case JCS_EXT_BGRX:
++  case JCS_EXT_BGRA:
++    lasxfct = jsimd_extbgrx_gray_convert_lasx;
++    lsxfct = jsimd_extbgrx_gray_convert_lsx;
++    break;
++  case JCS_EXT_XBGR:
++  case JCS_EXT_ABGR:
++    lasxfct = jsimd_extxbgr_gray_convert_lasx;
++    lsxfct = jsimd_extxbgr_gray_convert_lsx;
++    break;
++  case JCS_EXT_XRGB:
++  case JCS_EXT_ARGB:
++    lasxfct = jsimd_extxrgb_gray_convert_lasx;
++    lsxfct = jsimd_extxrgb_gray_convert_lsx;
++    break;
++  default:
++    lasxfct = jsimd_rgb_gray_convert_lasx;
++    lsxfct = jsimd_rgb_gray_convert_lsx;
++    break;
++  }
++
++  if (simd_support & JSIMD_LASX)
++    lasxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
++  else if (simd_support & JSIMD_LSX)
++    lsxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
++}
++
++GLOBAL(void)
++jsimd_ycc_rgb_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
++                      JDIMENSION input_row, JSAMPARRAY output_buf,
++                      int num_rows)
++{
++  void (*lasxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
++  void (*lsxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
++
++  switch (cinfo->out_color_space) {
++  case JCS_EXT_RGB:
++    lasxfct = jsimd_ycc_extrgb_convert_lasx;
++    lsxfct = jsimd_ycc_extrgb_convert_lsx;
++    break;
++  case JCS_EXT_RGBX:
++  case JCS_EXT_RGBA:
++    lasxfct = jsimd_ycc_extrgbx_convert_lasx;
++    lsxfct = jsimd_ycc_extrgbx_convert_lsx;
++    break;
++  case JCS_EXT_BGR:
++    lasxfct = jsimd_ycc_extbgr_convert_lasx;
++    lsxfct = jsimd_ycc_extbgr_convert_lsx;
++    break;
++  case JCS_EXT_BGRX:
++  case JCS_EXT_BGRA:
++    lasxfct = jsimd_ycc_extbgrx_convert_lasx;
++    lsxfct = jsimd_ycc_extbgrx_convert_lsx;
++    break;
++  case JCS_EXT_XBGR:
++  case JCS_EXT_ABGR:
++    lasxfct = jsimd_ycc_extxbgr_convert_lasx;
++    lsxfct = jsimd_ycc_extxbgr_convert_lsx;
++    break;
++  case JCS_EXT_XRGB:
++  case JCS_EXT_ARGB:
++    lasxfct = jsimd_ycc_extxrgb_convert_lasx;
++    lsxfct = jsimd_ycc_extxrgb_convert_lsx;
++    break;
++  default:
++    lasxfct = jsimd_ycc_rgb_convert_lasx;
++    lsxfct = jsimd_ycc_rgb_convert_lsx;
++    break;
++  }
++
++  if (simd_support & JSIMD_LASX)
++    lasxfct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
++  else if (simd_support & JSIMD_LSX)
++    lsxfct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
++}
++
++GLOBAL(void)
++jsimd_ycc_rgb565_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
++                         JDIMENSION input_row, JSAMPARRAY output_buf,
++                         int num_rows)
++{
++}
++
++GLOBAL(void)
++jsimd_c_null_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
++                     JSAMPIMAGE output_buf, JDIMENSION output_row,
++                     int num_rows)
++{
++}
++
++GLOBAL(int)
++jsimd_can_h2v2_downsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_h2v2_smooth_downsample(void)
++{
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_h2v1_downsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_h2v2_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
++                      JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_h2v2_downsample_lasx(cinfo->image_width, cinfo->max_v_samp_factor,
++                               compptr->v_samp_factor, compptr->width_in_blocks,
++                               input_data, output_data);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_h2v2_downsample_lsx(cinfo->image_width, cinfo->max_v_samp_factor,
++                              compptr->v_samp_factor, compptr->width_in_blocks,
++                              input_data, output_data);
++}
++
++GLOBAL(void)
++jsimd_h2v2_smooth_downsample(j_compress_ptr cinfo,
++                             jpeg_component_info *compptr,
++                             JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++}
++
++GLOBAL(void)
++jsimd_h2v1_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
++                      JSAMPARRAY input_data, JSAMPARRAY output_data)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_h2v1_downsample_lasx(cinfo->image_width, cinfo->max_v_samp_factor,
++                               compptr->v_samp_factor, compptr->width_in_blocks,
++                               input_data, output_data);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_h2v1_downsample_lsx(cinfo->image_width, cinfo->max_v_samp_factor,
++                              compptr->v_samp_factor, compptr->width_in_blocks,
++                              input_data, output_data);
++}
++
++GLOBAL(int)
++jsimd_can_h2v2_upsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_h2v1_upsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_int_upsample(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_h2v2_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                    JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_h2v2_upsample_lasx(cinfo->max_v_samp_factor, cinfo->output_width,
++                             input_data, output_data_ptr);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_h2v2_upsample_lsx(cinfo->max_v_samp_factor, cinfo->output_width,
++                            input_data, output_data_ptr);
++}
++
++GLOBAL(void)
++jsimd_h2v1_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                    JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_h2v1_upsample_lasx(cinfo->max_v_samp_factor, cinfo->output_width,
++                             input_data, output_data_ptr);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_h2v1_upsample_lsx(cinfo->max_v_samp_factor, cinfo->output_width,
++                            input_data, output_data_ptr);
++}
++
++GLOBAL(void)
++jsimd_int_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                   JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
++{
++}
++
++GLOBAL(int)
++jsimd_can_h2v2_fancy_upsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_h2v1_fancy_upsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_h2v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                          JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_h2v2_fancy_upsample_lasx(cinfo->max_v_samp_factor,
++                                   compptr->downsampled_width, input_data,
++                                   output_data_ptr);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_h2v2_fancy_upsample_lsx(cinfo->max_v_samp_factor,
++                                  compptr->downsampled_width, input_data,
++                                  output_data_ptr);
++}
++
++GLOBAL(void)
++jsimd_h2v1_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                          JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_h2v1_fancy_upsample_lasx(cinfo->max_v_samp_factor,
++                                   compptr->downsampled_width, input_data,
++                                   output_data_ptr);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_h2v1_fancy_upsample_lsx(cinfo->max_v_samp_factor,
++                                  compptr->downsampled_width, input_data,
++                                  output_data_ptr);
++}
++
++GLOBAL(int)
++jsimd_can_h2v2_merged_upsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_h2v1_merged_upsample(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_h2v2_merged_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
++                           JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf)
++{
++  void (*lasxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
++  void (*lsxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
++
++  switch (cinfo->out_color_space) {
++  case JCS_EXT_RGB:
++    lasxfct = jsimd_h2v2_extrgb_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_extrgb_merged_upsample_lsx;
++    break;
++  case JCS_EXT_RGBX:
++  case JCS_EXT_RGBA:
++    lasxfct = jsimd_h2v2_extrgbx_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_extrgbx_merged_upsample_lsx;
++    break;
++  case JCS_EXT_BGR:
++    lasxfct = jsimd_h2v2_extbgr_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_extbgr_merged_upsample_lsx;
++    break;
++  case JCS_EXT_BGRX:
++  case JCS_EXT_BGRA:
++    lasxfct = jsimd_h2v2_extbgrx_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_extbgrx_merged_upsample_lsx;
++    break;
++  case JCS_EXT_XBGR:
++  case JCS_EXT_ABGR:
++    lasxfct = jsimd_h2v2_extxbgr_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_extxbgr_merged_upsample_lsx;
++    break;
++  case JCS_EXT_XRGB:
++  case JCS_EXT_ARGB:
++    lasxfct = jsimd_h2v2_extxrgb_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_extxrgb_merged_upsample_lsx;
++    break;
++  default:
++    lasxfct = jsimd_h2v2_merged_upsample_lasx;
++    lsxfct = jsimd_h2v2_merged_upsample_lsx;
++    break;
++  }
++
++  if (simd_support & JSIMD_LASX)
++    lasxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
++  else if (simd_support & JSIMD_LSX)
++    lsxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
++}
++
++GLOBAL(void)
++jsimd_h2v1_merged_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
++                           JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf)
++{
++  void (*lasxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
++  void (*lsxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
++
++  switch (cinfo->out_color_space) {
++  case JCS_EXT_RGB:
++    lasxfct = jsimd_h2v1_extrgb_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_extrgb_merged_upsample_lsx;
++    break;
++  case JCS_EXT_RGBX:
++  case JCS_EXT_RGBA:
++    lasxfct = jsimd_h2v1_extrgbx_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_extrgbx_merged_upsample_lsx;
++    break;
++  case JCS_EXT_BGR:
++    lasxfct = jsimd_h2v1_extbgr_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_extbgr_merged_upsample_lsx;
++    break;
++  case JCS_EXT_BGRX:
++  case JCS_EXT_BGRA:
++    lasxfct = jsimd_h2v1_extbgrx_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_extbgrx_merged_upsample_lsx;
++    break;
++  case JCS_EXT_XBGR:
++  case JCS_EXT_ABGR:
++    lasxfct = jsimd_h2v1_extxbgr_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_extxbgr_merged_upsample_lsx;
++    break;
++  case JCS_EXT_XRGB:
++  case JCS_EXT_ARGB:
++    lasxfct = jsimd_h2v1_extxrgb_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_extxrgb_merged_upsample_lsx;
++    break;
++  default:
++    lasxfct = jsimd_h2v1_merged_upsample_lasx;
++    lsxfct = jsimd_h2v1_merged_upsample_lsx;
++    break;
++  }
++
++  if (simd_support & JSIMD_LASX)
++    lasxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
++  else if (simd_support & JSIMD_LSX)
++    lsxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
++}
++
++GLOBAL(int)
++jsimd_can_convsamp(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if (sizeof(DCTELEM) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_convsamp_float(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_convsamp(JSAMPARRAY sample_data, JDIMENSION start_col,
++               DCTELEM *workspace)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_convsamp_lasx(sample_data, start_col, workspace);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_convsamp_lsx(sample_data, start_col, workspace);
++}
++
++GLOBAL(void)
++jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
++                     FAST_FLOAT *workspace)
++{
++}
++
++GLOBAL(int)
++jsimd_can_fdct_islow(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(DCTELEM) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_fdct_ifast(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(DCTELEM) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_fdct_float(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_fdct_islow(DCTELEM *data)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_fdct_islow_lasx(data);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_fdct_islow_lsx(data);
++}
++
++GLOBAL(void)
++jsimd_fdct_ifast(DCTELEM *data)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_fdct_ifast_lasx(data);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_fdct_ifast_lsx(data);
++}
++
++GLOBAL(void)
++jsimd_fdct_float(FAST_FLOAT *data)
++{
++}
++
++GLOBAL(int)
++jsimd_can_quantize(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(JCOEF) != 2)
++    return 0;
++  if (sizeof(DCTELEM) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_quantize_float(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_quantize(JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_quantize_lasx(coef_block, divisors, workspace);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_quantize_lsx(coef_block, divisors, workspace);
++}
++
++GLOBAL(void)
++jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
++                     FAST_FLOAT *workspace)
++{
++}
++
++GLOBAL(int)
++jsimd_can_idct_2x2(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(JCOEF) != 2)
++    return 0;
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if (sizeof(ISLOW_MULT_TYPE) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_idct_4x4(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(JCOEF) != 2)
++    return 0;
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if (sizeof(ISLOW_MULT_TYPE) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_idct_6x6(void)
++{
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_idct_12x12(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_idct_2x2(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++               JCOEFPTR coef_block, JSAMPARRAY output_buf,
++               JDIMENSION output_col)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_idct_2x2_lasx(compptr->dct_table, coef_block, output_buf, output_col);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_idct_2x2_lsx(compptr->dct_table, coef_block, output_buf, output_col);
++}
++
++GLOBAL(void)
++jsimd_idct_4x4(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++               JCOEFPTR coef_block, JSAMPARRAY output_buf,
++               JDIMENSION output_col)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_idct_4x4_lasx(compptr->dct_table, coef_block, output_buf, output_col);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_idct_4x4_lsx(compptr->dct_table, coef_block, output_buf, output_col);
++}
++
++GLOBAL(void)
++jsimd_idct_6x6(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++               JCOEFPTR coef_block, JSAMPARRAY output_buf,
++               JDIMENSION output_col)
++{
++}
++
++GLOBAL(void)
++jsimd_idct_12x12(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                 JDIMENSION output_col)
++{
++}
++
++GLOBAL(int)
++jsimd_can_idct_islow(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(JCOEF) != 2)
++    return 0;
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if (sizeof(ISLOW_MULT_TYPE) != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_idct_ifast(void)
++{
++  init_simd();
++
++  /* The code is optimised for these values only */
++  if (DCTSIZE != 8)
++    return 0;
++  if (sizeof(JCOEF) != 2)
++    return 0;
++  if (BITS_IN_JSAMPLE != 8)
++    return 0;
++  if (sizeof(JDIMENSION) != 4)
++    return 0;
++  if (sizeof(IFAST_MULT_TYPE) != 2)
++    return 0;
++  if (IFAST_SCALE_BITS != 2)
++    return 0;
++
++  if (simd_support & JSIMD_LASX)
++    return 1;
++  if (simd_support & JSIMD_LSX)
++    return 1;
++
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_can_idct_float(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_idct_islow(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                 JDIMENSION output_col)
++{
++  unsigned char *output[8] = {
++    output_buf[0] + output_col,
++    output_buf[1] + output_col,
++    output_buf[2] + output_col,
++    output_buf[3] + output_col,
++    output_buf[4] + output_col,
++    output_buf[5] + output_col,
++    output_buf[6] + output_col,
++    output_buf[7] + output_col,
++  };
++
++  if (simd_support & JSIMD_LASX)
++    jsimd_idct_islow_lasx(cinfo, compptr, coef_block, output, output_col);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_idct_islow_lsx(cinfo, compptr, coef_block, output, output_col);
++}
++
++GLOBAL(void)
++jsimd_idct_ifast(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                 JDIMENSION output_col)
++{
++  if (simd_support & JSIMD_LASX)
++    jsimd_idct_ifast_lasx(compptr->dct_table, coef_block, output_buf,
++                          output_col);
++  else if (simd_support & JSIMD_LSX)
++    jsimd_idct_ifast_lsx(compptr->dct_table, coef_block, output_buf,
++                         output_col);
++}
++
++GLOBAL(void)
++jsimd_idct_float(j_decompress_ptr cinfo, jpeg_component_info *compptr,
++                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
++                 JDIMENSION output_col)
++{
++}
++
++GLOBAL(int)
++jsimd_can_huff_encode_one_block(void)
++{
++  return 0;
++}
++
++GLOBAL(JOCTET *)
++jsimd_huff_encode_one_block(void *state, JOCTET *buffer, JCOEFPTR block,
++                            int last_dc_val, c_derived_tbl *dctbl,
++                            c_derived_tbl *actbl)
++{
++  return NULL;
++}
++
++GLOBAL(int)
++jsimd_can_encode_mcu_AC_first_prepare(void)
++{
++  return 0;
++}
++
++GLOBAL(void)
++jsimd_encode_mcu_AC_first_prepare(const JCOEF *block,
++                                  const int *jpeg_natural_order_start, int Sl,
++                                  int Al, UJCOEF *values, size_t *zerobits)
++{
++}
++
++GLOBAL(int)
++jsimd_can_encode_mcu_AC_refine_prepare(void)
++{
++  return 0;
++}
++
++GLOBAL(int)
++jsimd_encode_mcu_AC_refine_prepare(const JCOEF *block,
++                                   const int *jpeg_natural_order_start, int Sl,
++                                   int Al, UJCOEF *absvalues, size_t *bits)
++{
++  return 0;
++}
+-- 
+2.52.0
+

--- a/runtime-imaging/libjpeg-turbo/autobuild/patches/0002-LOONGARCH-port-simd-to-3.2.0.patch
+++ b/runtime-imaging/libjpeg-turbo/autobuild/patches/0002-LOONGARCH-port-simd-to-3.2.0.patch
@@ -1,0 +1,2188 @@
+From e74bdb0f29a7fb9f69495e7b5f2b82dc8d53b88b Mon Sep 17 00:00:00 2001
+From: elysia <a.elysia@proton.me>
+Date: Tue, 7 Jul 2026 18:01:20 +0800
+Subject: [PATCH 2/2] LOONGARCH: port simd to 3.2.0
+
+Signed-off-by: elysia <a.elysia@proton.me>
+---
+ simd/CMakeLists.txt              |    4 +-
+ simd/jsimd.c                     |  176 +++++
+ simd/jsimdconst.h                |    5 +-
+ simd/jsimdint.h                  |   93 +++
+ simd/loongarch64/jccolor-lasx.c  |    4 +-
+ simd/loongarch64/jccolor-lsx.c   |    4 +-
+ simd/loongarch64/jcgray-lasx.c   |    4 +-
+ simd/loongarch64/jcgray-lsx.c    |    4 +-
+ simd/loongarch64/jcsample-lasx.c |    4 +-
+ simd/loongarch64/jcsample-lsx.c  |    4 +-
+ simd/loongarch64/jdcolor-lasx.c  |    6 +-
+ simd/loongarch64/jdcolor-lsx.c   |    6 +-
+ simd/loongarch64/jdmerge-lasx.c  |    6 +-
+ simd/loongarch64/jdmerge-lsx.c   |    6 +-
+ simd/loongarch64/jdsample-lasx.c |    4 +-
+ simd/loongarch64/jdsample-lsx.c  |    4 +-
+ simd/loongarch64/jfdctfst-lasx.c |    4 +-
+ simd/loongarch64/jfdctfst-lsx.c  |    4 +-
+ simd/loongarch64/jfdctint-lasx.c |    4 +-
+ simd/loongarch64/jfdctint-lsx.c  |    4 +-
+ simd/loongarch64/jidctfst-lasx.c |    6 +-
+ simd/loongarch64/jidctfst-lsx.c  |    6 +-
+ simd/loongarch64/jidctint-lasx.c |   29 +-
+ simd/loongarch64/jidctint-lsx.c  |   29 +-
+ simd/loongarch64/jidctred-lasx.c |    6 +-
+ simd/loongarch64/jidctred-lsx.c  |    6 +-
+ simd/loongarch64/jquanti-lasx.c  |    4 +-
+ simd/loongarch64/jquanti-lsx.c   |    4 +-
+ simd/loongarch64/jsimd.c         | 1060 ------------------------------
+ simd/loongarch64/jsimdcpu.c      |   47 ++
+ 30 files changed, 401 insertions(+), 1146 deletions(-)
+ delete mode 100644 simd/loongarch64/jsimd.c
+ create mode 100644 simd/loongarch64/jsimdcpu.c
+
+diff --git a/simd/CMakeLists.txt b/simd/CMakeLists.txt
+index 4840864c..88eb6f39 100644
+--- a/simd/CMakeLists.txt
++++ b/simd/CMakeLists.txt
+@@ -560,6 +560,8 @@ endif()
+ 
+ elseif(CPU_TYPE STREQUAL "loongarch64")
+ 
++set(SIMD_ARCHITECTURE LOONGARCH64 PARENT_SCOPE)
++
+ set(CMAKE_REQUIRED_FLAGS -mlsx)
+ check_c_source_compiles("
+   #include <lsxintrin.h>
+@@ -625,7 +627,7 @@ endforeach()
+ set_source_files_properties(${SIMD_SOURCES} PROPERTIES
+   COMPILE_FLAGS -mlasx)
+ 
+-add_library(simd OBJECT ${SIMD_SOURCES} ${CPU_TYPE}/jsimd.c)
++add_library(simd OBJECT ${SIMD_SOURCES} jsimd.c loongarch64/jsimdcpu.c)
+ 
+ if(CMAKE_POSITION_INDEPENDENT_CODE OR ENABLE_SHARED)
+   set_target_properties(simd PROPERTIES POSITION_INDEPENDENT_CODE 1)
+diff --git a/simd/jsimd.c b/simd/jsimd.c
+index 693d0a8a..568d71c8 100644
+--- a/simd/jsimd.c
++++ b/simd/jsimd.c
+@@ -91,6 +91,11 @@ init_simd(j_common_ptr cinfo)
+ #elif SIMD_ARCHITECTURE == MIPS64
+   if (!GETENV_S(env, 2, "JSIMD_FORCEMMI") && !strcmp(env, "1"))
+     simd_support = JSIMD_MMI;
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (!GETENV_S(env, 2, "JSIMD_FORCELSX") && !strcmp(env, "1"))
++    simd_support &= JSIMD_LSX;
++  if (!GETENV_S(env, 2, "JSIMD_FORCELASX") && !strcmp(env, "1"))
++    simd_support &= JSIMD_LASX;
+ #endif
+   if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
+     simd_support = 0;
+@@ -159,6 +164,15 @@ jsimd_set_rgb_ycc(j_compress_ptr cinfo)
+     SET_SIMD_EXTRGB_COLOR_CONVERTER(ycc, mmi);
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    SET_SIMD_EXTRGB_COLOR_CONVERTER(ycc, lasx);
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    SET_SIMD_EXTRGB_COLOR_CONVERTER(ycc, lsx);
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -216,6 +230,15 @@ jsimd_set_rgb_gray(j_compress_ptr cinfo)
+     SET_SIMD_EXTRGB_COLOR_CONVERTER(gray, mmi);
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    SET_SIMD_EXTRGB_COLOR_CONVERTER(gray, lasx);
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    SET_SIMD_EXTRGB_COLOR_CONVERTER(gray, lsx);
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -282,6 +305,15 @@ jsimd_set_ycc_rgb(j_decompress_ptr cinfo)
+     SET_SIMD_EXTRGB_COLOR_DECONVERTER(mmi);
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    SET_SIMD_EXTRGB_COLOR_DECONVERTER(lasx);
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    SET_SIMD_EXTRGB_COLOR_DECONVERTER(lsx);
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -363,6 +395,15 @@ jsimd_set_h2v1_downsample(j_compress_ptr cinfo)
+     cinfo->downsample->h2v1_downsample_simd = jsimd_h2v1_downsample_rvv;
+     return JSIMD_RVV;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->downsample->h2v1_downsample_simd = jsimd_h2v1_downsample_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->downsample->h2v1_downsample_simd = jsimd_h2v1_downsample_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -428,6 +469,15 @@ jsimd_set_h2v2_downsample(j_compress_ptr cinfo)
+     cinfo->downsample->h2v2_downsample_simd = jsimd_h2v2_downsample_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->downsample->h2v2_downsample_simd = jsimd_h2v2_downsample_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->downsample->h2v2_downsample_simd = jsimd_h2v2_downsample_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -488,6 +538,15 @@ jsimd_set_h2v1_upsample(j_decompress_ptr cinfo)
+     cinfo->upsample->h2v1_upsample_simd = jsimd_h2v1_upsample_rvv;
+     return JSIMD_RVV;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->upsample->h2v1_upsample_simd = jsimd_h2v1_upsample_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->upsample->h2v1_upsample_simd = jsimd_h2v1_upsample_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -546,6 +605,15 @@ jsimd_set_h2v2_upsample(j_decompress_ptr cinfo)
+     cinfo->upsample->h2v2_upsample_simd = jsimd_h2v2_upsample_rvv;
+     return JSIMD_RVV;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->upsample->h2v2_upsample_simd = jsimd_h2v2_upsample_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->upsample->h2v2_upsample_simd = jsimd_h2v2_upsample_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -611,6 +679,15 @@ jsimd_set_h2v1_fancy_upsample(j_decompress_ptr cinfo)
+     cinfo->upsample->h2v1_upsample_simd = jsimd_h2v1_fancy_upsample_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->upsample->h2v1_upsample_simd = jsimd_h2v1_fancy_upsample_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->upsample->h2v1_upsample_simd = jsimd_h2v1_fancy_upsample_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -676,6 +753,15 @@ jsimd_set_h2v2_fancy_upsample(j_decompress_ptr cinfo)
+     cinfo->upsample->h2v2_upsample_simd = jsimd_h2v2_fancy_upsample_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->upsample->h2v2_upsample_simd = jsimd_h2v2_fancy_upsample_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->upsample->h2v2_upsample_simd = jsimd_h2v2_fancy_upsample_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -776,6 +862,15 @@ jsimd_set_h2v1_merged_upsample(j_decompress_ptr cinfo)
+     SET_SIMD_EXTRGB_MERGED_UPSAMPLER(h2v1, mmi);
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    SET_SIMD_EXTRGB_MERGED_UPSAMPLER(h2v1, lasx);
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    SET_SIMD_EXTRGB_MERGED_UPSAMPLER(h2v1, lsx);
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -840,6 +935,15 @@ jsimd_set_h2v2_merged_upsample(j_decompress_ptr cinfo)
+     SET_SIMD_EXTRGB_MERGED_UPSAMPLER(h2v2, mmi);
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    SET_SIMD_EXTRGB_MERGED_UPSAMPLER(h2v2, lasx);
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    SET_SIMD_EXTRGB_MERGED_UPSAMPLER(h2v2, lsx);
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -897,6 +1001,15 @@ jsimd_set_convsamp(j_compress_ptr cinfo, convsamp_method_ptr *method)
+     *method = jsimd_convsamp_rvv;
+     return JSIMD_RVV;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    *method = jsimd_convsamp_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    *method = jsimd_convsamp_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -982,6 +1095,15 @@ jsimd_set_fdct_islow(j_compress_ptr cinfo, forward_DCT_method_ptr *method)
+     *method = jsimd_fdct_islow_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    *method = jsimd_fdct_islow_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    *method = jsimd_fdct_islow_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -1028,6 +1150,15 @@ jsimd_set_fdct_ifast(j_compress_ptr cinfo, forward_DCT_method_ptr *method)
+     *method = jsimd_fdct_ifast_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    *method = jsimd_fdct_ifast_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    *method = jsimd_fdct_ifast_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -1105,6 +1236,15 @@ jsimd_set_quantize(j_compress_ptr cinfo, quantize_method_ptr *method)
+     *method = jsimd_quantize_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    *method = jsimd_quantize_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    *method = jsimd_quantize_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -1196,6 +1336,15 @@ jsimd_set_idct_islow(j_decompress_ptr cinfo)
+     cinfo->idct->idct_simd = jsimd_idct_islow_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->idct->idct_simd = jsimd_idct_islow_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->idct->idct_simd = jsimd_idct_islow_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -1262,6 +1411,15 @@ jsimd_set_idct_ifast(j_decompress_ptr cinfo)
+     cinfo->idct->idct_simd = jsimd_idct_ifast_mmi;
+     return JSIMD_MMI;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->idct->idct_simd = jsimd_idct_ifast_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->idct->idct_simd = jsimd_idct_ifast_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -1362,6 +1520,15 @@ jsimd_set_idct_2x2(j_decompress_ptr cinfo)
+     cinfo->idct->idct_2x2_simd = jsimd_idct_2x2_neon;
+     return JSIMD_NEON;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->idct->idct_2x2_simd = jsimd_idct_2x2_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->idct->idct_2x2_simd = jsimd_idct_2x2_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+@@ -1411,6 +1578,15 @@ jsimd_set_idct_4x4(j_decompress_ptr cinfo)
+     cinfo->idct->idct_4x4_simd = jsimd_idct_4x4_neon;
+     return JSIMD_NEON;
+   }
++#elif SIMD_ARCHITECTURE == LOONGARCH64
++  if (cinfo->master->simd_support & JSIMD_LASX) {
++    cinfo->idct->idct_4x4_simd = jsimd_idct_4x4_lasx;
++    return JSIMD_LASX;
++  }
++  if (cinfo->master->simd_support & JSIMD_LSX) {
++    cinfo->idct->idct_4x4_simd = jsimd_idct_4x4_lsx;
++    return JSIMD_LSX;
++  }
+ #endif
+ 
+   return JSIMD_NONE;
+diff --git a/simd/jsimdconst.h b/simd/jsimdconst.h
+index 38f8855a..9b738c54 100644
+--- a/simd/jsimdconst.h
++++ b/simd/jsimdconst.h
+@@ -32,6 +32,7 @@
+ #define POWERPC  4
+ #define RISCV64  5
+ #define MIPS64   6
++#define LOONGARCH64 7
+ 
+ /* Bitmask for supported SIMD instruction sets */
+ 
+@@ -45,5 +46,7 @@
+ #define JSIMD_ALTIVEC    0x40
+ #define JSIMD_AVX2       0x80
+ #define JSIMD_MMI        0x100
+-#define JSIMD_MAX        0x100
++#define JSIMD_LSX        0x200
++#define JSIMD_LASX       0x400
++#define JSIMD_MAX        0x400
+ #define JSIMD_UNDEFINED  ~(JSIMD_MAX * 2U - 1U)
+diff --git a/simd/jsimdint.h b/simd/jsimdint.h
+index 8204dc34..5136fe7f 100644
+--- a/simd/jsimdint.h
++++ b/simd/jsimdint.h
+@@ -122,6 +122,11 @@ DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(gray, rvv)
+ DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(ycc, mmi)
+ DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(gray, mmi)
+ 
++DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(ycc, lsx)
++DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(gray, lsx)
++DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(ycc, lasx)
++DEFINE_SIMD_EXTRGB_COLOR_CONVERTERS(gray, lasx)
++
+ 
+ /* YCbCr-to-RGB Color Conversion */
+ 
+@@ -200,6 +205,9 @@ DEFINE_SIMD_EXTRGB_COLOR_DECONVERTERS(rvv)
+ 
+ DEFINE_SIMD_EXTRGB_COLOR_DECONVERTERS(mmi)
+ 
++DEFINE_SIMD_EXTRGB_COLOR_DECONVERTERS(lsx)
++DEFINE_SIMD_EXTRGB_COLOR_DECONVERTERS(lasx)
++
+ 
+ /* YCbCr-to-RGB565 Color Conversion */
+ 
+@@ -256,6 +264,19 @@ EXTERN(void) jsimd_h2v2_downsample_mmi
+   (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
+    JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
+ 
++EXTERN(void) jsimd_h2v1_downsample_lsx
++  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
++   JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
++EXTERN(void) jsimd_h2v2_downsample_lsx
++  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
++   JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
++EXTERN(void) jsimd_h2v1_downsample_lasx
++  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
++   JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
++EXTERN(void) jsimd_h2v2_downsample_lasx
++  (JDIMENSION image_width, int max_v_samp_factor, JDIMENSION v_samp_factor,
++   JDIMENSION width_in_blocks, JSAMPARRAY input_data, JSAMPARRAY output_data);
++
+ 
+ /* Plain Upsampling */
+ 
+@@ -301,6 +322,19 @@ EXTERN(void) jsimd_h2v2_upsample_rvv
+   (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
+    JSAMPARRAY *output_data_ptr);
+ 
++EXTERN(void) jsimd_h2v1_upsample_lsx
++  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++EXTERN(void) jsimd_h2v2_upsample_lsx
++  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++EXTERN(void) jsimd_h2v1_upsample_lasx
++  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++EXTERN(void) jsimd_h2v2_upsample_lasx
++  (int max_v_samp_factor, JDIMENSION output_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++
+ 
+ /* Fancy (Smooth) Upsampling */
+ 
+@@ -358,6 +392,19 @@ EXTERN(void) jsimd_h2v2_fancy_upsample_mmi
+   (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
+    JSAMPARRAY *output_data_ptr);
+ 
++EXTERN(void) jsimd_h2v1_fancy_upsample_lsx
++  (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++EXTERN(void) jsimd_h2v2_fancy_upsample_lsx
++  (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++EXTERN(void) jsimd_h2v1_fancy_upsample_lasx
++  (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++EXTERN(void) jsimd_h2v2_fancy_upsample_lasx
++  (int max_v_samp_factor, JDIMENSION downsampled_width, JSAMPARRAY input_data,
++   JSAMPARRAY *output_data_ptr);
++
+ 
+ /* Merged Upsampling/Color Conversion */
+ 
+@@ -443,6 +490,11 @@ DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v2, rvv)
+ DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v1, mmi)
+ DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v2, mmi)
+ 
++DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v1, lsx)
++DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v2, lsx)
++DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v1, lasx)
++DEFINE_SIMD_EXTRGB_MERGED_UPSAMPLERS(h2v2, lasx)
++
+ 
+ /* Integer Sample Conversion */
+ 
+@@ -464,6 +516,11 @@ EXTERN(void) jsimd_convsamp_altivec
+ EXTERN(void) jsimd_convsamp_rvv
+   (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
+ 
++EXTERN(void) jsimd_convsamp_lsx
++  (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
++EXTERN(void) jsimd_convsamp_lasx
++  (JSAMPARRAY sample_data, JDIMENSION start_col, DCTELEM *workspace);
++
+ 
+ /* Floating Point Sample Conversion */
+ 
+@@ -502,6 +559,11 @@ EXTERN(void) jsimd_fdct_ifast_rvv(DCTELEM *data);
+ EXTERN(void) jsimd_fdct_islow_mmi(DCTELEM *data);
+ EXTERN(void) jsimd_fdct_ifast_mmi(DCTELEM *data);
+ 
++EXTERN(void) jsimd_fdct_islow_lsx(DCTELEM *data);
++EXTERN(void) jsimd_fdct_ifast_lsx(DCTELEM *data);
++EXTERN(void) jsimd_fdct_islow_lasx(DCTELEM *data);
++EXTERN(void) jsimd_fdct_ifast_lasx(DCTELEM *data);
++
+ 
+ /* Floating Point Forward DCT */
+ 
+@@ -534,6 +596,11 @@ EXTERN(void) jsimd_quantize_rvv
+ EXTERN(void) jsimd_quantize_mmi
+   (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
+ 
++EXTERN(void) jsimd_quantize_lsx
++  (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
++EXTERN(void) jsimd_quantize_lasx
++  (JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace);
++
+ 
+ /* Floating Point Quantization */
+ 
+@@ -611,6 +678,19 @@ EXTERN(void) jsimd_idct_ifast_mmi
+   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+    JDIMENSION output_col);
+ 
++EXTERN(void) jsimd_idct_islow_lsx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++EXTERN(void) jsimd_idct_ifast_lsx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++EXTERN(void) jsimd_idct_islow_lasx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++EXTERN(void) jsimd_idct_ifast_lasx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++
+ 
+ /* Scaled Integer Inverse DCT */
+ 
+@@ -636,6 +716,19 @@ EXTERN(void) jsimd_idct_4x4_neon
+   (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
+    JDIMENSION output_col);
+ 
++EXTERN(void) jsimd_idct_2x2_lsx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++EXTERN(void) jsimd_idct_4x4_lsx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++EXTERN(void) jsimd_idct_2x2_lasx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++EXTERN(void) jsimd_idct_4x4_lasx
++  (void *dct_table, JCOEFPTR coef_block, JSAMPARRAY output_buf,
++   JDIMENSION output_col);
++
+ 
+ /* Huffman Encoding */
+ 
+diff --git a/simd/loongarch64/jccolor-lasx.c b/simd/loongarch64/jccolor-lasx.c
+index 0e291400..37e70477 100644
+--- a/simd/loongarch64/jccolor-lasx.c
++++ b/simd/loongarch64/jccolor-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jmacros_lasx.h"
+ 
+ /* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
+diff --git a/simd/loongarch64/jccolor-lsx.c b/simd/loongarch64/jccolor-lsx.c
+index e747ece2..cb7ad065 100644
+--- a/simd/loongarch64/jccolor-lsx.c
++++ b/simd/loongarch64/jccolor-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jmacros_lsx.h"
+ 
+ /* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
+diff --git a/simd/loongarch64/jcgray-lasx.c b/simd/loongarch64/jcgray-lasx.c
+index 75c3f85b..63943798 100644
+--- a/simd/loongarch64/jcgray-lasx.c
++++ b/simd/loongarch64/jcgray-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jmacros_lasx.h"
+ 
+ /* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
+diff --git a/simd/loongarch64/jcgray-lsx.c b/simd/loongarch64/jcgray-lsx.c
+index fd80401a..b2bc8c7e 100644
+--- a/simd/loongarch64/jcgray-lsx.c
++++ b/simd/loongarch64/jcgray-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jmacros_lsx.h"
+ 
+ /* Y  =  0.29900 * R + 0.58700 * G + 0.11400 * B */
+diff --git a/simd/loongarch64/jcsample-lasx.c b/simd/loongarch64/jcsample-lasx.c
+index 92dd2cfa..6e7b2baa 100644
+--- a/simd/loongarch64/jcsample-lasx.c
++++ b/simd/loongarch64/jcsample-lasx.c
+@@ -22,8 +22,10 @@
+  * 3. This notice may not be removed or altered from any source distribution.
+  */
+ 
++#define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
++
++#include "../jsimdint.h"
+ #include "jcsample.h"
+ #include "jmacros_lasx.h"
+ 
+diff --git a/simd/loongarch64/jcsample-lsx.c b/simd/loongarch64/jcsample-lsx.c
+index 1e7ff99e..600c1a18 100644
+--- a/simd/loongarch64/jcsample-lsx.c
++++ b/simd/loongarch64/jcsample-lsx.c
+@@ -22,8 +22,10 @@
+  * 3. This notice may not be removed or altered from any source distribution.
+  */
+ 
++#define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
++
++#include "../jsimdint.h"
+ #include "jcsample.h"
+ #include "jmacros_lsx.h"
+ 
+diff --git a/simd/loongarch64/jdcolor-lasx.c b/simd/loongarch64/jdcolor-lasx.c
+index a87fa625..1e90a387 100644
+--- a/simd/loongarch64/jdcolor-lasx.c
++++ b/simd/loongarch64/jdcolor-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jconfigint.h"
+ #include "jmacros_lasx.h"
+ 
+@@ -36,8 +36,6 @@
+ #define FIX_177200  116130
+ #define FIX_28586   18734
+ 
+-#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+-
+ #define LASX_DOTP2_W_H(_in0, _in1, _out0) \
+ { \
+   __m256i _tmp0, _tmp1, _tmp2, _tmp3; \
+diff --git a/simd/loongarch64/jdcolor-lsx.c b/simd/loongarch64/jdcolor-lsx.c
+index 137d53e2..412ce638 100644
+--- a/simd/loongarch64/jdcolor-lsx.c
++++ b/simd/loongarch64/jdcolor-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jconfigint.h"
+ #include "jmacros_lsx.h"
+ 
+@@ -35,8 +35,6 @@
+ #define FIX_177200  116130
+ #define FIX_28586   18734
+ 
+-#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+-
+ static INLINE unsigned char clip_pixel(int val)
+ {
+   return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
+diff --git a/simd/loongarch64/jdmerge-lasx.c b/simd/loongarch64/jdmerge-lasx.c
+index fa0945ad..d95fd50d 100644
+--- a/simd/loongarch64/jdmerge-lasx.c
++++ b/simd/loongarch64/jdmerge-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jconfigint.h"
+ #include "jmacros_lasx.h"
+ 
+@@ -35,8 +35,6 @@
+ #define FIX_177200  116130
+ #define FIX_28586   18734
+ 
+-#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+-
+ static INLINE unsigned char clip_pixel(int val)
+ {
+   return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
+diff --git a/simd/loongarch64/jdmerge-lsx.c b/simd/loongarch64/jdmerge-lsx.c
+index 57f30ba8..350c8d5c 100644
+--- a/simd/loongarch64/jdmerge-lsx.c
++++ b/simd/loongarch64/jdmerge-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jconfigint.h"
+ #include "jmacros_lsx.h"
+ 
+@@ -35,8 +35,6 @@
+ #define FIX_177200  116130
+ #define FIX_28586   18734
+ 
+-#define DESCALE(x,n)  (((x)+(1<<((n)-1)))>>(n))
+-
+ static INLINE unsigned char clip_pixel(int val)
+ {
+   return ((val & ~0xFF) ? ((-val) >> 31) & 0xFF : val);
+diff --git a/simd/loongarch64/jdsample-lasx.c b/simd/loongarch64/jdsample-lasx.c
+index d1af0d57..ffe14a1d 100644
+--- a/simd/loongarch64/jdsample-lasx.c
++++ b/simd/loongarch64/jdsample-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jmacros_lasx.h"
+ 
+ /*
+diff --git a/simd/loongarch64/jdsample-lsx.c b/simd/loongarch64/jdsample-lsx.c
+index 89c7016f..0a643333 100644
+--- a/simd/loongarch64/jdsample-lsx.c
++++ b/simd/loongarch64/jdsample-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "jmacros_lsx.h"
+ 
+ /*
+diff --git a/simd/loongarch64/jfdctfst-lasx.c b/simd/loongarch64/jfdctfst-lasx.c
+index 5ad5da61..23f7b9ff 100644
+--- a/simd/loongarch64/jfdctfst-lasx.c
++++ b/simd/loongarch64/jfdctfst-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+ #include "jmacros_lasx.h"
+ 
+diff --git a/simd/loongarch64/jfdctfst-lsx.c b/simd/loongarch64/jfdctfst-lsx.c
+index ae39d32d..0f740568 100644
+--- a/simd/loongarch64/jfdctfst-lsx.c
++++ b/simd/loongarch64/jfdctfst-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+ #include "jmacros_lsx.h"
+ 
+diff --git a/simd/loongarch64/jfdctint-lasx.c b/simd/loongarch64/jfdctint-lasx.c
+index 8418416e..19a302a1 100644
+--- a/simd/loongarch64/jfdctint-lasx.c
++++ b/simd/loongarch64/jfdctint-lasx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+ #include "jmacros_lasx.h"
+ 
+diff --git a/simd/loongarch64/jfdctint-lsx.c b/simd/loongarch64/jfdctint-lsx.c
+index aa105f9f..f60f972d 100644
+--- a/simd/loongarch64/jfdctint-lsx.c
++++ b/simd/loongarch64/jfdctint-lsx.c
+@@ -24,8 +24,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+ #include "jmacros_lsx.h"
+ 
+diff --git a/simd/loongarch64/jidctfst-lasx.c b/simd/loongarch64/jidctfst-lasx.c
+index e22d439d..23d01448 100644
+--- a/simd/loongarch64/jidctfst-lasx.c
++++ b/simd/loongarch64/jidctfst-lasx.c
+@@ -24,10 +24,10 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
++#include "../jsimddct.h"
+ #include "jmacros_lasx.h"
+ 
+ #define DCTSIZE 8
+diff --git a/simd/loongarch64/jidctfst-lsx.c b/simd/loongarch64/jidctfst-lsx.c
+index 9263d090..eb71bbc9 100644
+--- a/simd/loongarch64/jidctfst-lsx.c
++++ b/simd/loongarch64/jidctfst-lsx.c
+@@ -24,10 +24,10 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
++#include "../jsimddct.h"
+ #include "jmacros_lsx.h"
+ 
+ #define DCTSIZE 8
+diff --git a/simd/loongarch64/jidctint-lasx.c b/simd/loongarch64/jidctint-lasx.c
+index bb65f2ce..86776a0f 100644
+--- a/simd/loongarch64/jidctint-lasx.c
++++ b/simd/loongarch64/jidctint-lasx.c
+@@ -24,10 +24,10 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
++#include "../jsimddct.h"
+ #include "jmacros_lasx.h"
+ 
+ #define DCTSIZE     8
+@@ -71,11 +71,10 @@
+ }
+ 
+ GLOBAL(void)
+-jsimd_idct_islow_lasx(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                      JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-                      JDIMENSION output_col)
++jsimd_idct_islow_lasx(void *dct_table, JCOEFPTR coef_block,
++                      JSAMPARRAY output_buf, JDIMENSION output_col)
+ {
+-  JCOEFPTR quantptr = compptr->dct_table;
++  JCOEFPTR quantptr = dct_table;
+   __m256i coef01, coef23, coef45, coef67;
+   __m256i quant01, quant23, quant45, quant67;
+   __m256i zero = __lasx_xvldi(0);
+@@ -298,12 +297,12 @@ jsimd_idct_islow_lasx(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+   LASX_TRANSPOSE8x8_B(dcval0, dcval1, dcval2, dcval3, dcval4, dcval5, dcval6, dcval7,
+                       dcval0, dcval1, dcval2, dcval3, dcval4, dcval5, dcval6, dcval7);
+ 
+-  __lasx_xvstelm_d(dcval0, output_buf[0], 0, 0);
+-  __lasx_xvstelm_d(dcval1, output_buf[1], 0, 0);
+-  __lasx_xvstelm_d(dcval2, output_buf[2], 0, 0);
+-  __lasx_xvstelm_d(dcval3, output_buf[3], 0, 0);
+-  __lasx_xvstelm_d(dcval4, output_buf[4], 0, 0);
+-  __lasx_xvstelm_d(dcval5, output_buf[5], 0, 0);
+-  __lasx_xvstelm_d(dcval6, output_buf[6], 0, 0);
+-  __lasx_xvstelm_d(dcval7, output_buf[7], 0, 0);
++  __lasx_xvstelm_d(dcval0, output_buf[0] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval1, output_buf[1] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval2, output_buf[2] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval3, output_buf[3] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval4, output_buf[4] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval5, output_buf[5] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval6, output_buf[6] + output_col, 0, 0);
++  __lasx_xvstelm_d(dcval7, output_buf[7] + output_col, 0, 0);
+ }
+diff --git a/simd/loongarch64/jidctint-lsx.c b/simd/loongarch64/jidctint-lsx.c
+index d3fc4305..9279f204 100644
+--- a/simd/loongarch64/jidctint-lsx.c
++++ b/simd/loongarch64/jidctint-lsx.c
+@@ -24,10 +24,10 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
++#include "../jsimddct.h"
+ #include "jmacros_lsx.h"
+ 
+ #define DCTSIZE     8
+@@ -68,11 +68,10 @@
+ }
+ 
+ GLOBAL(void)
+-jsimd_idct_islow_lsx(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                     JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-                     JDIMENSION output_col)
++jsimd_idct_islow_lsx(void *dct_table, JCOEFPTR coef_block,
++                     JSAMPARRAY output_buf, JDIMENSION output_col)
+ {
+-  JCOEFPTR quantptr = compptr->dct_table;
++  JCOEFPTR quantptr = dct_table;
+   __m128i coef0, coef1, coef2, coef3, coef4, coef5, coef6, coef7;
+   __m128i tmp0, tmp1, tmp2;
+ 
+@@ -402,12 +401,12 @@ jsimd_idct_islow_lsx(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+   LSX_TRANSPOSE8x8_B(res0, res1, res2, res3, res4, res5, res6, res7,
+                      res0, res1, res2, res3, res4, res5, res6, res7);
+ 
+-  __lsx_vstelm_d(res0, output_buf[0], 0, 0);
+-  __lsx_vstelm_d(res1, output_buf[1], 0, 0);
+-  __lsx_vstelm_d(res2, output_buf[2], 0, 0);
+-  __lsx_vstelm_d(res3, output_buf[3], 0, 0);
+-  __lsx_vstelm_d(res4, output_buf[4], 0, 0);
+-  __lsx_vstelm_d(res5, output_buf[5], 0, 0);
+-  __lsx_vstelm_d(res6, output_buf[6], 0, 0);
+-  __lsx_vstelm_d(res7, output_buf[7], 0, 0);
++  __lsx_vstelm_d(res0, output_buf[0] + output_col, 0, 0);
++  __lsx_vstelm_d(res1, output_buf[1] + output_col, 0, 0);
++  __lsx_vstelm_d(res2, output_buf[2] + output_col, 0, 0);
++  __lsx_vstelm_d(res3, output_buf[3] + output_col, 0, 0);
++  __lsx_vstelm_d(res4, output_buf[4] + output_col, 0, 0);
++  __lsx_vstelm_d(res5, output_buf[5] + output_col, 0, 0);
++  __lsx_vstelm_d(res6, output_buf[6] + output_col, 0, 0);
++  __lsx_vstelm_d(res7, output_buf[7] + output_col, 0, 0);
+ }
+diff --git a/simd/loongarch64/jidctred-lasx.c b/simd/loongarch64/jidctred-lasx.c
+index 5ba48817..46a1643e 100644
+--- a/simd/loongarch64/jidctred-lasx.c
++++ b/simd/loongarch64/jidctred-lasx.c
+@@ -24,10 +24,10 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
++#include "../jsimddct.h"
+ #include "jmacros_lasx.h"
+ 
+ #define DCTSIZE 8
+diff --git a/simd/loongarch64/jidctred-lsx.c b/simd/loongarch64/jidctred-lsx.c
+index b5990cca..c0651df1 100644
+--- a/simd/loongarch64/jidctred-lsx.c
++++ b/simd/loongarch64/jidctred-lsx.c
+@@ -24,10 +24,10 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
++#include "../jsimddct.h"
+ #include "jmacros_lsx.h"
+ 
+ #define DCTSIZE 8
+diff --git a/simd/loongarch64/jquanti-lasx.c b/simd/loongarch64/jquanti-lasx.c
+index 487f897f..cdaaaaf8 100644
+--- a/simd/loongarch64/jquanti-lasx.c
++++ b/simd/loongarch64/jquanti-lasx.c
+@@ -26,8 +26,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+ #include "jmacros_lasx.h"
+ 
+diff --git a/simd/loongarch64/jquanti-lsx.c b/simd/loongarch64/jquanti-lsx.c
+index 8e2c71e1..534e4322 100644
+--- a/simd/loongarch64/jquanti-lsx.c
++++ b/simd/loongarch64/jquanti-lsx.c
+@@ -26,8 +26,8 @@
+ 
+ #define JPEG_INTERNALS
+ #include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
++
++#include "../jsimdint.h"
+ #include "../../src/jdct.h"
+ #include "jmacros_lsx.h"
+ 
+diff --git a/simd/loongarch64/jsimd.c b/simd/loongarch64/jsimd.c
+deleted file mode 100644
+index ec145bdc..00000000
+--- a/simd/loongarch64/jsimd.c
++++ /dev/null
+@@ -1,1060 +0,0 @@
+-/*
+- * jsimd_loongarch64.c
+- *
+- * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
+- * Copyright (C) 2009-2011, 2014, 2016, 2018, D. R. Commander.
+- * Copyright (C) 2013-2014, MIPS Technologies, Inc., California.
+- * Copyright (C) 2015, 2018, Matthieu Darbois.
+- * Copyright (C) 2021, 2023, Loongson Technology Corporation Limited, BeiJing.
+- *
+- * Based on the x86 SIMD extension for IJG JPEG library,
+- * Copyright (C) 1999-2006, MIYASAKA Masaru.
+- * For conditions of distribution and use, see copyright notice in jsimdext.inc
+- *
+- * This file contains the interface between the "normal" portions
+- * of the library and the SIMD implementations when running on a
+- * 64-bit LOONGARCH architecture.
+- */
+-
+-#define JPEG_INTERNALS
+-#include "../../src/jinclude.h"
+-#include "../../src/jpeglib.h"
+-#include "../../src/jsimd.h"
+-#include "../../src/jdct.h"
+-#include "../../src/jsimddct.h"
+-#include "../jsimd.h"
+-
+-#include <ctype.h>
+-#include <sys/auxv.h>
+-#include <asm/hwcap.h>
+-
+-static THREAD_LOCAL unsigned int simd_support = ~0;
+-
+-LOCAL(void)
+-check_loongarch_feature(void)
+-{
+-  simd_support = 0;
+-
+-  uint64_t hwcaps = getauxval(AT_HWCAP);
+-
+-  if (hwcaps & HWCAP_LOONGARCH_LSX)
+-      simd_support |= JSIMD_LSX;
+-  if (hwcaps & HWCAP_LOONGARCH_LASX)
+-      simd_support |= JSIMD_LASX;
+-}
+-
+-/*
+- * Check what SIMD accelerations are supported.
+- */
+-LOCAL(void)
+-init_simd(void)
+-{
+-#ifndef NO_GETENV
+-  char env[2] = { 0 };
+-#endif
+-
+-  if (simd_support != ~0U)
+-    return;
+-
+-  check_loongarch_feature();
+-
+-#ifndef NO_GETENV
+-  /* Force different settings through environment variables */
+-  if (!GETENV_S(env, 2, "JSIMD_FORCELSX") && !strcmp(env, "1"))
+-    simd_support &= JSIMD_LSX;
+-  if (!GETENV_S(env, 2, "JSIMD_FORCELASX") && !strcmp(env, "1"))
+-    simd_support &= JSIMD_LASX;
+-  if (!GETENV_S(env, 2, "JSIMD_FORCENONE") && !strcmp(env, "1"))
+-    simd_support = 0;
+-#endif
+-}
+-
+-GLOBAL(int)
+-jsimd_can_rgb_ycc(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_rgb_gray(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_ycc_rgb(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if ((RGB_PIXELSIZE != 3) && (RGB_PIXELSIZE != 4))
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_ycc_rgb565(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_c_can_null_convert(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_rgb_ycc_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
+-                      JSAMPIMAGE output_buf, JDIMENSION output_row,
+-                      int num_rows)
+-{
+-  void (*lasxfct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+-  void (*lsxfct)(JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+-
+-  switch (cinfo->in_color_space) {
+-  case JCS_EXT_RGB:
+-    lasxfct = jsimd_extrgb_ycc_convert_lasx;
+-    lsxfct = jsimd_extrgb_ycc_convert_lsx;
+-    break;
+-  case JCS_EXT_RGBX:
+-  case JCS_EXT_RGBA:
+-    lasxfct = jsimd_extrgbx_ycc_convert_lasx;
+-    lsxfct = jsimd_extrgbx_ycc_convert_lsx;
+-    break;
+-  case JCS_EXT_BGR:
+-    lasxfct = jsimd_extbgr_ycc_convert_lasx;
+-    lsxfct = jsimd_extbgr_ycc_convert_lsx;
+-    break;
+-  case JCS_EXT_BGRX:
+-  case JCS_EXT_BGRA:
+-    lasxfct = jsimd_extbgrx_ycc_convert_lasx;
+-    lsxfct = jsimd_extbgrx_ycc_convert_lsx;
+-    break;
+-  case JCS_EXT_XBGR:
+-  case JCS_EXT_ABGR:
+-    lasxfct = jsimd_extxbgr_ycc_convert_lasx;
+-    lsxfct = jsimd_extxbgr_ycc_convert_lsx;
+-    break;
+-  case JCS_EXT_XRGB:
+-  case JCS_EXT_ARGB:
+-    lasxfct = jsimd_extxrgb_ycc_convert_lasx;
+-    lsxfct = jsimd_extxrgb_ycc_convert_lsx;
+-    break;
+-  default:
+-    lasxfct = jsimd_rgb_ycc_convert_lasx;
+-    lsxfct = jsimd_rgb_ycc_convert_lsx;
+-    break;
+-  }
+-
+-  if (simd_support & JSIMD_LASX)
+-    lasxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+-  else if (simd_support & JSIMD_LSX)
+-    lsxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+-}
+-
+-GLOBAL(void)
+-jsimd_rgb_gray_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
+-                       JSAMPIMAGE output_buf, JDIMENSION output_row,
+-                       int num_rows)
+-{
+-  void (*lasxfct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+-  void (*lsxfct) (JDIMENSION, JSAMPARRAY, JSAMPIMAGE, JDIMENSION, int);
+-
+-  switch (cinfo->in_color_space) {
+-  case JCS_EXT_RGB:
+-    lasxfct = jsimd_extrgb_gray_convert_lasx;
+-    lsxfct = jsimd_extrgb_gray_convert_lsx;
+-    break;
+-  case JCS_EXT_RGBX:
+-  case JCS_EXT_RGBA:
+-    lasxfct = jsimd_extrgbx_gray_convert_lasx;
+-    lsxfct = jsimd_extrgbx_gray_convert_lsx;
+-    break;
+-  case JCS_EXT_BGR:
+-    lasxfct = jsimd_extbgr_gray_convert_lasx;
+-    lsxfct = jsimd_extbgr_gray_convert_lsx;
+-    break;
+-  case JCS_EXT_BGRX:
+-  case JCS_EXT_BGRA:
+-    lasxfct = jsimd_extbgrx_gray_convert_lasx;
+-    lsxfct = jsimd_extbgrx_gray_convert_lsx;
+-    break;
+-  case JCS_EXT_XBGR:
+-  case JCS_EXT_ABGR:
+-    lasxfct = jsimd_extxbgr_gray_convert_lasx;
+-    lsxfct = jsimd_extxbgr_gray_convert_lsx;
+-    break;
+-  case JCS_EXT_XRGB:
+-  case JCS_EXT_ARGB:
+-    lasxfct = jsimd_extxrgb_gray_convert_lasx;
+-    lsxfct = jsimd_extxrgb_gray_convert_lsx;
+-    break;
+-  default:
+-    lasxfct = jsimd_rgb_gray_convert_lasx;
+-    lsxfct = jsimd_rgb_gray_convert_lsx;
+-    break;
+-  }
+-
+-  if (simd_support & JSIMD_LASX)
+-    lasxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+-  else if (simd_support & JSIMD_LSX)
+-    lsxfct(cinfo->image_width, input_buf, output_buf, output_row, num_rows);
+-}
+-
+-GLOBAL(void)
+-jsimd_ycc_rgb_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+-                      JDIMENSION input_row, JSAMPARRAY output_buf,
+-                      int num_rows)
+-{
+-  void (*lasxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
+-  void (*lsxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY, int);
+-
+-  switch (cinfo->out_color_space) {
+-  case JCS_EXT_RGB:
+-    lasxfct = jsimd_ycc_extrgb_convert_lasx;
+-    lsxfct = jsimd_ycc_extrgb_convert_lsx;
+-    break;
+-  case JCS_EXT_RGBX:
+-  case JCS_EXT_RGBA:
+-    lasxfct = jsimd_ycc_extrgbx_convert_lasx;
+-    lsxfct = jsimd_ycc_extrgbx_convert_lsx;
+-    break;
+-  case JCS_EXT_BGR:
+-    lasxfct = jsimd_ycc_extbgr_convert_lasx;
+-    lsxfct = jsimd_ycc_extbgr_convert_lsx;
+-    break;
+-  case JCS_EXT_BGRX:
+-  case JCS_EXT_BGRA:
+-    lasxfct = jsimd_ycc_extbgrx_convert_lasx;
+-    lsxfct = jsimd_ycc_extbgrx_convert_lsx;
+-    break;
+-  case JCS_EXT_XBGR:
+-  case JCS_EXT_ABGR:
+-    lasxfct = jsimd_ycc_extxbgr_convert_lasx;
+-    lsxfct = jsimd_ycc_extxbgr_convert_lsx;
+-    break;
+-  case JCS_EXT_XRGB:
+-  case JCS_EXT_ARGB:
+-    lasxfct = jsimd_ycc_extxrgb_convert_lasx;
+-    lsxfct = jsimd_ycc_extxrgb_convert_lsx;
+-    break;
+-  default:
+-    lasxfct = jsimd_ycc_rgb_convert_lasx;
+-    lsxfct = jsimd_ycc_rgb_convert_lsx;
+-    break;
+-  }
+-
+-  if (simd_support & JSIMD_LASX)
+-    lasxfct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
+-  else if (simd_support & JSIMD_LSX)
+-    lsxfct(cinfo->output_width, input_buf, input_row, output_buf, num_rows);
+-}
+-
+-GLOBAL(void)
+-jsimd_ycc_rgb565_convert(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+-                         JDIMENSION input_row, JSAMPARRAY output_buf,
+-                         int num_rows)
+-{
+-}
+-
+-GLOBAL(void)
+-jsimd_c_null_convert(j_compress_ptr cinfo, JSAMPARRAY input_buf,
+-                     JSAMPIMAGE output_buf, JDIMENSION output_row,
+-                     int num_rows)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v2_downsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v2_smooth_downsample(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v1_downsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v2_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
+-                      JSAMPARRAY input_data, JSAMPARRAY output_data)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_h2v2_downsample_lasx(cinfo->image_width, cinfo->max_v_samp_factor,
+-                               compptr->v_samp_factor, compptr->width_in_blocks,
+-                               input_data, output_data);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_h2v2_downsample_lsx(cinfo->image_width, cinfo->max_v_samp_factor,
+-                              compptr->v_samp_factor, compptr->width_in_blocks,
+-                              input_data, output_data);
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v2_smooth_downsample(j_compress_ptr cinfo,
+-                             jpeg_component_info *compptr,
+-                             JSAMPARRAY input_data, JSAMPARRAY output_data)
+-{
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v1_downsample(j_compress_ptr cinfo, jpeg_component_info *compptr,
+-                      JSAMPARRAY input_data, JSAMPARRAY output_data)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_h2v1_downsample_lasx(cinfo->image_width, cinfo->max_v_samp_factor,
+-                               compptr->v_samp_factor, compptr->width_in_blocks,
+-                               input_data, output_data);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_h2v1_downsample_lsx(cinfo->image_width, cinfo->max_v_samp_factor,
+-                              compptr->v_samp_factor, compptr->width_in_blocks,
+-                              input_data, output_data);
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v2_upsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v1_upsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_int_upsample(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v2_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                    JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_h2v2_upsample_lasx(cinfo->max_v_samp_factor, cinfo->output_width,
+-                             input_data, output_data_ptr);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_h2v2_upsample_lsx(cinfo->max_v_samp_factor, cinfo->output_width,
+-                            input_data, output_data_ptr);
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v1_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                    JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_h2v1_upsample_lasx(cinfo->max_v_samp_factor, cinfo->output_width,
+-                             input_data, output_data_ptr);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_h2v1_upsample_lsx(cinfo->max_v_samp_factor, cinfo->output_width,
+-                            input_data, output_data_ptr);
+-}
+-
+-GLOBAL(void)
+-jsimd_int_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                   JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v2_fancy_upsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v1_fancy_upsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v2_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                          JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_h2v2_fancy_upsample_lasx(cinfo->max_v_samp_factor,
+-                                   compptr->downsampled_width, input_data,
+-                                   output_data_ptr);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_h2v2_fancy_upsample_lsx(cinfo->max_v_samp_factor,
+-                                  compptr->downsampled_width, input_data,
+-                                  output_data_ptr);
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v1_fancy_upsample(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                          JSAMPARRAY input_data, JSAMPARRAY *output_data_ptr)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_h2v1_fancy_upsample_lasx(cinfo->max_v_samp_factor,
+-                                   compptr->downsampled_width, input_data,
+-                                   output_data_ptr);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_h2v1_fancy_upsample_lsx(cinfo->max_v_samp_factor,
+-                                  compptr->downsampled_width, input_data,
+-                                  output_data_ptr);
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v2_merged_upsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_h2v1_merged_upsample(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v2_merged_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+-                           JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf)
+-{
+-  void (*lasxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+-  void (*lsxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+-
+-  switch (cinfo->out_color_space) {
+-  case JCS_EXT_RGB:
+-    lasxfct = jsimd_h2v2_extrgb_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_extrgb_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_RGBX:
+-  case JCS_EXT_RGBA:
+-    lasxfct = jsimd_h2v2_extrgbx_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_extrgbx_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_BGR:
+-    lasxfct = jsimd_h2v2_extbgr_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_extbgr_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_BGRX:
+-  case JCS_EXT_BGRA:
+-    lasxfct = jsimd_h2v2_extbgrx_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_extbgrx_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_XBGR:
+-  case JCS_EXT_ABGR:
+-    lasxfct = jsimd_h2v2_extxbgr_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_extxbgr_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_XRGB:
+-  case JCS_EXT_ARGB:
+-    lasxfct = jsimd_h2v2_extxrgb_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_extxrgb_merged_upsample_lsx;
+-    break;
+-  default:
+-    lasxfct = jsimd_h2v2_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v2_merged_upsample_lsx;
+-    break;
+-  }
+-
+-  if (simd_support & JSIMD_LASX)
+-    lasxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+-  else if (simd_support & JSIMD_LSX)
+-    lsxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+-}
+-
+-GLOBAL(void)
+-jsimd_h2v1_merged_upsample(j_decompress_ptr cinfo, JSAMPIMAGE input_buf,
+-                           JDIMENSION in_row_group_ctr, JSAMPARRAY output_buf)
+-{
+-  void (*lasxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+-  void (*lsxfct) (JDIMENSION, JSAMPIMAGE, JDIMENSION, JSAMPARRAY);
+-
+-  switch (cinfo->out_color_space) {
+-  case JCS_EXT_RGB:
+-    lasxfct = jsimd_h2v1_extrgb_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_extrgb_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_RGBX:
+-  case JCS_EXT_RGBA:
+-    lasxfct = jsimd_h2v1_extrgbx_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_extrgbx_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_BGR:
+-    lasxfct = jsimd_h2v1_extbgr_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_extbgr_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_BGRX:
+-  case JCS_EXT_BGRA:
+-    lasxfct = jsimd_h2v1_extbgrx_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_extbgrx_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_XBGR:
+-  case JCS_EXT_ABGR:
+-    lasxfct = jsimd_h2v1_extxbgr_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_extxbgr_merged_upsample_lsx;
+-    break;
+-  case JCS_EXT_XRGB:
+-  case JCS_EXT_ARGB:
+-    lasxfct = jsimd_h2v1_extxrgb_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_extxrgb_merged_upsample_lsx;
+-    break;
+-  default:
+-    lasxfct = jsimd_h2v1_merged_upsample_lasx;
+-    lsxfct = jsimd_h2v1_merged_upsample_lsx;
+-    break;
+-  }
+-
+-  if (simd_support & JSIMD_LASX)
+-    lasxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+-  else if (simd_support & JSIMD_LSX)
+-    lsxfct(cinfo->output_width, input_buf, in_row_group_ctr, output_buf);
+-}
+-
+-GLOBAL(int)
+-jsimd_can_convsamp(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if (sizeof(DCTELEM) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_convsamp_float(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_convsamp(JSAMPARRAY sample_data, JDIMENSION start_col,
+-               DCTELEM *workspace)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_convsamp_lasx(sample_data, start_col, workspace);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_convsamp_lsx(sample_data, start_col, workspace);
+-}
+-
+-GLOBAL(void)
+-jsimd_convsamp_float(JSAMPARRAY sample_data, JDIMENSION start_col,
+-                     FAST_FLOAT *workspace)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_fdct_islow(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(DCTELEM) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_fdct_ifast(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(DCTELEM) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_fdct_float(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_fdct_islow(DCTELEM *data)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_fdct_islow_lasx(data);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_fdct_islow_lsx(data);
+-}
+-
+-GLOBAL(void)
+-jsimd_fdct_ifast(DCTELEM *data)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_fdct_ifast_lasx(data);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_fdct_ifast_lsx(data);
+-}
+-
+-GLOBAL(void)
+-jsimd_fdct_float(FAST_FLOAT *data)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_quantize(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(JCOEF) != 2)
+-    return 0;
+-  if (sizeof(DCTELEM) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_quantize_float(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_quantize(JCOEFPTR coef_block, DCTELEM *divisors, DCTELEM *workspace)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_quantize_lasx(coef_block, divisors, workspace);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_quantize_lsx(coef_block, divisors, workspace);
+-}
+-
+-GLOBAL(void)
+-jsimd_quantize_float(JCOEFPTR coef_block, FAST_FLOAT *divisors,
+-                     FAST_FLOAT *workspace)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_2x2(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(JCOEF) != 2)
+-    return 0;
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if (sizeof(ISLOW_MULT_TYPE) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_4x4(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(JCOEF) != 2)
+-    return 0;
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if (sizeof(ISLOW_MULT_TYPE) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_6x6(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_12x12(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_2x2(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-               JDIMENSION output_col)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_idct_2x2_lasx(compptr->dct_table, coef_block, output_buf, output_col);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_idct_2x2_lsx(compptr->dct_table, coef_block, output_buf, output_col);
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_4x4(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-               JDIMENSION output_col)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_idct_4x4_lasx(compptr->dct_table, coef_block, output_buf, output_col);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_idct_4x4_lsx(compptr->dct_table, coef_block, output_buf, output_col);
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_6x6(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-               JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-               JDIMENSION output_col)
+-{
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_12x12(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-                 JDIMENSION output_col)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_islow(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(JCOEF) != 2)
+-    return 0;
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if (sizeof(ISLOW_MULT_TYPE) != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_ifast(void)
+-{
+-  init_simd();
+-
+-  /* The code is optimised for these values only */
+-  if (DCTSIZE != 8)
+-    return 0;
+-  if (sizeof(JCOEF) != 2)
+-    return 0;
+-  if (BITS_IN_JSAMPLE != 8)
+-    return 0;
+-  if (sizeof(JDIMENSION) != 4)
+-    return 0;
+-  if (sizeof(IFAST_MULT_TYPE) != 2)
+-    return 0;
+-  if (IFAST_SCALE_BITS != 2)
+-    return 0;
+-
+-  if (simd_support & JSIMD_LASX)
+-    return 1;
+-  if (simd_support & JSIMD_LSX)
+-    return 1;
+-
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_idct_float(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_islow(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-                 JDIMENSION output_col)
+-{
+-  unsigned char *output[8] = {
+-    output_buf[0] + output_col,
+-    output_buf[1] + output_col,
+-    output_buf[2] + output_col,
+-    output_buf[3] + output_col,
+-    output_buf[4] + output_col,
+-    output_buf[5] + output_col,
+-    output_buf[6] + output_col,
+-    output_buf[7] + output_col,
+-  };
+-
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_idct_islow_lasx(cinfo, compptr, coef_block, output, output_col);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_idct_islow_lsx(cinfo, compptr, coef_block, output, output_col);
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_ifast(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-                 JDIMENSION output_col)
+-{
+-  if (simd_support & JSIMD_LASX)
+-    jsimd_idct_ifast_lasx(compptr->dct_table, coef_block, output_buf,
+-                          output_col);
+-  else if (simd_support & JSIMD_LSX)
+-    jsimd_idct_ifast_lsx(compptr->dct_table, coef_block, output_buf,
+-                         output_col);
+-}
+-
+-GLOBAL(void)
+-jsimd_idct_float(j_decompress_ptr cinfo, jpeg_component_info *compptr,
+-                 JCOEFPTR coef_block, JSAMPARRAY output_buf,
+-                 JDIMENSION output_col)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_huff_encode_one_block(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(JOCTET *)
+-jsimd_huff_encode_one_block(void *state, JOCTET *buffer, JCOEFPTR block,
+-                            int last_dc_val, c_derived_tbl *dctbl,
+-                            c_derived_tbl *actbl)
+-{
+-  return NULL;
+-}
+-
+-GLOBAL(int)
+-jsimd_can_encode_mcu_AC_first_prepare(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(void)
+-jsimd_encode_mcu_AC_first_prepare(const JCOEF *block,
+-                                  const int *jpeg_natural_order_start, int Sl,
+-                                  int Al, UJCOEF *values, size_t *zerobits)
+-{
+-}
+-
+-GLOBAL(int)
+-jsimd_can_encode_mcu_AC_refine_prepare(void)
+-{
+-  return 0;
+-}
+-
+-GLOBAL(int)
+-jsimd_encode_mcu_AC_refine_prepare(const JCOEF *block,
+-                                   const int *jpeg_natural_order_start, int Sl,
+-                                   int Al, UJCOEF *absvalues, size_t *bits)
+-{
+-  return 0;
+-}
+diff --git a/simd/loongarch64/jsimdcpu.c b/simd/loongarch64/jsimdcpu.c
+new file mode 100644
+index 00000000..d1022a5b
+--- /dev/null
++++ b/simd/loongarch64/jsimdcpu.c
+@@ -0,0 +1,47 @@
++/*
++ * Copyright 2009 Pierre Ossman <ossman@cendio.se> for Cendio AB
++ * Copyright (C) 2009-2011, 2014, 2016, 2018, 2020, 2022, 2025,
++ *           D. R. Commander.
++ * Copyright (C) 2013-2014, MIPS Technologies, Inc., California.
++ * Copyright (C) 2015, 2018, Matthieu Darbois.
++ * Copyright (C) 2021, 2023, Loongson Technology Corporation Limited, BeiJing.
++ *
++ * This software is provided 'as-is', without any express or implied
++ * warranty.  In no event will the authors be held liable for any damages
++ * arising from the use of this software.
++ *
++ * Permission is granted to anyone to use this software for any purpose,
++ * including commercial applications, and to alter it and redistribute it
++ * freely, subject to the following restrictions:
++ *
++ * 1. The origin of this software must not be misrepresented; you must not
++ *    claim that you wrote the original software. If you use this software
++ *    in a product, an acknowledgment in the product documentation would be
++ *    appreciated but is not required.
++ * 2. Altered source versions must be plainly marked as such, and must not be
++ *    misrepresented as being the original software.
++ * 3. This notice may not be removed or altered from any source distribution.
++ *
++ * This file contains the interface between the "normal" portions
++ * of the library and the SIMD implementations when running on a
++ * 64-bit LOONGARCH architecture.
++ */
++
++#include "../jsimdint.h"
++
++#include <sys/auxv.h>
++#include <asm/hwcap.h>
++
++HIDDEN unsigned int
++jpeg_simd_cpu_support(void)
++{
++  unsigned int simd_support = 0;
++  uint64_t hwcaps = getauxval(AT_HWCAP);
++
++  if (hwcaps & HWCAP_LOONGARCH_LSX)
++    simd_support |= JSIMD_LSX;
++  if (hwcaps & HWCAP_LOONGARCH_LASX)
++    simd_support |= JSIMD_LASX;
++
++  return simd_support;
++}
+-- 
+2.52.0
+

--- a/runtime-imaging/libjpeg-turbo/spec
+++ b/runtime-imaging/libjpeg-turbo/spec
@@ -2,3 +2,4 @@ VER=3.2.0
 SRCS="git::commit=tags/$VER::https://github.com/libjpeg-turbo/libjpeg-turbo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1648"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- libjpeg-turbo: add LSX/LASX optimisation patch
    Signed-off-by: elysia-best <a.elysia@proton.me>

Package(s) Affected
-------------------

- libjpeg-turbo: 2:3.2.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libjpeg-turbo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
