### PR TITLE
libvips: update to 8.18.4

### DIFF
--- a/runtime-imaging/libvips/spec
+++ b/runtime-imaging/libvips/spec
@@ -1,5 +1,4 @@
-VER=8.18.0
-REL=4
+VER=8.18.4
 SRCS="tbl::https://github.com/libvips/libvips/releases/download/v$VER/vips-$VER.tar.xz"
-CHKSUMS="sha256::b85ab92280c30d22f5c8fe2f68b809cddb7eaac437d8c33474475dac84ddc574"
+CHKSUMS="sha256::2677bad6c422617fd1172d359c16af34e736965d042c214203a87187d26ff037"
 CHKUPDATE="anitya::id=5097"


### PR DESCRIPTION
Topic Description
-----------------

- libvips: update to 8.18.4
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libvips: 8.18.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvips
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
