### PR TITLE
CHKUPDATE typo fix survey 20260709

### DIFF
--- a/app-devel/conan/spec
+++ b/app-devel/conan/spec
@@ -1,4 +1,4 @@
 VER=2.27.1
 SRCS="git::commit=tags/$VER::https://github.com/conan-io/conan"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=34518"
+CHKUPDATE="anitya::id=34518"

--- a/app-games/dsda-doom/spec
+++ b/app-games/dsda-doom/spec
@@ -1,5 +1,5 @@
 VER=0.28.3
 SRCS="git::commit=tags/v$VER::https://github.com/kraflab/dsda-doom"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=337710"
+CHKUPDATE="anitya::id=337710"
 SUBDIR="dsda-doom/prboom2"

--- a/app-multimedia/cyanrip/spec
+++ b/app-multimedia/cyanrip/spec
@@ -2,4 +2,4 @@ VER=0.9.3.1
 REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/cyanreg/cyanrip"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=365884"
+CHKUPDATE="anitya::id=365884"

--- a/app-multimedia/electron-netease-cloud-music/spec
+++ b/app-multimedia/electron-netease-cloud-music/spec
@@ -2,4 +2,4 @@ VER=0.9.40
 
 SRCS="git::commit=tags/v$VER::https://github.com/Rocket1184/electron-netease-cloud-music.git"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=371637"
+CHKUPDATE="anitya::id=371637"

--- a/app-multimedia/spek-x/spec
+++ b/app-multimedia/spek-x/spec
@@ -2,4 +2,4 @@ VER=0.9.4
 REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/MikeWang000000/spek-X"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=377561"
+CHKUPDATE="anitya::id=377561"

--- a/app-utils/wtype/spec
+++ b/app-utils/wtype/spec
@@ -1,4 +1,4 @@
 VER=0.4
 SRCS="git::commit=tags/v$VER::https://github.com/atx/wtype"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=206490"
+CHKUPDATE="anitya::id=206490"

--- a/app-virtualization/muvm/spec
+++ b/app-virtualization/muvm/spec
@@ -1,4 +1,4 @@
 VER=0.4.1
 SRCS="git::commit=muvm-$VER::https://github.com/AsahiLinux/muvm.git"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=374721"
+CHKUPDATE="anitya::id=374721"

--- a/desktop-fonts/humor-sans/spec
+++ b/desktop-fonts/humor-sans/spec
@@ -1,4 +1,4 @@
 VER=1.0
-SRCS="file::http://antiyawn.com/uploads/Humor-Sans-$VER.ttf"
+SRCS="file::http://anityawn.com/uploads/Humor-Sans-$VER.ttf"
 CHKSUMS="sha256::2ded6a27448c9ed30aaff177744e2bcf1e52e0aab018b2a8be64565df633318f"
 REL=1

--- a/runtime-desktop/kdsingleapplication/spec
+++ b/runtime-desktop/kdsingleapplication/spec
@@ -1,5 +1,5 @@
 VER=1.2.0
 SRCS="git::commit=tags/v$VER::https://github.com/KDAB/KDSingleApplication"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=370439"
+CHKUPDATE="anitya::id=370439"
 REL=4

--- a/runtime-multimedia/dumb/spec
+++ b/runtime-multimedia/dumb/spec
@@ -1,4 +1,4 @@
 VER=2.0.3
 SRCS="git::commit=tags/$VER::https://github.com/kode54/dumb"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=9737"
+CHKUPDATE="anitya::id=9737"

--- a/runtime-multimedia/libebur128/spec
+++ b/runtime-multimedia/libebur128/spec
@@ -1,4 +1,4 @@
 VER=1.2.6
 SRCS="git::commit=tags/v$VER::https://github.com/jiixyj/libebur128"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=7316"
+CHKUPDATE="anitya::id=7316"

--- a/runtime-virtualization/libkrunfw/spec
+++ b/runtime-virtualization/libkrunfw/spec
@@ -1,5 +1,5 @@
 VER=4.10.0
 SRCS="git::commit=v$VER::https://github.com/containers/libkrunfw.git"
 CHKSUMS="SKIP"
-CHKUPDATE="antiya::id=380818"
+CHKUPDATE="anitya::id=380818"
 REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- libkrunfw: fix CHKUPDATE: antiya => anitya
- libebur128: fix CHKUPDATE: antiya => anitya
- dumb: fix CHKUPDATE: antiya => anitya
- kdsingleapplication: fix CHKUPDATE: antiya => anitya
- humor-sans: fix CHKUPDATE: antiya => anitya
- muvm: fix CHKUPDATE: antiya => anitya
- wtype: fix CHKUPDATE: antiya => anitya
- spek-x: fix CHKUPDATE: antiya => anitya
- electron-netease-cloud-music: fix CHKUPDATE: antiya => anitya
- cyanrip: fix CHKUPDATE: antiya => anitya

... and 2 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
