### PR TITLE
vpl-gpu-rt: update to 26.3.0

### DIFF
--- a/runtime-multimedia/vpl-gpu-rt/spec
+++ b/runtime-multimedia/vpl-gpu-rt/spec
@@ -1,4 +1,4 @@
-VER=26.2.4
+VER=26.3.0
 SRCS="git::commit=tags/intel-onevpl-$VER::https://github.com/intel/vpl-gpu-rt"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372126"


### PR DESCRIPTION
Topic Description
-----------------

- vpl-gpu-rt: update to 26.3.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- vpl-gpu-rt: 26.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vpl-gpu-rt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
