### PR TITLE
opencryptoki: security update to 3.27.0

### DIFF
--- a/runtime-cryptography/opencryptoki/spec
+++ b/runtime-cryptography/opencryptoki/spec
@@ -1,5 +1,4 @@
-VER=3.21.0
-REL=3
+VER=3.27.0
 SRCS="git::commit=tags/v$VER::https://github.com/opencryptoki/opencryptoki"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=112179"

--- a/topics/opencryptoki-3.27.0.toml
+++ b/topics/opencryptoki-3.27.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "openCryptoki 3.27.0"
+
+[caution]
+default = "Fixes an Out-of-bounds Read vulnerability (CVE-2026-40253, Severity: Medium)"
+zh_CN = "修复 1 个越界读取漏洞（漏洞编号 CVE-2026-40253，严重性：中）"
+
+[packages-v2]
+"opencryptoki" = "< 3.27.0"


### PR DESCRIPTION
Topic Description
-----------------

- opencryptoki: security update to 3.27.0

Package(s) Affected
-------------------

- opencryptoki: 3.27.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit opencryptoki
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
