### PR TITLE
X Survey 20260713

### DIFF
--- a/runtime-display/xorg-server/autobuild/defines
+++ b/runtime-display/xorg-server/autobuild/defines
@@ -9,25 +9,33 @@ BUILDDEP="wayland"
 PKGDES="X.Org display server"
 
 ABTYPE=meson
-MESON_AFTER="-Dipv6=true \
-             -Ddri1=true \
-             -Ddri3=true \
-             -Dxvfb=true \
-             -Dxnest=true \
-             -Dxcsecurity=true \
-             -Dxorg=true \
-             -Dxephyr=true \
-             -Dglamor=true \
-             -Dudev=true \
-             -Dsystemd_logind=true \
-             -Dlibunwind=true \
-             -Dsuid_wrapper=true \
-             -Dsha1=libgcrypt \
-             -Dxkb_dir=/usr/share/X11/xkb \
-             -Dxkb_output_dir=/var/lib/xkb \
-             -Ddefault_font_path=/usr/share/fonts"
-MESON_AFTER__RISCV64="${MESON_AFTER} -Dlibunwind=false"
-MESON_AFTER__ARM64="${MESON_AFTER} -Dlibunwind=false"
+MESON_AFTER=(
+    '-Dipv6=true'
+    '-Ddri1=true'
+    '-Ddri3=true'
+    '-Dxvfb=true'
+    '-Dxnest=true'
+    '-Dxcsecurity=true'
+    '-Dxorg=true'
+    '-Dxephyr=true'
+    '-Dglamor=true'
+    '-Dudev=true'
+    '-Dsystemd_logind=true'
+    '-Dlibunwind=true'
+    '-Dsuid_wrapper=true'
+    '-Dsha1=libgcrypt'
+    '-Dxkb_dir=/usr/share/X11/xkb'
+    '-Dxkb_output_dir=/var/lib/xkb'
+    '-Ddefault_font_path=/usr/share/fonts'
+)
+MESON_AFTER__RISCV64=(
+    "${MESON_AFTER[@]}"
+    '-Dlibunwind=false'
+)
+MESON_AFTER__ARM64=(
+    "${MESON_AFTER[@]}"
+    '-Dlibunwind=false'
+)
 
 PKGDEP__RETRO="xkeyboard-config x11-app x11-lib libdrm pixman \
                xcb-util-renderutil xcb-util-image xcb-util-keysyms \
@@ -36,51 +44,38 @@ PKGDEP__ARMV4="${PKGDEP__RETRO} libepoxy"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO} libepoxy"
 PKGDEP__ARMV7HF="${PKGDEP__RETRO} libepoxy"
 PKGDEP__I486="${PKGDEP__RETRO} libepoxy libunwind"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
 BUILDDEP__RETRO="x11-font mesa"
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 
-MESON_AFTER__RETRO=" \
-             -Dipv6=false \
-             -Ddri1=true \
-             -Ddri2=true \
-             -Ddri3=true \
-             -Dxvfb=false \
-             -Dxnest=false \
-             -Dxcsecurity=true \
-             -Dxorg=true \
-             -Dxephyr=false \
-             -Dglamor=false \
-             -Dudev=true \
-             -Dsystemd_logind=false \
-             -Dsuid_wrapper=true \
-             -Dsha1=libgcrypt \
-             -Dxkb_dir=/usr/share/X11/xkb \
-             -Dxkb_output_dir=/var/lib/xkb \
-             -Ddefault_font_path=/usr/share/fonts"
-MESON_AFTER__ARMV4=" \
-             ${MESON_AFTER__RETRO}"
-MESON_AFTER__ARMV6HF=" \
-             ${MESON_AFTER__RETRO} \
-             -Dglamor=true"
-MESON_AFTER__ARMV7HF=" \
-             ${MESON_AFTER__RETRO} \
-             -Dglamor=true"
-MESON_AFTER__I486="${MESON_AFTER__RETRO}"
-MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO}"
-MESON_AFTER__M68K="${MESON_AFTER__RETRO}"
-MESON_AFTER__POWERPC="${MESON_AFTER__RETRO}"
-MESON_AFTER__PPC64="${MESON_AFTER__RETRO}"
+MESON_AFTER__RETRO=(
+    '-Dipv6=false'
+    '-Ddri1=true'
+    '-Ddri2=true'
+    '-Ddri3=true'
+    '-Dxvfb=false'
+    '-Dxnest=false'
+    '-Dxcsecurity=true'
+    '-Dxorg=true'
+    '-Dxephyr=false'
+    '-Dglamor=false'
+    '-Dudev=true'
+    '-Dsystemd_logind=false'
+    '-Dsuid_wrapper=true'
+    '-Dsha1=libgcrypt'
+    '-Dxkb_dir=/usr/share/X11/xkb'
+    '-Dxkb_output_dir=/var/lib/xkb'
+    '-Ddefault_font_path=/usr/share/fonts'
+)
+MESON_AFTER__ARMV4=(
+    "${MESON_AFTER__RETRO[@]}"
+)
+MESON_AFTER__ARMV6HF=(
+    "${MESON_AFTER__RETRO[@]}"
+    '-Dglamor=true'
+)
+MESON_AFTER__ARMV7HF=(
+    "${MESON_AFTER__RETRO[@]}"
+    '-Dglamor=true'
+)
 
 PKGBREAK="nvidia<=375.10 virtualbox<=6.1.30 xf86-input-acecad<=1.5.0-6 \
           xf86-input-elographics<=1.4.2 xf86-input-evdev<=2.10.6-1 \

--- a/runtime-display/xorg-server/spec
+++ b/runtime-display/xorg-server/spec
@@ -1,4 +1,4 @@
-VER=21.1.23
+VER=21.1.24
 SRCS="git::commit=tags/xorg-server-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5250"

--- a/runtime-display/xwayland/autobuild/defines
+++ b/runtime-display/xwayland/autobuild/defines
@@ -5,27 +5,30 @@ PKGDEP="libepoxy libgcrypt libunwind pixman systemd wayland \
 BUILDDEP="egl-wayland wayland-protocols"
 PKGDES="X11 compatibility layer for Wayland"
 
-MESON_AFTER="-Dglamor=true \
-             -Dxvfb=true \
-             -Dglx=true \
-             -Dxdmcp=true \
-             -Dxdm-auth-1=true \
-             -Dsecure-rpc=true \
-             -Dipv6=true \
-             -Dinput_thread=true \
-             -Ddpms=true \
-             -Dxf86bigfont=true \
-             -Dscreensaver=true \
-             -Dxres=true \
-             -Dxace=true \
-             -Dxselinux=false \
-             -Dxinerama=true \
-             -Dxcsecurity=true \
-             -Dxv=true \
-             -Dmitshm=true \
-             -Dsha1=libgcrypt \
-             -Ddri3=true \
-             -Dlibunwind=true"
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dglamor=true'
+    '-Dxvfb=true'
+    '-Dglx=true'
+    '-Dxdmcp=true'
+    '-Dxdm-auth-1=true'
+    '-Dsecure-rpc=true'
+    '-Dipv6=true'
+    '-Dinput_thread=true'
+    '-Ddpms=true'
+    '-Dxf86bigfont=true'
+    '-Dscreensaver=true'
+    '-Dxres=true'
+    '-Dxace=true'
+    '-Dxselinux=false'
+    '-Dxinerama=true'
+    '-Dxcsecurity=true'
+    '-Dxv=true'
+    '-Dmitshm=true'
+    '-Dsha1=libgcrypt'
+    '-Ddri3=true'
+    '-Dlibunwind=true'
+)
 
 PKGBREAK="xorg-server<=1.20.11"
 PKGREP="xorg-server<=1.20.11"

--- a/runtime-display/xwayland/spec
+++ b/runtime-display/xwayland/spec
@@ -1,4 +1,4 @@
-VER=24.1.12
+VER=24.1.13
 SRCS="git::commit=tags/xwayland-$VER::https://gitlab.freedesktop.org/xorg/xserver.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180949"

--- a/topics/xorg-server-21.1.24-xwayland-24.1.13.toml
+++ b/topics/xorg-server-21.1.24-xwayland-24.1.13.toml
@@ -1,0 +1,14 @@
+security = true
+must_match_all = false
+
+[name]
+default = "X.Org Server 21.1.24 and Xwayland 24.1.13"
+zh_CN = "X.Org Server 21.1.24 和 Xwayland 24.1.13"
+
+[caution]
+default = "Fixes a Heap-based Buffer Overflow vulnerability (CVE-2026-55999, Severity: High) and a Use After Free vulnerability (CVE-2026-56000, Severity: High)"
+zh_CN = "修复 1 个基于堆的缓冲区溢出漏洞（漏洞编号 CVE-2026-55999，严重性：高）和 1 个释放后使用漏洞（漏洞编号 CVE-2026-56000，严重性：高）"
+
+[packages-v2]
+"xorg-server" = "< 21.1.24"
+"xwayland" = "< 24.1.13"


### PR DESCRIPTION
Topic Description
-----------------

- xorg-server: security update to 21.1.24
- erlang: security update to 29.0.3
- dovecot: security update to 2.4.4

Package(s) Affected
-------------------

- xorg-server: 21.1.24

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit xorg-server xwayland
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
