### PR TITLE
tigervnc: update to 1.16.2+xserver21.1.24

### DIFF
--- a/app-network/tigervnc/spec
+++ b/app-network/tigervnc/spec
@@ -1,9 +1,9 @@
 UPSTREAM_VER=1.16.2
-XORG_VER=21.1.23
+XORG_VER=21.1.24
 VER=${UPSTREAM_VER}+xserver${XORG_VER}
 SRCS="git::rename=tigervnc;commit=tags/v${UPSTREAM_VER}::https://github.com/TigerVNC/tigervnc.git \
       tbl::https://www.x.org/archive/individual/xserver/xorg-server-${XORG_VER}.tar.xz"
 CHKSUMS="SKIP \
-         sha256::e39832e5617dadaf072fdf9f0e19e5d2e1c2a13607ac280bac1aba9f8fe14634"
+         sha256::1a4eb36ca65cc3b1b936566d677a9786e13c11cd5806e951ac55f3f5ce3984af"
 SUBDIR="tigervnc"
 CHKUPDATE="anitya::id=4970"

--- a/topics/xorg-server-21.1.24-xwayland-24.1.13.toml
+++ b/topics/xorg-server-21.1.24-xwayland-24.1.13.toml
@@ -12,3 +12,4 @@ zh_CN = "修复 1 个基于堆的缓冲区溢出漏洞（漏洞编号 CVE-2026-5
 [packages-v2]
 "xorg-server" = "< 21.1.24"
 "xwayland" = "< 24.1.13"
+"tigervnc" = "< 1.16.2+xserver21.1.24"


### PR DESCRIPTION
Topic Description
-----------------

- tigervnc: update to 1.16.2+xserver21.1.24
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- tigervnc: 1.16.2+xserver21.1.24

Security Update?
----------------

No

Build Order
-----------

```
#buildit tigervnc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
