### PR TITLE
pygobject-3: update to 3.56.3

### DIFF
--- a/lang-python/pygobject-3/spec
+++ b/lang-python/pygobject-3/spec
@@ -1,5 +1,4 @@
-VER=3.54.3
+VER=3.56.3
 SRCS="git::commit=tags/${VER}::https://gitlab.gnome.org/GNOME/pygobject.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13158"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pygobject-3: update to 3.56.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- pygobject-3: 1:3.56.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit pygobject-3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
