### PR TITLE
go: update to 1.26.5+tools0.45.0

### DIFF
--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,11 +1,11 @@
-GO_VER=1.26.4
+GO_VER=1.26.5
 # Go tools can be updated independently.
 TOOLS_VER=0.45.0
 
 VER="${GO_VER}+tools${TOOLS_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools"
-CHKSUMS="sha256::4f668a32fbfc1132e6a881fb968c2f1dada631492a339211735fbb255a42602d \
+CHKSUMS="sha256::495be4bc87176ac567392e5b4116abd98466d33d7b49d41e764ccc6976b2dc42 \
          SKIP"
 CHKUPDATE="anitya::id=1227"
 SUBDIR="go"

--- a/topics/go-1.26.5+tools0.45.0.toml
+++ b/topics/go-1.26.5+tools0.45.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Go 1.26.5"
+
+[caution]
+default = "Fixes a root escape vulnerability (CVE-2026-39822, Severity: High) and an Encrypted Client Hello privacy leak vulnerability (CVE-2026-42505, Severity: Medium)"
+zh_CN = "修复了一个根目录逃逸漏洞（CVE-2026-39822，严重性：高）和一个 Encrypted Client Hello 隐私泄露漏洞（CVE-2026-42505，严重性：中等）"
+
+[packages-v2]
+go = "< 1.26.5+tools0.45.0"


### PR DESCRIPTION
Topic Description
-----------------

- go: update to 1.26.5+tools0.45.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- go: 1.26.5+tools0.45.0
- go-runtime: 1.26.5+tools0.45.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
