### PR TITLE
Darktable 5.6.0

### DIFF
--- a/app-creativity/darktable/autobuild/defines
+++ b/app-creativity/darktable/autobuild/defines
@@ -5,8 +5,8 @@ PKGDEP="colord-gtk dbus-glib exiv2 flickcurl graphicsmagick gtk-3 \
 	librsvg libsecret libsoup libtiff libwebp iso-codes \
 	libxslt openexr openjpeg pugixml sdl12-compat sqlite \
 	libosmgpsmap libcl jasper gmic lua-5.4 libheif libavif portmidi \
-	libcamera libjxl"
-BUILDDEP="cmake intltool po4a llvm"
+	libcamera libjxl onnxruntime potrace libarchive"
+BUILDDEP="cmake extra-cmake-modules intltool po4a llvm-22"
 PKGDES="Utility to organize and develop raw images"
 
 ABTYPE=cmakeninja
@@ -20,13 +20,14 @@ CMAKE_AFTER=(
 	-DBUILD_PRINT=ON
 	-DBUILD_RS_IDENTIFY=ON
 	-DBUILD_SHARED_LIBS=ON
-	-DBUILD_SSE2_CODEPATHS=OFF
 	-DBUILD_TOOLS=ON
+	-DCUSTOM_CFLAGS=ON
 	-DDONT_USE_INTERNAL_LUA=ON
 	-DENABLE_JASPER=ON
 	-DENABLE_LCMS=ON
 	-DENABLE_RAWSPEED=ON
-	-DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm
+	-DLLVM_DIR=/usr/lib/llvm-22/lib/cmake/llvm
+	-DUSE_AI=ON
 	-DUSE_AVIF=ON
 	-DUSE_CAMERA_SUPPORT=ON
 	-DUSE_COLORD=ON
@@ -35,9 +36,11 @@ CMAKE_AFTER=(
 	-DUSE_HEIF=ON
 	-DUSE_LIBSECRET=ON
 	-DUSE_LUA=ON
-	-DUSE_OPENCL=OFF
 	-DRAWSPEED_ENABLE_LTO=ON
 	-DCMAKE_SKIP_INSTALL_RPATH=OFF
+
+	-DBUILD_SSE2_CODEPATHS=OFF
+	-DUSE_OPENCL=OFF
 )
 CMAKE_AFTER__SSE=(
 	-DBUILD_SSE2_CODEPATHS=ON

--- a/app-creativity/darktable/spec
+++ b/app-creativity/darktable/spec
@@ -1,5 +1,4 @@
-VER=5.4.1
-REL=6
+VER=5.6.0
 EPOCH=1
 SRCS="git::commit=tags/release-$VER::https://github.com/darktable-org/darktable"
 CHKSUMS="SKIP"

--- a/runtime-imaging/exiv2/autobuild/defines
+++ b/runtime-imaging/exiv2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=exiv2
 PKGSEC=libs
-PKGDEP="expat gcc-runtime zlib gettext curl"
+PKGDEP="expat gcc-runtime zlib gettext curl inih"
 PKGDES="Exif and Iptc metadata manipulation library and tools"
 
 ABTYPE=cmakeninja

--- a/runtime-imaging/exiv2/spec
+++ b/runtime-imaging/exiv2/spec
@@ -1,4 +1,5 @@
 VER=0.28.8
+REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/Exiv2/exiv2"
 CHKSUMS=SKIP
 CHKUPDATE="anitya::id=769"


### PR DESCRIPTION
Topic Description
-----------------

- darktable: update to 5.6.0
- exiv2: add missing dep libINIReader.so provided by inih

Package(s) Affected
-------------------

- darktable: 5.6.0
- exiv2: 0.28.8-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit exiv2 darktable
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
