### PR TITLE
git: update to 2.55.0

### DIFF
--- a/app-vcs/git/01-git-core/defines
+++ b/app-vcs/git/01-git-core/defines
@@ -5,7 +5,7 @@ PKGDEP="curl expat openssl pcre2 perl perl-error cvsps perl-authen-sasl \
         libwww-perl perl-mime-tools perl-net-smtp-ssl perl-term-readkey \
         python-3 tk perl-dbi subversion brotli"
 PKGRECOM="git-lfs gitk git-gui"
-BUILDDEP="gettext xmlto emacs meson libsecret asciidoc"
+BUILDDEP="gettext xmlto emacs meson libsecret asciidoc rustc"
 
 PKGDEP__RETRO="curl expat openssl pcre2"
 BUILDDEP__RETRO="meson gettext xmlto libsecret asciidoc"
@@ -16,6 +16,13 @@ MESON_AFTER=(
     '-Ddocs=man'
     '-Ddefault_editor=/usr/bin/editor'
     '-Dcredential_helpers=libsecret'
+	'-Dgitk=disabled'
+	'-Dgit_gui=disabled'
+)
+
+MESON_AFTER__RETRO=(
+	"${MESON_AFTER[@]}"
+	"-Drust=disabled"
 )
 
 # FIXME: Race condition? Bad dependency? WTF?

--- a/app-vcs/git/01-git-core/defines.stage2
+++ b/app-vcs/git/01-git-core/defines.stage2
@@ -5,3 +5,8 @@ PKGDES="Fast distributed version control system"
 PKGDEP="curl expat openssl pcre2"
 
 ABTYPE=meson
+MESON_AFTER=(
+	'-Drust=disabled'
+	'-Dgitk=disabled'
+	'-Dgit_gui=disabled'
+)

--- a/app-vcs/git/03-git-gui/build
+++ b/app-vcs/git/03-git-gui/build
@@ -1,5 +1,0 @@
-abinfo "Building git-gui ..."
-make
-
-abinfo "Installing git-gui ..."
-make install DESTDIR="$PKGDIR"

--- a/app-vcs/git/03-git-gui/defines
+++ b/app-vcs/git/03-git-gui/defines
@@ -4,3 +4,4 @@ PKGDES="A graphical user interface for Git"
 PKGDEP="git"
 # git-gui is written in Tcl.
 ABHOST=noarch
+ABTYPE=meson

--- a/app-vcs/git/03-git-gui/prepare
+++ b/app-vcs/git/03-git-gui/prepare
@@ -1,4 +1,4 @@
-abinfo "Setting source directory to gitk-git ..."
+abinfo "Setting source directory to git-gui ..."
 export SAVED_SRCDIR=$SRCDIR
 export SRCDIR="$SAVED_SRCDIR/git-gui"
 

--- a/app-vcs/git/spec
+++ b/app-vcs/git/spec
@@ -1,5 +1,4 @@
-VER=2.52.0
-REL="3"
+VER=2.55.0
 
 # Use this for stable releases.
 SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
@@ -8,5 +7,5 @@ SRCS="https://cdn.kernel.org/pub/software/scm/git/git-$VER.tar.gz"
 #RC=2
 ##SRCS="https://cdn.kernel.org/pub/software/scm/git/testing/git-$VER.rc$RC.tar.xz"
 
-CHKSUMS="sha256::6880cb1e737e26f81cf7db9957ab2b5bb2aa1490d87619480b860816e0c10c32"
+CHKSUMS="sha256::0842dc384a23ac33ba3e570c4f3a8ded85963ee4713b1cd21153c3db41813d1e"
 CHKUPDATE="anitya::id=5350"


### PR DESCRIPTION
Topic Description
-----------------

- git: update to 2.55.0

Package(s) Affected
-------------------

- git: 2.55.0
- git-gui: 2.55.0
- gitk: 2.55.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit git
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
