### PR TITLE
clash-verge-rev: update to 2.5.2

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -10,7 +10,7 @@ PKGPROV="clash-verge"
 PKGEPOCH=1
 
 # FIXME: Vite not supported.
-FAIL_ARCH="(loongson3|riscv64)"
+FAIL_ARCH="@(loongson3|riscv64)"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_0_17_8_LIMBS_are_zero
 NOLTO=1

--- a/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0001-fix-tauri.conf.json-disable-bundle-distribution.patch
@@ -1,4 +1,4 @@
-From 00be40affb8da4df0abc55a38ed2585361392f1c Mon Sep 17 00:00:00 2001
+From 21d3e7ae47836e952b9293eab1be99410c63edbb Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:33:30 +0800
 Subject: [PATCH 01/13] fix(tauri.conf.json): disable bundle distribution
@@ -62,5 +62,5 @@ index eea413dd..318d0af8 100644
 +  "identifier": "io.github.clash-verge-rev.clash-verge-rev"
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0002-feat-drop-mihomo-alpha-support.patch
@@ -1,4 +1,4 @@
-From ab15613322cd450a37ce37de24ac4fb007bd4b48 Mon Sep 17 00:00:00 2001
+From 8c4c1e0f1fd6a590191e60be8f2b29b22d421d69 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Fri, 22 Mar 2024 22:45:34 +0800
 Subject: [PATCH 02/13] feat: drop mihomo-alpha support
@@ -26,5 +26,5 @@ index 1f0fd8e2..cab6fc20 100644
  export function ClashCoreViewer({ ref }: { ref?: Ref<DialogRef> }) {
    const { t } = useTranslation()
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0003-fix-src-tauri-tauri.conf.json-disable-Mihomo-bundlin.patch
@@ -1,4 +1,4 @@
-From 1ea6f548cce741f8b0b034b7fae47cf716c96dda Mon Sep 17 00:00:00 2001
+From f03769d08c6530524933c248671c2a719a0352e0 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 14:34:52 +0800
 Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
@@ -9,10 +9,10 @@ Subject: [PATCH 03/13] fix(src-tauri/tauri.conf.json): disable Mihomo bundling
  2 files changed, 14 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 3aa2daf7..f561f673 100644
+index b506f40a..4f4924e7 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -751,20 +751,7 @@ const resolveUnSetDnsScript = () =>
+@@ -752,20 +752,7 @@ const resolveUnSetDnsScript = () =>
  // Tasks
  // =======================
  const tasks = [
@@ -46,5 +46,5 @@ index f92d4b6f..30e04830 100755
      "category": "DeveloperTool",
      "shortDescription": "Clash Verge Rev",
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0004-Drop-check-update-feature-and-update-checker-compone.patch
@@ -1,4 +1,4 @@
-From 458eef5e55d7b455259eaf1ee526e5f9d429a976 Mon Sep 17 00:00:00 2001
+From 29681b05deb81b96d9c45909122f76989d931cf1 Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 10:55:11 +0800
 Subject: [PATCH 04/13] Drop check update feature and update checker component
@@ -6,19 +6,19 @@ Subject: [PATCH 04/13] Drop check update feature and update checker component
 Co-authored-by: eatradish <sakiiily@aosc.io>
 Co-authored-by: Mingcong Bai <jeffbai@aosc.io>
 ---
- src-tauri/src/core/updater.rs                 |  21 +-
+ src-tauri/src/core/updater.rs                 |  23 +-
  src/components/home/system-info-card.tsx      |  38 +-
  src/components/layout/update-button.tsx       |  36 --
- src/components/setting/mods/update-viewer.tsx | 436 ------------------
+ src/components/setting/mods/update-viewer.tsx | 453 ------------------
  .../setting/setting-verge-advanced.tsx        |  23 -
  .../setting/setting-verge-basic.tsx           |   3 -
  src/pages/_layout.tsx                         |  45 +-
- 7 files changed, 24 insertions(+), 578 deletions(-)
+ 7 files changed, 25 insertions(+), 596 deletions(-)
  delete mode 100644 src/components/layout/update-button.tsx
  delete mode 100644 src/components/setting/mods/update-viewer.tsx
 
 diff --git a/src-tauri/src/core/updater.rs b/src-tauri/src/core/updater.rs
-index 81da3cc8..fdb0a907 100644
+index 81da3cc8..8b703e9b 100644
 --- a/src-tauri/src/core/updater.rs
 +++ b/src-tauri/src/core/updater.rs
 @@ -292,26 +292,7 @@ impl SilentUpdater {
@@ -49,6 +49,15 @@ index 81da3cc8..fdb0a907 100644
      }
  }
  
+@@ -494,7 +475,7 @@ impl SilentUpdater {
+ 
+         loop {
+             if let Err(e) = self.check_and_download(&app_handle).await {
+-                logging!(warn, Type::System, "Silent updater: cycle error: {e}");
++                logging!(warn, Type::System, "Silent updater: cycle error: {e}\nNote: this won't affect you in any way since AOSC OS has disabled silent updater");
+             }
+ 
+             tokio::time::sleep(std::time::Duration::from_secs(24 * 60 * 60)).await;
 diff --git a/src/components/home/system-info-card.tsx b/src/components/home/system-info-card.tsx
 index 4198ea88..6b8842dc 100644
 --- a/src/components/home/system-info-card.tsx
@@ -149,24 +158,29 @@ index 67e4c110..00000000
 -}
 diff --git a/src/components/setting/mods/update-viewer.tsx b/src/components/setting/mods/update-viewer.tsx
 deleted file mode 100644
-index 077a6fc0..00000000
+index 1d260681..00000000
 --- a/src/components/setting/mods/update-viewer.tsx
 +++ /dev/null
-@@ -1,436 +0,0 @@
+@@ -1,453 +0,0 @@
 -import { alpha, Box, Button, LinearProgress } from '@mui/material'
 -import { relaunch } from '@tauri-apps/plugin-process'
 -import { open as openUrl } from '@tauri-apps/plugin-shell'
 -import type { DownloadEvent } from '@tauri-apps/plugin-updater'
 -import { useLockFn } from 'ahooks'
 -import type { Ref } from 'react'
--import { useImperativeHandle, useMemo, useRef, useState } from 'react'
+-import {
+-  lazy,
+-  Suspense,
+-  useImperativeHandle,
+-  useMemo,
+-  useRef,
+-  useState,
+-} from 'react'
 -import { useTranslation } from 'react-i18next'
--import ReactMarkdown from 'react-markdown'
--import rehypeRaw from 'rehype-raw'
+-import type { Options as ReactMarkdownOptions } from 'react-markdown'
 -
 -import { BaseDialog, DialogRef } from '@/components/base'
 -import { useUpdate } from '@/hooks/use-update'
--import { portableFlag } from '@/pages/_layout'
 -import { showNotice } from '@/services/notice-service'
 -import { useSetUpdateState, useUpdateState } from '@/services/states'
 -
@@ -193,6 +207,17 @@ index 077a6fc0..00000000
 -  /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][\t ]*\n?/i
 -const GITHUB_ALERT_CLASS_PATTERN =
 -  /markdown-alert-(note|tip|important|warning|caution)/
+-
+-const LazyReactMarkdown = lazy(async () => {
+-  const [{ default: ReactMarkdown }, { default: rehypeRaw }] =
+-    await Promise.all([import('react-markdown'), import('rehype-raw')])
+-
+-  return {
+-    default: (props: ReactMarkdownOptions) => (
+-      <ReactMarkdown {...props} rehypePlugins={[rehypeRaw]} />
+-    ),
+-  }
+-})
 -
 -const getAlertTypeFromClassName = (
 -  className: unknown,
@@ -298,10 +323,6 @@ index 077a6fc0..00000000
 -  }, [updateInfo])
 -
 -  const onUpdate = useLockFn(async () => {
--    if (portableFlag) {
--      showNotice.error('settings.modals.update.messages.portableError')
--      return
--    }
 -    if (!updateInfo?.body) return
 -    if (breakChangeFlag) {
 -      showNotice.error('settings.modals.update.messages.breakChangeError')
@@ -522,62 +543,67 @@ index 077a6fc0..00000000
 -          },
 -        }}
 -      >
--        <ReactMarkdown
--          remarkPlugins={[remarkGitHubAlerts]}
--          rehypePlugins={[rehypeRaw]}
--          components={{
--            a: ({ ...props }) => {
--              const { children } = props
--              return (
--                <a {...props} target="_blank" rel="noreferrer">
--                  {children}
--                </a>
--              )
--            },
--            blockquote: ({ className, children }) => {
--              const alertType = getAlertTypeFromClassName(className)
+-        {open && (
+-          <Suspense fallback={<LinearProgress />}>
+-            <LazyReactMarkdown
+-              remarkPlugins={[remarkGitHubAlerts]}
+-              components={{
+-                a: ({ ...props }) => {
+-                  const { children } = props
+-                  return (
+-                    <a {...props} target="_blank" rel="noreferrer">
+-                      {children}
+-                    </a>
+-                  )
+-                },
+-                blockquote: ({ className, children }) => {
+-                  const alertType = getAlertTypeFromClassName(className)
 -
--              if (!alertType) {
--                return <blockquote className={className}>{children}</blockquote>
--              }
+-                  if (!alertType) {
+-                    return (
+-                      <blockquote className={className}>{children}</blockquote>
+-                    )
+-                  }
 -
--              return (
--                <Box
--                  component="blockquote"
--                  className={className}
--                  sx={(theme) => {
--                    const color = GITHUB_ALERTS[alertType].color
--                    return {
--                      m: '12px 0 18px',
--                      px: 2,
--                      py: 1,
--                      borderLeft: `4px solid ${color}`,
--                      borderRadius: 1,
--                      bgcolor: alpha(
--                        color,
--                        theme.palette.mode === 'dark' ? 0.16 : 0.08,
--                      ),
--                      '& p': {
--                        my: 0.75,
--                      },
--                      '& .markdown-alert-title': {
--                        display: 'flex',
--                        alignItems: 'center',
--                        gap: 0.75,
--                        fontWeight: 700,
--                        lineHeight: 1.4,
--                      },
--                    }
--                  }}
--                >
--                  {children}
--                </Box>
--              )
--            },
--          }}
--        >
--          {markdownContent}
--        </ReactMarkdown>
+-                  return (
+-                    <Box
+-                      component="blockquote"
+-                      className={className}
+-                      sx={(theme) => {
+-                        const color = GITHUB_ALERTS[alertType].color
+-                        return {
+-                          m: '12px 0 18px',
+-                          px: 2,
+-                          py: 1,
+-                          borderLeft: `4px solid ${color}`,
+-                          borderRadius: 1,
+-                          bgcolor: alpha(
+-                            color,
+-                            theme.palette.mode === 'dark' ? 0.16 : 0.08,
+-                          ),
+-                          '& p': {
+-                            my: 0.75,
+-                          },
+-                          '& .markdown-alert-title': {
+-                            display: 'flex',
+-                            alignItems: 'center',
+-                            gap: 0.75,
+-                            fontWeight: 700,
+-                            lineHeight: 1.4,
+-                          },
+-                        }
+-                      }}
+-                    >
+-                      {children}
+-                    </Box>
+-                  )
+-                },
+-              }}
+-            >
+-              {markdownContent}
+-            </LazyReactMarkdown>
+-          </Suspense>
+-        )}
 -      </Box>
 -      {updateState && (
 -        <LinearProgress
@@ -648,7 +674,7 @@ index 119a023d..51231e2a 100644
          onClick={openDevTools}
          label={t('settings.components.verge.advanced.fields.openDevTools')}
 diff --git a/src/components/setting/setting-verge-basic.tsx b/src/components/setting/setting-verge-basic.tsx
-index 4d451246..099cce8d 100644
+index e50741e2..e7ac5e15 100644
 --- a/src/components/setting/setting-verge-basic.tsx
 +++ b/src/components/setting/setting-verge-basic.tsx
 @@ -21,7 +21,6 @@ import { MiscViewer } from './mods/misc-viewer'
@@ -676,10 +702,10 @@ index 4d451246..099cce8d 100644
  
        <SettingItem label={t('settings.components.verge.basic.fields.language')}>
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index ecdce94b..e3b9e4c3 100644
+index aeedf416..084102cb 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -308,32 +308,31 @@ const Layout = () => {
+@@ -340,32 +340,31 @@ const Layout = () => {
          {/* Custom titlebar - rendered only when decorated is false, memoized for performance */}
          {customTitlebar}
  
@@ -735,5 +761,5 @@ index ecdce94b..e3b9e4c3 100644
              {menuUnlocked && (
                <Box
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0005-Set-core-binary-name-as-mihomo.patch
@@ -1,4 +1,4 @@
-From 1683a89c85dcc51ef5175a7231e365c3926dd7d2 Mon Sep 17 00:00:00 2001
+From 2bb0f7616ad9176f692a0293e34a0c78853d1f5a Mon Sep 17 00:00:00 2001
 From: miwu04 <mail@alanlin.icu>
 Date: Sun, 2 Mar 2025 11:18:42 +0800
 Subject: [PATCH 05/13] Set core binary name as mihomo
@@ -47,7 +47,7 @@ index b306b2fe..571aefdc 100644
    zip.addLocalFolder(configDir, '.config')
  
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index f561f673..8568802a 100644
+index 4f4924e7..21fdd466 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -294,8 +294,8 @@ function clashMetaAlpha() {
@@ -206,5 +206,5 @@ index cab6fc20..28a76790 100644
    const onCoreChange = useLockFn(async (core: string) => {
      if (core === clash_core) return
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0006-feat-always-not-portable.patch
@@ -1,4 +1,4 @@
-From 423d6ee1234f5855c027eea47429cc7a50d2c31e Mon Sep 17 00:00:00 2001
+From d3bfac527244afdcb9334053a5903206fc2cb3d4 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 15:14:51 +0800
 Subject: [PATCH 06/13] feat: always not portable
@@ -8,7 +8,7 @@ Subject: [PATCH 06/13] feat: always not portable
  1 file changed, 10 deletions(-)
 
 diff --git a/src-tauri/src/utils/dirs.rs b/src-tauri/src/utils/dirs.rs
-index 2e986e1a..f06055f1 100644
+index 453f6365..88af3b10 100644
 --- a/src-tauri/src/utils/dirs.rs
 +++ b/src-tauri/src/utils/dirs.rs
 @@ -26,16 +26,6 @@ pub static PROFILE_YAML: &str = "profiles.yaml";
@@ -29,5 +29,5 @@ index 2e986e1a..f06055f1 100644
      Ok(())
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0007-Set-service-install-uninstall-script-path-to-usr-lib.patch
@@ -1,4 +1,4 @@
-From 88b431349501eed11839f39798d825294e852764 Mon Sep 17 00:00:00 2001
+From 7346f35274554a5a45b77b003e5a938c3ef495aa Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 16:03:51 +0800
 Subject: [PATCH 07/13] Set service install/uninstall script path to
@@ -9,10 +9,10 @@ Subject: [PATCH 07/13] Set service install/uninstall script path to
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/service.rs b/src-tauri/src/core/service.rs
-index d32b1b2d..056ceceb 100644
+index 50c98e5a..bf6e514f 100644
 --- a/src-tauri/src/core/service.rs
 +++ b/src-tauri/src/core/service.rs
-@@ -121,8 +121,10 @@ fn install_service() -> Result<()> {
+@@ -256,8 +256,10 @@ fn install_service() -> Result<()> {
  #[cfg(target_os = "linux")]
  fn uninstall_service() -> Result<()> {
      logging!(info, Type::Service, "uninstall service");
@@ -24,7 +24,7 @@ index d32b1b2d..056ceceb 100644
  
      if !uninstall_path.exists() {
          bail!(format!("uninstaller not found: {uninstall_path:?}"));
-@@ -177,8 +179,10 @@ fn uninstall_service() -> Result<()> {
+@@ -302,8 +304,10 @@ fn uninstall_service() -> Result<()> {
  #[cfg(target_os = "linux")]
  fn install_service() -> Result<()> {
      logging!(info, Type::Service, "install service");
@@ -37,5 +37,5 @@ index d32b1b2d..056ceceb 100644
      if !install_path.exists() {
          bail!(format!("installer not found: {install_path:?}"));
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0008-Do-not-use-gcc.patch
@@ -1,4 +1,4 @@
-From 37589fa0b1bd3366ed5e53378df2e4a33fee41ff Mon Sep 17 00:00:00 2001
+From 96ac4ffb67142c3d270af9fb3af2d083acacd280 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Mon, 13 Jan 2025 17:20:33 +0800
 Subject: [PATCH 08/13] Do not use gcc
@@ -24,5 +24,5 @@ index f894a1e9..00000000
 -clippy-all = "clippy --all-targets --all-features -- -D warnings"
 -clippy-only = "clippy --all-targets  --features clippy -- -D warnings"
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0009-Drop-Upgrade-core-button.patch
@@ -1,4 +1,4 @@
-From 157cff13410174be2478d8a801a9961d526e1800 Mon Sep 17 00:00:00 2001
+From 43a439357989112410271c9b40a904e9d45ec59a Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Tue, 14 Jan 2025 10:16:54 +0800
 Subject: [PATCH 09/13] Drop "Upgrade core" button
@@ -60,17 +60,17 @@ index 28a76790..4c64cdae 100644
                variant="contained"
                size="small"
 diff --git a/src/pages/_layout.tsx b/src/pages/_layout.tsx
-index e3b9e4c3..8f486129 100644
+index 084102cb..6b8ee985 100644
 --- a/src/pages/_layout.tsx
 +++ b/src/pages/_layout.tsx
-@@ -35,7 +35,6 @@ import { BaseErrorBoundary } from '@/components/base'
+@@ -43,7 +43,6 @@ import { BaseErrorBoundary, BaseLoading } from '@/components/base'
  import { LayoutItem } from '@/components/layout/layout-item'
  import { LayoutTraffic } from '@/components/layout/layout-traffic'
  import { NoticeManager } from '@/components/layout/notice-manager'
 -import { UpdateButton } from '@/components/layout/update-button'
- import { WindowControls } from '@/components/layout/window-controller'
- import { useI18n } from '@/hooks/use-i18n'
- import { useVerge } from '@/hooks/use-verge'
+ import {
+   WindowControls,
+   WindowResizeHandles,
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0010-fix-drop-Open-Core-Dir-function.patch
@@ -1,4 +1,4 @@
-From c47f5c7e91f13e2300409c381a0f0e95fca68140 Mon Sep 17 00:00:00 2001
+From 43507dc882970a06e152d01e4af8d5ff7cdfc950 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:46:10 +0800
 Subject: [PATCH 10/13] fix: drop Open Core Dir function
@@ -45,10 +45,10 @@ index 7012ce21..2fd3de09 100644
      open_dir => OPEN_DIR, "tray_open_dir", "tray.openDir",
      app_log => APP_LOG, "tray_app_log", "tray.appLog",
 diff --git a/src-tauri/src/core/tray/mod.rs b/src-tauri/src/core/tray/mod.rs
-index f6d9a355..1b8cb8b8 100644
+index 6981e83c..cc9b26b4 100644
 --- a/src-tauri/src/core/tray/mod.rs
 +++ b/src-tauri/src/core/tray/mod.rs
-@@ -770,8 +770,6 @@ async fn create_tray_menu(
+@@ -797,8 +797,6 @@ async fn create_tray_menu(
  
      let open_app_dir = &MenuItem::with_id(app_handle, MenuIds::CONF_DIR, &texts.conf_dir, true, None::<&str>)?;
  
@@ -57,7 +57,7 @@ index f6d9a355..1b8cb8b8 100644
      let open_logs_dir = &MenuItem::with_id(app_handle, MenuIds::LOGS_DIR, &texts.logs_dir, true, None::<&str>)?;
  
      let open_app_log = &MenuItem::with_id(app_handle, MenuIds::APP_LOG, &texts.app_log, true, None::<&str>)?;
-@@ -783,7 +781,7 @@ async fn create_tray_menu(
+@@ -810,7 +808,7 @@ async fn create_tray_menu(
          MenuIds::OPEN_DIR,
          &texts.open_dir,
          true,
@@ -66,7 +66,7 @@ index f6d9a355..1b8cb8b8 100644
      )?;
  
      let restart_clash = &MenuItem::with_id(
-@@ -953,9 +951,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
+@@ -984,9 +982,6 @@ fn on_menu_event(_: &AppHandle, event: MenuEvent) {
              MenuIds::CONF_DIR => {
                  let _ = cmd::open_app_dir().await;
              }
@@ -77,7 +77,7 @@ index f6d9a355..1b8cb8b8 100644
                  let _ = cmd::open_logs_dir().await;
              }
 diff --git a/src-tauri/src/lib.rs b/src-tauri/src/lib.rs
-index 55156df3..20f11c09 100644
+index fc19b303..2ccb8cc0 100644
 --- a/src-tauri/src/lib.rs
 +++ b/src-tauri/src/lib.rs
 @@ -140,7 +140,6 @@ mod app_init {
@@ -113,10 +113,10 @@ index 51231e2a..752003c2 100644
          onClick={openLogsDir}
          label={t('settings.components.verge.advanced.fields.openLogsDir')}
 diff --git a/src/services/cmds.ts b/src/services/cmds.ts
-index 960aacdf..0538e34a 100644
+index 096516e7..f0ebd1e0 100644
 --- a/src/services/cmds.ts
 +++ b/src/services/cmds.ts
-@@ -330,10 +330,6 @@ export async function openAppDir() {
+@@ -334,10 +334,6 @@ export async function openAppDir() {
    return invoke<void>('open_app_dir').catch((err) => showNotice.error(err))
  }
  
@@ -128,5 +128,5 @@ index 960aacdf..0538e34a 100644
    return invoke<void>('open_logs_dir').catch((err) => showNotice.error(err))
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0011-fix-disable-GeoData-update.patch
@@ -1,4 +1,4 @@
-From 3bc1e5bc02d00cf010912389a81baa740548d80b Mon Sep 17 00:00:00 2001
+From 650d27319f63c514b807e87bea278fa6d2add0d9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sat, 12 Apr 2025 10:56:35 +0800
 Subject: [PATCH 11/13] fix: disable GeoData update
@@ -10,10 +10,10 @@ We handle this via mihomo-rules-dat.
  2 files changed, 3 insertions(+), 25 deletions(-)
 
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 8568802a..59df0894 100644
+index 21fdd466..88b6a8a0 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
-@@ -719,17 +719,7 @@ const resolveMmdb = () =>
+@@ -720,17 +720,7 @@ const resolveMmdb = () =>
    resolveResource({
      file: 'Country.mmdb',
      downloadURL: `https://github.com/MetaCubeX/meta-rules-dat/releases/download/latest/country.mmdb`,
@@ -32,7 +32,7 @@ index 8568802a..59df0894 100644
  const resolveEnableLoopback = () =>
    resolveResource({
      file: 'enableLoopback.exe',
-@@ -753,8 +743,6 @@ const resolveUnSetDnsScript = () =>
+@@ -754,8 +744,6 @@ const resolveUnSetDnsScript = () =>
  const tasks = [
    { name: 'plugin', func: resolvePlugin, retry: 5, winOnly: true },
    { name: 'mmdb', func: resolveMmdb, retry: 5 },
@@ -42,7 +42,7 @@ index 8568802a..59df0894 100644
      name: 'enableLoopback',
      func: resolveEnableLoopback,
 diff --git a/src/components/setting/setting-clash.tsx b/src/components/setting/setting-clash.tsx
-index c41d97d3..369f2cdf 100644
+index 64bd74b5..d7836508 100644
 --- a/src/components/setting/setting-clash.tsx
 +++ b/src/components/setting/setting-clash.tsx
 @@ -66,13 +66,8 @@ const SettingClash = ({ onError }: Props) => {
@@ -61,7 +61,7 @@ index c41d97d3..369f2cdf 100644
  
    // 实现DNS设置开关处理函数
    const handleDnsToggle = useLockFn(async (enable: boolean) => {
-@@ -276,11 +271,6 @@ const SettingClash = ({ onError }: Props) => {
+@@ -279,11 +274,6 @@ const SettingClash = ({ onError }: Props) => {
          />
        )}
  
@@ -74,5 +74,5 @@ index c41d97d3..369f2cdf 100644
          label={t('settings.sections.clash.form.fields.tunnels.title')}
          onClick={() => tunnelRef.current?.open()}
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0012-Do-not-sidecar-mihomo-program.patch
@@ -1,4 +1,4 @@
-From f1160313c5607c6700c2d76968e9dc9b718ede25 Mon Sep 17 00:00:00 2001
+From 6e69bb994cef78f03dd09997ccbd64f9bbe3f729 Mon Sep 17 00:00:00 2001
 From: eatradish <sakiiily@aosc.io>
 Date: Sun, 2 Mar 2025 14:41:06 +0800
 Subject: [PATCH 12/13] Do not sidecar mihomo program
@@ -9,10 +9,10 @@ Subject: [PATCH 12/13] Do not sidecar mihomo program
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src-tauri/src/core/manager/state.rs b/src-tauri/src/core/manager/state.rs
-index eb4ad960..c63ff275 100644
+index e952e891..b3e3a7b0 100644
 --- a/src-tauri/src/core/manager/state.rs
 +++ b/src-tauri/src/core/manager/state.rs
-@@ -34,7 +34,7 @@ impl CoreManager {
+@@ -49,7 +49,7 @@ impl CoreManager {
          let previous_mask = unsafe { tauri_plugin_clash_verge_sysinfo::libc::umask(0o007) };
          let (mut rx, child) = app_handle
              .shell()
@@ -22,10 +22,10 @@ index eb4ad960..c63ff275 100644
                  "-d",
                  dirs::path_to_str(&config_dir)?,
 diff --git a/src-tauri/src/core/validate.rs b/src-tauri/src/core/validate.rs
-index 819d220a..2d2a0a4c 100644
+index 55d62ec9..6b3692f6 100644
 --- a/src-tauri/src/core/validate.rs
 +++ b/src-tauri/src/core/validate.rs
-@@ -343,7 +343,7 @@ impl CoreConfigValidator {
+@@ -351,7 +351,7 @@ impl CoreConfigValidator {
          let command =
              app_handle
                  .shell()
@@ -35,5 +35,5 @@ index 819d220a..2d2a0a4c 100644
          let output = command.output().await?;
  
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
+++ b/app-proxy/clash-verge-rev/autobuild/patches/0013-edit-dependencies-to-support-loongarch-ppc.patch
@@ -1,4 +1,4 @@
-From e089ed0ae0c4fb9d99114f7ef5e8a2cf8c33ac21 Mon Sep 17 00:00:00 2001
+From 08761b373e83df69e4f5d8a82611719972adf4c5 Mon Sep 17 00:00:00 2001
 From: stydxm <stydxm@outlook.com>
 Date: Sun, 9 Nov 2025 19:15:18 +0800
 Subject: [PATCH 13/13] edit dependencies to support loongarch & ppc
@@ -12,10 +12,10 @@ Signed-off-by: stydxm <stydxm@outlook.com>
  4 files changed, 12 insertions(+), 14 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index b13885be..c61edd72 100644
+index 4b817ca9..cb45cd63 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -658,7 +658,6 @@ dependencies = [
+@@ -648,7 +648,6 @@ dependencies = [
   "dashmap",
   "dynify",
   "fast-float2",
@@ -23,7 +23,7 @@ index b13885be..c61edd72 100644
   "futures-channel",
   "futures-concurrency",
   "futures-lite",
-@@ -2448,16 +2447,6 @@ dependencies = [
+@@ -2383,16 +2382,6 @@ dependencies = [
   "thiserror 2.0.18",
  ]
  
@@ -60,7 +60,7 @@ index 0f304e31..3842c949 100644
 +  "@vitejs/plugin-legacy": "^7.0.0"
 +  "@vitejs/plugin-react": "^5.0.0"
 diff --git a/scripts/prebuild.mjs b/scripts/prebuild.mjs
-index 59df0894..32380beb 100644
+index 88b6a8a0..86217968 100644
 --- a/scripts/prebuild.mjs
 +++ b/scripts/prebuild.mjs
 @@ -190,7 +190,8 @@ const META_ALPHA_MAP = {
@@ -84,10 +84,10 @@ index 59df0894..32380beb 100644
  
  // =======================
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 95bd1924..bc4918ff 100755
+index f5ffcdc5..1a0129d8 100755
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
-@@ -60,7 +60,7 @@ open = "5.3.5"
+@@ -60,7 +60,7 @@ open = "5.3.6"
  dunce = "1.0.5"
  nanoid = "0.5"
  chrono = "0.4.45"
@@ -97,5 +97,5 @@ index 95bd1924..bc4918ff 100755
  percent-encoding = "2.3.2"
  reqwest = { version = "0.13.4", features = [
 -- 
-2.52.0
+2.55.0
 

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -1,5 +1,5 @@
-VER=2.5.1+git20260613
-SRCS="git::commit=f763fcb244caab8476a79d44f8f40f049ad256bb;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
+VER=2.5.2
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/clash-verge-rev.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"
 ENVREQ="total_mem=30"

--- a/app-proxy/clash-verge-service-ipc/spec
+++ b/app-proxy/clash-verge-service-ipc/spec
@@ -1,4 +1,3 @@
-VER=2.3.0
-REL=2
-SRCS="git::commit=v$VER::https://github.com/clash-verge-rev/clash-verge-service-ipc"
+VER=2.3.3
+SRCS="git::commit=tags/v$VER::https://github.com/clash-verge-rev/clash-verge-service-ipc"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-service: update to 2.5.2
- clash-verge-service-ipc: update to 2.3.3

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-service-ipc clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
