### PR TITLE
libde265: security update to 1.1.1

### DIFF
--- a/runtime-multimedia/libde265/spec
+++ b/runtime-multimedia/libde265/spec
@@ -1,5 +1,4 @@
-VER=1.0.18
-REL=3
+VER=1.1.1
 SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libde265"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11239"

--- a/topics/libde265-1.1.1.toml
+++ b/topics/libde265-1.1.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libde265 1.1.1"
+
+[caution]
+default = "Fixes an Out-of-Bounds Write vulnerability (CVE-2026-49295, Severity: High) and an Integer Overflow vulnerability (CVE-2026-49346, Severity: High)"
+zh_CN = "修复 1 个越界写入漏洞（漏洞编号 CVE-2026-49295，严重性：高）和 1 个整数溢出漏洞（漏洞编号 CVE-2026-49346，严重性：高）"
+
+[packages-v2]
+"libde265" = "< 1.1.1"


### PR DESCRIPTION
Topic Description
-----------------

- libde265: security update to 1.1.1

Package(s) Affected
-------------------

- libde265: 1.1.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libde265
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
