### PR TITLE
s2tc drop Survey

### DIFF
--- a/runtime-display/mesa/autobuild/defines
+++ b/runtime-display/mesa/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=mesa
 PKGSEC=libs
 PKGDES="Runtime library for OpenGL, Vulkan, OpenCL, and more"
 PKGDEP="x11-lib libdrm expat systemd elfutils nettle \
-        libva wayland s2tc lm-sensors libglvnd llvm-runtime \
+        libva wayland lm-sensors libglvnd llvm-runtime \
         libcl libclc spirv-llvm-translator libdisplay-info \
         xcb-util-keysyms libconfig"
 PKGDEP__RETRO="x11-lib elfutils libdrm libglvnd libva llvm-runtime \

--- a/runtime-display/mesa/spec
+++ b/runtime-display/mesa/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=26.0.4
 VER=${UPSTREAM_VER//-/~}
-REL=1
+REL=2
 SRCS="tbl::https://archive.mesa3d.org/mesa-${VER}.tar.xz"
 CHKSUMS="sha256::6d91541e086f29bb003602d2c81070f2be4c0693a90b181ca91e46fa3953fe78"
 

--- a/runtime-display/s2tc/autobuild/defines
+++ b/runtime-display/s2tc/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=s2tc
-PKGSEC=libs
-PKGDES="S2tc texture compress library"
-BUILDDEP="libglvnd"
-
-ABSHADOW=no
-
-PKGEPOCH=1

--- a/runtime-display/s2tc/spec
+++ b/runtime-display/s2tc/spec
@@ -1,5 +1,0 @@
-VER=1.0+git20210317
-__COMMIT="e68f78f497cd96601248a4bca3bd009d7517d00d"
-SRCS="git::commit=${__COMMIT}::https://github.com/divVerent/s2tc"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=230529"

--- a/runtime-optenv32/s2tc+32/autobuild/defines
+++ b/runtime-optenv32/s2tc+32/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME=s2tc+32
-PKGSEC=libs
-PKGDEP="aosc-aaa+32 mesa+32"
-BUILDDEP="devel-base+32"
-PKGDES="S2TC texture compress library (32-bit x86 runtime)"
-
-PKGEPOCH=1
-
-ABHOST=optenv32

--- a/runtime-optenv32/s2tc+32/spec
+++ b/runtime-optenv32/s2tc+32/spec
@@ -1,5 +1,0 @@
-VER=1.0+git20210317
-__COMMIT="e68f78f497cd96601248a4bca3bd009d7517d00d"
-SRCS="git::commit=${__COMMIT}::https://github.com/divVerent/s2tc"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=230529"


### PR DESCRIPTION
Topic Description
-----------------

- s2tc+32: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>
- s2tc: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>
- mesa: adjust dependencies
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- mesa: 1:26.0.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mesa
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
