### PR TITLE
ROCm: 7.14 Extended Package

### DIFF
--- a/runtime-rocm/libhipcxx/autobuild/defines
+++ b/runtime-rocm/libhipcxx/autobuild/defines
@@ -1,0 +1,27 @@
+PKGNAME=libhipcxx
+PKGDES="Abstraction library to help with HIP C++ development"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-hipblas-common rocm-roctracer"
+BUILDDEP="cmake cargo rustc llvm maturin msgpack-c++ rocm-smi-lib"
+
+USECLANG=1
+
+NOLTO=1
+
+# Only Header
+ABSPLITDBG=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-Dlibhipcxx_ENABLE_CMAKE_TESTS=OFF'
+    '-DLIBCUDACXX_ENABLE_LIBCUDACXX_TESTS=OFF'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/libhipcxx/autobuild/prepare
+++ b/runtime-rocm/libhipcxx/autobuild/prepare
@@ -1,0 +1,11 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Setting HIP_PATH ..."
+export HIP_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Copying replacement autotools base files ..."
+cp -v /usr/bin/config.{guess,sub} "$SRCDIR"/cmake/

--- a/runtime-rocm/libhipcxx/spec
+++ b/runtime-rocm/libhipcxx/spec
@@ -1,0 +1,4 @@
+VER=7.14
+SRCS="git::commit=tags/therock-${VER}::https://github.com/ROCm/libhipcxx"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391626"

--- a/runtime-rocm/rocm-hipdnn/autobuild/defines
+++ b/runtime-rocm/rocm-hipdnn/autobuild/defines
@@ -1,0 +1,29 @@
+PKGNAME=rocm-hipdnn
+PKGDES="Graph-based deep learning library for AMD GPUs"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-roctracer"
+BUILDDEP="cmake spdlog"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DENABLE_CLANG_TIDY=OFF'
+    '-DHIPDNN_SKIP_TESTS=ON'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipdnn/autobuild/prepare
+++ b/runtime-rocm/rocm-hipdnn/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-hipdnn/spec
+++ b/runtime-rocm/rocm-hipdnn/spec
@@ -1,0 +1,5 @@
+VER=7.14
+SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
+CHKSUMS="SKIP"
+SUBDIR="rocm-libraries/projects/hipdnn"
+CHKUPDATE="anitya::id=383650"

--- a/runtime-rocm/rocm-hipfile/autobuild/defines
+++ b/runtime-rocm/rocm-hipfile/autobuild/defines
@@ -1,0 +1,22 @@
+PKGNAME=rocm-hipfile
+PKGDES="Library to provide direct-to-GPU I/O for AMD ROCm platforms"
+PKGSEC=devel
+PKGDEP="gcc-runtime rocm-clr"
+BUILDDEP="cmake rocm-llvm rocm-cmake"
+
+USECLANG=1
+
+# FIXME: LINKER_TYPE 'LLD' is unknown or not supported by this toolchain.
+NOLTO=1
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_HIP_COMPILER=/usr/lib/rocm/lib/llvm/bin/amdclang'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-hipfile/autobuild/prepare
+++ b/runtime-rocm/rocm-hipfile/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-hipfile/spec
+++ b/runtime-rocm/rocm-hipfile/spec
@@ -1,0 +1,5 @@
+VER=7.14
+SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
+CHKSUMS="SKIP"
+SUBDIR="rocm-systems/projects/hipfile"
+CHKUPDATE="anitya::id=386527"

--- a/runtime-rocm/rocm-rdc/autobuild/defines
+++ b/runtime-rocm/rocm-rdc/autobuild/defines
@@ -1,0 +1,24 @@
+PKGNAME=rocm-rdc
+PKGDES="Tools for ROCm Data Centers"
+PKGSEC=devel
+PKGDEP="gcc-runtime grpc rocm-amdsmi rocr-runtime rocm-rvs yaml-cpp"
+BUILDDEP="cmake rocm-llvm"
+
+USECLANG=1
+
+# FIXME: Segmentation Fault
+#  failed: null sections(STRTAB)
+#  rocm-clr rocclr/elf/elf.cpp:282
+ABSTRIP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-rdc/autobuild/patches/0001-remove-sse-flags.patch
+++ b/runtime-rocm/rocm-rdc/autobuild/patches/0001-remove-sse-flags.patch
@@ -1,0 +1,39 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index f329e448df..333069f319 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -60,7 +60,7 @@ set_property(
+ )
+ 
+ # Set compile flags
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+ set(CMAKE_CXX_FLAGS_DEBUG
+     "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
+     CACHE STRING
+diff --git a/example/CMakeLists.txt b/example/CMakeLists.txt
+index 378a200581..44a5f51262 100755
+--- a/example/CMakeLists.txt
++++ b/example/CMakeLists.txt
+@@ -32,7 +32,7 @@ option(CMAKE_VERBOSE_MAKEFILE "Enable verbose output" ON)
+ option(CMAKE_EXPORT_COMPILE_COMMANDS "Export compile commands for linters and autocompleters" ON)
+ 
+ # Set compile flags
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+ set(CMAKE_CXX_FLAGS_DEBUG
+     "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
+     CACHE STRING
+diff --git a/tests/example/CMakeLists.txt b/tests/example/CMakeLists.txt
+index d5614f387b..b79fa76e6c 100755
+--- a/tests/example/CMakeLists.txt
++++ b/tests/example/CMakeLists.txt
+@@ -23,7 +23,7 @@ message("                       Cmake Example Lib                           ")
+ message("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+ 
+ # Set compile flags
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -m64 -msse -msse2")
++set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+ set(CMAKE_CXX_FLAGS_DEBUG
+     "${CMAKE_CXX_FLAGS_DEBUG} -O0 -ggdb -DDEBUG"
+     CACHE STRING

--- a/runtime-rocm/rocm-rdc/autobuild/patches/0002-fallback-rdtsc.patch
+++ b/runtime-rocm/rocm-rdc/autobuild/patches/0002-fallback-rdtsc.patch
@@ -1,0 +1,29 @@
+diff --git a/rdc_libs/rdc/src/RdcPerfTimer.cc b/rdc_libs/rdc/src/RdcPerfTimer.cc
+index 47277bcc56..1f421a1e1f 100644
+--- a/rdc_libs/rdc/src/RdcPerfTimer.cc
++++ b/rdc_libs/rdc/src/RdcPerfTimer.cc
+@@ -22,7 +22,9 @@ THE SOFTWARE.
+ 
+ #include "rdc_lib/RdcPerfTimer.h"
+ 
++#ifdef __x86_64__
+ #include <x86intrin.h>
++#endif
+ 
+ namespace amd {
+ namespace rdc {
+@@ -139,7 +141,13 @@ uint64_t RdcPerfTimer::CoarseTimestampUs() {
+   clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+   return uint64_t(ts.tv_sec) * 1000000 + ts.tv_nsec / 1000;
+ }
+-
++#ifdef __loongarch_lp64
++inline uint64_t __rdtscp(unsigned int* unused){
++    uint64_t val;
++    asm("rdtime.d %0, 0": "=r"(val));
++    return val;
++}
++#endif
+ uint64_t RdcPerfTimer::MeasureTSCFreqHz() {
+   // Make a coarse interval measurement of TSC ticks for 1 gigacycles.
+   unsigned int unused;

--- a/runtime-rocm/rocm-rdc/autobuild/prepare
+++ b/runtime-rocm/rocm-rdc/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"

--- a/runtime-rocm/rocm-rdc/spec
+++ b/runtime-rocm/rocm-rdc/spec
@@ -1,0 +1,5 @@
+VER=7.14
+SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
+CHKSUMS="SKIP"
+SUBDIR="rocm-systems/projects/rdc"
+CHKUPDATE="anitya::id=386527"

--- a/runtime-rocm/rocm-rocprofiler-sdk/autobuild/defines
+++ b/runtime-rocm/rocm-rocprofiler-sdk/autobuild/defines
@@ -1,0 +1,23 @@
+PKGNAME=rocm-rocprofiler-sdk
+PKGDES="Low-level hardware performance analysis interface to profile and trace AMD GPU compute applications"
+PKGSEC=devel
+PKGDEP="gcc-runtime rocm-core rocm-llvm rocm-clr rocr-runtime rocm-rocprofiler-register rocm-rccl rocm-rocdecode rocm-rocjpeg"
+BUILDDEP="cmake"
+
+USECLANG=1
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DCMAKE_SKIP_RPATH=OFF'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib;/usr/lib/rocm/lib/llvm/lib'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DBUILD_TESTING=OFF'
+    '-DCMAKE_LINKER_TYPE=LLD'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64|riscv64)"

--- a/runtime-rocm/rocm-rocprofiler-sdk/spec
+++ b/runtime-rocm/rocm-rocprofiler-sdk/spec
@@ -1,0 +1,5 @@
+VER=7.14
+SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
+CHKSUMS="SKIP"
+SUBDIR="rocm-systems/projects/rocprofiler-sdk"
+CHKUPDATE="anitya::id=386527"

--- a/runtime-rocm/rocm-rocshmem/autobuild/defines
+++ b/runtime-rocm/rocm-rocshmem/autobuild/defines
@@ -1,0 +1,31 @@
+PKGNAME=rocm-rocshmem
+PKGDES="GPU-centric networking framework based on an OpenSHMEM-like interface"
+PKGSEC=devel
+PKGDEP="gcc-runtime rocm-amdsmi rocm-clr"
+BUILDDEP="cmake rocm-llvm rocm-cmake"
+
+USECLANG=1
+# FIXME: ld.lld: error: undefined symbol: rocshmem::print_build_info(std::ostream&)
+# >>> referenced by rocshmem_info.cpp:54 (/var/cache/acbs/build/acbs.wk9s1eje/rocm-systems/projects/rocshmem/tools/rocshmem_info.cpp:54)
+# >>>               tools/rocshmem_info.lto.o:(main)
+NOLTO=1
+
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+# Note: Keep librocshmem.a, pytorch dependency ...
+NOSTATIC=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+)
+
+FAIL_ARCH="!(amd64|loongarch64)"

--- a/runtime-rocm/rocm-rocshmem/autobuild/patches/0001-support-non-x86.patch
+++ b/runtime-rocm/rocm-rocshmem/autobuild/patches/0001-support-non-x86.patch
@@ -1,0 +1,34 @@
+diff --git a/src/reverse_offload/backend_ro.cpp b/src/reverse_offload/backend_ro.cpp
+index 936f292037..2b7a356a1a 100644
+--- a/src/reverse_offload/backend_ro.cpp
++++ b/src/reverse_offload/backend_ro.cpp
+@@ -23,9 +23,10 @@
+  *****************************************************************************/
+
+ #include "backend_ro.hpp"
+-
++#ifdef __x86_64__
+ #include <immintrin.h>
+ #include <smmintrin.h>
++#endif
+ #include <unistd.h>
+
+ #include <cassert>
+diff --git a/src/reverse_offload/queue.cpp b/src/reverse_offload/queue.cpp
+index bca71162c8..3c40faf0ba 100644
+--- a/src/reverse_offload/queue.cpp
++++ b/src/reverse_offload/queue.cpp
+@@ -85,7 +85,13 @@ void Queue::flush_hdp() {
+
+ void Queue::sfence_flush_hdp() {
+   if (envvar::ro::net_cpu_queue) {
++#ifdef __x86_64__
+     asm volatile("sfence" ::: "memory");
++#elif defined(__loongarch_lp64)
++    asm volatile("dbar 0" ::: "memory");
++#else
++#error "Need sfence impl"
++#endif
+     hdp_proxy_.get()->hdp_flush();
+   }
+ }

--- a/runtime-rocm/rocm-rocshmem/autobuild/prepare
+++ b/runtime-rocm/rocm-rocshmem/autobuild/prepare
@@ -1,0 +1,5 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"

--- a/runtime-rocm/rocm-rocshmem/spec
+++ b/runtime-rocm/rocm-rocshmem/spec
@@ -1,0 +1,5 @@
+VER=7.14
+SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
+CHKSUMS="SKIP"
+SUBDIR="rocm-systems/projects/rocshmem"
+CHKUPDATE="anitya::id=386527"

--- a/runtime-rocm/rocm-rvs/autobuild/defines
+++ b/runtime-rocm/rocm-rvs/autobuild/defines
@@ -1,0 +1,35 @@
+PKGNAME=rocm-rvs
+PKGDES="ROCm Validation Suite"
+PKGSEC=devel
+PKGDEP="rocm-llvm rocm-clr rocm-cmake rocm-roctracer rocm-smi-lib rocm-rocblas rocm-hiprand rocm-amdsmi"
+
+BUILDDEP="cmake yaml-cpp gtest"
+
+USECLANG=1
+
+# FIXME: ld.lld: error: undefined symbol: _Unwind_Resume
+NOLTO=1
+
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+# FIXME: Segmentation Fault
+#  failed: null sections(STRTAB)
+#  rocm-clr rocclr/elf/elf.cpp:282
+ABSTRIP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_C_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DROCM_PATH=/usr/lib/rocm'
+    '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DRVS_BUILD_TESTS=OFF'
+)
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-rvs/autobuild/patches/0001-remove-definitions-and-mf16c.patch
+++ b/runtime-rocm/rocm-rvs/autobuild/patches/0001-remove-definitions-and-mf16c.patch
@@ -1,0 +1,38 @@
+diff --git a/rvslib/CMakeLists.txt b/rvslib/CMakeLists.txt
+index 79b1bc2..13e7766 100644
+--- a/rvslib/CMakeLists.txt
++++ b/rvslib/CMakeLists.txt
+@@ -168,7 +168,6 @@ set(SOURCES_UT
+ ## define rvslib library
+ add_library(${RVS_TARGET} SHARED ${SOURCES})
+
+-target_compile_options(${RVS_TARGET} PRIVATE -mf16c)
+ target_compile_definitions(${RVS_TARGET} PRIVATE ROCM_USE_FLOAT16)
+ set_target_properties(${RVS_TARGET}
+  PROPERTIES SUFFIX .so.${LIB_VERSION_STRING}
+diff --git a/pbqt.so/CMakeLists.txt b/pbqt.so/CMakeLists.txt
+index ccaea42..597b1f4 100644
+--- a/pbqt.so/CMakeLists.txt
++++ b/pbqt.so/CMakeLists.txt
+@@ -42,8 +42,6 @@ message(STATUS "MODULE: ${RVS}")
+ add_definitions(-D__linux__)
+ add_definitions(-DUNIX_OS)
+ add_definitions(-DLINUX)
+-add_definitions(-D__AMD64__)
+-add_definitions(-D__x86_64__)
+ add_definitions(-DAMD_INTERNAL_BUILD)
+ add_definitions(-DLITTLEENDIAN_CPU=1)
+ add_definitions(-DHSA_LARGE_MODEL=)
+diff --git a/pebb.so/CMakeLists.txt b/pebb.so/CMakeLists.txt
+index 7f624fd..75346e3 100644
+--- a/pebb.so/CMakeLists.txt
++++ b/pebb.so/CMakeLists.txt
+@@ -42,8 +42,6 @@ message(STATUS "MODULE: ${RVS}")
+ add_definitions(-D__linux__)
+ add_definitions(-DUNIX_OS)
+ add_definitions(-DLINUX)
+-add_definitions(-D__AMD64__)
+-add_definitions(-D__x86_64__)
+ add_definitions(-DAMD_INTERNAL_BUILD)
+ add_definitions(-DLITTLEENDIAN_CPU=1)
+ add_definitions(-DHSA_LARGE_MODEL=)

--- a/runtime-rocm/rocm-rvs/autobuild/prepare
+++ b/runtime-rocm/rocm-rvs/autobuild/prepare
@@ -1,0 +1,18 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+# FIXME
+# need --rtlib=compiler-rt
+# /usr/bin/ld: bin/librvslib.so.0.0.0: undefined reference to `__extendhfsf2'
+# /usr/bin/ld: bin/librvslib.so.0.0.0: undefined reference to `__truncsfhf2'
+# need -Wl,--copy-dt-needed-entries
+# /usr/bin/ld: rvs/CMakeFiles/rvs.dir/src/rvs.cpp.o: undefined reference to symbol '_Unwind_Resume@@GCC_3.0'
+# /usr/bin/ld: /../lib/libgcc_s.so.1: error adding symbols: DSO missing from command line
+abinfo "FIX undefined reference ..."
+export LDFLAGS="$LDFLAGS --rtlib=compiler-rt -Wl,--copy-dt-needed-entries"

--- a/runtime-rocm/rocm-rvs/spec
+++ b/runtime-rocm/rocm-rvs/spec
@@ -1,0 +1,5 @@
+VER=7.2.4
+SRCS="git::commit=tags/rocm-${VER};rename=ROCmValidationSuite;copy-repo=true::https://github.com/ROCm/ROCmValidationSuite.git"
+CHKSUMS="SKIP"
+SUBDIR="ROCmValidationSuite"
+CHKUPDATE="anitya::id=391158"

--- a/runtime-rocm/rocm-transfer-bench/autobuild/defines
+++ b/runtime-rocm/rocm-transfer-bench/autobuild/defines
@@ -1,0 +1,25 @@
+PKGNAME=rocm-transfer-bench
+PKGDES="Utility to benchmark simultaneous copies between CPU/GPU memory with CPUs, GPU kernels, DMA engines, and NICs"
+PKGSEC=devel
+PKGDEP="numactl openmpi rdma-core rocr-runtime rocm-llvm rocm-clr rocm-amdsmi rocminfo"
+BUILDDEP="cmake rocm-cmake"
+
+USECLANG=1
+# Note: Control Flow Protection is not supported by GPU targets.
+#
+# https://github.com/llvm/llvm-project/issues/86450
+AB_FLAGS_CFP=0
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr/lib/rocm'
+    '-DCMAKE_CXX_COMPILER=/usr/lib/rocm/lib/llvm/bin/clang++'
+    '-DCMAKE_PREFIX_PATH=/usr/lib/rocm'
+    '-DCMAKE_SKIP_INSTALL_RPATH=OFF'
+    '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
+    '-DCMAKE_LINKER_TYPE=LLD'
+    '-DHIP_PLATFORM=amd'
+    '-DENABLE_NIC_EXEC=1'
+)
+
+FAIL_ARCH="!(amd64|arm64|loongarch64)"

--- a/runtime-rocm/rocm-transfer-bench/autobuild/prepare
+++ b/runtime-rocm/rocm-transfer-bench/autobuild/prepare
@@ -1,0 +1,8 @@
+abinfo "Setting ROCM_PATH ..."
+export ROCM_PATH=/usr/lib/rocm
+
+abinfo "Adding ROCm LLVM to PATH ..."
+export PATH="/usr/lib/rocm/lib/llvm/bin:$PATH"
+
+abinfo "Adding ROCm to PATH ..."
+export PATH="/usr/lib/rocm/bin:$PATH"

--- a/runtime-rocm/rocm-transfer-bench/spec
+++ b/runtime-rocm/rocm-transfer-bench/spec
@@ -1,0 +1,4 @@
+VER=1.64.00
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/ROCm/TransferBench"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391451"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocprofiler-sdk: add, 7.14
- rocm-transfer-bench: add, 1.64.00
- libhipcxx: add, 7.14
- rocm-rvs: add, 7.2.4
- rocm-hipdnn: add, 7.14
- rocm-rocshmem: add, 7.14
- rocm-rdc: add, 7.14
- rocm-hipfile: add, 7.14

Package(s) Affected
-------------------

- libhipcxx: 7.14
- rocm-hipdnn: 7.14
- rocm-hipfile: 7.14
- rocm-rdc: 7.14
- rocm-rocprofiler-sdk: 7.14
- rocm-rocshmem: 7.14-1
- rocm-rvs: 7.2.4
- rocm-transfer-bench: 1.64.00

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipfile rocm-rvs rocm-rdc rocm-rocshmem rocm-hipdnn libhipcxx rocm-transfer-bench rocm-rocprofiler-sdk
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
