### PR TITLE
binutils: backport a LoongArch alignment fix

### DIFF
--- a/app-devel/binutils/01-main/patches/0001-UPSTREAM-LoongArch-Fix-linker-relaxation-alignment.patch
+++ b/app-devel/binutils/01-main/patches/0001-UPSTREAM-LoongArch-Fix-linker-relaxation-alignment.patch
@@ -1,0 +1,141 @@
+From 9eb12706246ecf11d89e0e61275e0ac2b141fa01 Mon Sep 17 00:00:00 2001
+From: mengqinggang <mengqinggang@loongson.cn>
+Date: Tue, 16 Jun 2026 19:10:26 +0800
+Subject: [PATCH 1/2] UPSTREAM: LoongArch: Fix linker relaxation alignment
+
+When linking multiple objects, relaxation can cause alignment issues.
+Input section's output_offset is updated in relaxation without considering
+alignment. Update section output_offset by align_opwer.
+
+(cherry picked from commit 7858cadd335b3ffbc8e0250c0c180253d9f09489)
+---
+ bfd/elfnn-loongarch.c                         | 24 +++----------------
+ ld/testsuite/ld-loongarch-elf/relax-align-1.d | 13 ++++++++++
+ .../ld-loongarch-elf/relax-align-1a.s         |  5 ++++
+ .../ld-loongarch-elf/relax-align-1b.s         |  3 +++
+ ld/testsuite/ld-loongarch-elf/relax.exp       |  4 ++++
+ 5 files changed, 28 insertions(+), 21 deletions(-)
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-align-1.d
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-align-1a.s
+ create mode 100644 ld/testsuite/ld-loongarch-elf/relax-align-1b.s
+
+diff --git a/bfd/elfnn-loongarch.c b/bfd/elfnn-loongarch.c
+index 2c67cccd9fb..3bce672ba91 100644
+--- a/bfd/elfnn-loongarch.c
++++ b/bfd/elfnn-loongarch.c
+@@ -5715,11 +5715,6 @@ loongarch_relax_pcala_addi (bfd *abfd, asection *sec, asection *sym_sec,
+   uint32_t add = bfd_get (32, abfd, contents + rel_lo->r_offset);
+   uint32_t rd = LARCH_GET_RD (pca);
+ 
+-  /* This section's output_offset need to subtract the bytes of instructions
+-     relaxed by the previous sections, so it needs to be updated beforehand.
+-     size_input_section already took care of updating it after relaxation,
+-     so we additionally update once here.  */
+-  sec->output_offset = sec->output_section->size;
+   bfd_vma pc = sec_addr (sec)
+ 	       + loongarch_calc_relaxed_addr (info, rel_hi->r_offset);
+   if (sym_sec == sec)
+@@ -5780,11 +5775,6 @@ loongarch_relax_call36 (bfd *abfd, asection *sec, asection *sym_sec,
+   uint32_t jirl = bfd_get (32, abfd, contents + rel->r_offset + 4);
+   uint32_t rd = LARCH_GET_RD (jirl);
+ 
+-  /* This section's output_offset need to subtract the bytes of instructions
+-     relaxed by the previous sections, so it needs to be updated beforehand.
+-     size_input_section already took care of updating it after relaxation,
+-     so we additionally update once here.  */
+-  sec->output_offset = sec->output_section->size;
+   bfd_vma pc = sec_addr (sec)
+ 	       + loongarch_calc_relaxed_addr (info, rel->r_offset);
+   if (sym_sec == sec)
+@@ -5841,11 +5831,6 @@ loongarch_relax_pcala_ld (bfd *abfd, asection *sec,
+ 			  bool *again ATTRIBUTE_UNUSED,
+ 			  bfd_vma max_alignment)
+ {
+-  /* This section's output_offset need to subtract the bytes of instructions
+-     relaxed by the previous sections, so it needs to be updated beforehand.
+-     size_input_section already took care of updating it after relaxation,
+-     so we additionally update once here.  */
+-  sec->output_offset = sec->output_section->size;
+   bfd_vma pc = sec_addr (sec)
+ 	       + loongarch_calc_relaxed_addr (info, rel_hi->r_offset);
+   if (sym_sec == sec)
+@@ -5998,11 +5983,6 @@ loongarch_relax_tls_ld_gd_desc (bfd *abfd, asection *sec, asection *sym_sec,
+   uint32_t add = bfd_get (32, abfd, contents + rel_lo->r_offset);
+   uint32_t rd = LARCH_GET_RD (pca);
+ 
+-  /* This section's output_offset need to subtract the bytes of instructions
+-     relaxed by the previous sections, so it needs to be updated beforehand.
+-     size_input_section already took care of updating it after relaxation,
+-     so we additionally update once here.  */
+-  sec->output_offset = sec->output_section->size;
+   bfd_vma pc = sec_addr (sec)
+ 	       + loongarch_calc_relaxed_addr (info, rel_hi->r_offset);
+   if (sym_sec == sec)
+@@ -6177,7 +6157,9 @@ loongarch_elf_relax_section (bfd *abfd, asection *sec,
+      so we additionally update once here.  */
+ 
+   /* update before tls trans and relax, or may cause same pcadd_hi20 address.  */
+-  sec->output_offset = sec->output_section->size;
++
++  sec->output_offset = align_power (sec->output_section->size,
++				    sec->alignment_power);
+ 
+   for (unsigned int i = 0; i < sec->reloc_count; i++)
+     {
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-align-1.d b/ld/testsuite/ld-loongarch-elf/relax-align-1.d
+new file mode 100644
+index 00000000000..5681efb16d1
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-align-1.d
+@@ -0,0 +1,13 @@
++#source: relax-align-1a.s
++#source: relax-align-1b.s
++#ld: -e0
++#objdump: -d
++
++#...
++.*:	54000400 	bl          	4.*<f>
++#...
++.*[0|8]:	02c001ac 	addi.d      	\$t0, \$t1, 0
++#...
++.*0:	02c005ac 	addi.d      	\$t0, \$t1, 1
++#...
++.*0:	02c005ac 	addi.d      	\$t0, \$t1, 1
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-align-1a.s b/ld/testsuite/ld-loongarch-elf/relax-align-1a.s
+new file mode 100644
+index 00000000000..2b7f3ecb6be
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-align-1a.s
+@@ -0,0 +1,5 @@
++.text
++  call f
++f:
++  .align 3
++  addi.d $t0, $t1, 0
+diff --git a/ld/testsuite/ld-loongarch-elf/relax-align-1b.s b/ld/testsuite/ld-loongarch-elf/relax-align-1b.s
+new file mode 100644
+index 00000000000..2ed480a6c1b
+--- /dev/null
++++ b/ld/testsuite/ld-loongarch-elf/relax-align-1b.s
+@@ -0,0 +1,3 @@
++addi.d $t0, $t1, 1
++.align 4
++addi.d $t0, $t1, 1
+diff --git a/ld/testsuite/ld-loongarch-elf/relax.exp b/ld/testsuite/ld-loongarch-elf/relax.exp
+index 7c32a65244c..31787a93967 100644
+--- a/ld/testsuite/ld-loongarch-elf/relax.exp
++++ b/ld/testsuite/ld-loongarch-elf/relax.exp
+@@ -46,6 +46,10 @@ proc run_partial_linking_align_test {} {
+   }
+ }
+ 
++if [istarget loongarch*-*-*] {
++  run_dump_test "relax-align-1"
++}
++
+ if [istarget loongarch64-*-*] {
+   if [isbuild loongarch64-*-*] {
+     run_dump_test "relax-align-ignore-start"
+-- 
+2.55.0
+

--- a/app-devel/binutils/01-main/patches/0002-AOSCOS-libiberty-append-O2-to-cpp-invocations.patch
+++ b/app-devel/binutils/01-main/patches/0002-AOSCOS-libiberty-append-O2-to-cpp-invocations.patch
@@ -1,7 +1,7 @@
-From accbeabfbb56eafbf476fcda2bedff4a5046ea80 Mon Sep 17 00:00:00 2001
+From b4d279704a0e79c8cbaf54dbd66024f07b170169 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 2 Feb 2025 23:52:54 +0800
-Subject: [PATCH] AOSCOS: libiberty: append -O2 to cpp invocations
+Subject: [PATCH 2/2] AOSCOS: libiberty: append -O2 to cpp invocations
 
 In the current autobuild version, CPPFLAGS contains -D_FORTIFY_SOURCE=3
 without -O.  Thus the preprocessor will emit a warning, causing the
@@ -103,5 +103,5 @@ index 4c72b5a9283..d84ef723a20 100755
  ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
  ac_compiler_gnu=$ac_cv_c_compiler_gnu
 -- 
-2.52.0
+2.55.0
 

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -2,3 +2,4 @@ VER=2.46.1
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::e127a709cba24c76de8936cb7083dd768f28cd37eb010492e2f19b71eb1294e4"
 CHKUPDATE="anitya::id=7981"
+REL=1

--- a/runtime-common/libffi/spec
+++ b/runtime-common/libffi/spec
@@ -1,5 +1,4 @@
-VER=3.4.8
+VER=3.6.0
 SRCS="tbl::https://github.com/libffi/libffi/releases/download/v${VER}/libffi-${VER}.tar.gz"
-CHKSUMS="sha256::bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b"
+CHKSUMS="sha256::31ff1fe32deaebfbb388727f32677bb254bf2a41382c51464c0b1837c9ee9828"
 CHKUPDATE="anitya::id=1611"
-REL=1


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- binutils: backport a LoongArch alignment fix
    - Tracking AOSC patches at AOSC-Tracking/binutils-gdb @
      aosc/binutils-2_46_1 (HEAD: b4d279704a0e79c8cbaf54dbd66024f07b170169)
- libffi: update to 3.6.0
    - Rebuild with patched binutils to avoid the slower fall back path
      triggered by the misalignment of the static trampoline table on
      LoongArch.


Package(s) Affected
-------------------

- binutils: `2.46.1-1`
- libffi: `3.6.0`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit binutils libffi
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
