### PR TITLE
nginx: update to 1.30.4

### DIFF
--- a/app-web/nginx/spec
+++ b/app-web/nginx/spec
@@ -1,11 +1,11 @@
-NGINX_VER=1.30.3
+NGINX_VER=1.30.4
 BROTLI_VER=1.0.0~rc1+git20231009
 VER="${NGINX_VER}+brotli${BROTLI_VER}"
 # Note: After v1.0.0rc, there are still some necessary updates (including upstream submodules), 
 # so the following commit refers to the latest one in master branch.
 SRCS="tbl::https://nginx.org/download/nginx-$NGINX_VER.tar.gz \
       git::commit=a71f9312c2deb28875acc7bacfdd5695a111aa53;rename=ngx_brotli::https://github.com/google/ngx_brotli.git"
-CHKSUMS="sha256::e5823dc6f45610993def93ebf6cfce68264af4958c77e874b7d20f3709001b8f \
+CHKSUMS="sha256::4261dc90e9e47c1c4041276e9aaa3d48ebe2e664f728e14fa95ae6c67d57a08b \
          SKIP"
 CHKUPDATE="anitya::id=5413"
 SUBDIR="nginx-$NGINX_VER"

--- a/topics/nginx-1.30.4.toml
+++ b/topics/nginx-1.30.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "nginx 1.30.4"
+
+[caution]
+default = "Fixes 3 security vulnerabilities disclosed in F5 Security Advisory on Jul 15, 2026 (including 1 of Critical severity)"
+zh_CN = "修复 F5 在 2026 年 7 月 15 日发布的安全公告中披露的 3 个安全漏洞（含 1 个严重漏洞）"
+
+[packages-v2]
+"nginx" = "< 1.30.4"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add nginx-1.30.4.toml
    Signed-off-by: MutsukiC <mutsuki@aosc.io>
- nginx: update to 1.30.4
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- nginx: 1.30.4+brotli1.0.0~rc1+git20231009

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit nginx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
