### PR TITLE
openvpn: security update to 2.7.5

### DIFF
--- a/app-network/openvpn/spec
+++ b/app-network/openvpn/spec
@@ -1,4 +1,4 @@
-VER=2.7.4
+VER=2.7.5
 SRCS="tbl::https://swupdate.openvpn.net/community/releases/openvpn-$VER.tar.gz"
-CHKSUMS="sha256::18db05f3d5eee3663db1914590044e5f96ff5cd47b6e7846c6a350806c23dbce"
+CHKSUMS="sha256::c6864b3c7d4e059c7d6ce22d1b5fa646c8b379a06af872eeb9792b6083a44ac4"
 CHKUPDATE="anitya::id=2567"

--- a/topics/openvpn-2.7.5.toml
+++ b/topics/openvpn-2.7.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "OpenVPN 2.7.5"
+
+[caution]
+default = "Fixes a Reachable Assertion vulnerability (CVE-2026-13122, Severity: Medium) and a Missing Release of Memory after Effective Lifetime vulnerability (CVE-2026-13698, Severity: High)"
+zh_CN = "修复 1 个可达断言漏洞（漏洞编号 CVE-2026-13122，严重性：中）和 1 个内存有效生命周期后未释放漏洞（漏洞编号 CVE-2026-13698，严重性：高）"
+
+[packages-v2]
+"openvpn" = "< 2.7.5"


### PR DESCRIPTION
Topic Description
-----------------

- openvpn: security update to 2.7.5

Package(s) Affected
-------------------

- openvpn: 2.7.5

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit openvpn
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
