### PR TITLE
coturn: security update to 4.14.0

### DIFF
--- a/app-network/coturn/spec
+++ b/app-network/coturn/spec
@@ -1,4 +1,4 @@
-VER=4.10.0
+VER=4.14.0
 SRCS="git::commit=tags/$VER::https://github.com/coturn/coturn.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=105341"

--- a/topics/coturn-4.14.0.toml
+++ b/topics/coturn-4.14.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Coturn 4.14.0"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (including 2 of high severity and 2 of medium severity)"
+zh_CN = "修复 4 个安全漏洞（含 2 个高危漏洞和 2 个中危漏洞）"
+
+[packages-v2]
+"coturn" = "< 4.14.0"


### PR DESCRIPTION
Topic Description
-----------------

- coturn: security update to 4.14.0

Package(s) Affected
-------------------

- coturn: 4.14.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit coturn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
