### PR TITLE
openblas: update to 0.3.34

### DIFF
--- a/app-scientific/openblas/autobuild/beyond
+++ b/app-scientific/openblas/autobuild/beyond
@@ -1,2 +1,2 @@
 abinfo "Removing duplicated headers with Lapack ..."
-rm -fv "$PKGDIR"/usr/include/{cblas.h,lapack*}
+rm -v "$PKGDIR"/usr/include/{cblas.h,lapack*}

--- a/app-scientific/openblas/autobuild/build
+++ b/app-scientific/openblas/autobuild/build
@@ -1,15 +1,15 @@
 abinfo "Setting kernel target for OpenBLAS ..."
 if ab_match_arch amd64; then
-    export TARGETCONF="DYNAMIC_ARCH=1 DYNAMIC_OLDER=1 TARGET=PRESCOTT"
+    export TARGETCONF="DYNAMIC_OLDER=1 TARGET=PRESCOTT"
 elif ab_match_arch arm64; then
-    export TARGETCONF="DYNAMIC_ARCH=1 TARGET=ARMV8"
-elif ab_match_arch loongarch64; then
-    # FIXME: LoongArch SIMD not yet supported?
+    export TARGETCONF="TARGET=ARMV8"
+elif ab_match_arch loongarch64 ||
+     ab_match_arch loongarch64_nosimd; then
     export TARGETCONF="TARGET=GENERIC"
 elif ab_match_arch loongson3; then
     export TARGETCONF="TARGET=LOONGSON3A"
 elif ab_match_arch ppc64el; then
-    export TARGETCONF="DYNAMIC_ARCH=1 TARGET=POWER8"
+    export TARGETCONF="TARGET=POWER8"
 elif ab_match_arch riscv64; then
     export TARGETCONF="TARGET=RISCV64_GENERIC"
 else
@@ -17,7 +17,11 @@ else
 fi
 
 abinfo "Building OpenBLAS ..."
-make PREFIX="$PKGDIR/usr" $TARGETCONF
+make \
+    PREFIX="$PKGDIR/usr" \
+    DYNAMIC_ARCH=1 \
+    $TARGETCONF
 
 abinfo "Installing OpenBLAS ..."
-make PREFIX="$PKGDIR/usr" install
+make install \
+    PREFIX="$PKGDIR/usr"

--- a/app-scientific/openblas/autobuild/defines
+++ b/app-scientific/openblas/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=openblas
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="An optimized BLAS library based on GotoBLAS2 1.13 BSD version"
+PKGDES="Optimized BLAS library"
 
 NOSTATIC=0

--- a/app-scientific/openblas/spec
+++ b/app-scientific/openblas/spec
@@ -1,4 +1,4 @@
-VER=0.3.30
+VER=0.3.34
 SRCS="git::commit=tags/v$VER::https://github.com/xianyi/OpenBLAS"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2540"


### PR DESCRIPTION
Topic Description
-----------------

- openblas: update to 0.3.34
    Enable dynamic arch detection for all architectures, performance diffs
    as tested on LoongArch devices:
    YuanBao \(3C6000/D \* 2\):
    Before:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :     4.2828 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :    62.2031 GF
    After:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :    61.8451 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :   385.9555 GF
    ---
    Stomatopoda \(3C5000 \* 1\):
    Before:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :     4.2822 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :    53.0891 GF
    After:
    numactl -C 0 ./sgemmbench.openblas 256
    SGEMM Performance N =    256 :    61.0555 GF
    ./sgemmbench.openblas 1024
    SGEMM Performance N =   1024 :   244.8988 GF
    Co-authored-by: Jiajie Chen <c@jia.je>

Package(s) Affected
-------------------

- openblas: 0.3.34

Security Update?
----------------

No

Build Order
-----------

```
#buildit openblas
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
