### PR TITLE
dnscrypt: update to 2.1.18

### DIFF
--- a/app-network/dnscrypt/autobuild/patches/0001-AOSCOS-chore-adapt-to-AOSC-OS-directory-structure.patch
+++ b/app-network/dnscrypt/autobuild/patches/0001-AOSCOS-chore-adapt-to-AOSC-OS-directory-structure.patch
@@ -1,18 +1,18 @@
-From c5c18065437d6b78d831f42d5ed993f90c07f864 Mon Sep 17 00:00:00 2001
+From 24e0082f0be495b040d3e5249dc860dee3689a19 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 18 Feb 2025 16:13:59 +0800
 Subject: [PATCH] AOSCOS: chore: adapt to AOSC OS directory structure
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---
- dnscrypt-proxy/example-dnscrypt-proxy.toml | 32 +++++++++++-----------
- 1 file changed, 16 insertions(+), 16 deletions(-)
+ dnscrypt-proxy/example-dnscrypt-proxy.toml | 44 +++++++++++-----------
+ 1 file changed, 22 insertions(+), 22 deletions(-)
 
 diff --git a/dnscrypt-proxy/example-dnscrypt-proxy.toml b/dnscrypt-proxy/example-dnscrypt-proxy.toml
-index 6ecd9152..6d2f1a68 100644
+index 8d53a795..7ed82f99 100644
 --- a/dnscrypt-proxy/example-dnscrypt-proxy.toml
 +++ b/dnscrypt-proxy/example-dnscrypt-proxy.toml
-@@ -171,7 +171,7 @@ keepalive = 30
+@@ -228,7 +228,7 @@ keepalive = 30
  ## This file is different from other log files, and will not be
  ## automatically rotated by the application.
  
@@ -21,7 +21,7 @@ index 6ecd9152..6d2f1a68 100644
  
  
  ## When using a log file, only keep logs from the most recent launch.
-@@ -181,7 +181,7 @@ keepalive = 30
+@@ -238,7 +238,7 @@ keepalive = 30
  
  ## Use the system logger (syslog on Unix, Event Log on Windows)
  
@@ -29,8 +29,8 @@ index 6ecd9152..6d2f1a68 100644
 +use_syslog = true
  
  
- ## The maximum concurrency to reload certificates from the resolvers.
-@@ -379,7 +379,7 @@ reject_ttl = 10
+ ## Automatic log files rotation
+@@ -445,7 +445,7 @@ reject_ttl = 10
  
  ## See the `example-forwarding-rules.txt` file for an example
  
@@ -38,8 +38,8 @@ index 6ecd9152..6d2f1a68 100644
 +forwarding_rules = '/etc/dnscrypt-proxy/forwarding-rules.txt'
  
  
- 
-@@ -395,7 +395,7 @@ reject_ttl = 10
+ ###############################################################################
+@@ -460,7 +460,7 @@ reject_ttl = 10
  ##
  ## See the `example-cloaking-rules.txt` file for an example
  
@@ -48,7 +48,7 @@ index 6ecd9152..6d2f1a68 100644
  
  ## TTL used when serving entries in cloaking-rules.txt
  
-@@ -449,7 +449,7 @@ cache_neg_max_ttl = 600
+@@ -512,7 +512,7 @@ cache_neg_max_ttl = 600
  ## check for connectivity and captive portals, along with hard-coded
  ## IP addresses to return.
  
@@ -56,8 +56,8 @@ index 6ecd9152..6d2f1a68 100644
 +# map_file = '/etc/dnscrypt-proxy/example-captive-portals.txt'
  
  
- 
-@@ -481,8 +481,8 @@ cache_neg_max_ttl = 600
+ ###############################################################################
+@@ -543,8 +543,8 @@ cache_neg_max_ttl = 600
  ## openssl req -x509 -nodes -newkey rsa:2048 -days 5000 -sha256 -keyout localhost.pem -out localhost.pem
  ## See the documentation (wiki) for more information.
  
@@ -67,8 +67,8 @@ index 6ecd9152..6d2f1a68 100644
 +# cert_key_file = "/var/lib/dnscrypt-proxy/localhost.pem"
  
  
- 
-@@ -553,12 +553,12 @@ format = 'tsv'
+ ###############################################################################
+@@ -616,12 +616,12 @@ format = 'tsv'
  
  ## Path to the file of blocking rules (absolute, or relative to the same directory as the config file)
  
@@ -83,7 +83,7 @@ index 6ecd9152..6d2f1a68 100644
  
  
  ## Optional log format: tsv or ltsv (default: tsv)
-@@ -581,12 +581,12 @@ format = 'tsv'
+@@ -643,12 +643,12 @@ format = 'tsv'
  
  ## Path to the file of blocking rules (absolute, or relative to the same directory as the config file)
  
@@ -98,7 +98,7 @@ index 6ecd9152..6d2f1a68 100644
  
  
  ## Optional log format: tsv or ltsv (default: tsv)
-@@ -609,12 +609,12 @@ format = 'tsv'
+@@ -670,12 +670,12 @@ format = 'tsv'
  
  ## Path to the file of allow list rules (absolute, or relative to the same directory as the config file)
  
@@ -113,7 +113,7 @@ index 6ecd9152..6d2f1a68 100644
  
  
  ## Optional log format: tsv or ltsv (default: tsv)
-@@ -637,12 +637,12 @@ format = 'tsv'
+@@ -695,12 +695,12 @@ format = 'tsv'
  
  ## Path to the file of allowed ip rules (absolute, or relative to the same directory as the config file)
  
@@ -128,15 +128,67 @@ index 6ecd9152..6d2f1a68 100644
  
  ## Optional log format: tsv or ltsv (default: tsv)
  
-@@ -747,7 +747,7 @@ format = 'tsv'
-   # [sources.quad9-resolvers]
-   #   urls = ['https://www.quad9.net/quad9-resolvers.md']
-   #   minisign_key = 'RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN'
--  #   cache_file = 'quad9-resolvers.md'
-+  #   cache_file = '/var/cache/dnscrypt-proxy/quad9-resolvers.md'
-   #   prefix = 'quad9-'
+@@ -777,7 +777,7 @@ urls = [
+   'https://download.dnscrypt.info/resolvers-list/v3/public-resolvers.md',
+   'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/public-resolvers.md'
+ ]
+-cache_file = 'public-resolvers.md'
++cache_file = '/var/cache/dnscrypt-proxy/public-resolvers.md'
+ minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+ refresh_delay = 73
+ prefix = ''
+@@ -790,7 +790,7 @@ urls = [
+   'https://download.dnscrypt.info/resolvers-list/v3/relays.md',
+   'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/relays.md'
+ ]
+-cache_file = 'relays.md'
++cache_file = '/var/cache/dnscrypt-proxy/relays.md'
+ minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+ refresh_delay = 73
+ prefix = ''
+@@ -799,13 +799,13 @@ prefix = ''
  
-   ### Another example source, with resolvers censoring some websites not appropriate for children
+ # [sources.odoh-servers]
+ #   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-servers.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-servers.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/odoh-servers.md']
+-#   cache_file = 'odoh-servers.md'
++#   cache_file = '/var/cache/dnscrypt-proxy/odoh-servers.md'
+ #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+ #   refresh_delay = 73
+ #   prefix = ''
+ # [sources.odoh-relays]
+ #   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/odoh-relays.md', 'https://download.dnscrypt.info/resolvers-list/v3/odoh-relays.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/odoh-relays.md']
+-#   cache_file = 'odoh-relays.md'
++#   cache_file = '/var/cache/dnscrypt-proxy/odoh-relays.md'
+ #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+ #   refresh_delay = 73
+ #   prefix = ''
+@@ -815,7 +815,7 @@ prefix = ''
+ # [sources.quad9-resolvers]
+ #   urls = ['https://quad9.net/dnscrypt/quad9-resolvers.md']
+ #   minisign_key = 'RWQBphd2+f6eiAqBsvDZEBXBGHQBJfeG6G+wJPPKxCZMoEQYpmoysKUN'
+-#   cache_file = 'quad9-resolvers.md'
++#   cache_file = '/var/cache/dnscrypt-proxy/quad9-resolvers.md'
+ #   prefix = 'quad9-'
+ 
+ ### Another example source, with resolvers censoring some websites not appropriate for children
+@@ -823,7 +823,7 @@ prefix = ''
+ 
+ # [sources.parental-control]
+ #   urls = ['https://raw.githubusercontent.com/DNSCrypt/dnscrypt-resolvers/master/v3/parental-control.md', 'https://download.dnscrypt.info/resolvers-list/v3/parental-control.md', 'https://cdn.jsdelivr.net/gh/DNSCrypt/dnscrypt-resolvers@master/v3/parental-control.md']
+-#   cache_file = 'parental-control.md'
++#   cache_file = '/var/cache/dnscrypt-proxy/parental-control.md'
+ #   minisign_key = 'RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3'
+ 
+ ### dnscry.pt servers - See https://www.dnscry.pt
+@@ -831,7 +831,7 @@ prefix = ''
+ #  [sources.dnscry-pt-resolvers]
+ #    urls = ["https://www.dnscry.pt/resolvers.md"]
+ #    minisign_key = "RWQM31Nwkqh01x88SvrBL8djp1NH56Rb4mKLHz16K7qsXgEomnDv6ziQ"
+-#    cache_file = "dnscry.pt-resolvers.md"
++#    cache_file = "/var/cache/dnscrypt-proxy/dnscry.pt-resolvers.md"
+ #    refresh_delay = 73
+ #    prefix = "dnscry.pt-"
+ 
 -- 
-2.48.1
+2.55.0
 

--- a/app-network/dnscrypt/spec
+++ b/app-network/dnscrypt/spec
@@ -1,5 +1,4 @@
-VER=2.1.7
-REL=6
+VER=2.1.18
 SRCS="git::commit=tags/$VER::https://github.com/DNSCrypt/dnscrypt-proxy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15546"


### PR DESCRIPTION
Topic Description
-----------------

- dnscrypt: update to 2.1.18
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- dnscrypt: 2.1.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit dnscrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
