### PR TITLE
gawk: update to 5.4.1

### DIFF
--- a/app-utils/gawk/spec
+++ b/app-utils/gawk/spec
@@ -1,4 +1,4 @@
-VER=5.4.0
+VER=5.4.1
 SRCS="tbl::https://ftp.gnu.org/gnu/gawk/gawk-$VER.tar.xz"
-CHKSUMS="sha256::3dd430f0cd3b4428c6c3f6afc021b9cd3c1f8c93f7a688dc268ca428a90b4ac1"
+CHKSUMS="sha256::07f6f7342b7febe4313fc2c2542ad93d64fe20ad8717200109f105a826f5fd37"
 CHKUPDATE="anitya::id=868"


### PR DESCRIPTION
Topic Description
-----------------

- gawk: update to 5.4.1
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gawk: 5.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gawk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
