### PR TITLE
xdg-user-dirs: add spiral flag, fixing debian dependencies compability

### DIFF
--- a/app-admin/xdg-user-dirs/autobuild/defines
+++ b/app-admin/xdg-user-dirs/autobuild/defines
@@ -8,3 +8,5 @@ MESON_AFTER=(
     '-Ddocs=false'
     '-Dnls=true'
 )
+
+PKGPROV="xdg-user-dirs_spiral"

--- a/app-admin/xdg-user-dirs/spec
+++ b/app-admin/xdg-user-dirs/spec
@@ -1,5 +1,5 @@
 VER=0.19
-REL=1
+REL=2
 SRCS="tbl::https://user-dirs.freedesktop.org/releases/xdg-user-dirs-$VER.tar.xz"
 CHKSUMS="sha256::e92deb929c10d4b29329397af8a2585101247f7e6177ac6f1d28e82130ed8c19"
 CHKUPDATE="anitya::id=8637"


### PR DESCRIPTION
Topic Description
-----------------

- xdg-user-dirs: add spiral flag, fixing debian dependencies compability

Package(s) Affected
-------------------

- xdg-user-dirs: 0.19-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit xdg-user-dirs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
