### PR TITLE
libcamera: update to 0.7.2

### DIFF
--- a/runtime-devices/libcamera/autobuild/defines
+++ b/runtime-devices/libcamera/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=libcamera
 PKGSEC=libs
-PKGDES="A cross-platform camera support library"
+PKGDES="Cross-platform camera support library"
 PKGDEP="lttng-ust systemd yaml libdrm libevent libjpeg-turbo libtiff sdl2 \
-        elfutils libunwind gstreamer glib gnutls qt-6 openssl libevent gtest"
+        elfutils libunwind gstreamer glib gnutls qt-6 openssl libevent gtest \
+        libyuv"
 PKGDEP__ARM64="${PKGDEP} libpisp"
 BUILDDEP="jinja2 ply pyyaml"
 
@@ -15,10 +16,15 @@ PKGBREAK="pipewire<=1.4.10"
 MESON_AFTER=(
     '-Dandroid=disabled'
     '-Dcam=enabled'
+    '-Dcam-output-kms=enabled'
+    '-Dcam-output-sdl2=enabled'
+    '-Dcam-jpeg=enabled'
     '-Ddocumentation=disabled'
     '-Ddoc_werror=false'
     '-Dgstreamer=enabled'
     '-Dlc-compliance=enabled'
+    '-Dlibdw=enabled'
+    '-Dlibunwind=enabled'
     '-Dpipelines=auto'
     '-Dpycamera=disabled'
     '-Dqcam=enabled'

--- a/runtime-devices/libcamera/spec
+++ b/runtime-devices/libcamera/spec
@@ -1,4 +1,4 @@
-VER=0.7.1
+VER=0.7.2
 SRCS="git::commit=tags/v${VER}::https://git.libcamera.org/libcamera/libcamera.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=301902"

--- a/runtime-devices/libpisp/autobuild/defines
+++ b/runtime-devices/libpisp/autobuild/defines
@@ -1,8 +1,10 @@
 PKGNAME=libpisp
 PKGSEC=libs
 PKGDES="Library to generate runtime configuration for the Raspberry Pi ISP (PiSP)"
-PKGDEP="cxxopts boost"
-BUILDDEP="nlohmann-json"
+# NOTE: libpisp's pkg-config specifies nlohmann-json as required
+PKGDEP="cxxopts boost nlohmann-json"
+
+ABTYPE=meson
 
 # FIXME: gstreamer feature requires the following merge request to be merged
 # Link: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/9247

--- a/runtime-devices/libpisp/spec
+++ b/runtime-devices/libpisp/spec
@@ -1,4 +1,5 @@
 VER=1.6.0
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/raspberrypi/libpisp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378526"


### PR DESCRIPTION
Topic Description
-----------------

- libcamera: update to 0.7.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libcamera: 0.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpisp libcamera
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
