### PR TITLE
wayvnc: update to 0.10.1

### DIFF
--- a/runtime-network/wayvnc/spec
+++ b/runtime-network/wayvnc/spec
@@ -1,4 +1,4 @@
-VER=0.10.0
+VER=0.10.1
 SRCS="git::commit=tags/v$VER::https://github.com/any1/wayvnc.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=137711"


### PR DESCRIPTION
Topic Description
-----------------

- wayvnc: update to 0.10.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wayvnc: 0.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wayvnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
