### PR TITLE
v2raya: update to 2.4.6

### DIFF
--- a/app-proxy/v2raya/autobuild/beyond
+++ b/app-proxy/v2raya/autobuild/beyond
@@ -1,3 +1,5 @@
+# $SRCDIR: v2raA/service
+
 export FILE_DIR="${SRCDIR}/../install/universal"
 
 abinfo "Installing desktop file ..."
@@ -9,5 +11,7 @@ abinfo "Installing icon ..."
 install -Dvm644 "${FILE_DIR}/v2raya.png" \
 	"${PKGDIR}/usr/share/icons/hicolor/512x512/apps/v2raya.png"
 
-abinfo "Renaming v2rayA to v2raya ..."
-mv -v "${PKGDIR}/usr/bin/v2rayA" "${PKGDIR}/usr/bin/v2raya"
+abinfo "Linking to geofile directory ..."
+install -dv "$PKGDIR"/usr/share/v2raya
+ln -sv ../v2ray-rules-dat/{geoip.dat,geosite.dat} \
+    "$PKGDIR"/usr/share/v2raya/

--- a/app-proxy/v2raya/autobuild/build
+++ b/app-proxy/v2raya/autobuild/build
@@ -1,0 +1,21 @@
+# FIXME: Go PIE not supported on loongarch64 and loongson3.
+if ! ab_match_arch loongarch64 && \
+   ! ab_match_arch loongarch64_nosimd && \
+   ! ab_match_arch loongson3; then
+    abinfo "Enabling buildmode=pie ..."
+    export GOFLAGS="${GOFLAGS} -buildmode=pie"
+fi
+
+# $SRCDIR: v2raA/service
+
+abinfo "Building v2rayA..."
+go build -trimpath -ldflags "-X github.com/v2rayA/v2rayA/conf.Version=$PKGVER" -mod=readonly -o v2raya
+
+abinfo "Building v2rayA Core..."
+pushd ../core
+go build -trimpath -ldflags "-X main.Version=$PKGVER" -mod=readonly -o v2raya_core ./main
+popd
+
+abinfo "Installing the binaries..."
+install -Dvm755 "$SRCDIR"/v2raya "$PKGDIR"/usr/bin/v2raya
+install -Dvm755 "$SRCDIR"/../core/v2raya_core "$PKGDIR"/usr/bin/v2raya_core

--- a/app-proxy/v2raya/autobuild/defines
+++ b/app-proxy/v2raya/autobuild/defines
@@ -1,8 +1,6 @@
 PKGNAME=v2raya
 PKGSEC=net
 PKGDES="Client for Project V with web UI"
-PKGDEP="v2ray"
+PKGDEP="v2ray-rules-dat"
 BUILDDEP="go"
-
-ABTYPE=gomod
-GO_LDFLAGS=("-X 'github.com/v2rayA/v2rayA/conf.Version=$PKGVER'")
+ABTYPE=self

--- a/app-proxy/v2raya/autobuild/overrides/etc/default/v2raya
+++ b/app-proxy/v2raya/autobuild/overrides/etc/default/v2raya
@@ -3,7 +3,7 @@
 V2RAYA_ADDRESS=0.0.0.0:2017
 
 # Executable v2ray binary path. Auto-detect if put it empty.
-V2RAYA_V2RAY_BIN=/usr/bin/v2ray
+V2RAYA_V2RAY_BIN=/usr/bin/v2raya_core
 
 # v2rayA configuration directory
 V2RAYA_CONFIG=/etc/v2raya

--- a/app-proxy/v2raya/autobuild/prepare
+++ b/app-proxy/v2raya/autobuild/prepare
@@ -1,3 +1,5 @@
+# $SRCDIR: v2raA/service
+
 abinfo "Placing pre-built web resource ..."
-mkdir -pv "$SRCDIR"/service/server/router
+mkdir -pv "$SRCDIR"/../service/server/router
 cp -rv "$SRCDIR"/../../web "$SRCDIR"/../service/server/router/web

--- a/app-proxy/v2raya/spec
+++ b/app-proxy/v2raya/spec
@@ -1,8 +1,7 @@
-VER=2.2.7.5
-REL=3
+VER=2.4.6
 SRCS="git::commit=tags/v$VER::https://github.com/v2rayA/v2rayA.git \
       tbl::https://github.com/v2rayA/v2rayA/releases/download/v$VER/web.tar.gz"
 CHKSUMS="SKIP \
-         sha256::89bff9248a9cba8b7bda6e1202ac565dbca377319423868835235deddbfb182a"
+         sha256::f29aa1e1232fc57da73377544589129d16606b20db1f3b0ea5596320dc608edb"
 CHKUPDATE="anitya::id=326097"
 SUBDIR="v2raya/service"


### PR DESCRIPTION
Topic Description
-----------------

- v2raya: update to 2.4.6

Package(s) Affected
-------------------

- v2raya: 2.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit v2raya
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
