### PR TITLE
wireshark: update to 4.6.7

### DIFF
--- a/app-network/wireshark/autobuild/patches/0001-AOSCOS-ui-drop-download-page-URL-entry.patch
+++ b/app-network/wireshark/autobuild/patches/0001-AOSCOS-ui-drop-download-page-URL-entry.patch
@@ -1,0 +1,132 @@
+From bb4f6ead574da5b94c151de1d693b0a71a648ad4 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Thu, 16 Jul 2026 12:29:40 +0800
+Subject: [PATCH] AOSCOS: ui: drop download page URL entry
+
+A bit pointless, no?
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ ui/help_url.c                                    | 6 ------
+ ui/help_url.h                                    | 2 --
+ ui/qt/wireshark_main_window.cpp                  | 1 -
+ ui/qt/wireshark_main_window_slots.cpp            | 1 -
+ ui/stratoshark/stratoshark_main_window.cpp       | 1 -
+ ui/stratoshark/stratoshark_main_window_slots.cpp | 1 -
+ ui/urls.h                                        | 2 --
+ 7 files changed, 14 deletions(-)
+
+diff --git a/ui/help_url.c b/ui/help_url.c
+index 4aa1012946..bf7e4b96bb 100644
+--- a/ui/help_url.c
++++ b/ui/help_url.c
+@@ -74,9 +74,6 @@ topic_action_url(topic_action_e action)
+     case(ONLINEPAGE_WIRESHARK_WIKI):
+         url = g_strdup(WS_WIKI_HOME_URL);
+         break;
+-    case(ONLINEPAGE_WIRESHARK_DOWNLOAD):
+-        url = g_strdup(WS_DOWNLOAD_URL);
+-        break;
+     case(ONLINEPAGE_DOCS):
+         url = g_strdup(WS_DOCS_URL);
+         break;
+@@ -115,9 +112,6 @@ topic_action_url(topic_action_e action)
+     case(ONLINEPAGE_STRATOSHARK_WIKI):
+         url = g_strdup(SS_WIKI_HOME_URL);
+         break;
+-    case(ONLINEPAGE_STRATOSHARK_DOWNLOAD):
+-        url = g_strdup(SS_DOWNLOAD_URL);
+-        break;
+ 
+     /* local manual pages */
+     case(LOCALPAGE_MAN_WIRESHARK):
+diff --git a/ui/help_url.h b/ui/help_url.h
+index 8b78a60cf6..963df085f8 100644
+--- a/ui/help_url.h
++++ b/ui/help_url.h
+@@ -30,7 +30,6 @@ typedef enum {
+     ONLINEPAGE_WIRESHARK_WIKI,
+     ONLINEPAGE_USERGUIDE,
+     ONLINEPAGE_FAQ,
+-    ONLINEPAGE_WIRESHARK_DOWNLOAD,
+     ONLINEPAGE_DOCS,
+     ONLINEPAGE_SAMPLE_FILES,
+     ONLINEPAGE_CAPTURE_SETUP,
+@@ -43,7 +42,6 @@ typedef enum {
+     /* pages online at stratoshark.org */
+     ONLINEPAGE_STRATOSHARK_HOME,
+     ONLINEPAGE_STRATOSHARK_WIKI,
+-    ONLINEPAGE_STRATOSHARK_DOWNLOAD,
+ 
+     /* local manual pages */
+     LOCALPAGE_MAN_WIRESHARK = 100,
+diff --git a/ui/qt/wireshark_main_window.cpp b/ui/qt/wireshark_main_window.cpp
+index 076e66e2f0..3984cbf6f2 100644
+--- a/ui/qt/wireshark_main_window.cpp
++++ b/ui/qt/wireshark_main_window.cpp
+@@ -725,7 +725,6 @@ main_ui_->goToLineEdit->setValidator(goToLineQiv);
+     main_ui_->actionHelpWebsite->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_WIRESHARK_HOME)));
+     main_ui_->actionHelpFAQ->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_FAQ)));
+     main_ui_->actionHelpAsk->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_ASK)));
+-    main_ui_->actionHelpDownloads->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_WIRESHARK_DOWNLOAD)));
+     main_ui_->actionHelpWiki->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_WIRESHARK_WIKI)));
+     main_ui_->actionHelpSampleCaptures->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_SAMPLE_CAPTURES)));
+     main_ui_->actionHelpReleaseNotes->setToolTip(gchar_free_to_qstring(topic_action_url(LOCALPAGE_WIRESHARK_RELEASE_NOTES)));
+diff --git a/ui/qt/wireshark_main_window_slots.cpp b/ui/qt/wireshark_main_window_slots.cpp
+index 0c9f825dcd..b12c5ddd9a 100644
+--- a/ui/qt/wireshark_main_window_slots.cpp
++++ b/ui/qt/wireshark_main_window_slots.cpp
+@@ -4054,7 +4054,6 @@ void WiresharkMainWindow::connectHelpMenuActions()
+     connect(main_ui_->actionHelpWebsite, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_WIRESHARK_HOME); });
+     connect(main_ui_->actionHelpFAQ, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_FAQ); });
+     connect(main_ui_->actionHelpAsk, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_ASK); });
+-    connect(main_ui_->actionHelpDownloads, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_WIRESHARK_DOWNLOAD); });
+     connect(main_ui_->actionHelpWiki, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_WIRESHARK_WIKI); });
+     connect(main_ui_->actionHelpSampleCaptures, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_SAMPLE_FILES); });
+     connect(main_ui_->actionHelpReleaseNotes, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(LOCALPAGE_WIRESHARK_RELEASE_NOTES); });
+diff --git a/ui/stratoshark/stratoshark_main_window.cpp b/ui/stratoshark/stratoshark_main_window.cpp
+index 8110513e61..44254c4ddb 100644
+--- a/ui/stratoshark/stratoshark_main_window.cpp
++++ b/ui/stratoshark/stratoshark_main_window.cpp
+@@ -676,7 +676,6 @@ main_ui_->goToLineEdit->setValidator(goToLineQiv);
+     main_ui_->actionHelpWebsite->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_STRATOSHARK_HOME)));
+     main_ui_->actionHelpFAQ->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_FAQ)));
+     main_ui_->actionHelpAsk->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_ASK)));
+-    main_ui_->actionHelpDownloads->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_STRATOSHARK_DOWNLOAD)));
+     main_ui_->actionHelpWiki->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_STRATOSHARK_WIKI)));
+     main_ui_->actionHelpSampleCaptures->setToolTip(gchar_free_to_qstring(topic_action_url(ONLINEPAGE_SAMPLE_CAPTURES)));
+     main_ui_->actionHelpReleaseNotes->setToolTip(gchar_free_to_qstring(topic_action_url(LOCALPAGE_STRATOSHARK_RELEASE_NOTES)));
+diff --git a/ui/stratoshark/stratoshark_main_window_slots.cpp b/ui/stratoshark/stratoshark_main_window_slots.cpp
+index b0f7c9ff0d..2050ababac 100644
+--- a/ui/stratoshark/stratoshark_main_window_slots.cpp
++++ b/ui/stratoshark/stratoshark_main_window_slots.cpp
+@@ -3261,7 +3261,6 @@ void StratosharkMainWindow::connectHelpMenuActions()
+     connect(main_ui_->actionHelpWebsite, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_STRATOSHARK_HOME); });
+     connect(main_ui_->actionHelpFAQ, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_FAQ); });
+     connect(main_ui_->actionHelpAsk, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_ASK); });
+-    connect(main_ui_->actionHelpDownloads, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_STRATOSHARK_DOWNLOAD); });
+     connect(main_ui_->actionHelpWiki, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_STRATOSHARK_WIKI); });
+     connect(main_ui_->actionHelpSampleCaptures, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(ONLINEPAGE_SAMPLE_FILES); });
+     connect(main_ui_->actionHelpReleaseNotes, &QAction::triggered, this, [=]() { mainApp->helpTopicAction(LOCALPAGE_STRATOSHARK_RELEASE_NOTES); });
+diff --git a/ui/urls.h b/ui/urls.h
+index bb70e1da51..87761a54d1 100644
+--- a/ui/urls.h
++++ b/ui/urls.h
+@@ -11,14 +11,12 @@
+  */
+ 
+ #define WS_HOME_PAGE_URL "https://www.wireshark.org"
+-#define WS_DOWNLOAD_URL  "https://www.wireshark.org/download.html"
+ #define WS_DOCS_URL      "https://www.wireshark.org/docs/"
+ #define WS_FAQ_URL       "https://www.wireshark.org/faq.html"
+ #define WS_Q_AND_A_URL   "https://ask.wireshark.org"
+ #define WS_WIKI_HOME_URL "https://wiki.wireshark.org"
+ 
+ #define SS_HOME_PAGE_URL "https://stratoshark.org"
+-#define SS_DOWNLOAD_URL  "https://stratoshark.org"
+ #define SS_WIKI_HOME_URL "https://wiki.wireshark.org/stratoshark"
+ 
+ 
+-- 
+2.52.0
+

--- a/app-network/wireshark/spec
+++ b/app-network/wireshark/spec
@@ -1,5 +1,4 @@
-VER=4.6.6
-REL=1
+VER=4.6.7
 SRCS="tbl::https://www.wireshark.org/download/src/all-versions/wireshark-$VER.tar.xz"
-CHKSUMS="sha256::27e7ff780cd68a7466082be82ca26c06a002e74a71646ef3a6e4683e444c1a86"
+CHKSUMS="sha256::242929b8c10ba89a8d3bcad7ff2eba8effb648d30f48e270d2e5e6ff94d88613"
 CHKUPDATE="anitya::id=5137"


### PR DESCRIPTION
Topic Description
-----------------

- wireshark: update to 4.6.7
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- wireshark: 4.6.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireshark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
