### PR TITLE
minicom: try fix segfault

### DIFF
--- a/app-utils/minicom/autobuild/patches/0001-AOSCOS-fix-alignment-of-Chinese-help-screen-text.patch
+++ b/app-utils/minicom/autobuild/patches/0001-AOSCOS-fix-alignment-of-Chinese-help-screen-text.patch
@@ -1,7 +1,7 @@
 From b02db4d0d6eec5aaddfc0b6daa95e787f68efece Mon Sep 17 00:00:00 2001
 From: CyberNeko-AI <cyberneko.ai@aosc.io>
 Date: Sun, 12 Apr 2026 17:18:49 +0800
-Subject: [PATCH] AOSCOS: fix alignment of Chinese help screen text
+Subject: [PATCH 1/2] AOSCOS: fix alignment of Chinese help screen text
 
 - removed `po/stamp-po` to let the build system to re-evaluate
 and rebuild the `.gmo` files from `.po`
@@ -87,5 +87,5 @@ index 6387f2a..ff98842 100644
  #: src/help.c:69
  msgid "Select function or press Enter for none."
 -- 
-2.52.0
+2.55.0.windows.3
 

--- a/app-utils/minicom/autobuild/patches/0002-AOSCOS-vt100-fix-segfault-on-multi-byte-UTF-8-input.patch
+++ b/app-utils/minicom/autobuild/patches/0002-AOSCOS-vt100-fix-segfault-on-multi-byte-UTF-8-input.patch
@@ -1,0 +1,87 @@
+From 98535e4f65d8d1dd5fce238b029fbe71a3edb409 Mon Sep 17 00:00:00 2001
+From: Kexy Biscuit <kexybiscuit@aosc.io>
+Date: Wed, 22 Jul 2026 15:33:56 +0800
+Subject: [PATCH 2/2] AOSCOS: vt100: fix segfault on multi-byte UTF-8 input
+
+When do_terminal() receives multi-byte UTF-8 characters (e.g. U+2500
+BOX DRAWINGS LIGHT HORIZONTAL), it decodes them to wchar_t via
+one_mbtowc() and passes both the raw first byte (ch) and the decoded
+wide character (wc) to vt_out().
+
+However, vt_out() always processes the raw byte through vt_inmap[] and
+vt_trans[] translation tables before checking whether wc is already set.
+For multi-byte sequences, these byte-level translations corrupt the
+first byte (e.g. 0xe2 becomes a different value), and the subsequent
+wc value passed to mc_wputc() may no longer correspond to the intended
+character.
+
+Repeated occurrences corrupt the terminal cursor state (win->curx),
+eventually driving it negative.  The _write() function's bounds check
+(x < COLS && y < LINES) did not guard against negative coordinates,
+so a negative x was used to index into gmap[], causing a segmentation
+fault.
+
+Fix by moving the byte-level translation (vt_inmap/vt_trans) inside
+the wc == 0 branch so it is only applied when no pre-decoded wide
+character is available.  Also add x >= 0 && y >= 0 guards to _write()
+as a defensive measure.
+
+This commit is authored with assistance from AI/LLM:
+
+- Model: xiaomi/mimo-v2.5-pro
+- Platform: Xiaomi MiMo
+- Agent platform: MiMoCode
+- Prompt:
+  Investigate the reason of a segmentation fault on version 2.11.1
+  with the provided backtrace.
+
+Assisted-by: MiMo <noreply@xiaomi.com>
+---
+ src/vt100.c  | 13 +++++++------
+ src/window.c |  4 ++--
+ 2 files changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/src/vt100.c b/src/vt100.c
+index 2f0f62e..3b1eba6 100644
+--- a/src/vt100.c
++++ b/src/vt100.c
+@@ -1083,13 +1083,14 @@ void vt_out(int ch, wchar_t wc)
+     case 0: /* Normal character */
+       if (vt_docap == 1)
+         fputc(P_CONVCAP[0] == 'Y' ? vt_inmap[c] : c, capfp);
+-      if (!using_iconv()) {
+-        c = vt_inmap[c];    /* conversion 04.09.97 / jl */
+-        if (vt_type == VT100 && vt_trans[vt_charset] && vt_asis == 0)
+-          c = vt_trans[vt_charset][c];
+-      }
+-      if (wc == 0)
++      if (wc == 0) {
++        if (!using_iconv()) {
++          c = vt_inmap[c];    /* conversion 04.09.97 / jl */
++          if (vt_type == VT100 && vt_trans[vt_charset] && vt_asis == 0)
++            c = vt_trans[vt_charset][c];
++        }
+         one_mbtowc (&wc, (char *)&c, 1); /* returns 1 */
++      }
+       if (vt_insert)
+         mc_winschar2(vt_win, wc, 1);
+       else
+diff --git a/src/window.c b/src/window.c
+index a41b928..80d4c53 100644
+--- a/src/window.c
++++ b/src/window.c
+@@ -351,9 +351,9 @@ static int _write(wchar_t c, int doit, int x, int y, char attr, char color)
+     oldc.color = color;
+   }
+ #ifdef ST_LINE
+-  if (x < COLS && y <= LINES)
++  if (x >= 0 && y >= 0 && x < COLS && y <= LINES)
+ #else
+-  if (x < COLS && y < LINES)
++  if (x >= 0 && y >= 0 && x < COLS && y < LINES)
+ #endif
+   {
+     if (doit != 0) {
+-- 
+2.55.0.windows.3
+

--- a/app-utils/minicom/spec
+++ b/app-utils/minicom/spec
@@ -1,4 +1,5 @@
 VER=2.11.1
+REL=1
 SRCS="git::commit=tags/${VER}::https://salsa.debian.org/minicom-team/minicom.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1983"


### PR DESCRIPTION
Topic Description
-----------------

- minicom: try fix segfault

Package(s) Affected
-------------------

- minicom: 2.11.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit minicom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
