### PR TITLE
mediainfo: update to 26.05

### DIFF
--- a/app-multimedia/mediainfo/spec
+++ b/app-multimedia/mediainfo/spec
@@ -1,5 +1,5 @@
-VER=25.04
+VER=26.05
 SRCS="https://mediaarea.net/download/source/mediainfo/$VER/mediainfo_$VER.tar.xz"
-CHKSUMS="sha256::4b2553fe9104332d3baca5fe61b6b87af4d493108c5b863801cdb0a4826a33ae"
+CHKSUMS="sha256::f852093f9050022d699606eeabb38b24da5523d0212fab64dc4e4d3e46b56de1"
 CHKUPDATE="anitya::id=8240"
 SUBDIR="MediaInfo/Project/GNU/CLI"


### PR DESCRIPTION
Topic Description
-----------------

- mediainfo: update to 26.05
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- mediainfo: 26.05

Security Update?
----------------

No

Build Order
-----------

```
#buildit mediainfo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
