### PR TITLE
kicad: remove FAIL_ARCH

### DIFF
--- a/app-electronics/kicad/autobuild/defines
+++ b/app-electronics/kicad/autobuild/defines
@@ -27,7 +27,3 @@ CMAKE_AFTER=(
 
 PKGREP="kicad-i18n<=4.0.0"
 PKGBREAK="kicad-i18n<=4.0.0"
-
-# Note: Current loongarch64_nosimd machines does not have a graphics
-#       performance that is enough for PCB designing.
-FAIL_ARCH="(loongarch64_nosimd)"

--- a/app-electronics/kicad/spec
+++ b/app-electronics/kicad/spec
@@ -11,3 +11,4 @@ CHKSUMS="SKIP \
          SKIP"
 SUBDIR="kicad-$VER"
 CHKUPDATE="anitya::id=8432"
+ENVREQ="total_mem_per_core=1"


### PR DESCRIPTION
Topic Description
-----------------

- kicad: remove FAIL_ARCH
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- kicad: 10.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit kicad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
