### PR TITLE
crash: update to 9.0.2+gdb16.2

### DIFF
--- a/app-devel/crash/autobuild/build
+++ b/app-devel/crash/autobuild/build
@@ -1,8 +1,8 @@
 abinfo "Unpacking GDB source ..."
-cp -v "$SRCDIR"/../gdb-$GDBVER.tar.gz \
+cp -v "$SRCDIR"/../gdb-$__GDBVER.tar.gz \
     "$SRCDIR"/
 make gdb_unzip \
-    GDB="gdb-$GDBVER"
+    GDB="gdb-$__GDBVER"
 for i in "$SRCDIR"/autobuild/patches/*.gdb_unzip; do
     abinfo "Applying GDB patch $i ..."
     patch -Np1 -i $i
@@ -11,7 +11,8 @@ done
 abinfo "Building Crash ..."
 make \
     CFLAGS="${CPPFLAGS} ${CFLAGS} -DHAVE_CONFIG_H -DHAVE_FCNTL_H -DHAVE_INTTYPES_H -DHAVE_LIMITS_H -DHAVE_MALLOC_H -DHAVE_STDINT_H -DHAVE_STDLIB_H -DHAVE_STRING_H -DHAVE_SYS_PARAM_H -DHAVE_SYS_STAT_H -DHAVE_UNISTD_H -DNEED_DECLARATION_ERRNO" \
-    LDFLAGS="${LDFLAGS}"
+    LDFLAGS="${LDFLAGS}"\
+    GDB="gdb-$__GDBVER"
 
 abinfo "Installing Crash ..."
 install -Dvm755 "$SRCDIR"/crash \

--- a/app-devel/crash/autobuild/defines
+++ b/app-devel/crash/autobuild/defines
@@ -2,7 +2,3 @@ PKGNAME=crash
 PKGSEC=devel
 PKGDEP="xz ncurses"
 PKGDES="Linux Kernel crashdump analysis"
-
-GDBVER=7.6
-
-NOLTO__PPC64EL=1

--- a/app-devel/crash/spec
+++ b/app-devel/crash/spec
@@ -1,8 +1,9 @@
-VER=8.0.5
-GDBVER=7.6
-SRCS="tbl::https://github.com/crash-utility/crash/archive/$VER.tar.gz \
-      file::rename=gdb-$GDBVER.tar.gz::http://ftp.gnu.org/gnu/gdb/gdb-$GDBVER.tar.gz"
-CHKSUMS="sha256::b3ec57a844706ef044b607ba67bc5ef62d9deef8aec3fb2d7ea4f77dff24f1ef \
-         sha256::8070389a5dcc104eb0be483d582729f98ed4d761ad19cedd3f17b5d2502faa36"
+__VER=9.0.2
+__GDBVER=16.2
+VER="${__VER}+gdb${__GDBVER}"
+SRCS="git::commit=tags/$__VER::https://github.com/crash-utility/crash \
+      file::rename=gdb-$__GDBVER.tar.gz::http://ftp.gnu.org/gnu/gdb/gdb-$__GDBVER.tar.gz"
+CHKSUMS="SKIP \
+         sha256::bdc1da4a033280ac752e7d34b0418efaa45bed093235cb88e62ea961752a37f8"
 CHKUPDATE="anitya::id=9939"
-SUBDIR="crash-$VER"
+SUBDIR="crash"


### PR DESCRIPTION
Topic Description
-----------------

- crash: update to 9.0.2+gdb16.2
    - fix redundant downloading of gdb
    - use git source for crash
    - forward GDBVER to other scripts using __GDBVER

Package(s) Affected
-------------------

- crash: 9.0.2+gdb16.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit crash
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
