### PR TITLE
vscodium: update to 1.126.04524

### DIFF
--- a/app-editors/vscodium/autobuild/build
+++ b/app-editors/vscodium/autobuild/build
@@ -33,6 +33,11 @@ else
   aberr "Platform not supported" && exit 1
 fi
 
+# Playwright's postinstall script may hang in versions earlier than v1.16.0.
+# Since we won't run tests here, it's safe to skip the browser download.
+abinfo "Setting Playwright flag to skip browser download ..."
+export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+
 abinfo "Building ..."
 "$SRCDIR"/build.sh
 

--- a/app-editors/vscodium/autobuild/defines
+++ b/app-editors/vscodium/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME="vscodium"
 PKGSEC="devel"
 PKGDES="Visual Studio Code - Open Source"
 PKGDEP="alsa-lib at-spi2-core cups desktop-file-utils fontconfig gtk-3 gconf libnotify libsecret nss x11-lib"
-BUILDDEP="jq llvm make nodejs-22 pkg-config rustc"
+BUILDDEP="jq llvm make nodejs-24 pkg-config rustc"
 PKGPROV="codium"
 
 ABTYPE=self

--- a/app-editors/vscodium/autobuild/patches/0001-fix-cli-add-an-option-to-use-system-Cargo-rustc.patch
+++ b/app-editors/vscodium/autobuild/patches/0001-fix-cli-add-an-option-to-use-system-Cargo-rustc.patch
@@ -1,4 +1,4 @@
-From e40285ae0a4b883ba33c0d3ec8905f03538481be Mon Sep 17 00:00:00 2001
+From e00b3a16e81c282c7604c88c5285f39d2e61e75f Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 11:23:43 +0800
 Subject: [PATCH 1/3] fix(cli): add an option to use system Cargo/rustc
@@ -13,7 +13,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/build_cli.sh b/build_cli.sh
-index 21d3b46..5a9b17a 100755
+index 84c8781..05443f4 100755
 --- a/build_cli.sh
 +++ b/build_cli.sh
 @@ -50,7 +50,9 @@ elif [[ "${OS_NAME}" == "windows" ]]; then
@@ -27,7 +27,7 @@ index 21d3b46..5a9b17a 100755
  
    cargo build --release --target "${VSCODE_CLI_TARGET}" --bin=code
  
-@@ -101,7 +103,9 @@ else
+@@ -89,7 +91,9 @@ else
    fi
  
    if [[ -n "${VSCODE_CLI_TARGET}" ]]; then

--- a/app-editors/vscodium/autobuild/patches/0002-fix-build_cli.sh-drop-hard-coded-cross-compiler-sett.patch
+++ b/app-editors/vscodium/autobuild/patches/0002-fix-build_cli.sh-drop-hard-coded-cross-compiler-sett.patch
@@ -1,32 +1,37 @@
-From 2701336f6bfc0008e2f404ab81156f4f4f99351f Mon Sep 17 00:00:00 2001
+From 0da915a6248e7e50bc5ea0d866883ee65f213a31 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 12:49:44 +0800
 Subject: [PATCH 2/3] fix(build_cli.sh): drop hard-coded cross compiler setting
 
 ARM != cross compile.
 ---
- build_cli.sh | 8 +-------
- 1 file changed, 1 insertion(+), 7 deletions(-)
+ build_cli.sh | 11 ++++++++---
+ 1 file changed, 8 insertions(+), 3 deletions(-)
 
 diff --git a/build_cli.sh b/build_cli.sh
-index 5a9b17a..72299a8 100755
+index 05443f4..3f9aed6 100755
 --- a/build_cli.sh
 +++ b/build_cli.sh
-@@ -64,13 +64,7 @@ else
+@@ -64,11 +64,16 @@ else
  
    if [[ "${VSCODE_ARCH}" == "arm64" ]]; then
      VSCODE_CLI_TARGET="aarch64-unknown-linux-gnu"
--    
--    if [[ "${CI_BUILD}" != "no" ]]; then
++  elif [[ "${VSCODE_ARCH}" == "armhf" ]]; then
++    VSCODE_CLI_TARGET="armv7-unknown-linux-gnueabihf"
++
++    export OPENSSL_LIB_DIR="$( pwd )/openssl/out/arm-linux/lib"
++    export OPENSSL_INCLUDE_DIR="$( pwd )/openssl/out/arm-linux/include"
+ 
+     if [[ "${CI_BUILD}" != "no" ]]; then
 -      export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 -      export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
 -      export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
--      export PKG_CONFIG_ALLOW_CROSS=1
--    fi
-+
-   elif [[ "${VSCODE_ARCH}" == "armhf" ]]; then
-     VSCODE_CLI_TARGET="armv7-unknown-linux-gnueabihf"
- 
++      export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
++      export CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc
++      export CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++
+       export PKG_CONFIG_ALLOW_CROSS=1
+     fi
+   elif [[ "${VSCODE_ARCH}" == "ppc64le" ]]; then
 -- 
 2.52.0
 

--- a/app-editors/vscodium/autobuild/patches/0003-fix-replace-typescript-native-preview-for-loongarch6.patch.loongarch64
+++ b/app-editors/vscodium/autobuild/patches/0003-fix-replace-typescript-native-preview-for-loongarch6.patch.loongarch64
@@ -1,40 +1,40 @@
-From 036baa7b15718585f633ba88597af7f377b5876a Mon Sep 17 00:00:00 2001
+From abad05e6619897a330f44ba10d47967c71e5506c Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Tue, 26 May 2026 16:32:35 +0800
 Subject: [PATCH 3/3] fix: replace @typescript/native-preview for loongarch64
 
 ---
- patches/90-tsgo.patch | 360 ++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 360 insertions(+)
+ patches/90-tsgo.patch | 359 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 359 insertions(+)
  create mode 100644 patches/90-tsgo.patch
 
 diff --git a/patches/90-tsgo.patch b/patches/90-tsgo.patch
 new file mode 100644
-index 0000000..aeb135d
+index 0000000..768274e
 --- /dev/null
 +++ b/patches/90-tsgo.patch
-@@ -0,0 +1,360 @@
+@@ -0,0 +1,359 @@
 +diff --git a/package-lock.json b/package-lock.json
-+index 68f23433..12cf740e 100644
++index 81d315f0..951ae606 100644
 +--- a/package-lock.json
 ++++ b/package-lock.json
-+@@ -99,7 +99,7 @@
++@@ -105,7 +105,7 @@
 +         "@types/yauzl": "^2.10.0",
 +         "@types/yazl": "^2.4.2",
 +         "@typescript-eslint/utils": "^8.45.0",
-+-        "@typescript/native-preview": "^7.0.0-dev.20260429",
-++        "@typescript/native-preview": "npm:@loongdotjs/typescript-native-preview@7.0.0-dev.20260429.1",
++-        "@typescript/native-preview": "^7.0.0-dev.20260609",
+++        "@typescript/native-preview": "npm:@loongdotjs/typescript-native-preview@^7.0.0-dev.20260609.1",
 +         "@vscode/component-explorer": "^0.2.1-27",
 +         "@vscode/component-explorer-cli": "^0.2.1-27",
 +         "@vscode/gulp-electron": "1.41.3",
-+@@ -1760,6 +1760,176 @@
++@@ -1744,6 +1744,176 @@
 +         "node": ">= 20"
 +       }
 +     },
 ++    "node_modules/@loongdotjs/typescript-native-preview-darwin-arm64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-darwin-arm64/-/typescript-native-preview-darwin-arm64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-LMRxapMp1KX4qJ2XRO+5SGMCD5nfwe8aQsfqL6UkWr/OrNoG0cwz6m7R3yt8+O2bfrKif5UP9nl4LmmMoybBsA==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-darwin-arm64/-/typescript-native-preview-darwin-arm64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-vOY3AU7If61zqmihiMrFQ6R3Pmuy9SPDtgVbQqsnCEIcDmILOiZV+MD7liRXtSuDPLcQ0zPlWv7sQR3Irz0nng==",
 ++      "cpu": [
 ++        "arm64"
 ++      ],
@@ -49,9 +49,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-darwin-x64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-darwin-x64/-/typescript-native-preview-darwin-x64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-uFEsvO6ybgA602lb9lxXHQzYgWfm8LZwR67HDtYRNgLCJnMwrE4nkUlfy72gNiIG2t0TtkI5WySNmUjqY5vS/Q==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-darwin-x64/-/typescript-native-preview-darwin-x64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-LlOI1FVVluFR787hXZpbGgvgse4bjlgg4UTqn4VkFpk+xbOegYyI1Fjf6NAt4LDeYiYt9y0qE1QuaqlhbQxbHQ==",
 ++      "cpu": [
 ++        "x64"
 ++      ],
@@ -66,9 +66,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-linux-arm": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-arm/-/typescript-native-preview-linux-arm-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-HFy6zdU5b2cdB+NQXeIgEVyU6bKXlFoCR6uUoZl2wKkBiIvUeWeaNFP7clKYkAEpPJVjsIGXhBLbc4DMocmdWA==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-arm/-/typescript-native-preview-linux-arm-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-r0ZdjdYnQkL61Mbis1YvKNPGLcjFRuf7raEqd2ycXh0yL/c5Qb/wj1qSQ/ZWdbRR4wXnU/z9PCZAu1Safq4QOg==",
 ++      "cpu": [
 ++        "arm"
 ++      ],
@@ -83,9 +83,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-linux-arm64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-arm64/-/typescript-native-preview-linux-arm64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-CQo3/e581KTX8SLQpLmKTMuBBt/oS0g8pCeQPDQ5KBKzuqNbqA66x4cF5P+K5DVC+wPkon1nxynh9fSw+WSGEQ==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-arm64/-/typescript-native-preview-linux-arm64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-Lm+89fOrYH1S6DOkRXap2S7jTuVWZPbCfbiwRpyBu7djf62rlMNqwIh0xNUYoRBuPe5vNhGtWk6B5wssW1aw3w==",
 ++      "cpu": [
 ++        "arm64"
 ++      ],
@@ -100,9 +100,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-linux-loong64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-loong64/-/typescript-native-preview-linux-loong64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-X1VjX8SwwpN0RwEU75PLiSxwqpzt60hqeLelvPndka8kEx6I1B4uLyfZGlVk1lpjIC97jlVYER2v+gvUU9fmmA==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-loong64/-/typescript-native-preview-linux-loong64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-jjv2oey94FXVYvWpMlBrbBoXszY/CcbDNd/4yv1Kj0aH2ar+WNV+yY3eaupREbXVIVWH9WiTz1244GjwhmyX3w==",
 ++      "cpu": [
 ++        "loong64"
 ++      ],
@@ -117,9 +117,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-linux-ppc64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-ppc64/-/typescript-native-preview-linux-ppc64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-NTafk6Y8bOQaKMDtgnB2XvBY5gK1XedL6m0uGn48GElR6bGblatfJJkqfhe3gBstkIJ3F0KBI4M5VPaFI/Plzg==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-ppc64/-/typescript-native-preview-linux-ppc64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-0jP6qm1v8UjA3fenKhpoLxqWHRoMtBuCgUHDuEZPgX09iLhf3vAteqOLwavME6geXHDrs/c2xnP6LILt7KFr/g==",
 ++      "cpu": [
 ++        "ppc64"
 ++      ],
@@ -134,9 +134,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-linux-riscv64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-riscv64/-/typescript-native-preview-linux-riscv64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-dXVuouI6yjqwbCzt6eYj67U3/mcyAIx7tCzvSpJ4kk9cw/0mdmfZGz811U/ToDzulHrc8n7tfiqluJdy2mgw2w==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-riscv64/-/typescript-native-preview-linux-riscv64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-0TlEB99TaWN6c298mjwIzQejfSFFVNFOMTrrZ8ISXvfhMXdNCDod4lFA8Jb53iXCjLvF8IZ7Dms5emSH3xgcEQ==",
 ++      "cpu": [
 ++        "riscv64"
 ++      ],
@@ -151,9 +151,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-linux-x64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-x64/-/typescript-native-preview-linux-x64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-GT6q7WKG9IXQyd/gr5Emsb7EJBiM+0UIL/fLkttF+Hpne8gBX8b2TGH05ene1SeIx6Ucg9wMHWtaGGQL9N6vSg==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-linux-x64/-/typescript-native-preview-linux-x64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-0xyfd1t5/81k7PM+9XAn6IWEB/C2XJknKhgauvvOmtpHVbY2uBK4hya+Y2xOP5M8/sQ+It0vHjZYqjF2idHXBw==",
 ++      "cpu": [
 ++        "x64"
 ++      ],
@@ -168,9 +168,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-win32-arm64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-win32-arm64/-/typescript-native-preview-win32-arm64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-Gi9amIJbnsB+rRZilz4BfKzwjMMUByNY6vsnKJuo/Y6bc3RBshsDwa0M5dJIso+pGnW+pvBw7RsP4Gn0hfedqg==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-win32-arm64/-/typescript-native-preview-win32-arm64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-N//tCQ4etGykZYXS/yg4tqe23mZmjN7/J/vmb98U0iKG5+hNn/KsecWE2G5Ndez6Epte/s+sZ5ojW+v9fG5Gfw==",
 ++      "cpu": [
 ++        "arm64"
 ++      ],
@@ -185,9 +185,9 @@ index 0000000..aeb135d
 ++      }
 ++    },
 ++    "node_modules/@loongdotjs/typescript-native-preview-win32-x64": {
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-win32-x64/-/typescript-native-preview-win32-x64-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-HANLKowKVzJTrWN2vRoxv2ehYGRoLMKyGnXNhCawmWhODzMDt2K6CWg0CSPCXmBknZ+F5PSk840xRbAbYalLAw==",
+++      "version": "7.0.0-dev.20260609.1",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview-win32-x64/-/typescript-native-preview-win32-x64-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-Ps2o8kPIywesFZwPaq/Iblm4uxBxMYpo2IscIibtkj7Y0ldXRrzo06x8ob2AU7NkAnWZOSJj85G2/Qh3Fq1tLQ==",
 ++      "cpu": [
 ++        "x64"
 ++      ],
@@ -204,37 +204,36 @@ index 0000000..aeb135d
 +     "node_modules/@malept/cross-spawn-promise": {
 +       "version": "1.1.1",
 +       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-+@@ -3424,9 +3594,10 @@
++@@ -3508,9 +3678,10 @@
 +       }
 +     },
 +     "node_modules/@typescript/native-preview": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-UcEslgHBaHYPAisVQcyARDfps7nKyugmUyXcsfE1HiHcVuvZ4tBJ5C93sG1FDeHWJ9skGQ68ec+Xsx086geAfg==",
 ++      "name": "@loongdotjs/typescript-native-preview",
-++      "version": "7.0.0-dev.20260429.1",
-++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview/-/typescript-native-preview-7.0.0-dev.20260429.1.tgz",
-++      "integrity": "sha512-InBSX6kIIcyctkL5VpP3roKWc1kEmi2ucrtoNsQo0/jcr7EGpLeBVxAA0rXPHFjMjszaZbdhg/0hGkQB7RO6Fg==",
++       "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-1HOuH/u/451O3hx4Z9fesNqarpeit6UfkgwK96sCVWi5p69F0N3v+6bI969lLIjF7K9dbYQNiWUaZ6Wik87iKg==",
+++      "resolved": "https://registry.npmjs.org/@loongdotjs/typescript-native-preview/-/typescript-native-preview-7.0.0-dev.20260609.1.tgz",
+++      "integrity": "sha512-SIMyUxOqbeG0u8wIqLmo5AFjVWdRxHgwIpQXnyKOj+jtfpw9pkMUzFE7DGYQcjDrJq6d1EVFg1se3d6/zpreOQ==",
 +       "dev": true,
 +       "license": "Apache-2.0",
 +       "bin": {
-+@@ -3436,132 +3607,16 @@
++@@ -3520,132 +3691,16 @@
 +         "node": ">=16.20.0"
 +       },
 +       "optionalDependencies": {
-+-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260506.1",
-+-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260506.1",
-+-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260506.1",
-+-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260506.1",
-+-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260506.1",
-+-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260506.1",
-+-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260506.1"
++-        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260609.1",
++-        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260609.1",
++-        "@typescript/native-preview-linux-arm": "7.0.0-dev.20260609.1",
++-        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260609.1",
++-        "@typescript/native-preview-linux-x64": "7.0.0-dev.20260609.1",
++-        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260609.1",
++-        "@typescript/native-preview-win32-x64": "7.0.0-dev.20260609.1"
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-darwin-arm64": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-dAd7qG2J508+4CRSuoEA0EUxViIedQ0D+8xKoZiM0EQHCwww8glWYCo72UTjcRZctS3QbJY3PtGSvo3nzL4oVw==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-Yf/zHEadP/yUiWUdM/mZVfEVFJuGMf6nhRSFif0vp+FwtfGU4jmlpNF7BTJJdOHrrcWkwEJKzAoMCtEtyxhuyQ==",
 +-      "cpu": [
 +-        "arm64"
 +-      ],
@@ -249,9 +248,9 @@ index 0000000..aeb135d
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-darwin-x64": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-1Q7Elncpuiozvx3HCTgFbSxNz2m2FIkO1QW5f15igcZDG3vMW4QglNflmXosc69bzYI7KfYZuaGX3yGzJkGbfg==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-z4dYWI57CPHs0wV/FWFth8fWmqYH7iOm7THOfZ5Fv0jo/SWK6kE1kEUIqIAExqo7ueRNqSrCw0I8U1J4TJszAw==",
 +-      "cpu": [
 +-        "x64"
 +-      ],
@@ -266,9 +265,9 @@ index 0000000..aeb135d
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-linux-arm": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-MfYn1p+aOorZ2Y+7sqLvSoAXPEz/RfKgHfeYO240Udco30B4oapm7Hsq2PsS9Z2Oth/RorGjY0jLP2OhnkY2Ig==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-mEtN8BbAgVtBu/5MVomYquXNvgok2C0KG6V0D4SV1jfBJNtlcqbp0WuIqT0bnM9DA4TgzcHvnFMpwGSK/dqI5A==",
 +-      "cpu": [
 +-        "arm"
 +-      ],
@@ -283,9 +282,9 @@ index 0000000..aeb135d
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-linux-arm64": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-Q1W4DHplR2urmtPwoz9tw6XUGWRNXF+CIXJQ8ZpIZFj/OHgvTw8vkYkKFuaEao3lSjTsR4lQe/wL2Xr5K0hxuA==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-OxNVWH9IhrMAzNlDyDit1dPO64GFIDPOUKoruIkJ9A1ZEONfIHXG5f+V3si9jtuNmuomiz9FjpbzOqLsgaxt+w==",
 +-      "cpu": [
 +-        "arm64"
 +-      ],
@@ -300,9 +299,9 @@ index 0000000..aeb135d
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-linux-x64": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-b+sbLBCIchbrGQNbjIvVN2qd+ieqqp/nghi0n2zOAKGPsfd5wG6ceqxWJKADdBDCohsCCGt//rZccUwFugIsyA==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-KO8WO1gBIC09T3255RlTY42TGu8en5mEkLPQu2wkMn+dX2T8KYL64zXrCeLeUWa0NvmVdJUeyWu3pFOn3zKemw==",
 +-      "cpu": [
 +-        "x64"
 +-      ],
@@ -317,9 +316,9 @@ index 0000000..aeb135d
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-win32-arm64": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-l59d8pZjFT7GoWpgCOy6aBcxLSALphA91X4Z/2XHo5HnM0bQ/yJjB7XMeUQZBdk5DZCdZL+sWTfmXLRggm7sFg==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-+8q19LWjnMKK6SF3PLeMEalbfWDYWHs0AU8kSFCBCke/RLoDG4FjQzVtLgUo+KWhsmZMosiEyqEnZmSlED2tIQ==",
 +-      "cpu": [
 +-        "arm64"
 +-      ],
@@ -334,9 +333,9 @@ index 0000000..aeb135d
 +-      }
 +-    },
 +-    "node_modules/@typescript/native-preview-win32-x64": {
-+-      "version": "7.0.0-dev.20260506.1",
-+-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260506.1.tgz",
-+-      "integrity": "sha512-dJDLSzaz2xjRYYmTSfcCepZUi3ITjQSJ6Gk5YGplMF57UmZCAGI+ns4Te/V74IJiQigXqTnyEIGorwsOqhW8gQ==",
++-      "version": "7.0.0-dev.20260609.1",
++-      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260609.1.tgz",
++-      "integrity": "sha512-qNPcss+6yRoNFfFIKQbPwJWYxDfOZwyL8JBJh4J+yMLOad/+/AOjsO4EtZsIpv5PMCjpnD75coBoDkw+5NkItw==",
 +-      "cpu": [
 +-        "x64"
 +-      ],
@@ -348,29 +347,29 @@ index 0000000..aeb135d
 +-      ],
 +-      "engines": {
 +-        "node": ">=16.20.0"
-++        "@loongdotjs/typescript-native-preview-darwin-arm64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-darwin-x64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-linux-arm": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-linux-arm64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-linux-loong64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-linux-ppc64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-linux-riscv64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-linux-x64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-win32-arm64": "7.0.0-dev.20260429.1",
-++        "@loongdotjs/typescript-native-preview-win32-x64": "7.0.0-dev.20260429.1"
+++        "@loongdotjs/typescript-native-preview-darwin-arm64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-darwin-x64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-linux-arm": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-linux-arm64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-linux-loong64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-linux-ppc64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-linux-riscv64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-linux-x64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-win32-arm64": "7.0.0-dev.20260609.1",
+++        "@loongdotjs/typescript-native-preview-win32-x64": "7.0.0-dev.20260609.1"
 +       }
 +     },
-+     "node_modules/@vscode/codicons": {
++     "node_modules/@typespec/ts-http-runtime": {
 +diff --git a/package.json b/package.json
-+index 5defb1ef..ff08c471 100644
++index 36485330..fc96f635 100644
 +--- a/package.json
 ++++ b/package.json
-+@@ -176,7 +176,7 @@
++@@ -189,7 +189,7 @@
 +     "@types/yauzl": "^2.10.0",
 +     "@types/yazl": "^2.4.2",
 +     "@typescript-eslint/utils": "^8.45.0",
-+-    "@typescript/native-preview": "^7.0.0-dev.20260429",
-++    "@typescript/native-preview": "npm:@loongdotjs/typescript-native-preview@7.0.0-dev.20260429.1",
++-    "@typescript/native-preview": "^7.0.0-dev.20260609",
+++    "@typescript/native-preview": "npm:@loongdotjs/typescript-native-preview@^7.0.0-dev.20260609.1",
 +     "@vscode/component-explorer": "^0.2.1-27",
 +     "@vscode/component-explorer-cli": "^0.2.1-27",
 +     "@vscode/gulp-electron": "1.41.3",

--- a/app-editors/vscodium/spec
+++ b/app-editors/vscodium/spec
@@ -1,4 +1,4 @@
-VER=1.121.03429
+VER=1.126.04524
 SRCS="git::rename=vscodium;commit=tags/$VER::https://github.com/VSCodium/vscodium.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=326631"


### PR DESCRIPTION
Topic Description
-----------------

- vscodium: update to 1.126.04524
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- vscodium: 1.126.04524

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscodium
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
