### PR TITLE
runc: security update to 1.5.0

### DIFF
--- a/app-admin/runc/autobuild/defines
+++ b/app-admin/runc/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=runc
 PKGSEC=admin
-PKGDEP="criu libseccomp"
+PKGDEP="criu libseccomp libpathrs"
 BUILDDEP="go go-md2man"
 PKGDES="CLI tool for spawning and running containers according to the OCI specification"
 

--- a/app-admin/runc/spec
+++ b/app-admin/runc/spec
@@ -1,5 +1,4 @@
-VER=1.4.0
-REL=4
+VER=1.5.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/opencontainers/runc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7462"

--- a/runtime-common/libpathrs/autobuild/build
+++ b/runtime-common/libpathrs/autobuild/build
@@ -1,0 +1,5 @@
+abinfo "Building libpathrs ..."
+make release EXTRA_RUSTC_FLAGS="-C linker=clang"
+
+abinfo "Installing libpathrs ..."
+"$SRCDIR"/install.sh DESTDIR="$PKGDIR" --prefix=/usr --lib=/usr/lib --disable-static

--- a/runtime-common/libpathrs/autobuild/defines
+++ b/runtime-common/libpathrs/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=libpathrs
+PKGSEC=libs
+PKGDES="C-friendly API to make path resolution safer on Linux"
+PKGDEP="glibc"
+BUILDDEP="rustc llvm"
+
+ABTYPE=self
+NOPARALLEL=1

--- a/runtime-common/libpathrs/spec
+++ b/runtime-common/libpathrs/spec
@@ -1,0 +1,4 @@
+VER=0.2.5
+SRCS="git::commit=tags/v$VER::https://github.com/cyphar/libpathrs"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=390701"

--- a/topics/runc-1.5.0.toml
+++ b/topics/runc-1.5.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "runc 1.5.0"
+
+[caution]
+default = "Fixes a Symlink Following following vulnerability (CVE-2026-41579, Severity: Low)"
+zh_CN = "修复 1 个符号链接跟随漏洞（漏洞编号 CVE-2026-41579，严重性：低）"
+
+[packages-v2]
+"runc" = "< 1.5.0"


### PR DESCRIPTION
Topic Description
-----------------

- runc: security update to 1.5.0

Package(s) Affected
-------------------

- runc: 1.5.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit runc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
