### PR TITLE
rnote: update to 0.14.2

### DIFF
--- a/app-doc/rnote/spec
+++ b/app-doc/rnote/spec
@@ -1,5 +1,4 @@
-VER=0.13.1
-REL=4
+VER=0.14.2
 SRCS="git::commit=tags/v$VER::https://github.com/flxzt/rnote.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375549"


### PR DESCRIPTION
Topic Description
-----------------

- rnote: update to 0.14.2
    Co-authored-by: 斬風千雪 \(@chiyuki0325\) <me@chyk.ink>

Package(s) Affected
-------------------

- rnote: 0.14.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit rnote
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
