### PR TITLE
fcitx5-pinyin-moegirl: update to 20260713

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260712
+VER=20260713
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::7c2ce1f699fe1d62fad08be93e279a699f898d06756db7d82322c41c32132b85 \
-         sha256::778236c72c9687dbebcbbbcc904d44d7d1b9e70fee7a7a9b4eca7299dcb476ac \
+CHKSUMS="sha256::666a5372894a4e32418a7a3ece454aea106fffeca5940881891e89cb8481755b \
+         sha256::15c6b9bd6766a9a4673fa89de13a95185b13c67ca70284133200169ed179798d \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.

--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260511
+VER=20260712
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::1fd499464c19259f4b3038b27d75d99bccc2ab71370a36d208178f8dfd693dde \
-         sha256::aedaf0b8f36f87492ba1b4c33f7a13ac0b30623f402c26484eb7ee756e445df7 \
+CHKSUMS="sha256::7c2ce1f699fe1d62fad08be93e279a699f898d06756db7d82322c41c32132b85 \
+         sha256::778236c72c9687dbebcbbbcc904d44d7d1b9e70fee7a7a9b4eca7299dcb476ac \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260713

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260713
- rime-pinyin-moegirl: 20260713

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
