### PR TITLE
wolfssl: security update to 5.9.2

### DIFF
--- a/runtime-cryptography/wolfssl/autobuild/defines
+++ b/runtime-cryptography/wolfssl/autobuild/defines
@@ -12,3 +12,5 @@ AUTOTOOLS_AFTER=(
     '--disable-static'
     '--disable-armasm'  # Error: selected processor does not support `sha256h2 q1,q25,v24.4s'
 )
+
+PKGBREAK="ngtcp2<=1.23.0"

--- a/runtime-cryptography/wolfssl/spec
+++ b/runtime-cryptography/wolfssl/spec
@@ -1,4 +1,4 @@
-VER=5.9.1
+VER=5.9.2
 SRCS="git::commit=tags/v${VER}-stable::https://github.com/wolfSSL/wolfssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21631"

--- a/runtime-web/ngtcp2/spec
+++ b/runtime-web/ngtcp2/spec
@@ -1,4 +1,5 @@
 VER=1.23.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/ngtcp2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370247"

--- a/topics/woflssl-5.9.2.toml
+++ b/topics/woflssl-5.9.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "wolfSSL 5.9.2"
+
+[caution]
+default = "Fixes 18 security vulnerabilities (including 6 of High, and 12 of Medium severity)"
+zh_CN = "修复 18 个安全漏洞（含 6 个高危漏洞和 12 个中危漏洞）"
+
+[packages-v2]
+"wolfssl" = "< 5.9.2"


### PR DESCRIPTION
Topic Description
-----------------

- wolfssl: security update to 5.9.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- wolfssl: 5.9.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit wolfssl:-pkgbreak ngtcp2 wolfssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
