### PR TITLE
gitea: update to 1.27.0

### DIFF
--- a/app-vcs/gitea/autobuild/defines
+++ b/app-vcs/gitea/autobuild/defines
@@ -6,3 +6,19 @@ PKGSUG="mariadb memcached postgresql sqlite"
 BUILDDEP="go nodejs"
 
 ABTYPE=self
+
+# FIXME: Missing architecture support
+#
+# # modernc.org/libc
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:61:14: undefined: newFile
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:62:15: undefined: newFile
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:63:15: undefined: newFile
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:238:22: undefined: long
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:287:32: undefined: ulong
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:330:39: undefined: long
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:527:37: undefined: ulong
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:973:22: undefined: long
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:1916:34: undefined: long
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:2620:48: undefined: long
+# /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:2620:48: too many errors 
+FAIL_ARCH="@(loongson3)"

--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,4 +1,4 @@
-VER=1.26.2
+VER=1.27.0
 SRCS="tbl::https://dl.gitea.com/gitea/$VER/gitea-src-$VER.tar.gz"
-CHKSUMS="sha256::ce1462ad93dcbf3221a452457008b8159cbab3d0c93958179b88649df1e401cf"
+CHKSUMS="sha256::012df875bfa7764ade92301ac5e4225fc2c2aab7b3b40b4d6e7149a926253496"
 CHKUPDATE="anitya::id=13537"

--- a/topics/gitea-1.27.0.toml
+++ b/topics/gitea-1.27.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Gitea 1.27.0"
+
+[caution]
+default = "Fixes 45 security vulnerabilities"
+zh_CN = "修复 45 个安全漏洞"
+
+[packages-v2]
+"gitea" = "< 1.27.0"


### PR DESCRIPTION
Topic Description
-----------------

- gitea: mark loongson3 as FAIL_ARCH
- gitea: update to 1.27.0
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- gitea: 1.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit gitea
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
