### PR TITLE
freerdp: update to 3.30.0

### DIFF
--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=3.28.0
+VER=3.30.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::61b7c02f64695a0ee883335ffbbce446e119f46bbf3653e1a71bebf6750ffae3"
+CHKSUMS="sha256::e2687d02dea6fede004d36391dac1a74ce57a210f8867fd95033171d4909590c"
 CHKUPDATE="anitya::id=10442"

--- a/topics/freerdp-3.30.0.toml
+++ b/topics/freerdp-3.30.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "FreeRDP 3.30.0"
+
+[caution]
+default = "Fixes 3 security vulnerabilities partially publicly disclosed by FreeRDP Security Team (including 1 of high severity)"
+zh_CN = "修复 FreeRDP 安全团队部分披露的 3 个安全漏洞（含 1 个高危漏洞）"
+
+[packages-v2]
+freerdp = "< 2:3.30.0"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.30.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- freerdp: 2:3.30.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
