### PR TITLE
neatvnc: update to 1.0.1

### DIFF
--- a/runtime-network/neatvnc/spec
+++ b/runtime-network/neatvnc/spec
@@ -1,4 +1,4 @@
-VER=1.0.0
+VER=1.0.1
 SRCS="git::commit=tags/v$VER::https://github.com/any1/neatvnc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370162"


### PR DESCRIPTION
Topic Description
-----------------

- neatvnc: update to 1.0.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- neatvnc: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit neatvnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
