### PR TITLE
giflib: fix PKGBREAK

### DIFF
--- a/runtime-imaging/giflib/autobuild/defines
+++ b/runtime-imaging/giflib/autobuild/defines
@@ -5,11 +5,11 @@ PKGSEC=libs
 
 ABTYPE=self
 
-PKGBREAK="emacs<=30.2-4 emukit<=20240730 fim<=1:0.7.1-2 fontforge<=20251009-4 \
+PKGBREAK="emacs<=30.2-4 fim<=1:0.7.1-2 fontforge<=20251009-4 \
           gdal<=3.13.1-1 imlib2<=1.5.1-2 khtml<=5.115.0 kodi<=21.3-4 \
           krita<=5.2.15-4 leptonica<=1.84.1-1 libgdiplus<=6.2-1 \
           libjxl<=0.11.2-1 libksquirrel-trinity<=14.1.6 libwebp<=1.6.0-1 \
-          localsearch<=3.10.2-3 openimageio<=2.5.19.1-9 openjdk<=4:25-1 \
+          localsearch<=3.10.2-3 openimageio<=2.5.19.1-9 \
           openjdk-17<=17.0.16+ga-1 openjdk-21<=21.0.8+ga-1 \
           openjdk-22<=22.0.2+ga-6 openjdk-23<=23.0.2+ga-4 \
           openjdk-24<=24.0.2+ga-1 openjdk-25<=25.0.2+ga-1 \

--- a/runtime-imaging/giflib/spec
+++ b/runtime-imaging/giflib/spec
@@ -1,4 +1,5 @@
 VER=6.1.3
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/giflib/files/giflib-$VER.tar.gz/download"
 CHKSUMS="sha256::b65b66b99f0424b93525f987386f22fc5efb9da2bfc92ad4a532249aaffbab0e"
 CHKUPDATE="anitya::id=1158"


### PR DESCRIPTION
Topic Description
-----------------

- giflib: fix PKGBREAK

Package(s) Affected
-------------------

- giflib: 6.1.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit giflib:-pkgbreak giflib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
