### PR TITLE
libxml2: update to 2.15.3

### DIFF
--- a/runtime-common/libxml2/autobuild/patches/0001-BACKPORT-CVE-2026-11979.patch
+++ b/runtime-common/libxml2/autobuild/patches/0001-BACKPORT-CVE-2026-11979.patch
@@ -1,0 +1,77 @@
+From c2e233fc1b341685fc99621b2768b503f777a72e Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Fri, 22 May 2026 12:21:20 +0200
+Subject: [PATCH] xmlcatalog: overflow check for large --shell commands
+
+Fix https://gitlab.gnome.org/GNOME/libxml2/-/work_items/1124
+---
+ test/catalogs/test.sh | 11 +++++++++++
+ xmlcatalog.c          | 16 ++++++++++++++++
+ 2 files changed, 27 insertions(+)
+
+diff --git a/test/catalogs/test.sh b/test/catalogs/test.sh
+index 7e5eaa760..84e8b90a2 100755
+--- a/test/catalogs/test.sh
++++ b/test/catalogs/test.sh
+@@ -10,6 +10,17 @@ fi
+ 
+ exitcode=0
+ 
++# Test xmlcatalog --shell command line
++# Case 1: Really long argument (470 chars)
++input=""; for i in {1..470}; do input="${input}A"; done
++echo $input | $xmlcatalog --shell test/catalogs/dockbook.xml || exit 1
++# Case 2: public + long argument
++input="public "; for i in {1..470}; do input="${input}A"; done
++echo $input | $xmlcatalog --shell test/catalogs/dockbook.xml || exit 1
++# Case 3: public + lots of args
++input="public "; for i in {1..80}; do input="${input} x"; done
++echo $input | $xmlcatalog --shell test/catalogs/dockbook.xml || exit 1
++
+ for i in test/catalogs/*.script ; do
+     name=$(basename $i .script)
+     xml="./test/catalogs/$name.xml"
+diff --git a/xmlcatalog.c b/xmlcatalog.c
+index 1e7380431..f8d84ac9c 100644
+--- a/xmlcatalog.c
++++ b/xmlcatalog.c
+@@ -135,6 +135,12 @@ static void usershell(void) {
+ 	       (*cur != '\n') && (*cur != '\r')) {
+ 	    if (*cur == 0)
+ 		break;
++            /* Do not read beyond the command array capacity */
++            if (i >= (int)sizeof(command) - 2) {
++                printf("Invalid command %s\n", cur);
++                i = 0;
++                break;
++            }
+ 	    command[i++] = *cur++;
+ 	}
+ 	command[i] = 0;
+@@ -152,6 +158,11 @@ static void usershell(void) {
+ 	while ((*cur != '\n') && (*cur != '\r') && (*cur != 0)) {
+ 	    if (*cur == 0)
+ 		break;
++            if (i >= (int)sizeof(arg) - 2) {
++                printf("Invalid arg %s\n", arg);
++                i = 0;
++                break;
++            }
+ 	    arg[i++] = *cur++;
+ 	}
+ 	arg[i] = 0;
+@@ -164,6 +175,11 @@ static void usershell(void) {
+ 	cur = arg;
+ 	memset(argv, 0, sizeof(argv));
+ 	while (*cur != 0) {
++            if (i >= (int)sizeof(argv) / (int)sizeof(char*)) {
++                printf("Too much arguments\n");
++                break;
++            }
++
+ 	    while ((*cur == ' ') || (*cur == '\t')) cur++;
+ 	    if (*cur == '\'') {
+ 		cur++;
+-- 
+GitLab
+

--- a/runtime-common/libxml2/spec
+++ b/runtime-common/libxml2/spec
@@ -1,5 +1,4 @@
-VER=2.15.1
-REL=4
+VER=2.15.3
 SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/GNOME/libxml2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1783"

--- a/runtime-optenv32/libxml2+32/autobuild/patches/0001-BACKPORT-CVE-2026-11979.patch
+++ b/runtime-optenv32/libxml2+32/autobuild/patches/0001-BACKPORT-CVE-2026-11979.patch
@@ -1,0 +1,77 @@
+From c2e233fc1b341685fc99621b2768b503f777a72e Mon Sep 17 00:00:00 2001
+From: Daniel Garcia Moreno <daniel.garcia@suse.com>
+Date: Fri, 22 May 2026 12:21:20 +0200
+Subject: [PATCH] xmlcatalog: overflow check for large --shell commands
+
+Fix https://gitlab.gnome.org/GNOME/libxml2/-/work_items/1124
+---
+ test/catalogs/test.sh | 11 +++++++++++
+ xmlcatalog.c          | 16 ++++++++++++++++
+ 2 files changed, 27 insertions(+)
+
+diff --git a/test/catalogs/test.sh b/test/catalogs/test.sh
+index 7e5eaa760..84e8b90a2 100755
+--- a/test/catalogs/test.sh
++++ b/test/catalogs/test.sh
+@@ -10,6 +10,17 @@ fi
+ 
+ exitcode=0
+ 
++# Test xmlcatalog --shell command line
++# Case 1: Really long argument (470 chars)
++input=""; for i in {1..470}; do input="${input}A"; done
++echo $input | $xmlcatalog --shell test/catalogs/dockbook.xml || exit 1
++# Case 2: public + long argument
++input="public "; for i in {1..470}; do input="${input}A"; done
++echo $input | $xmlcatalog --shell test/catalogs/dockbook.xml || exit 1
++# Case 3: public + lots of args
++input="public "; for i in {1..80}; do input="${input} x"; done
++echo $input | $xmlcatalog --shell test/catalogs/dockbook.xml || exit 1
++
+ for i in test/catalogs/*.script ; do
+     name=$(basename $i .script)
+     xml="./test/catalogs/$name.xml"
+diff --git a/xmlcatalog.c b/xmlcatalog.c
+index 1e7380431..f8d84ac9c 100644
+--- a/xmlcatalog.c
++++ b/xmlcatalog.c
+@@ -135,6 +135,12 @@ static void usershell(void) {
+ 	       (*cur != '\n') && (*cur != '\r')) {
+ 	    if (*cur == 0)
+ 		break;
++            /* Do not read beyond the command array capacity */
++            if (i >= (int)sizeof(command) - 2) {
++                printf("Invalid command %s\n", cur);
++                i = 0;
++                break;
++            }
+ 	    command[i++] = *cur++;
+ 	}
+ 	command[i] = 0;
+@@ -152,6 +158,11 @@ static void usershell(void) {
+ 	while ((*cur != '\n') && (*cur != '\r') && (*cur != 0)) {
+ 	    if (*cur == 0)
+ 		break;
++            if (i >= (int)sizeof(arg) - 2) {
++                printf("Invalid arg %s\n", arg);
++                i = 0;
++                break;
++            }
+ 	    arg[i++] = *cur++;
+ 	}
+ 	arg[i] = 0;
+@@ -164,6 +175,11 @@ static void usershell(void) {
+ 	cur = arg;
+ 	memset(argv, 0, sizeof(argv));
+ 	while (*cur != 0) {
++            if (i >= (int)sizeof(argv) / (int)sizeof(char*)) {
++                printf("Too much arguments\n");
++                break;
++            }
++
+ 	    while ((*cur == ' ') || (*cur == '\t')) cur++;
+ 	    if (*cur == '\'') {
+ 		cur++;
+-- 
+GitLab
+

--- a/runtime-optenv32/libxml2+32/spec
+++ b/runtime-optenv32/libxml2+32/spec
@@ -1,4 +1,4 @@
-VER=2.15.1
+VER=2.15.3
 SRCS="git::commit=tags/v$VER::https://gitlab.gnome.org/GNOME/libxml2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1783"

--- a/topics/libxml2-2.15.3.toml
+++ b/topics/libxml2-2.15.3.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libxml2 2.15.3"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (2 of high severity and 1 of medium severity)"
+zh_CN = "修复 6 个安全漏洞（含 2 个高危漏洞和 1 个中危漏洞）"
+
+[packages-v2]
+"libxml2" = "< 2.15.3"
+"libxml2+32" = "< 2.15.3"


### PR DESCRIPTION
Topic Description
-----------------

- libxml2+32: update to 2.15.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- libxml2: update to 2.15.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libxml2: 2.15.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libxml2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
