### PR TITLE
dnsmasq: security update to 2.93

### DIFF
--- a/app-network/dnsmasq/spec
+++ b/app-network/dnsmasq/spec
@@ -1,4 +1,4 @@
-VER=2.92
+VER=2.93
 SRCS="tbl::http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$VER.tar.xz"
-CHKSUMS="sha256::4bf50c2c1018f9fbc26037df51b90ecea0cb73d46162846763b92df0d6c3a458"
+CHKSUMS="sha256::0c00d4e5c97c8306e5fb932b348b34269c9c29a0e7df0e8e82958b407092bc19"
 CHKUPDATE="anitya::id=444"

--- a/topics/dnsmasq-2.93.toml
+++ b/topics/dnsmasq-2.93.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "dnsmasq 2.93"
+
+[caution]
+default = "Fixes a Heap-Based Buffer Overflow vulnerability (CVE-2026-12725, Severity: Medium) and a Heap Out-of-Bounds Read vulnerability (CVE-2026-12969, Severity: Medium)"
+zh_CN = "修复 1 个基于堆的缓冲区溢出漏洞（漏洞编号 CVE-2026-12725，严重性：中）和 1 个堆越界读取漏洞（漏洞编号 CVE-2026-12969，严重性：中）"
+
+[packages-v2]
+"dnsmasq" = "< 2.93"


### PR DESCRIPTION
Topic Description
-----------------

- dnsmasq: security update to 2.93

Package(s) Affected
-------------------

- dnsmasq: 2.93

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit dnsmasq
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
