### PR TITLE
FAIL_ARCH Test Survey 2060718

### DIFF
--- a/app-devel/acbs/spec
+++ b/app-devel/acbs/spec
@@ -1,4 +1,4 @@
-VER=20260602
+VER=20260718
 SRCS="git::commit=tags/$VER::https://github.com/AOSC-Dev/acbs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226984"

--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,5 @@
-VER=4.17.10
-SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/autobuild4"
+VER=4.17.11
+REL=999
+SRCS="git::commit=afterglow-fixes-20260630::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/misc-tests/testpkg1/autobuild/build
+++ b/misc-tests/testpkg1/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Creating a dummy package ..."
+mkdir -pv "$PKGDIR"/usr

--- a/misc-tests/testpkg1/autobuild/defines
+++ b/misc-tests/testpkg1/autobuild/defines
@@ -3,3 +3,7 @@ PKGSEC=misc
 PKGDES="Test Package 1"
 
 FAIL_ARCH="@(amd64|arm64)"
+
+ABSTRIP=0
+ABSPLITDBG=0
+

--- a/misc-tests/testpkg1/autobuild/defines
+++ b/misc-tests/testpkg1/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=testpkg1
+PKGSEC=misc
+PKGDES="Test Package 1"
+
+FAIL_ARCH="@(amd64|arm64)"

--- a/misc-tests/testpkg1/spec
+++ b/misc-tests/testpkg1/spec
@@ -1,0 +1,3 @@
+VER=1
+DUMMYSRC=1
+SUBDIR="."

--- a/misc-tests/testpkg2/autobuild/build
+++ b/misc-tests/testpkg2/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Creating a dummy package ..."
+mkdir -pv "$PKGDIR"/usr

--- a/misc-tests/testpkg2/autobuild/defines
+++ b/misc-tests/testpkg2/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=testpkg2
+PKGSEC=misc
+PKGDES="Test Package 2"
+
+FAIL_ARCH="!(amd64|arm64)"

--- a/misc-tests/testpkg2/autobuild/defines
+++ b/misc-tests/testpkg2/autobuild/defines
@@ -3,3 +3,7 @@ PKGSEC=misc
 PKGDES="Test Package 2"
 
 FAIL_ARCH="!(amd64|arm64)"
+
+ABSTRIP=0
+ABSPLITDBG=0
+

--- a/misc-tests/testpkg2/spec
+++ b/misc-tests/testpkg2/spec
@@ -1,0 +1,3 @@
+VER=1
+DUMMYSRC=1
+SUBDIR="."

--- a/misc-tests/testpkg3/autobuild/build
+++ b/misc-tests/testpkg3/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Creating a dummy package ..."
+mkdir -pv "$PKGDIR"/usr

--- a/misc-tests/testpkg3/autobuild/defines
+++ b/misc-tests/testpkg3/autobuild/defines
@@ -3,3 +3,7 @@ PKGSEC=misc
 PKGDES="Test Package 3"
 
 FAIL_ARCH="(amd64|arm64)"
+
+ABSTRIP=0
+ABSPLITDBG=0
+

--- a/misc-tests/testpkg3/autobuild/defines
+++ b/misc-tests/testpkg3/autobuild/defines
@@ -2,8 +2,7 @@ PKGNAME=testpkg3
 PKGSEC=misc
 PKGDES="Test Package 3"
 
-FAIL_ARCH="(amd64|arm64)"
+FAIL_ARCH="!(amd64|arm64)"
 
 ABSTRIP=0
 ABSPLITDBG=0
-

--- a/misc-tests/testpkg3/autobuild/defines
+++ b/misc-tests/testpkg3/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=testpkg3
+PKGSEC=misc
+PKGDES="Test Package 3"
+
+FAIL_ARCH="(amd64|arm64)"

--- a/misc-tests/testpkg3/spec
+++ b/misc-tests/testpkg3/spec
@@ -1,0 +1,3 @@
+VER=1
+DUMMYSRC=1
+SUBDIR="."

--- a/misc-tests/testpkg4/autobuild/build
+++ b/misc-tests/testpkg4/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Creating a dummy package ..."
+mkdir -pv "$PKGDIR"/usr

--- a/misc-tests/testpkg4/autobuild/defines
+++ b/misc-tests/testpkg4/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=testpkg4
+PKGSEC=misc
+PKGDES="Test Package 4"
+
+FAIL_ARCH="!(mainline)"

--- a/misc-tests/testpkg4/autobuild/defines
+++ b/misc-tests/testpkg4/autobuild/defines
@@ -3,3 +3,7 @@ PKGSEC=misc
 PKGDES="Test Package 4"
 
 FAIL_ARCH="!(mainline)"
+
+ABSTRIP=0
+ABSPLITDBG=0
+

--- a/misc-tests/testpkg4/spec
+++ b/misc-tests/testpkg4/spec
@@ -1,0 +1,3 @@
+VER=1
+DUMMYSRC=1
+SUBDIR="."

--- a/misc-tests/testpkg5/autobuild/build
+++ b/misc-tests/testpkg5/autobuild/build
@@ -1,0 +1,2 @@
+abinfo "Creating a dummy package ..."
+mkdir -pv "$PKGDIR"/usr

--- a/misc-tests/testpkg5/autobuild/defines
+++ b/misc-tests/testpkg5/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=testpkg5
+PKGSEC=misc
+PKGDES="Test Package 5"
+
+FAIL_ARCH="@(mainline)"

--- a/misc-tests/testpkg5/autobuild/defines
+++ b/misc-tests/testpkg5/autobuild/defines
@@ -3,3 +3,7 @@ PKGSEC=misc
 PKGDES="Test Package 5"
 
 FAIL_ARCH="@(mainline)"
+
+ABSTRIP=0
+ABSPLITDBG=0
+

--- a/misc-tests/testpkg5/spec
+++ b/misc-tests/testpkg5/spec
@@ -1,0 +1,3 @@
+VER=1
+DUMMYSRC=1
+SUBDIR="."


### PR DESCRIPTION
Topic Description
-----------------

- acbs: update to 20260718
- autobuild4: update to 4.7.11-999
- testpkg5: new, 1
- testpkg4: new, 1
- testpkg3: new, 1
- testpkg2: new, 1
- testpkg1: new, 1

Package(s) Affected
-------------------

- acbs: 2:20260718
- autobuild4: 4.17.11-999
- testpkg1: 1
- testpkg2: 1
- testpkg3: 1
- testpkg4: 1
- testpkg5: 1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 acbs testpkg1 testpkg2 testpkg3 testpkg4 testpkg5
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
