### PR TITLE
ncmpc: update to 0.53

### DIFF
--- a/app-multimedia/ncmpc/spec
+++ b/app-multimedia/ncmpc/spec
@@ -1,5 +1,4 @@
-VER=0.52
-REL=1
+VER=0.53
 SRCS="https://www.musicpd.org/download/ncmpc/${VER%.*}/ncmpc-${VER}.tar.xz"
-CHKSUMS="sha256::3af225496fe363a8534a9780fb46ae1bd17baefd80cf4ba7430a19cddd73eb1a"
+CHKSUMS="sha256::92c68bb9bf294d48209587b19df9005db7247e9c38d7e4fb74f8586e6f23c56f"
 CHKUPDATE="anitya::id=2055"


### PR DESCRIPTION
Topic Description
-----------------

- ncmpc: update to 0.53
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ncmpc: 0.53

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncmpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
