### PR TITLE
tuwunel: update to 1.8.1

### DIFF
--- a/app-web/tuwunel/autobuild/patches/0001-use-ring-instead-of-aws-lc-rs.patch
+++ b/app-web/tuwunel/autobuild/patches/0001-use-ring-instead-of-aws-lc-rs.patch
@@ -1,4 +1,4 @@
-From 75360ec57de885e378350bea62c06fededc111bf Mon Sep 17 00:00:00 2001
+From d0d5103e97ea63862dc921d918b43743c37321d0 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <i@lain.vg>
 Date: Sun, 7 Jun 2026 20:00:33 +0800
 Subject: [PATCH 1/2] use ring instead of aws-lc-rs
@@ -9,7 +9,7 @@ Subject: [PATCH 1/2] use ring instead of aws-lc-rs
  2 files changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/Cargo.toml b/Cargo.toml
-index 44cb3f8b..0572faea 100644
+index 2dc68d51..63bf4f57 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
 @@ -250,7 +250,7 @@ features = [
@@ -21,7 +21,7 @@ index 44cb3f8b..0572faea 100644
  default-features = false
  features = ["sync", "tls-rustls"]
  
-@@ -406,7 +406,7 @@ features = ["server"]
+@@ -420,7 +420,7 @@ features = ["server"]
  [workspace.dependencies.rustls]
  version = "0.23"
  default-features = false

--- a/app-web/tuwunel/autobuild/patches/0002-update-Cargo.lock-for-patching.patch
+++ b/app-web/tuwunel/autobuild/patches/0002-update-Cargo.lock-for-patching.patch
@@ -1,17 +1,17 @@
-From 9a52ee3d0b18cfae9893c992184722b98be04022 Mon Sep 17 00:00:00 2001
+From c3b71250b6486fa62fa17a66af001f8facb34903 Mon Sep 17 00:00:00 2001
 From: "Lain \"Fearyncess\" Yang" <i@lain.vg>
-Date: Sun, 7 Jun 2026 20:01:08 +0800
+Date: Wed, 15 Jul 2026 11:25:51 +0800
 Subject: [PATCH 2/2] update Cargo.lock for patching
 
 ---
- Cargo.lock | 45 +++++++++++++++++++++++----------------------
- 1 file changed, 23 insertions(+), 22 deletions(-)
+ Cargo.lock | 43 ++++++++++++++++++++++---------------------
+ 1 file changed, 22 insertions(+), 21 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 39b67c56..eb307edc 100644
+index b5d288f2..7e1a7d0c 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -115,9 +115,9 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+@@ -124,9 +124,9 @@ checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
  
  [[package]]
  name = "asn1-rs"
@@ -23,8 +23,8 @@ index 39b67c56..eb307edc 100644
  dependencies = [
   "asn1-rs-derive",
   "asn1-rs-impl",
-@@ -125,15 +125,15 @@ dependencies = [
-  "nom",
+@@ -134,15 +134,15 @@ dependencies = [
+  "nom 7.1.3",
   "num-traits",
   "rusticata-macros",
 - "thiserror 2.0.18",
@@ -42,7 +42,7 @@ index 39b67c56..eb307edc 100644
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -1148,9 +1148,9 @@ dependencies = [
+@@ -1157,9 +1157,9 @@ dependencies = [
  
  [[package]]
  name = "der-parser"
@@ -54,7 +54,7 @@ index 39b67c56..eb307edc 100644
  dependencies = [
   "asn1-rs",
   "displaydoc",
-@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+@@ -1332,7 +1332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
  dependencies = [
   "libc",
@@ -63,7 +63,7 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -2368,7 +2368,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+@@ -2365,7 +2365,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
  [[package]]
  name = "lber"
  version = "0.4.3"
@@ -71,8 +71,8 @@ index 39b67c56..eb307edc 100644
 +source = "git+https://github.com/matrix-construct/ldap3?rev=7d423314b9dbc66347284e38fc2b78c3d8f3d494#7d423314b9dbc66347284e38fc2b78c3d8f3d494"
  dependencies = [
   "bytes",
-  "nom",
-@@ -2377,7 +2377,7 @@ dependencies = [
+  "nom 7.1.3",
+@@ -2374,7 +2374,7 @@ dependencies = [
  [[package]]
  name = "ldap3"
  version = "0.11.3"
@@ -81,15 +81,15 @@ index 39b67c56..eb307edc 100644
  dependencies = [
   "async-trait",
   "bytes",
-@@ -2388,6 +2388,7 @@ dependencies = [
+@@ -2385,6 +2385,7 @@ dependencies = [
   "log",
-  "nom",
+  "nom 7.1.3",
   "percent-encoding",
 + "ring",
   "rustls",
   "rustls-native-certs",
   "thiserror 1.0.69",
-@@ -2733,7 +2734,7 @@ version = "0.50.3"
+@@ -2761,7 +2762,7 @@ version = "0.50.3"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
  dependencies = [
@@ -98,7 +98,7 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -3033,9 +3034,9 @@ dependencies = [
+@@ -3061,9 +3062,9 @@ dependencies = [
  
  [[package]]
  name = "oid-registry"
@@ -110,7 +110,7 @@ index 39b67c56..eb307edc 100644
  dependencies = [
   "asn1-rs",
  ]
-@@ -4050,7 +4051,7 @@ dependencies = [
+@@ -4071,7 +4072,7 @@ dependencies = [
   "errno",
   "libc",
   "linux-raw-sys",
@@ -119,7 +119,7 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -4109,7 +4110,7 @@ dependencies = [
+@@ -4130,7 +4131,7 @@ dependencies = [
   "security-framework",
   "security-framework-sys",
   "webpki-root-certs",
@@ -128,8 +128,8 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -4646,7 +4647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+@@ -4673,7 +4674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
  dependencies = [
   "libc",
 - "windows-sys 0.61.2",
@@ -137,12 +137,8 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -4776,10 +4777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
- checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
- dependencies = [
-  "fastrand",
-- "getrandom 0.3.4",
-+ "getrandom 0.4.2",
+@@ -4806,7 +4807,7 @@ dependencies = [
+  "getrandom 0.4.3",
   "once_cell",
   "rustix",
 - "windows-sys 0.61.2",
@@ -150,7 +146,7 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -6010,7 +6011,7 @@ version = "0.1.11"
+@@ -5989,7 +5990,7 @@ version = "0.1.11"
  source = "registry+https://github.com/rust-lang/crates.io-index"
  checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
  dependencies = [
@@ -159,7 +155,7 @@ index 39b67c56..eb307edc 100644
  ]
  
  [[package]]
-@@ -6365,9 +6366,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+@@ -6256,9 +6257,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
  
  [[package]]
  name = "x509-parser"
@@ -171,8 +167,8 @@ index 39b67c56..eb307edc 100644
  dependencies = [
   "asn1-rs",
   "data-encoding",
-@@ -6376,7 +6377,7 @@ dependencies = [
-  "nom",
+@@ -6267,7 +6268,7 @@ dependencies = [
+  "nom 7.1.3",
   "oid-registry",
   "rusticata-macros",
 - "thiserror 2.0.18",

--- a/app-web/tuwunel/spec
+++ b/app-web/tuwunel/spec
@@ -1,4 +1,4 @@
-VER=1.7.1
+VER=1.8.1
 SRCS="git::commit=tags/v${VER}::https://github.com/matrix-construct/tuwunel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=386525"


### PR DESCRIPTION
Topic Description
-----------------

- tuwunel: update to 1.8.1

Package(s) Affected
-------------------

- tuwunel: 1.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tuwunel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
