### PR TITLE
oma: update to 1.27.1

### DIFF
--- a/app-admin/amo/autobuild/postinst
+++ b/app-admin/amo/autobuild/postinst
@@ -5,4 +5,6 @@ if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-decon
         if [ -f "/usr/lib/systemd/system/amo.service" ]; then
                 systemctl enable --now amo.service || true
         fi
+	# Reload on upgrade.
+	systemctl try-restart amo.service
 fi

--- a/app-admin/amo/spec
+++ b/app-admin/amo/spec
@@ -1,4 +1,4 @@
-VER=0.2.0
+VER=0.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/amo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391048"

--- a/app-admin/amo/spec
+++ b/app-admin/amo/spec
@@ -1,4 +1,4 @@
-VER=0.4.1
+VER=0.4.2
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/amo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391048"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,4 @@
-VER=1.26.6
+VER=1.27.1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"

--- a/topics/oma-1.27.1.toml
+++ b/topics/oma-1.27.1.toml
@@ -1,0 +1,13 @@
+security = false
+must_match_all = false
+
+[name]
+default = "oma 1.27"
+zh_CN = "小熊猫包管理 (oma) 1.27"
+
+[caution]
+default = "Includes an interface for the history and undo subcommands, as well as accelerated searching and command-not-found prompts powered by the amo D-Bus service"
+zh_CN = "包含全新历史 (oma history) 及撤销 (oma undo) 界面，引入 D-Bus 服务 amo 加速搜索及未知命令提示"
+
+[packages-v2]
+"oma" = "< 1.27.1"


### PR DESCRIPTION
Topic Description
-----------------

- amo: update to 0.4.1
    Also try-restart on upgrade.
- oma: update to 1.27.1

Package(s) Affected
-------------------

- amo: 0.4.1
- oma: 1.27.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit amo oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
