### PR TITLE
86box: update to 6.0

### DIFF
--- a/app-emulation/86box-roms/spec
+++ b/app-emulation/86box-roms/spec
@@ -1,5 +1,5 @@
-VER=5.2+git20251113
-SRCS="git::commit=e550378d005cc5318159470a6b7e527aabc944ba::https://github.com/86Box/roms"
+VER=6.0+git20260713
+SRCS="git::commit=e7f193bd263169ccc264575f7cdef76d8b4cf272::https://github.com/86Box/roms"
 CHKSUMS="SKIP"
 # Note: We will just follow master, there is no point in following tags.
 #CHKUPDATE="anitya::id=268433"

--- a/app-emulation/86box/autobuild/beyond
+++ b/app-emulation/86box/autobuild/beyond
@@ -4,7 +4,7 @@ install -Dvm644 "$SRCDIR"/src/unix/assets/net.86box.86Box.desktop \
 
 abinfo "Installing icons ..."
 mkdir -pv "$PKGDIR"/usr/share/icons/hicolor
-for i in 48 64 72 96 128 192 256 512; do
+for i in 16 20 24 32 48 64 72 128 256; do
     install -Dvm644 "$SRCDIR"/src/unix/assets/${i}x${i}/net.86box.86Box.png \
         "$PKGDIR"/usr/share/icons/hicolor/${i}x${i}/apps/net.86box.86Box.png
 done

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,4 +1,4 @@
-VER=5.2
+VER=6.0
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
Topic Description
-----------------

- 86box: update to 6.0
- 86box-roms: update to 6.0+git20260713

Package(s) Affected
-------------------

- 86box: 6.0
- 86box-roms: 6.0+git20260713

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box 86box-roms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`