### PR TITLE
podof: security update to 1.1.1

### DIFF
--- a/app-doc/calibre/spec
+++ b/app-doc/calibre/spec
@@ -1,4 +1,5 @@
 VER=9.11.0
+REL=1
 SRCS="tbl::https://download.calibre-ebook.com/$VER/calibre-$VER.tar.xz"
 CHKSUMS="sha256::50d42e3b32ec5116f6b1df099537f4becaf36bfedecf9f581b743f11d8b6cb36"
 CHKUPDATE="anitya::id=6141"

--- a/app-productivity/scribus/spec
+++ b/app-productivity/scribus/spec
@@ -1,5 +1,5 @@
 VER=1.6.6
-REL=2
+REL=3
 SRCS="https://sourceforge.net/projects/scribus/files/scribus/$VER/scribus-$VER.tar.xz"
 CHKSUMS="sha256::fdfe3e7cbe84b760b38d0561ed8736f9d25d4923adde6e15e03760d83be6166d"
 CHKUPDATE="anitya::id=4773"

--- a/runtime-doc/podofo/autobuild/defines
+++ b/runtime-doc/podofo/autobuild/defines
@@ -1,8 +1,7 @@
 PKGNAME=podofo
 PKGSEC=libs
 PKGDES="C++ library to work with the PDF file format"
-PKGDEP="lua openssl fontconfig libtiff libidn libjpeg-turbo"
-PKGBREAK="calibre<=5.30.0-3 gdal<=3.8.4-1 scribus<=1.6.1"
+PKGDEP="openssl fontconfig libtiff libjpeg-turbo"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
@@ -12,4 +11,4 @@ CMAKE_AFTER=(
     '-DPODOFO_HAVE_TIFF_LIB=1'
 )
 
-NOLTO__LOONGSON3=1
+PKGBREAK="calibre<=9.11.0 gdal<=3.13.1-1 scribus<=1.6.6-2"

--- a/runtime-doc/podofo/spec
+++ b/runtime-doc/podofo/spec
@@ -1,5 +1,4 @@
-VER=0.10.3
-REL=2
+VER=1.1.1
 SRCS="git::commit=tags/$VER::https://github.com/podofo/podofo.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10527"

--- a/runtime-gis/gdal/spec
+++ b/runtime-gis/gdal/spec
@@ -2,4 +2,4 @@ VER=3.13.1
 SRCS="git::commit=tags/v${VER}::https://github.com/OSGeo/gdal"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=881"
-REL=1
+REL=2

--- a/topics/podofo-1.1.1.toml
+++ b/topics/podofo-1.1.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "podofo 1.1.1"
+
+[caution]
+default = "Fixes an Use After Free vulnerability (CVE-2025-46205, Severity: High)"
+zh_CN = "修复一个释放后使用漏洞（CVE-2025-46205，严重性：高）"
+
+[packages-v2]
+"podofo" = "< 1.1.2"


### PR DESCRIPTION
Topic Description
-----------------

- scribus: rebuild for podofo
    Signed-off-by: stydxm <stydxm@outlook.com>
- gdal: rebuild for podofo
    Signed-off-by: stydxm <stydxm@outlook.com>
- calibre: rebuild for podofo
    Signed-off-by: stydxm <stydxm@outlook.com>
- podofo: security update to 1.1.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

Yes

Build Order
-----------

```
#buildit podofo calibre gdal scribus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
