### PR TITLE
php: security update to 8.5.8

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,5 +1,5 @@
-VER=8.5.6
+VER=8.5.8
 EPOCH=1
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::826c600b7c6f956bd335558ca3bdbcab23b22126c1cc8d9348be2280a2204bb7"
+CHKSUMS="sha256::58910198d19e873048fe87cdfe16bc790025417ede3d1651bfa1c4b533d573f2"
 CHKUPDATE="anitya::id=3627"

--- a/topics/php-8.5.8.toml
+++ b/topics/php-8.5.8.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PHP 8.5.8"
+
+[caution]
+default = "Fixes a Heap-based Buffer Overflow vulnerability (CVE-2026-14355, Severity: Medium)"
+zh_CN = "修复 1 个堆缓冲区溢出漏洞（漏洞编号 CVE-2026-14355，严重性：中）"
+
+[packages-v2]
+"php" = "< 1:8.5.8"


### PR DESCRIPTION
Topic Description
-----------------

- php: security update to 8.5.8

Package(s) Affected
-------------------

- php: 8.5.8

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
