### PR TITLE
nginx: security update to 1.31.3

### DIFF
--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,11 +1,11 @@
-NGINX_VER=1.30.3
+NGINX_VER=1.31.3
 BROTLI_VER=1.0.0~rc1+git20231009
 VER="${NGINX_VER}+brotli${BROTLI_VER}"
 # Note: After v1.0.0rc, there are still some necessary updates (including upstream submodules), 
 # so the following commit refers to the latest one in master branch.
 SRCS="tbl::https://nginx.org/download/nginx-$NGINX_VER.tar.gz \
       git::commit=a71f9312c2deb28875acc7bacfdd5695a111aa53;rename=ngx_brotli::https://github.com/google/ngx_brotli.git"
-CHKSUMS="sha256::e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f \
+CHKSUMS="sha256::a7657c50811c2d92d9895395e8b873ef60398142c4db21eb647811c38f6dd525 \
          SKIP"
 CHKUPDATE="anitya::id=5413"
 SUBDIR="nginx-$NGINX_VER"

--- a/topics/nginx-1.31.3.toml
+++ b/topics/nginx-1.31.3.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "nginx 1.31.3"
+
+[caution]
+default = "Fixes a Heap-based Buffer Overflow vulnerability (CVE-2026-42533, Severity: Critical)"
+zh_CN = "修复 1 个堆缓冲区溢出漏洞（CVE-2026-42533，严重性：严重）"
+
+[packages-v2]
+"nginx" = "< 1.31.3"


### PR DESCRIPTION
Topic Description
-----------------

- nginx: security update to 1.31.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- nginx: 1.31.3+brotli1.0.0~rc1+git20231009

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
