### PR TITLE
polkit: add spiral aliases

### DIFF
--- a/app-admin/polkit/autobuild/defines
+++ b/app-admin/polkit/autobuild/defines
@@ -38,4 +38,5 @@ MESON_AFTER__M68K="${MESON_AFTER__RETRO}"
 MESON_AFTER__POWERPC="${MESON_AFTER__RETRO}"
 MESON_AFTER__PPC64="${MESON_AFTER__RETRO}"
 
-PKGEPOCH=1
+# Note: Extra provides for Spiral.
+PKGPROV="pkexec_spiral polkitd_spiral"

--- a/app-admin/polkit/autobuild/defines.stage2
+++ b/app-admin/polkit/autobuild/defines.stage2
@@ -10,5 +10,3 @@ MESON_AFTER=(
     "-Dgtk_doc=false"
     "-Dintrospection=false"
 )
-
-PKGEPOCH=1

--- a/app-admin/polkit/spec
+++ b/app-admin/polkit/spec
@@ -1,5 +1,6 @@
 VER=126
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/polkit-org/polkit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=3682"
+EPOCH=1


### PR DESCRIPTION
Topic Description
-----------------

- polkit: add spiral aliases
    ... and move EPOCH to the spec file

Package(s) Affected
-------------------

- polkit: 126-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit polkit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
