### PR TITLE
vscode: update to 1.128.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.127.0
+VER=1.128.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::0cddc13023bf713dfc4774d4f24418b53d32180bfd73f50ff960bc5cdaf56a2d"
-CHKSUMS__ARM64="sha256::55d7fda22a4097d5a23842360264f771edd7d309f07362a6acf2ae93ba6016a5"
+CHKSUMS__AMD64="sha256::ee7ff012cf872e497d665486e56c5b1a12e36cca0c07c97887c997cbfdc797b1"
+CHKSUMS__ARM64="sha256::eb394338250dc7f5371c8c8e6a26d632c7aa977843d6ee7a496132c301a8ea05"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.128.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.128.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
