### PR TITLE
xcaddy: update to 0.4.6

### DIFF
--- a/app-web/xcaddy/spec
+++ b/app-web/xcaddy/spec
@@ -1,5 +1,4 @@
-VER=0.4.5
-REL=6
+VER=0.4.6
 SRCS="git::commit=tags/v$VER::https://github.com/caddyserver/xcaddy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376781"


### PR DESCRIPTION
Topic Description
-----------------

- xcaddy: update to 0.4.6
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- xcaddy: 0.4.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit xcaddy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
