### PR TITLE
libebur128: drop redundant package in tree

### DIFF
--- a/runtime-common/libebur128/autobuild/defines
+++ b/runtime-common/libebur128/autobuild/defines
@@ -1,4 +1,0 @@
-PKGNAME=libebur128
-PKGSEC=libs
-PKGDEP="glibc cmake"
-PKGDES="A library that implements the EBU R 128 standard for loudness normalisation"

--- a/runtime-common/libebur128/spec
+++ b/runtime-common/libebur128/spec
@@ -1,4 +1,0 @@
-VER=1.2.6
-SRCS="git::commit=v$VER::https://github.com/jiixyj/libebur128.git"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=7316"

--- a/runtime-multimedia/libebur128/autobuild/defines
+++ b/runtime-multimedia/libebur128/autobuild/defines
@@ -1,4 +1,9 @@
 PKGNAME=libebur128
 PKGSEC=sound
-PKGDES="Library implementing the EBU R128 loudness standard"
+PKGDES="Library to implement the EBU R128 loudness standard"
 PKGDEP="glibc"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DENABLE_INTERNAL_QUEUE_H=OFF'
+)

--- a/runtime-multimedia/libebur128/spec
+++ b/runtime-multimedia/libebur128/spec
@@ -1,4 +1,5 @@
 VER=1.2.6
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/jiixyj/libebur128"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7316"


### PR DESCRIPTION
Topic Description
-----------------

- libebur128: rebuild to make sure we are building the right package
    Previously, we had two libebur128's in the tree, making it non-
    determinant as to which package we ended up building.
- libebur128: drop redundant package in tree
    Use runtime-multimedia/libebur128.

Package(s) Affected
-------------------

- libebur128: 1.2.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libebur128
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
