### PR TITLE
aosc-xdg-menu: rebuild to update dependencies

### DIFF
--- a/runtime-data/aosc-xdg-menu/autobuild/build
+++ b/runtime-data/aosc-xdg-menu/autobuild/build
@@ -1,3 +1,4 @@
+abinfo "Installing utilities and configurations ..."
 install -Dvm0755 "$SRCDIR"/xdg_menu \
     "$PKGDIR"/usr/bin/xdg_menu
 install -Dvm0755 "$SRCDIR"/xdg_menu_su \
@@ -7,12 +8,15 @@ install -Dvm0755 "$SRCDIR"/update-menus \
 install -Dvm0644 "$SRCDIR"/update-menus.conf \
     "$PKGDIR"/etc/update-menus.conf
 
+abinfo "Installing desktop-directories data ..."
 mkdir -pv "$PKGDIR"/usr/share/desktop-directories/
 cp -v aosc-desktop-directories/* \
     "$PKGDIR"/usr/share/desktop-directories/
 
+abinfo "Installing XDG menus ..."
 mkdir -pv "$PKGDIR"/etc/xdg/menus/
 cp -v aosc-xdg-menu/* \
     "$PKGDIR"/etc/xdg/menus/
 
+abinfo "Creating cache directory for XDG menu states ..."
 mkdir -pv "$PKGDIR"/var/cache/xdg-menu

--- a/runtime-data/aosc-xdg-menu/autobuild/triggers
+++ b/runtime-data/aosc-xdg-menu/autobuild/triggers
@@ -1,1 +1,1 @@
-interest /usr/share/applications
+interest-noawait /usr/share/applications

--- a/runtime-data/aosc-xdg-menu/spec
+++ b/runtime-data/aosc-xdg-menu/spec
@@ -1,5 +1,5 @@
 VER=20200412
-REL=1
-SRCS="git::commit=cad0f3759aef6c7a5ce5148de40556321c80ef45::https://github.com/AOSC-Dev/aosc-xdg-menu"
+REL=2
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-xdg-menu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230635"


### PR DESCRIPTION
Topic Description
-----------------

- aosc-xdg-menu: rebuild to update dependencies
    - Making sure the new dependency on perl-xml-parser is post-Perl 5.42.
    - Downgrade trigger interest to noawait.

Package(s) Affected
-------------------

- aosc-xdg-menu: 20200412-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-xdg-menu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
