### PR TITLE
pkgconf: update to 3.0.0

### DIFF
--- a/app-devel/pkgconf/autobuild/defines
+++ b/app-devel/pkgconf/autobuild/defines
@@ -3,7 +3,11 @@ PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="Package compiler and linker metadata toolkit"
 
-ABTYPE=autotools
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dfuzzing=false'
+    '-Danalyzer=false'
+)
 
 PKGBREAK="pkg-config<=0.29.2-4"
 PKGREP="pkg-config<=0.29.2-4"

--- a/app-devel/pkgconf/spec
+++ b/app-devel/pkgconf/spec
@@ -1,4 +1,4 @@
-VER=2.5.1
+VER=3.0.0
 SRCS="tbl::https://distfiles.ariadne.space/pkgconf/pkgconf-$VER.tar.xz"
-CHKSUMS="sha256::cd05c9589b9f86ecf044c10a2269822bc9eb001eced2582cfffd658b0a50c243"
+CHKSUMS="sha256::40c814bd28bbbe331468a84bde67c53ae382dd226baec043f3e7c5ba3f2129e4"
 CHKUPDATE="anitya::id=12753"


### PR DESCRIPTION
Topic Description
-----------------

- pkgconf: update to 3.0.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- pkgconf: 3.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
