### PR TITLE
gpsd: disable hotplugging of generic usb serial adapters

### DIFF
--- a/app-scientific/gpsd/autobuild/patches/0002-DEBIAN-disable-hotplugging-of-generic-use-serial-adapters.patch
+++ b/app-scientific/gpsd/autobuild/patches/0002-DEBIAN-disable-hotplugging-of-generic-use-serial-adapters.patch
@@ -1,0 +1,23 @@
+Disable hotplugging of generic usb<>serial adapters.
+These adapters are too common to hit them with the gpsd hotplug script.
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=550964
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=696020
+Index: pkg-gpsd/gpsd.rules.in
+===================================================================
+--- pkg-gpsd.orig/gpsd.rules.in	2026-01-17 17:24:11.898915583 +0100
++++ pkg-gpsd/gpsd.rules.in	2026-01-17 17:24:11.896956600 +0100
+@@ -91,10 +91,12 @@
+ 
+ # Cygnal Integrated Products, Inc. CP210x Composite Device
+ # (Used by Holux m241 and Wintec grays2 wbt-201) [linux module: cp210x]
+-ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="gps%n", @UDEVCOMMAND@
++# !!! rule disabled in AOSC OS because it matches way too many generic serial converters
++#ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", SYMLINK+="gps%n", @UDEVCOMMAND@
+ 
+ # Cygnal Integrated Products, Inc. [linux module: cp210x]
+-ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", SYMLINK+="gps%n", @UDEVCOMMAND@
++# !!! rule disabled in AOSC OS because it matches way too many generic serial converters
++#ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea71", SYMLINK+="gps%n", @UDEVCOMMAND@
+ 
+ # Cypress M8/CY7C64013 (Delorme uses these) [linux module: cypress_m8]
+ ATTRS{idVendor}=="1163", ATTRS{idProduct}=="0100", SYMLINK+="gps%n", @UDEVCOMMAND@

--- a/app-scientific/gpsd/spec
+++ b/app-scientific/gpsd/spec
@@ -1,4 +1,5 @@
 VER=3.27.5
+REL=1
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/gpsd/gpsd-$VER.tar.gz"
 CHKSUMS="sha256::409873f5048462ef1ac413a51ab35caa8b50b31be62b3347bee1cc2994e7c649"
 CHKUPDATE="anitya::id=6846"


### PR DESCRIPTION
Topic Description
-----------------

- gpsd: disable hotplugging of generic usb serial adapters
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gpsd: 3.27.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gpsd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
