### PR TITLE
libebml: security update to 1.4.6

### DIFF
--- a/runtime-multimedia/libebml/spec
+++ b/runtime-multimedia/libebml/spec
@@ -1,4 +1,4 @@
-VER=1.4.5
+VER=1.4.6
 SRCS="git::commit=tags/release-$VER::https://github.com/Matroska-Org/libebml"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7879"

--- a/topics/libebml-1.4.6.toml
+++ b/topics/libebml-1.4.6.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libebml 1.4.6"
+
+[caution]
+default = "Fixes an Out-of-bounds Write vulnerability (CVE-2021-3405, Severity: Medium) and an Integer Overflow vulnerability (CVE-2023-52339, Severity: Medium)"
+zh_CN = "修复 1 个越界写漏洞（漏洞编号 CVE-2021-3405，严重性：中）和 1 个整数溢出漏洞（漏洞编号 CVE-2023-52339，严重性：中）"
+
+[packages-v2]
+"libebml" = "< 1.4.6"


### PR DESCRIPTION
Topic Description
-----------------

- libebml: security update to 1.4.6

Package(s) Affected
-------------------

- libebml: 1.4.6

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libebml
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
