### PR TITLE
v2raya: update to 2.4.7

### DIFF
--- a/app-proxy/v2raya/spec
+++ b/app-proxy/v2raya/spec
@@ -1,8 +1,7 @@
-VER=2.2.7.5
-REL=3
+VER=2.4.7
 SRCS="git::commit=tags/v$VER::https://github.com/v2rayA/v2rayA.git \
       tbl::https://github.com/v2rayA/v2rayA/releases/download/v$VER/web.tar.gz"
 CHKSUMS="SKIP \
-         sha256::89bff9248a9cba8b7bda6e1202ac565dbca377319423868835235deddbfb182a"
+         sha256::b9ee3e93bd590f15f5a62a6774bb6fe8a33a0d56c2a6ac6532a1155cb93feb66"
 CHKUPDATE="anitya::id=326097"
 SUBDIR="v2raya/service"


### PR DESCRIPTION
Topic Description
-----------------

- v2raya: update to 2.4.7
    Co-authored-by: 斬風千雪 \(@chiyuki0325\) <me@chyk.ink>

Package(s) Affected
-------------------

- v2raya: 2.4.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2raya
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
