### PR TITLE
libssh: security update to 0.12.1

### DIFF
--- a/runtime-network/libssh/autobuild/defines
+++ b/runtime-network/libssh/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=libssh
 PKGSEC=libs
 PKGDEP="krb5 openssl zlib libfido2"
-PKGDES="A client-side C library implementing the SSH protocol"
+PKGDES="C library implementing the SSHv2 protocol"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
     '-DWITH_GSSAPI=ON'
     '-DWITH_FIDO2=ON'

--- a/runtime-network/libssh/spec
+++ b/runtime-network/libssh/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
+VER=0.12.1
 SRCS="tbl::https://git.libssh.org/projects/libssh.git/snapshot/libssh-$VER.tar.gz"
-CHKSUMS="sha256::a93c97f539f23a213734fa4a1807c7da577ad155d78145d44fd2af26bfb0e2ea"
+CHKSUMS="sha256::e88f4aa02b8c77849c3937c2c9a2fbc160e1e128ca276539f45297e3b09fe3a0"
 CHKUPDATE="anitya::id=1729"

--- a/runtime-optenv32/libssh+32/autobuild/defines
+++ b/runtime-optenv32/libssh+32/autobuild/defines
@@ -2,8 +2,9 @@ PKGNAME=libssh+32
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 krb5+32 openssl+32 zlib+32"
 BUILDDEP="devel-base+32"
-PKGDES="A client-side C library implementing the SSH protocol (32-bit x86 runtime)"
+PKGDES="C library implementing the SSHv2 protocol"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
     '-DWITH_GSSAPI=ON'
     '-DWITH_ZLIB=/opt/32/lib'

--- a/runtime-optenv32/libssh+32/spec
+++ b/runtime-optenv32/libssh+32/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
+VER=0.12.1
 SRCS="tbl::https://git.libssh.org/projects/libssh.git/snapshot/libssh-$VER.tar.gz"
-CHKSUMS="sha256::a93c97f539f23a213734fa4a1807c7da577ad155d78145d44fd2af26bfb0e2ea"
+CHKSUMS="sha256::e88f4aa02b8c77849c3937c2c9a2fbc160e1e128ca276539f45297e3b09fe3a0"
 CHKUPDATE="anitya::id=1729"

--- a/topics/libssh-0.12.1.toml
+++ b/topics/libssh-0.12.1.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "libssh 0.12.1"
+
+[caution]
+default = "Fixes 12 security vulnerabilities (including 1 of high severity and 5 of medium severity)"
+zh_CN = "修复 12 个安全漏洞（含 1 个高危漏洞和 5 个中危漏洞）"
+
+[packages-v2]
+"libssh" = "< 0.12.1"
+"libssh+32" = "< 0.12.1"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add libssh-0.12.1.toml
    Signed-off-by: stydxm <stydxm@outlook.com>
- libssh+32: security update to 0.12.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- libssh: security update to 0.12.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- libssh: 0.12.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
