### PR TITLE
.NET SDK 10.0.110

### DIFF
--- a/lang-dotnet/dotnet10/01-source-built-artifacts/build
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/build
@@ -28,7 +28,7 @@ else
 fi
 
 abinfo "Installing build artifacts ..."
-temp=`mktemp -d`
+temp=$(mktemp -d)
 mkdir -pv "$temp"/artifacts
 tar -xzvf /opt/Private.SourceBuilt.Artifacts.* -C "$temp"/artifacts
 mkdir -pv "$temp"/prereqs/packages/archive/

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/build.stage2
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/build.stage2
@@ -34,7 +34,7 @@ wget https://repo.aosc.io/aosc-repacks/dotnet-10/"$sdk_file"
 wget https://repo.aosc.io/aosc-repacks/dotnet-10/"$artifact_file"
 
 abinfo "Installing bootstrap .NET SDK ..."
-temp=`mktemp -d`
+temp=$(mktemp -d)
 mkdir -pv "$temp"/dotnet-sdk
 tar -xzvf $sdk_file -C "$temp"/dotnet-sdk
 mkdir -pv "$temp"/artifacts

--- a/lang-dotnet/dotnet10/spec
+++ b/lang-dotnet/dotnet10/spec
@@ -1,5 +1,4 @@
-VER=10.0.109
+VER=10.0.110
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/dotnet/dotnet.git"
 CHKSUMS="SKIP"
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(10\.0\.1.+?)\""
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- dotnet10: update to 10.0.110

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-sdk-10.0-source-built-artifacts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
