### PR TITLE
freerdp: update to 3.29.0

### DIFF
--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=3.28.0
+VER=3.29.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::61b7c02f64695a0ee883335ffbbce446e119f46bbf3653e1a71bebf6750ffae3"
+CHKSUMS="sha256::01ceccc39421bfb234cf668dac8f05844a908020dc4a9eebfbc706a64212f230"
 CHKUPDATE="anitya::id=10442"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.29.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- freerdp: 2:3.29.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
