### PR TITLE
rocm: Libraries without MachineLearning update to 7.14[1/3]

### DIFF
--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas-common"

--- a/runtime-rocm/rocm-hipblaslt/spec
+++ b/runtime-rocm/rocm-hipblaslt/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblaslt"

--- a/runtime-rocm/rocm-origami/spec
+++ b/runtime-rocm/rocm-origami/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/shared/origami"

--- a/runtime-rocm/rocm-rocblas/spec
+++ b/runtime-rocm/rocm-rocblas/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocblas"

--- a/runtime-rocm/rocm-rocfft/spec
+++ b/runtime-rocm/rocm-rocfft/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocfft"

--- a/runtime-rocm/rocm-rocrand/spec
+++ b/runtime-rocm/rocm-rocrand/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocrand"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocrand: update to 7.14
- rocm-rocfft: update to 7.14
- rocm-rocblas: update to 7.14
- rocm-hipblaslt: update to 7.14
- rocm-origami: update to 7.14
- rocm-hipblas-common: update to 7.14

Package(s) Affected
-------------------

- rocm-hipblas-common: 7.14
- rocm-hipblaslt: 7.14
- rocm-origami: 7.14
- rocm-rocblas: 7.14
- rocm-rocfft: 7.14
- rocm-rocrand: 7.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-hipblas-common rocm-origami rocm-hipblaslt rocm-rocblas rocm-rocfft rocm-rocrand
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
