### PR TITLE
pkgconf: update to 3.0.4

### DIFF
--- a/app-devel/pkgconf/spec
+++ b/app-devel/pkgconf/spec
@@ -1,4 +1,4 @@
-VER=3.0.2
+VER=3.0.4
 SRCS="tbl::https://distfiles.ariadne.space/pkgconf/pkgconf-$VER.tar.xz"
-CHKSUMS="sha256::42ce89ba4c45e6fefaab970bf81d3fadfb738f8d5243460fa67bc4fed84b0db0"
+CHKSUMS="sha256::91ce346b47f46b87d680c6928e6c43240b9cdc7a31afbea19f2298de4dbe266d"
 CHKUPDATE="anitya::id=12753"


### PR DESCRIPTION
Topic Description
-----------------

- pkgconf: update to 3.0.4
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- pkgconf: 3.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
