### PR TITLE
vscode：update to 1.130.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.129.0
+VER=1.130.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::a25c73aa4a7461d3d605f272add35fd661c881400c75b4809d6cb277632791c4"
-CHKSUMS__ARM64="sha256::c228f157e6febac1ab503ebab1f89c78420172594c775f76fca95000c0817e97"
+CHKSUMS__AMD64="sha256::63835d9a09ba93c88fb57d35fad0f4c28788221285c7120281ac53ff2deaf183"
+CHKSUMS__ARM64="sha256::4b67f4e83154dfb281ed5e8ed7be03d9ce3c489bb00c8653c5207d61744d864b"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

vscode:update to 1.130.0

Package(s) Affected
-------------------

vscode:1.130.0

Security Update?
----------------
No

Build Order
-----------


```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [X] AMD64 `amd64`
- [X] AArch64 `arm64`
