### PR TITLE
navidrome: update to 0.63.0

### DIFF
--- a/app-multimedia/navidrome/spec
+++ b/app-multimedia/navidrome/spec
@@ -1,4 +1,4 @@
-VER=0.62.0
+VER=0.63.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/navidrome/navidrome.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326646"


### PR DESCRIPTION
Topic Description
-----------------

- navidrome: update to 0.63.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- navidrome: 0.63.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit navidrome
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
