### PR TITLE
box64: update to 0.4.3+4

### DIFF
--- a/app-emulation/box64/autobuild/defines
+++ b/app-emulation/box64/autobuild/defines
@@ -1,38 +1,41 @@
 PKGNAME=box64
 PKGSEC=utils
-PKGDEP="gcc-runtime glibc ncurses"
 PKGDES="Userspace emulator for running x86-64 applications on non-x86 systems"
+PKGDEP="gcc-runtime glibc ncurses pygobject-3 qt-5 solid x11-lib \
+        kcompletion kconfig kcoreaddons kio kjobwidgets kservice kwidgetsaddons kwindowsystem"
+BUILDDEP="extra-cmake-modules"
 ABTYPE="cmakeninja"
 
 # Note: -DCI=ON, regenerates function wrappers, which is unnecessary for packaging?
 CMAKE_AFTER=(
-    "-DCI=ON"
-    "-DBOX32=ON"
-    "-DBOX32_BINFMT=ON"
+    '-DCI=ON'
+    '-DBOX32=ON'
+    '-DBOX32_BINFMT=ON'
+    '-DBOX64_KDE_PROFILE_PLUGIN=ON'
 )
 
 CMAKE_AFTER__ARM64=(
     "${CMAKE_AFTER[@]}"
-    "-DARM64=ON"
-    "-DARM_DYNAREC=ON"
+    '-DARM64=ON'
+    '-DARM_DYNAREC=ON'
 )
 
 CMAKE_AFTER__LOONGARCH64=(
     "${CMAKE_AFTER[@]}"
-    "-DLARCH64=ON"
-    "-DLARCH64_DYNAREC=ON"
+    '-DLARCH64=ON'
+    '-DLARCH64_DYNAREC=ON'
 )
 
 CMAKE_AFTER__PPC64EL=(
     "${CMAKE_AFTER[@]}"
-    "-DPPC64LE=ON"
-    "-DPPC64LE_DYNAREC=ON"
+    '-DPPC64LE=ON'
+    '-DPPC64LE_DYNAREC=ON'
 )
 
 CMAKE_AFTER__RISCV64=(
     "${CMAKE_AFTER[@]}"
-    "-DRV64=ON"
-    "-DRV64_DYNAREC=ON"
+    '-DRV64=ON'
+    '-DRV64_DYNAREC=ON'
 )
 
 CMAKE_AFTER__LOONGARCH64_NOSIMD=(

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=0.4.3-3
+UPSTREAM_VER=0.4.3-4
 VER=${UPSTREAM_VER//\-/+}
 # Note: copy-repo is required for "box64 -v" to show the commit hash
 SRCS="git::commit=tags/v${UPSTREAM_VER};copy-repo=true::https://github.com/ptitSeb/box64.git"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.4.3+3
    - Enable KDE profile plugin.

Package(s) Affected
-------------------

- box64: 0.4.3+4

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
