### PR TITLE
libraw: security update to 0.22.2

### DIFF
--- a/runtime-imaging/libraw/spec
+++ b/runtime-imaging/libraw/spec
@@ -1,4 +1,4 @@
-VER=0.22.1
-SRCS="tbl::https://github.com/LibRaw/LibRaw/archive/$VER.tar.gz"
-CHKSUMS="sha256::e676248284075605aa2697a66eeed7dc258820bd1d4988c724d29edffd726726"
+VER=0.22.2
+SRCS="git::commit=tags/$VER::https://github.com/LibRaw/LibRaw"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1709"

--- a/topics/libraw-0.22.2.toml
+++ b/topics/libraw-0.22.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "LibRaw 0.22.2"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (4 of critical severity)"
+zh_CN = "修复 4 处安全漏洞（含 4 个严重漏洞）"
+
+[packages-v2]
+"libraw" = "< 0.22.2"


### PR DESCRIPTION
Topic Description
-----------------

- libraw: security update to 0.22.2

Package(s) Affected
-------------------

- libraw: 0.22.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libraw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
