### PR TITLE
pkgconf: update to 3.0.2

### DIFF
--- a/app-devel/pkgconf/spec
+++ b/app-devel/pkgconf/spec
@@ -1,4 +1,4 @@
-VER=3.0.1
+VER=3.0.2
 SRCS="tbl::https://distfiles.ariadne.space/pkgconf/pkgconf-$VER.tar.xz"
-CHKSUMS="sha256::640b0d03a6d9e385d8bdcdac071a5cdf5fbd3f45942d454b711ae46271489b30"
+CHKSUMS="sha256::42ce89ba4c45e6fefaab970bf81d3fadfb738f8d5243460fa67bc4fed84b0db0"
 CHKUPDATE="anitya::id=12753"


### PR DESCRIPTION
Topic Description
-----------------

- pkgconf: update to 3.0.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- pkgconf: 3.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
