### PR TITLE
lldpd: security update to 1.0.22

### DIFF
--- a/app-network/lldpd/spec
+++ b/app-network/lldpd/spec
@@ -1,5 +1,4 @@
-VER=1.0.18
-REL=2
+VER=1.0.22
 SRCS="git::commit=tags/$VER::https://github.com/lldpd/lldpd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14019"

--- a/topics/lldpd-1.0.22.toml
+++ b/topics/lldpd-1.0.22.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "lldpd 1.0.22"
+
+[caution]
+default = "Fixes an Out-of-bounds Read vulnerability (CVE-2026-46433, Severity: Medium)"
+zh_CN = "修复 1 个越界读取漏洞（CVE-2026-46433，严重性：中）"
+
+[packages-v2]
+"lldpd" = "< 1.0.22"


### PR DESCRIPTION
Topic Description
-----------------

- lldpd: security update to 1.0.22

Package(s) Affected
-------------------

- lldpd: 1.0.22

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit lldpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
