### PR TITLE
erlang: security update to 29.0.3

### DIFF
--- a/lang-erlang/erlang/spec
+++ b/lang-erlang/erlang/spec
@@ -1,4 +1,4 @@
-VER=29.0.2
+VER=29.0.3
 SRCS="tbl::https://github.com/erlang/otp/releases/download/OTP-$VER/otp_src_$VER.tar.gz"
-CHKSUMS="sha256::b9a7714fdd282c4a7113651b1e2728a58799e60ffe20e545f5cc94c621527b15"
+CHKSUMS="sha256::f920c660b16794bcb7270d1cbf680f7747c719650bcd6ac449508a32c2a8972a"
 CHKUPDATE="anitya::id=707"

--- a/topics/erlang-29.0.3.toml
+++ b/topics/erlang-29.0.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Erlang 29.0.3"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (including 2 of High and 4 of Medium severity)"
+zh_CN = "修复 6 个安全漏洞（含 2 个高危漏洞和 4 个中危漏洞）"
+
+[packages-v2]
+"erlang" = "< 29.0.3"


### PR DESCRIPTION
Topic Description
-----------------

- erlang: security update to 29.0.3
- dovecot: security update to 2.4.4

Package(s) Affected
-------------------

- erlang: 29.0.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit erlang
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
