### PR TITLE
codex: update to 0.144.1

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,19 +1,20 @@
-From adae3cf15b5bfaee98013e8751e8353e87872908 Mon Sep 17 00:00:00 2001
+From d8f8e36d9ef36a1222d88b66d53c71d079c8a72f Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 23 Jun 2026 13:51:19 +0800
 Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
-
-Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 ---
  codex-rs/Cargo.lock | 2 --
  codex-rs/Cargo.toml | 2 ++
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index cd658f9a88..123f5915f8 100644
+index 023c5dfaa3..6152548673 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -14319,8 +14319,6 @@ dependencies = [
+@@ -14447,8 +14447,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "149.2.0"
@@ -23,10 +24,10 @@ index cd658f9a88..123f5915f8 100644
   "bindgen",
   "bitflags 2.10.0",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index d469506851..a0ab8042ac 100644
+index 596ec1a89d..eae6985efe 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -552,5 +552,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -564,5 +564,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  
@@ -34,6 +35,3 @@ index d469506851..a0ab8042ac 100644
 +
  [patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
  tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "4fffad30fe373adbdcffab9545e9e9bf4f2fc19f" }
--- 
-2.52.0
-

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-fix-cargo.lock.patch
@@ -1,15 +1,16 @@
-From 8c38b6827cd4445188245c056b7bd30b24892d7b Mon Sep 17 00:00:00 2001
+From 2d1a521393fd84ce0a9888859ff85669d075fd64 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Tue, 23 Jun 2026 13:52:20 +0800
 Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
-
-Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
 ---
- codex-rs/Cargo.lock | 254 ++++++++++++++++++++++----------------------
- 1 file changed, 127 insertions(+), 127 deletions(-)
+ codex-rs/Cargo.lock | 264 ++++++++++++++++++++++----------------------
+ 1 file changed, 132 insertions(+), 132 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 123f5915f8..e1123a1102 100644
+index 6152548673..c9bb1777a6 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -394,7 +394,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
@@ -17,899 +18,939 @@ index 123f5915f8..e1123a1102 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1863,7 +1863,7 @@ dependencies = [
+@@ -1868,7 +1868,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-graph-store"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-protocol",
   "codex-state",
-@@ -1877,7 +1877,7 @@ dependencies = [
+@@ -1882,7 +1882,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-identity"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1896,7 +1896,7 @@ dependencies = [
+@@ -1901,7 +1901,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1917,7 +1917,7 @@ dependencies = [
+@@ -1922,7 +1922,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1926,7 +1926,7 @@ dependencies = [
+@@ -1931,7 +1931,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1959,7 +1959,7 @@ dependencies = [
+@@ -1966,7 +1966,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -2051,7 +2051,7 @@ dependencies = [
+@@ -2060,7 +2060,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -2078,7 +2078,7 @@ dependencies = [
+@@ -2087,7 +2087,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-daemon"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2099,7 +2099,7 @@ dependencies = [
+@@ -2108,7 +2108,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2127,7 +2127,7 @@ dependencies = [
+@@ -2137,7 +2137,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2149,7 +2149,7 @@ dependencies = [
+@@ -2159,7 +2159,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-transport"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2188,7 +2188,7 @@ dependencies = [
+@@ -2201,7 +2201,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2208,7 +2208,7 @@ dependencies = [
+@@ -2221,7 +2221,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -2228,7 +2228,7 @@ dependencies = [
+@@ -2241,7 +2241,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
   "tokio",
-@@ -2237,7 +2237,7 @@ dependencies = [
+@@ -2250,7 +2250,7 @@ dependencies = [
  
  [[package]]
  name = "codex-aws-auth"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "aws-config",
   "aws-credential-types",
-@@ -2252,7 +2252,7 @@ dependencies = [
+@@ -2265,7 +2265,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -2269,7 +2269,7 @@ dependencies = [
+@@ -2282,7 +2282,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "serde",
   "serde_json",
-@@ -2278,7 +2278,7 @@ dependencies = [
+@@ -2291,7 +2291,7 @@ dependencies = [
  
  [[package]]
  name = "codex-bwrap"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "cc",
   "libc",
-@@ -2287,7 +2287,7 @@ dependencies = [
+@@ -2300,7 +2300,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2309,7 +2309,7 @@ dependencies = [
+@@ -2321,7 +2321,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
-  "assert_cmd",
-@@ -2385,7 +2385,7 @@ dependencies = [
+  "app_test_support",
+@@ -2398,7 +2398,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
-  "bytes",
-  "codex-utils-cargo-bin",
-@@ -2415,7 +2415,7 @@ dependencies = [
+  "codex-http-client",
+  "eventsource-stream",
+@@ -2410,7 +2410,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-config"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "base64 0.22.1",
   "chrono",
-@@ -2439,7 +2439,7 @@ dependencies = [
+@@ -2434,7 +2434,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2470,7 +2470,7 @@ dependencies = [
+@@ -2465,7 +2465,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2484,7 +2484,7 @@ dependencies = [
+@@ -2479,7 +2479,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "chrono",
   "codex-cloud-tasks-client",
-@@ -2493,7 +2493,7 @@ dependencies = [
+@@ -2488,7 +2488,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-code-mode-protocol",
   "codex-protocol",
-@@ -2508,11 +2508,11 @@ dependencies = [
+@@ -2504,7 +2504,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-host"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
+ dependencies = [
+  "anyhow",
+  "codex-code-mode",
+@@ -2520,7 +2520,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-protocol"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-protocol",
   "pretty_assertions",
-@@ -2524,11 +2524,11 @@ dependencies = [
+@@ -2532,11 +2532,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -2576,7 +2576,7 @@ dependencies = [
+@@ -2584,7 +2584,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
-  "codex-app-server-protocol",
-@@ -2593,7 +2593,7 @@ dependencies = [
+  "codex-config",
+@@ -2602,7 +2602,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-connectors-extension"
+-version = "0.0.0"
++version = "0.144.1"
+ dependencies = [
+  "codex-connectors",
+  "codex-core-plugins",
+@@ -2614,7 +2614,7 @@ dependencies = [
  
  [[package]]
  name = "codex-context-fragments"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -2601,7 +2601,7 @@ dependencies = [
+@@ -2622,7 +2622,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2725,7 +2725,7 @@ dependencies = [
+@@ -2749,7 +2749,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-api"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-analytics",
   "codex-app-server-protocol",
-@@ -2745,7 +2745,7 @@ dependencies = [
+@@ -2770,7 +2770,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-plugins"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2790,7 +2790,7 @@ dependencies = [
+@@ -2818,7 +2818,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-skills"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-analytics",
-@@ -2825,7 +2825,7 @@ dependencies = [
+@@ -2852,7 +2852,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2871,7 +2871,7 @@ dependencies = [
+@@ -2898,7 +2898,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2916,7 +2916,7 @@ dependencies = [
+@@ -2950,7 +2950,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-exec-server-protocol"
+-version = "0.0.0"
++version = "0.144.1"
+ dependencies = [
+  "base64 0.22.1",
+  "codex-file-system",
+@@ -2965,7 +2965,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2933,7 +2933,7 @@ dependencies = [
+@@ -2982,7 +2982,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy-legacy"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "allocative",
   "anyhow",
-@@ -2953,7 +2953,7 @@ dependencies = [
+@@ -3002,7 +3002,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -2962,7 +2962,7 @@ dependencies = [
+@@ -3011,7 +3011,7 @@ dependencies = [
  
  [[package]]
  name = "codex-extension-api"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-config",
   "codex-context-fragments",
-@@ -2975,7 +2975,7 @@ dependencies = [
+@@ -3025,7 +3025,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-extension-items"
+-version = "0.0.0"
++version = "0.144.1"
+ dependencies = [
+  "codex-utils-absolute-path",
+  "pretty_assertions",
+@@ -3037,7 +3037,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-migration"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-hooks",
   "pretty_assertions",
-@@ -2987,7 +2987,7 @@ dependencies = [
+@@ -3049,7 +3049,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-sessions"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "chrono",
   "codex-app-server-protocol",
-@@ -3001,7 +3001,7 @@ dependencies = [
+@@ -3063,7 +3063,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -3014,7 +3014,7 @@ dependencies = [
+@@ -3076,7 +3076,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-login",
-@@ -3027,7 +3027,7 @@ dependencies = [
+@@ -3090,7 +3090,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3043,7 +3043,7 @@ dependencies = [
+@@ -3106,7 +3106,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-system"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "bytes",
   "codex-protocol",
-@@ -3055,7 +3055,7 @@ dependencies = [
+@@ -3118,7 +3118,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-watcher"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "notify",
   "pretty_assertions",
-@@ -3066,7 +3066,7 @@ dependencies = [
+@@ -3129,7 +3129,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3091,7 +3091,7 @@ dependencies = [
+@@ -3154,7 +3154,7 @@ dependencies = [
  
  [[package]]
  name = "codex-goal-extension"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3113,7 +3113,7 @@ dependencies = [
+@@ -3176,7 +3176,7 @@ dependencies = [
  
  [[package]]
  name = "codex-guardian"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-core",
   "codex-extension-api",
-@@ -3122,7 +3122,7 @@ dependencies = [
+@@ -3185,7 +3185,7 @@ dependencies = [
  
  [[package]]
  name = "codex-home"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-extension-api",
   "codex-utils-absolute-path",
-@@ -3133,7 +3133,7 @@ dependencies = [
+@@ -3196,7 +3196,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3156,7 +3156,7 @@ dependencies = [
+@@ -3219,7 +3219,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-http-client"
+-version = "0.0.0"
++version = "0.144.1"
+ dependencies = [
+  "bytes",
+  "codex-utils-cargo-bin",
+@@ -3250,7 +3250,7 @@ dependencies = [
  
  [[package]]
  name = "codex-image-generation-extension"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
+  "base64 0.22.1",
   "codex-api",
-  "codex-core",
-@@ -3179,7 +3179,7 @@ dependencies = [
+@@ -3277,7 +3277,7 @@ dependencies = [
  
  [[package]]
  name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-utils-absolute-path",
   "codex-utils-home-dir",
-@@ -3189,7 +3189,7 @@ dependencies = [
+@@ -3287,7 +3287,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "keyring",
   "tracing",
-@@ -3197,7 +3197,7 @@ dependencies = [
+@@ -3295,7 +3295,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "clap",
   "codex-core",
-@@ -3221,7 +3221,7 @@ dependencies = [
+@@ -3320,7 +3320,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -3235,7 +3235,7 @@ dependencies = [
+@@ -3334,7 +3334,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3277,7 +3277,7 @@ dependencies = [
+@@ -3375,7 +3375,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -3311,7 +3311,7 @@ dependencies = [
+@@ -3410,7 +3410,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-extension"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-config",
-  "codex-core",
-@@ -3335,7 +3335,7 @@ dependencies = [
+  "codex-connectors-extension",
+@@ -3435,7 +3435,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-arg0",
-@@ -3368,7 +3368,7 @@ dependencies = [
+@@ -3469,7 +3469,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-extension"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-core",
   "codex-extension-api",
-@@ -3389,7 +3389,7 @@ dependencies = [
+@@ -3490,7 +3490,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-read"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -3399,7 +3399,7 @@ dependencies = [
+@@ -3500,7 +3500,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-write"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3436,7 +3436,7 @@ dependencies = [
+@@ -3537,7 +3537,7 @@ dependencies = [
  
  [[package]]
  name = "codex-message-history"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-config",
   "memchr",
-@@ -3450,7 +3450,7 @@ dependencies = [
+@@ -3551,7 +3551,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-agent-identity",
   "codex-api",
-@@ -3473,7 +3473,7 @@ dependencies = [
+@@ -3574,7 +3574,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider-info"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-api",
-  "codex-app-server-protocol",
-@@ -3490,7 +3490,7 @@ dependencies = [
+  "codex-protocol",
+@@ -3590,7 +3590,7 @@ dependencies = [
  
  [[package]]
  name = "codex-models-manager"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "chrono",
-  "codex-app-server-protocol",
-@@ -3510,7 +3510,7 @@ dependencies = [
+  "codex-collaboration-mode-templates",
+@@ -3610,7 +3610,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3545,7 +3545,7 @@ dependencies = [
+@@ -3646,7 +3646,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -3565,7 +3565,7 @@ dependencies = [
+@@ -3666,7 +3666,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -3597,7 +3597,7 @@ dependencies = [
+@@ -3697,7 +3697,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-config",
   "codex-protocol",
-@@ -3609,7 +3609,7 @@ dependencies = [
+@@ -3710,7 +3710,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -3617,7 +3617,7 @@ dependencies = [
+@@ -3718,7 +3718,7 @@ dependencies = [
  
  [[package]]
  name = "codex-prompts"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-context-fragments",
-@@ -3631,7 +3631,7 @@ dependencies = [
+@@ -3732,7 +3732,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -3672,7 +3672,7 @@ dependencies = [
+@@ -3774,7 +3774,7 @@ dependencies = [
  
  [[package]]
  name = "codex-realtime-webrtc"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "libwebrtc",
   "thiserror 2.0.18",
-@@ -3681,7 +3681,7 @@ dependencies = [
+@@ -3783,7 +3783,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3692,7 +3692,7 @@ dependencies = [
+@@ -3794,7 +3794,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3709,7 +3709,7 @@ dependencies = [
+@@ -3811,7 +3811,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "axum",
-@@ -3751,7 +3751,7 @@ dependencies = [
+@@ -3852,7 +3852,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3776,7 +3776,7 @@ dependencies = [
+@@ -3876,7 +3876,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout-trace"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-code-mode",
-@@ -3792,7 +3792,7 @@ dependencies = [
+@@ -3892,7 +3892,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-network-proxy",
-@@ -3815,7 +3815,7 @@ dependencies = [
+@@ -3915,7 +3915,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "age",
   "anyhow",
-@@ -3836,7 +3836,7 @@ dependencies = [
+@@ -3936,7 +3936,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3857,7 +3857,7 @@ dependencies = [
+@@ -3957,7 +3957,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3877,7 +3877,7 @@ dependencies = [
+@@ -3977,7 +3977,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-utils-absolute-path",
   "include_dir",
-@@ -3886,7 +3886,7 @@ dependencies = [
+@@ -3986,7 +3986,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills-extension"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-core-skills",
   "codex-exec-server",
-@@ -3908,7 +3908,7 @@ dependencies = [
+@@ -4008,7 +4008,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3932,7 +3932,7 @@ dependencies = [
+@@ -4032,7 +4032,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-uds",
-@@ -3944,7 +3944,7 @@ dependencies = [
+@@ -4044,7 +4044,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -3952,7 +3952,7 @@ dependencies = [
+@@ -4052,7 +4052,7 @@ dependencies = [
  
  [[package]]
  name = "codex-test-binary-support"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-arg0",
   "tempfile",
-@@ -3960,7 +3960,7 @@ dependencies = [
+@@ -4060,7 +4060,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-manager-sample"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3971,7 +3971,7 @@ dependencies = [
+@@ -4071,7 +4071,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-store"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "chrono",
   "codex-git-utils",
-@@ -3992,7 +3992,7 @@ dependencies = [
+@@ -4093,7 +4093,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
-  "codex-app-server-protocol",
   "codex-code-mode",
-@@ -4016,7 +4016,7 @@ dependencies = [
+  "codex-connectors",
+@@ -4118,7 +4118,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -4126,7 +4126,7 @@ dependencies = [
+@@ -4228,7 +4228,7 @@ dependencies = [
  
  [[package]]
  name = "codex-uds"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "async-io",
   "pretty_assertions",
-@@ -4138,7 +4138,7 @@ dependencies = [
+@@ -4240,7 +4240,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "dirs",
   "dunce",
-@@ -4152,14 +4152,14 @@ dependencies = [
+@@ -4254,14 +4254,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-protocol",
  ]
@@ -917,134 +958,134 @@ index 123f5915f8..e1123a1102 100644
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "lru 0.16.3",
   "sha1 0.10.6",
-@@ -4168,7 +4168,7 @@ dependencies = [
+@@ -4270,7 +4270,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -4177,7 +4177,7 @@ dependencies = [
+@@ -4279,7 +4279,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -4189,15 +4189,15 @@ dependencies = [
+@@ -4291,15 +4291,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-utils-absolute-path",
   "dirs",
-@@ -4207,7 +4207,7 @@ dependencies = [
+@@ -4309,7 +4309,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -4220,7 +4220,7 @@ dependencies = [
+@@ -4322,7 +4322,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -4229,7 +4229,7 @@ dependencies = [
+@@ -4331,7 +4331,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -4239,7 +4239,7 @@ dependencies = [
+@@ -4341,7 +4341,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -4248,7 +4248,7 @@ dependencies = [
+@@ -4350,7 +4350,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -4258,7 +4258,7 @@ dependencies = [
+@@ -4360,7 +4360,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path-uri"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-absolute-path",
-@@ -4274,7 +4274,7 @@ dependencies = [
+@@ -4376,7 +4376,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-exec-server",
   "codex-utils-absolute-path",
-@@ -4287,7 +4287,7 @@ dependencies = [
+@@ -4389,7 +4389,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -4303,7 +4303,7 @@ dependencies = [
+@@ -4405,7 +4405,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "assert_matches",
   "thiserror 2.0.18",
-@@ -4313,14 +4313,14 @@ dependencies = [
+@@ -4415,14 +4415,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "rustls",
  ]
@@ -1052,25 +1093,25 @@ index 123f5915f8..e1123a1102 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-core",
   "codex-model-provider-info",
-@@ -4331,7 +4331,7 @@ dependencies = [
+@@ -4433,7 +4433,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -4341,14 +4341,14 @@ dependencies = [
+@@ -4443,14 +4443,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1078,16 +1119,16 @@ index 123f5915f8..e1123a1102 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -4358,14 +4358,14 @@ dependencies = [
+@@ -4460,14 +4460,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1095,46 +1136,52 @@ index 123f5915f8..e1123a1102 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -4373,7 +4373,7 @@ dependencies = [
+@@ -4475,7 +4475,7 @@ dependencies = [
  
  [[package]]
  name = "codex-web-search-extension"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "codex-api",
   "codex-core",
-@@ -4392,7 +4392,7 @@ dependencies = [
+@@ -4495,7 +4495,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-websocket-client"
+-version = "0.0.0"
++version = "0.144.1"
+ dependencies = [
+  "codex-http-client",
+  "codex-utils-rustls-provider",
+@@ -4511,7 +4511,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4649,7 +4649,7 @@ dependencies = [
+@@ -4768,7 +4768,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -9035,7 +9035,7 @@ dependencies = [
+@@ -9154,7 +9154,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.142.0"
++version = "0.144.1"
  dependencies = [
   "anyhow",
   "codex-login",
--- 
-2.52.0
-

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.142.0
+VER=0.144.1
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=149.2.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.144.1
    This commit is authored with assistance from AI/LLM:
    - Model: GPT-5.6 Sol
    - Platform: OpenAI \(https://openai.com/\)
    - Agent platform: Codex CLI \(https://developers.openai.com/codex/cli/\)
    - Prompt: 更新自己，参考以前的更新方法。
    Assisted-by: Codex <codex@openai.com>

Package(s) Affected
-------------------

- codex: 0.144.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`


# AI Assistance Usage Declaration

This issue/PR is authored with assistance from AI/LLM:

- Model: `GPT-5.6 Sol`
- Platform: OpenAI (https://openai.com/)
- Agent platform: Codex CLI (https://developers.openai.com/codex/cli/)
- Prompt: `更新自己，参考以前的更新方法。`