### PR TITLE
botan: security update to 3.12.0

### DIFF
--- a/app-utils/keepassxc/spec
+++ b/app-utils/keepassxc/spec
@@ -1,5 +1,5 @@
 VER=2.7.12
-REL=1
+REL=2
 SRCS="https://github.com/keepassxreboot/keepassxc/releases/download/${VER}/keepassxc-${VER}-src.tar.xz"
 CHKSUMS="sha256::be34eeb297881adea4f894c7c6e4a1835bd7927f8043ddea495040df4792a7de"
 CHKUPDATE="anitya::id=15656"

--- a/runtime-cryptography/botan/autobuild/defines
+++ b/runtime-cryptography/botan/autobuild/defines
@@ -3,6 +3,6 @@ PKGSEC=libs
 PKGDES="C++ cryptography library"
 BUILDDEP="docutils"
 PKGREP="botan-3"
-PKGBREAK="botan-3<=3.5.0-1 keepassxc<=2.7.12"
+PKGBREAK="botan-3<=3.5.0-1 keepassxc<=2.7.12-1"
 
 AB_FLAGS_O3=1

--- a/runtime-cryptography/botan/spec
+++ b/runtime-cryptography/botan/spec
@@ -1,4 +1,4 @@
-VER=3.11.1
+VER=3.12.0
 SRCS="tbl::https://botan.randombit.net/releases/Botan-$VER.tar.xz"
-CHKSUMS="sha256::c1cd7152519f4188591fa4f6ddeb116bc1004491f5f3c58aa99b00582eb8a137"
+CHKSUMS="sha256::5370f98dc15f8c222ee1ce52cd61c8756a53be0dc57cc4c1b0714d5a09ad74fb"
 CHKUPDATE="anitya::id=214"

--- a/topics/botan-3.12.0.toml
+++ b/topics/botan-3.12.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Botan 3.12.0"
+
+[caution]
+default = "Fixes an Inefficient Algorithmic Complexity vulnerability (CVE-2026-44378, Severity: High)"
+zh_CN = "修复 1 个算法复杂度不当漏洞（漏洞编号 CVE-2026-44378，严重性：高）"
+
+[packages-v2]
+"botan" = "< 3.12.0"


### PR DESCRIPTION
Topic Description
-----------------

- botan: security update to 3.12.0

Package(s) Affected
-------------------

- botan: 3.12.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit botan keepassxc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
