### PR TITLE
verilator: update to 5.050

### DIFF
--- a/app-electronics/verilator/autobuild/defines
+++ b/app-electronics/verilator/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=verilator
 PKGSEC=electronics
-PKGDEP="gcc perl"
+PKGDEP="gcc perl python-3"
+PKGRECOM="zlib lz4"
 PKGDES="Verilog simulator that compiles Verilog code into C++/SystemC"
 
 ABTYPE=autotools

--- a/app-electronics/verilator/spec
+++ b/app-electronics/verilator/spec
@@ -1,4 +1,4 @@
-VER=5.046
+VER=5.050
 SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/verilator/verilator"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5085"


### PR DESCRIPTION
Topic Description
-----------------

- verilator: update to 5.050
    - Add missing dependency python-3.
    - Add zlib and lz4 \(for compressed waveform\) to PKGRECOM.

Package(s) Affected
-------------------

- verilator: 5.050

Security Update?
----------------

No

Build Order
-----------

```
#buildit verilator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
