### PR TITLE
weechat: update to 4.9.3

### DIFF
--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,5 +1,4 @@
-VER=4.9.2
+VER=4.9.3
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::d1389a9e521bda0c4ebfa108e2abf885ee6c5150c385299f5dca0181a43a0914"
+CHKSUMS="sha256::5c7d9539fa86c99ea76a551a889a92bac21eab7bb2790dbd346452d00b10c37c"
 CHKUPDATE="anitya::id=5122"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.9.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- weechat: 4.9.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
