### PR TITLE
mjpegtools+32: update to 2.2.1

### DIFF
--- a/runtime-optenv32/mjpegtools+32/autobuild/defines
+++ b/runtime-optenv32/mjpegtools+32/autobuild/defines
@@ -1,12 +1,16 @@
 PKGNAME=mjpegtools+32
 PKGSEC=utils
-PKGDEP="aosc-aaa+32 libjpeg-turbo+32 libpng+32 sdl+32 libdv+32"
+PKGDEP="aosc-aaa+32 libjpeg-turbo+32 libpng+32 sdl+32 libdv+32 v4l-utils+32"
 BUILDDEP="devel-base+32"
-PKGDES="Tools for manipulating and playback of MPEG compressed media files (32-bit x86 runtime)"
+PKGDES="Tools to work with MPEG media files (32-bit x86 runtime)"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-largefile'
+    '--with-v4l'
     '--without-gtk'
+    # FIXME: libquicktime requires FFmpeg < 5. To revisit.
+    '--without-libquicktime'
 )
 
 ABHOST=optenv32

--- a/runtime-optenv32/mjpegtools+32/spec
+++ b/runtime-optenv32/mjpegtools+32/spec
@@ -1,5 +1,4 @@
-VER=2.1.0
-REL=3
+VER=2.2.1
 SRCS="tbl::https://sourceforge.net/projects/mjpeg/files/mjpegtools/$VER/mjpegtools-$VER.tar.gz"
-CHKSUMS="sha256::864f143d7686377f8ab94d91283c696ebd906bf256b2eacc7e9fb4dddcedc407"
+CHKSUMS="sha256::b180536d7d9960b05e0023a197b00dcb100929a49aab71d19d55f4a1b210f49a"
 CHKUPDATE="anitya::id=14612"


### PR DESCRIPTION
Topic Description
-----------------

- mjpegtools+32: update to 2.2.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- mjpegtools+32: 2.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mjpegtools+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
