### PR TITLE
tsukimi: update to 26.7.2

### DIFF
--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,4 @@
-VER=26.7.1
+VER=26.7.2
 SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376111"


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: update to 26.7.2
    Co-authored-by: \(@MutsukiC\) <mutsuki@aosc.io>

Package(s) Affected
-------------------

- tsukimi: 26.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
