### PR TITLE
typst: update to 0.15.1

### DIFF
--- a/app-doc/typst/spec
+++ b/app-doc/typst/spec
@@ -1,4 +1,4 @@
-VER=0.15.0
+VER=0.15.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/typst/typst"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=332526"


### PR DESCRIPTION
Topic Description
-----------------

- typst: update to 0.15.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- typst: 1:0.15.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit typst
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
