### PR TITLE
freecad: rebuild for vtk update

### DIFF
--- a/app-creativity/freecad/spec
+++ b/app-creativity/freecad/spec
@@ -1,4 +1,5 @@
 VER=1.1.1
+REL=1
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/FreeCAD/FreeCAD.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=836"


### PR DESCRIPTION
Topic Description
-----------------

- freecad: rebuild for vtk update
    When running the Defeaturing workbench downloadable from the Addon
    Manager, some shared object from FreeCAD reports:
    \`\`\`
    /usr/lib/freecad/lib/libSMDS.so: undefined symbol: _ZN19vtkUnstructuredGrid12GetCellTypesEP12vtkCellTypes
    \`\`\`
    Rebuild FreeCAD to solve this.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- freecad: 1.1.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit freecad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
