### PR TITLE
Zathura Survey 20260723

### DIFF
--- a/app-doc/zathura-cb/autobuild/defines
+++ b/app-doc/zathura-cb/autobuild/defines
@@ -5,6 +5,3 @@ BUILDDEP="meson"
 PKGDES="Comic book support for Zathura"
 
 ABTYPE=meson
-MESON_AFTER=(
-    '-Dtests=disabled'
-)

--- a/app-doc/zathura-cb/spec
+++ b/app-doc/zathura-cb/spec
@@ -1,5 +1,4 @@
-VER=2026.05.10
-REL=1
+VER=2026.07.18
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-cb"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14845"

--- a/app-doc/zathura-djvu/autobuild/defines
+++ b/app-doc/zathura-djvu/autobuild/defines
@@ -5,6 +5,3 @@ BUILDDEP="meson"
 PKGDES="DjVu support for Zathura"
 
 ABTYPE=meson
-MESON_AFTER=(
-    '-Dtests=disabled'
-)

--- a/app-doc/zathura-djvu/spec
+++ b/app-doc/zathura-djvu/spec
@@ -1,5 +1,4 @@
-VER=2026.05.10
-REL=1
+VER=2026.07.18
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-djvu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11036"

--- a/app-doc/zathura-pdf-poppler/autobuild/defines
+++ b/app-doc/zathura-pdf-poppler/autobuild/defines
@@ -5,6 +5,3 @@ BUILDDEP="meson"
 PKGDES="Poppler PDF backend support for Zathura"
 
 ABTYPE=meson
-MESON_AFTER=(
-    '-Dtests=disabled'
-)

--- a/app-doc/zathura-pdf-poppler/spec
+++ b/app-doc/zathura-pdf-poppler/spec
@@ -1,5 +1,4 @@
-VER=2026.05.10
-REL=1
+VER=2026.07.18
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-pdf-poppler"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14847"

--- a/app-doc/zathura-ps/autobuild/defines
+++ b/app-doc/zathura-ps/autobuild/defines
@@ -5,6 +5,3 @@ BUILDDEP="meson"
 PKGDES="PostScript support for Zathura"
 
 ABTYPE=meson
-MESON_AFTER=(
-    '-Dtests=disabled'
-)

--- a/app-doc/zathura-ps/spec
+++ b/app-doc/zathura-ps/spec
@@ -1,5 +1,4 @@
-VER=2026.02.03
-REL=1
+VER=2026.07.18
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura-ps"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=14848"

--- a/app-doc/zathura/autobuild/defines
+++ b/app-doc/zathura/autobuild/defines
@@ -10,9 +10,10 @@ MESON_AFTER=(
     '-Dseccomp=enabled'
     '-Dlandlock=enabled'
     '-Dmanpages=enabled'
-    '-Dtests=disabled'
+    '-Dtests-x11=disabled'
+    '-Dtests-wayland=disabled'
     '-Dconvert-icon=enabled'
 )
 
-PKGBREAK="zathura-cb<=2026.05.10 zathura-djvu<=2026.05.10 \
-          zathura-pdf-poppler<=2026.05.10 zathura-ps<=2026.02.03"
+PKGBREAK="zathura-cb<=2026.05.10-1 zathura-djvu<=2026.05.10-1 \
+          zathura-pdf-poppler<=2026.05.10-1 zathura-ps<=2026.02.03-1"

--- a/app-doc/zathura/spec
+++ b/app-doc/zathura/spec
@@ -1,4 +1,4 @@
-VER=2026.07.02
+VER=2026.07.18
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/zathura"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5298"

--- a/runtime-desktop/girara/spec
+++ b/runtime-desktop/girara/spec
@@ -1,4 +1,4 @@
-VER=2026.07.07
+VER=2026.07.18
 SRCS="git::commit=tags/$VER::https://github.com/pwmt/girara"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6750"


### PR DESCRIPTION
Topic Description
-----------------

- zathura-ps: update to 2026.07.18
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-pdf-poppler: update to 2026.07.18
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-djvu: update to 2026.07.18
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura-cb: update to 2026.07.18
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- zathura: update to 2026.07.18
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- girara: update to 2026.07.18
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- girara: 2026.07.18
- zathura: 2026.07.18
- zathura-cb: 2026.07.18
- zathura-djvu: 2026.07.18
- zathura-pdf-poppler: 2026.07.18
- zathura-ps: 2026.07.18

Security Update?
----------------

No

Build Order
-----------

```
#buildit girara zathura zathura-cb zathura-djvu zathura-pdf-poppler zathura-ps
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
