### PR TITLE
vscode: update to 1.129.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.128.0
+VER=1.129.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::ee7ff012cf872e497d665486e56c5b1a12e36cca0c07c97887c997cbfdc797b1"
-CHKSUMS__ARM64="sha256::eb394338250dc7f5371c8c8e6a26d632c7aa977843d6ee7a496132c301a8ea05"
+CHKSUMS__AMD64="sha256::a25c73aa4a7461d3d605f272add35fd661c881400c75b4809d6cb277632791c4"
+CHKSUMS__ARM64="sha256::c228f157e6febac1ab503ebab1f89c78420172594c775f76fca95000c0817e97"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.129.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.129.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
