### PR TITLE
ngspice: build shared objects

### DIFF
--- a/app-electronics/kicad/autobuild/defines
+++ b/app-electronics/kicad/autobuild/defines
@@ -27,7 +27,3 @@ CMAKE_AFTER=(
 
 PKGREP="kicad-i18n<=4.0.0"
 PKGBREAK="kicad-i18n<=4.0.0"
-
-# Note: Current loongarch64_nosimd machines does not have a graphics
-#       performance that is enough for PCB designing.
-FAIL_ARCH="(loongarch64_nosimd)"

--- a/app-electronics/kicad/spec
+++ b/app-electronics/kicad/spec
@@ -1,4 +1,5 @@
 VER=10.0.4
+REL=1
 SRCS="git::commit=tags/$VER;rename=kicad-$VER::https://gitlab.com/kicad/code/kicad \
       git::commit=tags/$VER;rename=kicad-footprints-$VER::https://gitlab.com/kicad/libraries/kicad-footprints \
       git::commit=tags/$VER;rename=kicad-symbols-$VER::https://gitlab.com/kicad/libraries/kicad-symbols \

--- a/app-electronics/ngspice/autobuild/defines
+++ b/app-electronics/ngspice/autobuild/defines
@@ -4,3 +4,6 @@ PKGDEP="readline fftw libbsd x11-lib"
 PKGDES="SPICE-based circuit simulator"
 
 ABTYPE=autotools
+AUTOTOOLS_AFTER=(
+    '--with-ngshared'
+)

--- a/app-electronics/ngspice/spec
+++ b/app-electronics/ngspice/spec
@@ -1,4 +1,5 @@
 VER=46
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/ngspice/files/ng-spice-rework/$VER/ngspice-$VER.tar.gz"
 CHKSUMS="sha256::a0d1699af1940b06649276dcd6ff5a566c8c0cad01b2f7b5e99dedbb4d64c19b"
 CHKUPDATE="anitya::id=20590"


### PR DESCRIPTION
Topic Description
-----------------

- kicad: rebuild for ngspice
    Signed-off-by: stydxm <stydxm@outlook.com>
- ngspice: build shared objects
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit ngspice kicad
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
