### PR TITLE
nerdctl: update to 2.3.4

### DIFF
--- a/app-containers/nerdctl/spec
+++ b/app-containers/nerdctl/spec
@@ -1,4 +1,4 @@
-VER=2.3.1
+VER=2.3.4
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/containerd/nerdctl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="aniya::id=242901"


### PR DESCRIPTION
Topic Description
-----------------

- nerdctl: update to 2.3.4

Package(s) Affected
-------------------

- nerdctl: 2.3.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit nerdctl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
