### PR TITLE
ntfs-3g: update to 2026.7.7

### DIFF
--- a/app-admin/ntfs-3g/autobuild/defines
+++ b/app-admin/ntfs-3g/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ntfs-3g
 PKGSEC=admin
 PKGDEP="util-linux fuse gnutls attr libgcrypt libconfig"
-PKGDES="NTFS filesystem driver and utilities"
+PKGDES="NTFS filesystem driver and utilities (userspace)"
 
 ABTYPE=autotools
 AUTOTOOLS_AFTER=(
@@ -14,4 +14,3 @@ AUTOTOOLS_AFTER=(
     "--enable-extras"
     "--enable-quarantined"
 )
-PKGEPOCH=1

--- a/app-admin/ntfs-3g/autobuild/defines
+++ b/app-admin/ntfs-3g/autobuild/defines
@@ -14,3 +14,9 @@ AUTOTOOLS_AFTER=(
     "--enable-extras"
     "--enable-quarantined"
 )
+
+PKGBREAK="""
+partclone<=0.3.38
+testdisk<=7.2
+wimlib<=1.14.4
+"""

--- a/app-admin/ntfs-3g/autobuild/patches/0001-AOSCOS-fix-add-setu-gid-handling-for-external-libfus.patch
+++ b/app-admin/ntfs-3g/autobuild/patches/0001-AOSCOS-fix-add-setu-gid-handling-for-external-libfus.patch
@@ -1,7 +1,7 @@
-From 6b189259e85bf2d83423fc10c1aa908295f18255 Mon Sep 17 00:00:00 2001
+From 93e4c419b25d2c89d3a220f3675371e962f653d6 Mon Sep 17 00:00:00 2001
 From: Kay Lin <kaymw@aosc.io>
 Date: Thu, 16 Jun 2022 18:10:07 -0700
-Subject: [PATCH 1/2] fix: add setu/gid handling for external libfuse
+Subject: [PATCH 1/3] AOSCOS: fix: add setu/gid handling for external libfuse
 
 Many packagers use the external libfuse for new upstream improvements
 and to avoid redundancy. There is no good technical reason to keep the
@@ -13,6 +13,7 @@ implementation. This would be a bug shared with internal libfuse, and I
 do not intend to reach that far now.
 
 Co-authored-by: Mingye Wang <arthur200126@gmail.com>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  libfuse-lite/fusermount.c | 101 ++---------------------------------
  libfuse-lite/priv.h       | 107 ++++++++++++++++++++++++++++++++++++++
@@ -267,7 +268,7 @@ index 00000000..d43feffa
 +}
 +#endif /* __SOLARIS__ */
 diff --git a/src/lowntfs-3g.c b/src/lowntfs-3g.c
-index 9330500c..3300fd2f 100644
+index e4ff0bf9..3e611c6c 100644
 --- a/src/lowntfs-3g.c
 +++ b/src/lowntfs-3g.c
 @@ -286,13 +286,7 @@ static const char ntfs_bad_reparse[] = "unsupported reparse tag 0x%08lx";
@@ -340,7 +341,7 @@ index 9330500c..3300fd2f 100644
  	if (err)
  		goto err_out;
 diff --git a/src/ntfs-3g.c b/src/ntfs-3g.c
-index d8227e71..1fee91f7 100644
+index 820733e8..2d0f6577 100644
 --- a/src/ntfs-3g.c
 +++ b/src/ntfs-3g.c
 @@ -221,13 +221,7 @@ static const char ntfs_bad_reparse[] = "unsupported reparse tag 0x%08lx";
@@ -395,5 +396,5 @@ index d8227e71..1fee91f7 100644
  	if (err)
  		goto err_out;
 -- 
-2.36.0
+2.52.0
 

--- a/app-admin/ntfs-3g/autobuild/patches/0002-FEDORA-ntfsck-return-on-in-unsupported-filesystem-ca.patch
+++ b/app-admin/ntfs-3g/autobuild/patches/0002-FEDORA-ntfsck-return-on-in-unsupported-filesystem-ca.patch
@@ -1,12 +1,13 @@
-From f33e91f2db544cd1ae17e1b80612d952e9e42927 Mon Sep 17 00:00:00 2001
+From c1f0b2a9b1ce9369febf31a4ef20727a92635450 Mon Sep 17 00:00:00 2001
 From: Kay Lin <kaymw@aosc.io>
 Date: Thu, 16 Jun 2022 18:16:29 -0700
-Subject: [PATCH 2/2] ntfsck: return on in unsupported filesystem cases
+Subject: [PATCH 2/3] FEDORA: ntfsck: return on in unsupported filesystem cases
 
 Cherry-picked from Fedora package sources. Prevents unexpected
 failures while fscking on boot.
 
 Co-authored-by: Tom Callaway <spot@fedoraproject.org>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
  ntfsprogs/ntfsck.c |  6 +++++-
  src/lowntfs-3g.c   | 14 --------------
@@ -31,7 +32,7 @@ index 8c126411..cbd163cc 100644
  }
  
 diff --git a/src/lowntfs-3g.c b/src/lowntfs-3g.c
-index 3300fd2f..34e4dd9a 100644
+index 3e611c6c..bf53843e 100644
 --- a/src/lowntfs-3g.c
 +++ b/src/lowntfs-3g.c
 @@ -289,20 +289,6 @@ int restore_privs(void);
@@ -56,7 +57,7 @@ index 3300fd2f..34e4dd9a 100644
  static void ntfs_fuse_update_times(ntfs_inode *ni, ntfs_time_update_flags mask)
  {
 diff --git a/src/ntfs-3g.c b/src/ntfs-3g.c
-index 1fee91f7..a6a85927 100644
+index 2d0f6577..b1771115 100644
 --- a/src/ntfs-3g.c
 +++ b/src/ntfs-3g.c
 @@ -224,20 +224,6 @@ int restore_privs(void);
@@ -81,5 +82,5 @@ index 1fee91f7..a6a85927 100644
  /**
   * ntfs_fuse_is_named_data_stream - check path to be to named data stream
 -- 
-2.36.0
+2.52.0
 

--- a/app-admin/ntfs-3g/autobuild/patches/0003-AOSCOS-fix-add-missing-header.patch
+++ b/app-admin/ntfs-3g/autobuild/patches/0003-AOSCOS-fix-add-missing-header.patch
@@ -1,14 +1,14 @@
-From ab6a5fd82e113d6814ed474c076e30b6c4ac4e2c Mon Sep 17 00:00:00 2001
+From 6ea8a21fa1f671210ad0f8175b24d4c2c2da5517 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Mon, 11 Aug 2025 21:08:14 +0800
-Subject: [PATCH 3/3] fix: add missing header
+Subject: [PATCH 3/3] AOSCOS: fix: add missing header
 
 ---
  include/ntfs-3g/ntfstime.h | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/include/ntfs-3g/ntfstime.h b/include/ntfs-3g/ntfstime.h
-index f3a89dd..f069371 100644
+index f3a89dd8..f0693711 100644
 --- a/include/ntfs-3g/ntfstime.h
 +++ b/include/ntfs-3g/ntfstime.h
 @@ -29,6 +29,7 @@
@@ -20,5 +20,5 @@ index f3a89dd..f069371 100644
  #ifdef HAVE_GETTIMEOFDAY
  #include <sys/time.h>
 -- 
-2.50.1
+2.52.0
 

--- a/app-admin/ntfs-3g/spec
+++ b/app-admin/ntfs-3g/spec
@@ -1,12 +1,12 @@
-VER=2022.10.3
-REL=1
-SRCS="tbl::https://download.tuxera.com/opensource/ntfs-3g_ntfsprogs-$VER.tgz \
+VER=2026.7.7
+EPOCH=1
+SRCS="git::commit=tags/$VER::https://github.com/tuxera/ntfs-3g \
       tbl::https://github.com/ebiggers/ntfs-3g-system-compression/releases/download/v1.0/ntfs-3g-system-compression-1.0.tar.gz \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/dedup.zip \
       tbl::https://repo.aosc.io/aosc-repacks/advanced-ntfs-3g/onedrive.zip"
-CHKSUMS="sha256::f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c \
+CHKSUMS="SKIP \
          sha256::c4a26f3a704f5503ec1b3af5e4bb569590c6752616e68a3227fc717417efaaae \
          sha256::a435efd5a81c69cf2ff7ba5f93a5672923e8548b9e287e3f3db30902a286be9b \
          sha256::fd5e1b7d58d2590254de176654e7c2b90340dde904ecd2e8640c30bc6b9e6684"
-SUBDIR="ntfs-3g_ntfsprogs-$VER"
+SUBDIR="ntfs-3g"
 CHKUPDATE="anitya::id=2504"

--- a/app-admin/partclone/autobuild/defines
+++ b/app-admin/partclone/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=utils
 PKGDEP="libreiserfs ntfs-3g"
 PKGDES="Utilities to save and restore used blocks on a partition"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-extfs'
     '--enable-xfs'

--- a/app-admin/partclone/autobuild/defines
+++ b/app-admin/partclone/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=partclone
 PKGSEC=utils
 PKGDEP="libreiserfs ntfs-3g"
+BUILDDEP="docbook-xsl libxslt"
 PKGDES="Utilities to save and restore used blocks on a partition"
 
 ABTYPE=autotools

--- a/app-admin/partclone/spec
+++ b/app-admin/partclone/spec
@@ -1,4 +1,4 @@
-VER=0.3.38
+VER=0.3.47
 SRCS="tbl::https://github.com/Thomas-Tsai/partclone/archive/refs/tags/$VER.tar.gz"
-CHKSUMS="sha256::5afd6f558e83026e9270396394bc95308fbe1543f8b963a4fb5331bc7b0ed9d9"
+CHKSUMS="sha256::8215844d14737d8fbb09fe1b1eafe688a8c790eafc8413a26c08e5795ac9ccd3"
 CHKUPDATE="anitya::id=141535"

--- a/app-utils/testdisk/autobuild/defines
+++ b/app-utils/testdisk/autobuild/defines
@@ -1,6 +1,11 @@
 PKGNAME=testdisk
 PKGSEC=utils
-PKGDEP="libjpeg-turbo libreiserfs ntfs-3g openssl qt-4"
-PKGDES="Checks and undeletes partitions, and utility for photo recovery"
+PKGDEP="libjpeg-turbo libreiserfs ntfs-3g openssl qt-5"
+PKGDES="Utility to check for and undelete partitions, files, and photos"
 
-AUTOTOOLS_AFTER="--without-ewf --enable-sudo --enable-qt"
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--without-ewf'
+    '--enable-sudo'
+    '--enable-qt'
+)

--- a/app-utils/testdisk/autobuild/prepare
+++ b/app-utils/testdisk/autobuild/prepare
@@ -1,4 +1,0 @@
-ln -s /usr/lib/qt4/bin/moc "$SRCDIR"/moc-qt4
-ln -s /usr/lib/qt4/bin/rcc "$SRCDIR"/rcc-qt4
-
-export PATH="$SRCDIR:$PATH"

--- a/app-utils/testdisk/spec
+++ b/app-utils/testdisk/spec
@@ -1,4 +1,5 @@
 VER=7.2
+REL=1
 SRCS="tbl::https://www.cgsecurity.org/testdisk-$VER.tar.bz2"
 CHKSUMS="sha256::f8343be20cb4001c5d91a2e3bcd918398f00ae6d8310894a5a9f2feb813c283f"
 CHKUPDATE="anitya::id=4955"

--- a/app-utils/wimlib/autobuild/defines
+++ b/app-utils/wimlib/autobuild/defines
@@ -2,8 +2,10 @@ PKGNAME=wimlib
 PKGSEC=utils
 PKGDEP="openssl fuse-3 libxml2 ntfs-3g"
 PKGSUG="cdrkit mtools syslinux cabextract"
-PKGDES="Tools and libraries for creating, extracting, and modifying Windows Imaging (WIM) archives"
+PKGDES="Tools and libraries to work with Windows Imaging (WIM) archives"
 
-AUTOTOOLS_AFTER="--with-fuse \
-                 --with-ntfs-3g"
-RECONF=0
+ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--with-fuse'
+    '--with-ntfs-3g'
+)

--- a/app-utils/wimlib/spec
+++ b/app-utils/wimlib/spec
@@ -1,4 +1,4 @@
-VER=1.14.4
+VER=1.14.5
 SRCS="tbl::https://wimlib.net/downloads/wimlib-$VER.tar.gz"
-CHKSUMS="sha256::3633db2b6c8b255eb86d3bf3df3059796bd1f08e50b8c9728c7eb66662e51300"
+CHKSUMS="sha256::84221a3abd5b91228f15f8e6065c335a336237b5738197b75bf419eea561a194"
 CHKUPDATE="anitya::id=16320"

--- a/topics/ntfs-3g-2026.7.7.toml
+++ b/topics/ntfs-3g-2026.7.7.toml
@@ -1,0 +1,12 @@
+security = true
+must_match_all = false
+
+[name]
+default = "NTFS-3G 2026.7.7"
+
+[caution]
+default = "Fixes 9 security vulnerabilities (severity details pending)"
+zh_CN = "修复 9 个安全漏洞（漏洞严重性细节待定）"
+
+[packages-v2]
+"ntfs-3g" = "< 1:2026.7.7"


### PR DESCRIPTION
Topic Description
-----------------

- wimlib: update to 1.14.5
    - Clean up build scripts.
    - Improve PKGDES.
- testdisk: rebuild for ntfs-3g 2026.7.7; use Qt 5
- partclone: update to 0.3.47
- ntfs-3g: add PKGBREAK
- topics: add ntfs-3g-2026.7.7.toml
- ntfs-3g: update to 2026.7.7
    Track patches at AOSC-Tracking/ntfs-3g @ aosc/2026.7.7
    \(HEAD: 6ea8a21fa1f671210ad0f8175b24d4c2c2da5517\).
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ntfs-3g: 2026.7.7
- partclone: 0.3.47
- testdisk: 7.2-1
- wimlib: 1.14.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit ntfs-3g partclone testdisk wimlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
