### PR TITLE
oma: add amo RECOM

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -3,6 +3,7 @@ PKGDES="Default package management interface"
 PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp nettle openssl \
         systemd xz glibc ripgrep zstd aosc-os-repository-data \
         aosc-os-repository-template aosc-os-keyring"
+PKGRECOM="amo"
 BUILDDEP="rustc llvm"
 PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,4 +1,5 @@
 VER=1.27.1
+REL=1
 SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- oma: add amo RECOM
    We missed this when coming from oma-preview.

Package(s) Affected
-------------------

- oma: 1.27.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
