### PR TITLE
c-ares: security update to 1.34.8

### DIFF
--- a/runtime-network/c-ares/autobuild/defines
+++ b/runtime-network/c-ares/autobuild/defines
@@ -1,5 +1,5 @@
-PKGNAME="c-ares"
-PKGDES="C library that performs DNS requests and name resolves asynchronously"
+PKGNAME=c-ares
+PKGDES="C library to asynchronously perform DNS requests and name resolutions"
 PKGDEP="glibc"
 PKGSEC=libs
 

--- a/runtime-network/c-ares/spec
+++ b/runtime-network/c-ares/spec
@@ -1,4 +1,4 @@
-VER=1.34.6
+VER=1.34.8
 SRCS="git::commit=tags/v$VER::https://github.com/c-ares/c-ares"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5840"

--- a/topics/c-ares-1.34.8.toml
+++ b/topics/c-ares-1.34.8.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "c-ares 1.34.8"
+
+[caution]
+default = "Fixes a Use-After-Free vulnerability (CVE-2026-33630, Severity: High)"
+zh_CN = "修复 1 个释放后使用漏洞（漏洞编号 CVE-2026-33630，严重性：高）"
+
+[packages-v2]
+"c-ares" = "< 1.34.8"


### PR DESCRIPTION
Topic Description
-----------------

- c-ares: security update to 1.34.8

Package(s) Affected
-------------------

- c-ares: 1.34.8

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit c-ares
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
