### PR TITLE
ttf-deepin-opensymbol: new, 2.2

### DIFF
--- a/desktop-fonts/ttf-deepin-opensymbol/autobuild/build
+++ b/desktop-fonts/ttf-deepin-opensymbol/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Installing Deepin OpenSymbol font files ..."
+install -Dvm644 "$SRCDIR"/*.ttf \
+    -t "$PKGDIR"/usr/share/fonts/TTF/
+
+abinfo "Installing license ..."
+install -Dvm644 "$SRCDIR"/license \
+    "$PKGDIR"/usr/share/doc/deepin-opensymbol-fonts/license

--- a/desktop-fonts/ttf-deepin-opensymbol/autobuild/defines
+++ b/desktop-fonts/ttf-deepin-opensymbol/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=ttf-deepin-opensymbol
+PKGSEC=non-free/fonts
+PKGDEP="fontconfig"
+PKGDES="Deepin OpenSymbol symbol fonts"
+
+ABHOST=noarch

--- a/desktop-fonts/ttf-deepin-opensymbol/spec
+++ b/desktop-fonts/ttf-deepin-opensymbol/spec
@@ -1,0 +1,6 @@
+VER=2.2
+SRCS="tbl::https://cdimage.deepin.com/applications/ttf-deepin-opensymbol/DeepinOpenSymbol_V$VER.zip \
+      file::rename=license::https://raw.githubusercontent.com/linuxdeepin/ttf-deepin-opensymbol/$VER/license"
+CHKSUMS="sha256::866cd726d2c2f39e6a4c094e255b024d0e2c3862ef3af74d39410555b119abba \
+         sha256::408f1fd6d958cca631ad4c011efd7fca83656be2e7ba4ff630f60b97535fe29a"
+CHKUPDATE="anitya::id=391093"


### PR DESCRIPTION
Topic Description
-----------------

- ttf-deepin-opensymbol: new, 2.2

Package(s) Affected
-------------------

- ttf-deepin-opensymbol: 2.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ttf-deepin-opensymbol
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
