### PR TITLE
qemu: update to 11.0.2

### DIFF
--- a/app-virtualization/qemu/01-shared/build
+++ b/app-virtualization/qemu/01-shared/build
@@ -56,6 +56,7 @@ SYSTEM_CONFIGURE_FLAGS=(
     '--enable-libdaxctl'
     '--enable-fuse-lseek'
     '--disable-selinux'
+    '--enable-plugins'
 )
 
 USER_CONFIGURE_FLAGS=(

--- a/app-virtualization/qemu/01-shared/defines
+++ b/app-virtualization/qemu/01-shared/defines
@@ -12,7 +12,7 @@ PKGDEP="alsa-lib brltty bzip2 cairo canokey-qemu capstone curl \
 BUILDDEP="spice-protocol xmlto dtc sphinx jack glib-static \
           libgcrypt-static libgpg-error-static libnfs-static pcre-static \
           zlib-static zstd-static acpica-unix linux+api rustc"
-PKGDES="A KVM based virtualization client"
+PKGDES="System emulator and KVM-based virtualization client"
 
 AB_FLAGS_SPECS=0
 ABTYPE=self

--- a/app-virtualization/qemu/01-shared/defines.stage2
+++ b/app-virtualization/qemu/01-shared/defines.stage2
@@ -10,7 +10,7 @@ PKGDEP="pixman libcacard libjpeg-turbo libpng sdl alsa-lib nss \
 BUILDDEP="spice-protocol xmlto doxygen dtc sphinx jack glib-static \
           libgcrypt-static libgpg-error-static libnfs-static pcre-static \
           zlib-static zstd-static acpica-unix linux+api"
-PKGDES="A KVM based virtualization client"
+PKGDES="System emulator and KVM-based virtualization client"
 
 AB_FLAGS_SPECS=0
 NOLTO__LOONGSON3=1

--- a/app-virtualization/qemu/01-shared/patches/0002-linux-user-implement-fsmount-2-series-of-syscalls.patch
+++ b/app-virtualization/qemu/01-shared/patches/0002-linux-user-implement-fsmount-2-series-of-syscalls.patch
@@ -1,0 +1,125 @@
+From 4de263f68c3d22422ad5d6454c5849842bd177ba Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Tue, 26 May 2026 18:07:27 +0800
+Subject: [PATCH 2/3] linux-user: implement fsmount(2) series of syscalls
+
+This series of syscalls replaces the old mount(2) syscall with a series
+of syscalls that operates around a filesystem context. This series of
+syscalls is available since Linux 5.2 and glibc 2.36+.
+
+Their users include systemd since v259 and libmount from util-linux, and
+possibly other widely used projects.
+
+Preliminary checks are implemented to ensure the validity of the
+interface.
+
+Signed-off-by: Xinhui Yang <cyan@cyano.uk>
+---
+ linux-user/syscall.c | 91 ++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 91 insertions(+)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 65bbeb8551..e033f06569 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -14348,6 +14348,97 @@ static abi_long do_syscall1(CPUArchState *cpu_env, int num, abi_long arg1,
+         return do_map_shadow_stack(cpu_env, arg1, arg2, arg3);
+ #endif
+ 
++#if defined(TARGET_NR_fsopen)
++    case TARGET_NR_fsopen:
++        {
++            p = lock_user_string(arg1);
++            if (!p) {
++                return -TARGET_EFAULT;
++            }
++            ret = get_errno(fsopen(p, arg2));
++            unlock_user(p, arg1, 0);
++        }
++        return ret;
++    case TARGET_NR_fsconfig:
++        {
++            /*
++             * fsconfig(int, int, char *, void *, int)
++             * NOTE: p4 is nullable and its type might not be a string.
++             */
++            void *p3, *p4;
++            int cmd = (int) arg2;
++            switch (cmd) {
++            case FSCONFIG_SET_BINARY:
++            case FSCONFIG_SET_STRING:
++            case FSCONFIG_SET_PATH:
++            case FSCONFIG_SET_PATH_EMPTY:
++                p3 = lock_user_string(arg3);
++                if (!p3) {
++                    return -TARGET_EFAULT;
++                }
++                if (cmd != FSCONFIG_SET_BINARY) {
++                    /* key and value must be strings. */
++                    p4 = lock_user_string(arg4);
++                } else {
++                    /*
++                     * Otherwise the value must be a raw buffer with its
++                     * length specified in arg5 (aux).
++                     */
++                    p4 = lock_user(VERIFY_READ, arg4, arg5, 1);
++                }
++                if (!p4) {
++                    unlock_user(p3, arg3, 0);
++                    return -TARGET_EFAULT;
++                }
++                ret = get_errno(fsconfig(arg1, arg2, p3, p4, arg5));
++                unlock_user(p3, arg3, 0);
++                unlock_user(p4, arg4, 0);
++                break;
++
++            case FSCONFIG_SET_FLAG:
++            case FSCONFIG_SET_FD:
++                /* arg4 (value) must be NULL. */
++                if (arg4) {
++                    return -TARGET_EFAULT;
++                }
++                p3 = lock_user_string(arg3);
++                if (!p3) {
++                    return -TARGET_EFAULT;
++                }
++                ret = get_errno(fsconfig(arg1, arg2, p3, NULL, arg5));
++                unlock_user(p3, arg3, 0);
++                break;
++            case FSCONFIG_CMD_CREATE:
++            case FSCONFIG_CMD_RECONFIGURE:
++#ifdef FSCONFIG_CMD_CREATE_EXCL
++            /*
++             * FSCONFIG_CMD_CREATE_EXCL is only available since Linux
++             * 6.6. Guarding it to allow building with pre-6.6 headers.
++             */
++            case FSCONFIG_CMD_CREATE_EXCL:
++#endif
++                /* key and value must be NULL, aux must be 0. */
++                if (arg3 || arg4 || arg5) {
++                    return -TARGET_EFAULT;
++                }
++                ret = get_errno(fsconfig(arg1, arg2, NULL, NULL, 0));
++                break;
++            default:
++                return -TARGET_EFAULT;
++            }
++        }
++        return ret;
++    case TARGET_NR_fsmount:
++        ret = get_errno(fsmount(arg1, arg2, arg3));
++        return ret;
++    case TARGET_NR_fspick:
++        {
++            p = lock_user_string(arg2);
++            ret = get_errno(fspick(arg1, p, arg3));
++            unlock_user(p, arg2, 0);
++        }
++        return ret;
++#endif
+     default:
+         qemu_log_mask(LOG_UNIMP, "Unsupported syscall: %d\n", num);
+         return -TARGET_ENOSYS;
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/01-shared/patches/0003-linux-user-strace-add-fsmount-series-of-syscalls.patch
+++ b/app-virtualization/qemu/01-shared/patches/0003-linux-user-strace-add-fsmount-series-of-syscalls.patch
@@ -1,0 +1,175 @@
+From 7b7775a89f8d2bd1948136a11457c5538cb1d532 Mon Sep 17 00:00:00 2001
+From: Xinhui Yang <cyan@cyano.uk>
+Date: Wed, 27 May 2026 10:13:13 +0800
+Subject: [PATCH 3/3] linux-user/strace: add fsmount series of syscalls
+
+Following the addition of fsmount(2) series of syscalls in the syscall
+handler, strace support is added, with a dedicated function to print the
+parameters of fsconfig(2), which contains parameters that can be
+interpreted as multiple types.
+
+Snippet of the strace dump when running `mount -t tmpfs tmpfs /media`:
+
+18 fsopen(tmpfs,1) = 3
+18 read(3,0x407fcf1c,8191) = -1 errno=61 (No data available)
+18 fsconfig(3,FSCONFIG_SET_STRING,"source","tmpfs",0) = 0
+18 read(3,0x407fce3c,8191) = -1 errno=61 (No data available)
+18 fsconfig(3,FSCONFIG_CMD_CREATE,NULL,NULL,0) = 0
+18 read(3,0x407fce3c,8191) = -1 errno=61 (No data available)
+18 fsmount(3,1,0) = 4
+18 read(3,0x407fce3c,8191) = -1 errno=61 (No data available)
+18 statx(4,"",AT_EMPTY_PATH|AT_STATX_SYNC_AS_STAT,0x1000,0x407fee98) = 0
+18 move_mount(4,,-100,/media,4) = 0
+18 read(3,0x407fcfcc,8191) = -1 errno=61 (No data available)
+18 close(3) = 0
+18 close(4) = 0
+
+Signed-off-by: Xinhui Yang <cyan@cyano.uk>
+Reviewed-by: Pierrick Bouvier <pierrick.bouvier@oss.qualcomm.com>
+---
+ linux-user/strace.c    | 105 +++++++++++++++++++++++++++++++++++++++++
+ linux-user/strace.list |  15 ++++++
+ 2 files changed, 120 insertions(+)
+
+diff --git a/linux-user/strace.c b/linux-user/strace.c
+index 2cbaf94c89..d861f311f6 100644
+--- a/linux-user/strace.c
++++ b/linux-user/strace.c
+@@ -4344,6 +4344,111 @@ print_statx(CPUArchState *cpu_env, const struct syscallname *name,
+ }
+ #endif
+ 
++#ifdef TARGET_NR_fsconfig
++static void
++print_fsconfig_cmd_name(int cmd)
++{
++    switch (cmd) {
++    case FSCONFIG_SET_FLAG:
++        qemu_log("%s%s", "FSCONFIG_SET_FLAG", get_comma(0));
++        break;
++    case FSCONFIG_SET_STRING:
++        qemu_log("%s%s", "FSCONFIG_SET_STRING", get_comma(0));
++        break;
++    case FSCONFIG_SET_BINARY:
++        qemu_log("%s%s", "FSCONFIG_SET_BINARY", get_comma(0));
++        break;
++    case FSCONFIG_SET_PATH:
++        qemu_log("%s%s", "FSCONFIG_SET_PATH", get_comma(0));
++        break;
++    case FSCONFIG_SET_PATH_EMPTY:
++        qemu_log("%s%s", "FSCONFIG_SET_PATH_EMPTY", get_comma(0));
++        break;
++    case FSCONFIG_SET_FD:
++        qemu_log("%s%s", "FSCONFIG_SET_FD", get_comma(0));
++        break;
++    case FSCONFIG_CMD_CREATE:
++        qemu_log("%s%s", "FSCONFIG_CMD_CREATE", get_comma(0));
++        break;
++    case FSCONFIG_CMD_RECONFIGURE:
++        qemu_log("%s%s", "FSCONFIG_CMD_RECONFIGURE", get_comma(0));
++        break;
++#ifdef FSCONFIG_CMD_CREATE_EXCL
++    case FSCONFIG_CMD_CREATE_EXCL:
++        /* Only available since Linux 6.6. */
++        qemu_log("%s%s", "FSCONFIG_CMD_CREATE_EXCL", get_comma(0));
++        break;
++#endif
++    default:
++        qemu_log("%s (%d)%s", "UNKNOWN_CMD", cmd, get_comma(0));
++        break;
++    }
++}
++
++static void
++print_fsconfig(CPUArchState *cpu_env, const struct syscallname *name,
++            abi_long arg0, abi_long arg1, abi_long arg2,
++            abi_long arg3, abi_long arg4, abi_long arg5)
++{
++    /*
++     * fsconfig(int fd, int cmd, char* key, void* value, int aux)
++     * Where:
++     * fd: file descriptor returned by fsopen().
++     * cmd: integer constant specifying a command.
++     * key: a string, can be NULL on certain commands.
++     * value: any data in a buffer, can be NULL, raw buffer or a string.
++     * aux: axillary values such as flags for FSCONFIG_SET_PATH.
++     */
++    int cmd = (int) arg1;
++    print_syscall_prologue(name);
++    print_raw_param("%d", arg0, 0);
++    print_fsconfig_cmd_name(cmd);
++    /* Process arg2 (key). */
++    switch (cmd) {
++    case FSCONFIG_SET_FLAG:
++    case FSCONFIG_SET_STRING:
++    case FSCONFIG_SET_BINARY:
++    case FSCONFIG_SET_PATH:
++    case FSCONFIG_SET_PATH_EMPTY:
++    case FSCONFIG_SET_FD:
++        print_string(arg2, 0);
++        break;
++    default:
++        print_pointer(arg2, 0);
++        break;
++    }
++    /* Process arg3 (value). */
++    switch (cmd) {
++    case FSCONFIG_SET_STRING:
++    case FSCONFIG_SET_PATH:
++    case FSCONFIG_SET_PATH_EMPTY:
++        print_string(arg3, 0);
++        break;
++    default:
++        print_pointer(arg3, 0);
++        break;
++    }
++    /*
++     * Process arg4 (aux).
++     * On FSCONFIG_SET_PATH and FSCONFIG_SET_PATH_EMPTY, aux can
++     * be either 0 or AT_FDCWD.
++     * On FSCONFIG_SET_BINARY, aux is an integer to state the length
++     * of the buffer pointed by arg3.
++     * Otherwise, it must be 0.
++     */
++    switch (cmd) {
++    case FSCONFIG_SET_PATH:
++    case FSCONFIG_SET_PATH_EMPTY:
++        print_at_dirfd(arg4, 1);
++        break;
++    default:
++        print_raw_param("%d", arg4, 1);
++        break;
++    }
++    print_syscall_epilogue(name);
++}
++#endif
++
+ #ifdef TARGET_NR_ioctl
+ static void
+ print_ioctl(CPUArchState *cpu_env, const struct syscallname *name,
+diff --git a/linux-user/strace.list b/linux-user/strace.list
+index 6162a407f9..3a366b8cac 100644
+--- a/linux-user/strace.list
++++ b/linux-user/strace.list
+@@ -1722,3 +1722,18 @@
+ #ifdef TARGET_NR_rseq
+ { TARGET_NR_rseq, "rseq" , "%s(%p,%u,%d,%#x)", NULL, NULL },
+ #endif
++#ifdef TARGET_NR_fsopen
++{ TARGET_NR_fsopen, "fsopen", "%s(%s,%d)", NULL, NULL },
++#endif
++#ifdef TARGET_NR_fsconfig
++{ TARGET_NR_fsconfig, "fsconfig", NULL, print_fsconfig, NULL },
++#endif
++#ifdef TARGET_NR_fsmount
++{ TARGET_NR_fsmount, "fsmount", "%s(%d,%d,%d)", NULL, NULL },
++#endif
++#ifdef TARGET_NR_move_mount
++{ TARGET_NR_move_mount, "move_mount", "%s(%d,%s,%d,%s,%d)", NULL, NULL },
++#endif
++#ifdef TARGET_NR_fspick
++{ TARGET_NR_fspick, "fspick", "%s(%d,%s,%d)", NULL, NULL },
++#endif
+-- 
+2.52.0
+

--- a/app-virtualization/qemu/02-static-aarch64/defines
+++ b/app-virtualization/qemu/02-static-aarch64/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for aarch64(static version)"
+PKGDES="QEMU user mode emulation binaries for AArch64 (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/03-static-alpha/defines
+++ b/app-virtualization/qemu/03-static-alpha/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for alpha(static version)"
+PKGDES="QEMU user mode emulation binaries for DEC Alpha (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/04-static-arm/defines
+++ b/app-virtualization/qemu/04-static-arm/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for arm(static version)"
+PKGDES="QEMU user mode emulation binaries for 32-bit Arm (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/05-static-armeb/defines
+++ b/app-virtualization/qemu/05-static-armeb/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for armeb(static version)"
+PKGDES="QEMU user mode emulation binaries for 32-bit, big-endian Arm (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/07-static-i386/defines
+++ b/app-virtualization/qemu/07-static-i386/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for i386(static version)"
+PKGDES="QEMU user mode emulation binaries for 32-bit x86 (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/08-static-m68k/defines
+++ b/app-virtualization/qemu/08-static-m68k/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for m68k(static version)"
+PKGDES="QEMU user mode emulation binaries for Motorolla 68000 (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/09-static-microblaze/defines
+++ b/app-virtualization/qemu/09-static-microblaze/defines
@@ -3,7 +3,7 @@ PKGSEC=admin
 PKGDEP=""
 BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
           libnfs-static pcre-static zlib-static zstd-static liburing"
-PKGDES="QEMU user mode emulation binaries for microblaze(static version)"
+PKGDES="QEMU user mode emulation binaries for MicroBlaze (static version)"
 
 AB_FLAGS_SPECS=0
 PKGBREAK="qemu-user-static<=2.8.0"

--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,4 @@
-VER=11.0.1
+VER=11.0.2
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
-CHKSUMS="sha256::0d235f5820278d914a3155ec27af8e4258d697ea892895570807d69c0cb8cd64"
+CHKSUMS="sha256::3745f6ea88e2e87fe0dc838b2b1d4e0a770bf48e01a1d5a186842a1fff76ccf5"
 CHKUPDATE="anitya::id=13607"


### PR DESCRIPTION
Topic Description
-----------------

- qemu: update to 11.0.2
    - Enable plugins explicitly \(although default on upstream\).
    - Improve PKGDES.
    - Add patches implementing fsmount\(2\) series of syscalls.
    Co-authored-by: Xinhui Yang <cyan@cyano.uk>

Package(s) Affected
-------------------

- qemu: 11.0.2
- qemu-aarch64-static: 11.0.2
- qemu-alpha-static: 11.0.2
- qemu-arm-static: 11.0.2
- qemu-armeb-static: 11.0.2
- qemu-guest-agent: 11.0.2
- qemu-i386-static: 11.0.2
- qemu-loongarch64-static: 11.0.2
- qemu-m68k-static: 11.0.2
- qemu-microblaze-static: 11.0.2
- qemu-microblazeel-static: 11.0.2
- qemu-mips-static: 11.0.2
- qemu-mips64-static: 11.0.2
- qemu-mips64el-static: 11.0.2
- qemu-mipsel-static: 11.0.2
- qemu-mipsn32-static: 11.0.2
- qemu-mipsn32el-static: 11.0.2
- qemu-or32-static: 11.0.2
- qemu-ppc-static: 11.0.2
- qemu-ppc64-static: 11.0.2
- qemu-ppc64le-static: 11.0.2
- qemu-riscv32-static: 11.0.2
- qemu-riscv64-static: 11.0.2
- qemu-s390x-static: 11.0.2
- qemu-sh4-static: 11.0.2
- qemu-sh4eb-static: 11.0.2
- qemu-sparc-static: 11.0.2
- qemu-sparc32plus-static: 11.0.2
- qemu-sparc64-static: 11.0.2
- qemu-user-static: 11.0.2
- qemu-x86-64-static: 11.0.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qemu
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
