### PR TITLE
openimageio: update to 3.1.15.0

### DIFF
--- a/app-creativity/blender/autobuild/defines
+++ b/app-creativity/blender/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=blender
 PKGSEC=graphics
-PKGDES="A fully integrated 3D graphics creation suite"
+PKGDES="Integrated 3D graphics creation suite"
 PKGDEP="alembic ceres ffmpeg fftw fmt freetype gcc-runtime gflags glibc \
         glog gmp hicolor-icon-theme imath jemalloc jack libepoxy libharu \
         libjpeg-turbo libpng libsndfile libspnav libwebp libxkbcommon \

--- a/app-creativity/blender/spec
+++ b/app-creativity/blender/spec
@@ -1,6 +1,5 @@
-VER=5.1.2
+VER=5.2.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://projects.blender.org/blender/blender.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=201"
 ENVREQ__LOONGSON3="total_mem=60"
-REL=1

--- a/runtime-display/openshadinglanguage/spec
+++ b/runtime-display/openshadinglanguage/spec
@@ -1,4 +1,5 @@
 VER=1.15.5.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/OpenShadingLanguage"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=112681"

--- a/runtime-imaging/openimageio/autobuild/defines
+++ b/runtime-imaging/openimageio/autobuild/defines
@@ -23,6 +23,6 @@ CMAKE_AFTER=(
 )
 
 # Break old blender due to updated sonames.
-PKGBREAK="blender<=4.0.2-4"
+PKGBREAK="blender<=5.1.2-1 openshadinglanguage<=1.15.5.0"
 # ... and other deprecated packages
 PKGKBREAK+=" luxrays<=1.6-7 luxrender<=1.6-5"

--- a/runtime-imaging/openimageio/spec
+++ b/runtime-imaging/openimageio/spec
@@ -1,5 +1,4 @@
-VER=2.5.19.1
-REL=11
+VER=3.1.15.0
 SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/OpenImageIO"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2548"


### PR DESCRIPTION
Topic Description
-----------------

- openshadinglanguage: rebuild for openimageio
    Signed-off-by: stydxm <stydxm@outlook.com>
- blender: update to 5.2.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- openimageio: update to 3.1.15.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit openimageio openshadinglanguage blender
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
