### PR TITLE
libcava: update to 1.0.0

### DIFF
--- a/app-utils/waybar/autobuild/patches/0001-AOSCOS-fix-build-with-libcava-1.0.0.patch
+++ b/app-utils/waybar/autobuild/patches/0001-AOSCOS-fix-build-with-libcava-1.0.0.patch
@@ -1,0 +1,40 @@
+From 9c6045c7e56216ef4277b42d609431748900b48b Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <wukaiyang@loongfans.cn>
+Date: Tue, 21 Jul 2026 10:49:13 +0800
+Subject: [PATCH] AOSCOS: fix build with libcava 1.0.0
+
+Signed-off-by: Kaiyang Wu <wukaiyang@loongfans.cn>
+---
+ meson.build                       | 2 +-
+ src/modules/cava/cava_backend.cpp | 2 --
+ 2 files changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index db9407eb..d94fdb0c 100644
+--- a/meson.build
++++ b/meson.build
+@@ -498,7 +498,7 @@ else
+ endif
+ 
+ cava = dependency('libcava',
+-                  version : '>=0.10.7',
++                  version : '>=1.0.0',
+                   required: get_option('cava'),
+                   fallback : ['libcava', 'cava_dep'],
+                   not_found_message: 'cava is not found. Building waybar without cava')
+diff --git a/src/modules/cava/cava_backend.cpp b/src/modules/cava/cava_backend.cpp
+index c576f0cf..bc46b73c 100644
+--- a/src/modules/cava/cava_backend.cpp
++++ b/src/modules/cava/cava_backend.cpp
+@@ -200,8 +200,6 @@ void waybar::modules::cava::CavaBackend::loadConfig() {
+   prm_.xaxis = ::cava::xaxis_scale::NONE;
+   prm_.mono_opt = ::cava::AVERAGE;
+   prm_.autobars = 0;
+-  if (config_["gravity"].isInt()) prm_.gravity = config_["gravity"].asInt();
+-  if (config_["integral"].isInt()) prm_.integral = config_["integral"].asInt();
+ 
+   if (config_["framerate"].isInt()) prm_.framerate = config_["framerate"].asInt();
+   // Calculate delay for Update() thread
+-- 
+2.55.0
+

--- a/app-utils/waybar/spec
+++ b/app-utils/waybar/spec
@@ -1,5 +1,5 @@
 VER=0.15.0
-REL=1
+REL=2
 # NOTE: the sole submodule is the AUR package repository
 SRCS="git::commit=tags/$VER;submodule=false::https://github.com/Alexays/Waybar.git"
 CHKSUMS="SKIP"

--- a/runtime-multimedia/libcava/autobuild/defines
+++ b/runtime-multimedia/libcava/autobuild/defines
@@ -22,4 +22,4 @@ MESON_AFTER=(
     '-Doutput_sdl_glsl=enabled'
 )
 
-PKGBREAK="waybar<=0.14.0-1"
+PKGBREAK="waybar<=0.15.0-1"

--- a/runtime-multimedia/libcava/spec
+++ b/runtime-multimedia/libcava/spec
@@ -1,4 +1,4 @@
-VER=0.10.7
+VER=1.0.0
 SRCS="git::commit=tags/$VER::https://github.com/LukashonakV/cava"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372377"


### PR DESCRIPTION
Topic Description
-----------------

- libcava: update to 1.0.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libcava: 1.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcava:-pkgbreak waybar libcava
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
