### PR TITLE
[PREVIEW] LoongVPU 1.0.0

### DIFF
--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/build
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/build
@@ -1,0 +1,10 @@
+abinfo "Unpacking loongvpu-kernel-dkms ..."
+dpkg -x "$SRCDIR"/loongvpu-kernel-dkms_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Removing untested 2K1000LA drivers ..."
+rm -rv "$PKGDIR"/usr/src/loongvpu-ls2k1000la-${__UPSTREAM_VER%%-*}
+
+abinfo "Patching module sources to fix build with newer kernel versions ..."
+cd "$PKGDIR"/usr/src/loongvpu-ls2k3000-${__UPSTREAM_VER%%-*}/
+ab_apply_patches "$SRCDIR"/autobuild/patches.deferred/*.patch

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/build
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/build
@@ -3,8 +3,10 @@ dpkg -x "$SRCDIR"/loongvpu-kernel-dkms_${__UPSTREAM_VER}_loong64.deb \
     "$PKGDIR"/
 
 abinfo "Removing untested 2K1000LA drivers ..."
-rm -rv "$PKGDIR"/usr/src/loongvpu-ls2k1000la-${__UPSTREAM_VER%%-*}
+rm -rv "$PKGDIR"/usr/src/loongvpu-ls2k1000la-0.1.0
 
 abinfo "Patching module sources to fix build with newer kernel versions ..."
+# FIXME: upstream forgot to rename the folders
+mv "$PKGDIR"/usr/src/loongvpu-ls2k3000-0.1.0 "$PKGDIR"/usr/src/loongvpu-ls2k3000-${__UPSTREAM_VER%%-*}/
 cd "$PKGDIR"/usr/src/loongvpu-ls2k3000-${__UPSTREAM_VER%%-*}/
 ab_apply_patches "$SRCDIR"/autobuild/patches.deferred/*.patch

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/defines
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/defines
@@ -1,0 +1,8 @@
+PKGNAME=loongvpu-kernel-dkms
+PKGSEC=libs
+PKGDEP="dracut dkms"
+PKGDES="Kernel module sources (DKMS) for LoongVPU kernel-mode drivers"
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"
+ABSPLITDBG=0

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0001-loongvpu-include-hantro_device.h-defined-MAX-macro-o.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0001-loongvpu-include-hantro_device.h-defined-MAX-macro-o.patch
@@ -1,8 +1,8 @@
 From f06012a39f85012ffe6d23969f4fda6b23d2eaef Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Mon, 13 Oct 2025 11:02:29 +0800
-Subject: [PATCH 1/9] loongvpu: include/hantro_device.h: defined MAX macro only
- when the
+Subject: [PATCH 01/10] loongvpu: include/hantro_device.h: defined MAX macro
+ only when the
 
 upstream kernel headers do not define this macro
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0001-loongvpu-include-hantro_device.h-defined-MAX-macro-o.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0001-loongvpu-include-hantro_device.h-defined-MAX-macro-o.patch
@@ -1,0 +1,28 @@
+From f06012a39f85012ffe6d23969f4fda6b23d2eaef Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Mon, 13 Oct 2025 11:02:29 +0800
+Subject: [PATCH 1/9] loongvpu: include/hantro_device.h: defined MAX macro only
+ when the
+
+upstream kernel headers do not define this macro
+---
+ include/hantro_device.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/hantro_device.h b/include/hantro_device.h
+index e610769..4058851 100644
+--- a/include/hantro_device.h
++++ b/include/hantro_device.h
+@@ -23,7 +23,9 @@
+ 
+ #include "hantro.h"
+ 
++#ifndef MAX
+ #define MAX(a, b) (((a) > (b)) ? (a) : (b))
++#endif
+ 
+ /* #define MAX(a, b)                 \
+  * ({ typeof(a) a_ = (a);            \
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0002-loongvpu-set-FOP_UNSIGNED_OFFSET-for-drm_file.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0002-loongvpu-set-FOP_UNSIGNED_OFFSET-for-drm_file.patch
@@ -1,7 +1,7 @@
 From 8032802b25c166001d50992bae726c2780d5545f Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Fri, 17 Oct 2025 14:10:50 +0800
-Subject: [PATCH 2/9] loongvpu: set FOP_UNSIGNED_OFFSET for drm_file
+Subject: [PATCH 02/10] loongvpu: set FOP_UNSIGNED_OFFSET for drm_file
 
 Link: https://lore.kernel.org/r/20240809-work-fop_unsigned-v1-1-658e054d893e@kernel.org
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0002-loongvpu-set-FOP_UNSIGNED_OFFSET-for-drm_file.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0002-loongvpu-set-FOP_UNSIGNED_OFFSET-for-drm_file.patch
@@ -1,0 +1,27 @@
+From 8032802b25c166001d50992bae726c2780d5545f Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Fri, 17 Oct 2025 14:10:50 +0800
+Subject: [PATCH 2/9] loongvpu: set FOP_UNSIGNED_OFFSET for drm_file
+
+Link: https://lore.kernel.org/r/20240809-work-fop_unsigned-v1-1-658e054d893e@kernel.org
+---
+ hantro/hantro_drm.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hantro/hantro_drm.c b/hantro/hantro_drm.c
+index eb61582..64a365c 100644
+--- a/hantro/hantro_drm.c
++++ b/hantro/hantro_drm.c
+@@ -1612,6 +1612,9 @@ const struct file_operations hantro_fops = {
+ 	.read = drm_read,
+ 	.unlocked_ioctl = hantro_ioctl, //drm_ioctl,
+ 	.compat_ioctl = drm_compat_ioctl,
++#ifdef FOP_UNSIGNED_OFFSET
++	.fop_flags = FOP_UNSIGNED_OFFSET,
++#endif
+ };
+ 
+ static void hantro_gem_vm_close(struct vm_area_struct *vma)
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0003-loongvpu-fix-error-handling-for-vgem-creation.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0003-loongvpu-fix-error-handling-for-vgem-creation.patch
@@ -1,7 +1,7 @@
 From aa01639dc4ad33c7903248dad3047138f81a9c09 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 18 Oct 2025 10:09:16 +0800
-Subject: [PATCH 3/9] loongvpu: fix error handling for vgem creation
+Subject: [PATCH 03/10] loongvpu: fix error handling for vgem creation
 
 ---
  hantro/hantro_drm.c | 1 +

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0003-loongvpu-fix-error-handling-for-vgem-creation.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0003-loongvpu-fix-error-handling-for-vgem-creation.patch
@@ -1,0 +1,24 @@
+From aa01639dc4ad33c7903248dad3047138f81a9c09 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sat, 18 Oct 2025 10:09:16 +0800
+Subject: [PATCH 3/9] loongvpu: fix error handling for vgem creation
+
+---
+ hantro/hantro_drm.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hantro/hantro_drm.c b/hantro/hantro_drm.c
+index 64a365c..2027eac 100644
+--- a/hantro/hantro_drm.c
++++ b/hantro/hantro_drm.c
+@@ -154,6 +154,7 @@ static int hantro_gem_dumb_create_internal(struct drm_file *file_priv,
+ 	if (ret) {
+ 		FreeMem(cma_obj);
+ 		kfree(cma_obj);
++		goto out;
+ 	}
+ 	init_hantro_resv(&cma_obj->kresv, cma_obj);
+ 	cma_obj->handle = args->handle;
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0004-loongvpu-convert-all-locally-used-functions-to-stati.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0004-loongvpu-convert-all-locally-used-functions-to-stati.patch
@@ -1,7 +1,7 @@
 From 1bfa0e6cb235d6e7bebfd9b0261aff0d0bd1692f Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 18 Oct 2025 10:22:46 +0800
-Subject: [PATCH 4/9] loongvpu: convert all locally used functions to static
+Subject: [PATCH 04/10] loongvpu: convert all locally used functions to static
  functions
 
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0004-loongvpu-convert-all-locally-used-functions-to-stati.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0004-loongvpu-convert-all-locally-used-functions-to-stati.patch
@@ -1,0 +1,118 @@
+From 1bfa0e6cb235d6e7bebfd9b0261aff0d0bd1692f Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sat, 18 Oct 2025 10:22:46 +0800
+Subject: [PATCH 4/9] loongvpu: convert all locally used functions to static
+ functions
+
+---
+ hantro/devicemgr.c       | 2 +-
+ hantro/hantro_drv.c      | 4 ++--
+ hantro/hantro_fence.c    | 2 +-
+ hantro/hantro_mem_pool.c | 4 ++--
+ hantro/hantro_vcmd.c     | 6 +++---
+ 5 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/hantro/devicemgr.c b/hantro/devicemgr.c
+index 9df8021..a530aa3 100644
+--- a/hantro/devicemgr.c
++++ b/hantro/devicemgr.c
+@@ -624,7 +624,7 @@ int add_mmunode(u32 sliceindex, struct mmu_t *mmucore)
+ 	return 0;
+ }
+ 
+-int add_vcmdnode(u32 sliceindex, struct hantrovcmd_t *vcmdcore)
++static int add_vcmdnode(u32 sliceindex, struct hantrovcmd_t *vcmdcore)
+ {
+ 	struct hantrovcmd_t *pvcmd;
+ 	struct hantrodec_t *pdec;
+diff --git a/hantro/hantro_drv.c b/hantro/hantro_drv.c
+index 6b803c2..59dbe51 100644
+--- a/hantro/hantro_drv.c
++++ b/hantro/hantro_drv.c
+@@ -933,7 +933,7 @@ static struct pci_driver loongvpu_encoder_driver = {
+ };
+ #endif
+ 
+-void __exit hantro_cleanup(void)
++static void __exit hantro_cleanup(void)
+ {
+ 	int vcmd_en;
+ 	hantro_ioctl_id ioctl_id_par;
+@@ -1106,7 +1106,7 @@ static void __init probe_hantroHW(unsigned long reg_base,
+ 	}
+ }
+ 
+-int __init hantro_init(void)
++static int __init hantro_init(void)
+ {
+ 	int result, i;
+ 	struct hantro_base_addr subsys_info;
+diff --git a/hantro/hantro_fence.c b/hantro/hantro_fence.c
+index 8bb52a5..dbf2ac4 100644
+--- a/hantro/hantro_fence.c
++++ b/hantro/hantro_fence.c
+@@ -123,7 +123,7 @@ int init_hantro_resv(
+ 	return 0;
+ }
+ 
+-int hantro_waitfence(hantro_fence_t *pfence)
++static int hantro_waitfence(hantro_fence_t *pfence)
+ {
+ 	if (test_bit(HANTRO_FENCE_FLAG_SIGNAL_BIT, &pfence->flags))
+ 		return 0;
+diff --git a/hantro/hantro_mem_pool.c b/hantro/hantro_mem_pool.c
+index 9b79a5c..e5ee3db 100644
+--- a/hantro/hantro_mem_pool.c
++++ b/hantro/hantro_mem_pool.c
+@@ -66,7 +66,7 @@ int memory_pool_free(unsigned long addr)
+ 	return -1;
+ }
+ 
+-int memalloc_release(struct inode *inode)
++static int memalloc_release(struct inode *inode)
+ {
+ 	int i;
+ 
+@@ -76,7 +76,7 @@ int memalloc_release(struct inode *inode)
+ 	return 0;
+ }
+ 
+-int alloc_pages_pool(void)
++static int alloc_pages_pool(void)
+ {
+ 	int i, j;
+ 	struct sysinfo mem_info;
+diff --git a/hantro/hantro_vcmd.c b/hantro/hantro_vcmd.c
+index e89e3a7..fc4935d 100644
+--- a/hantro/hantro_vcmd.c
++++ b/hantro/hantro_vcmd.c
+@@ -2942,7 +2942,7 @@ static int hantro_vcmd_mem_pool_init(vcmd_dev_str *subsys_dev)
+ 	return 0;
+ }
+ 
+-int hantro_vcmd_subsys_probe(vcmd_dev_str *subsys_dev)
++static int hantro_vcmd_subsys_probe(vcmd_dev_str *subsys_dev)
+ {
+ 	vcmd_core_str *subsys_core;
+ 	u32 i, k;
+@@ -3217,7 +3217,7 @@ enc_init:
+ 	return 0;
+ }
+ 
+-int hantro_get_core_type(u32 sub_module_type)
++static int hantro_get_core_type(u32 sub_module_type)
+ {
+ 	int core_type;
+ 
+@@ -3418,7 +3418,7 @@ static void cmdbuf_update_jmp_cmd(int hw_version_id,
+  * Return: pointer to N or NULL if N doesn't exist.
+  */
+ 
+-void vcmd_delink_rm_cmdbuf(vcmd_core_str *subsys_core, bi_list_node *cmdbuf_node)
++static void vcmd_delink_rm_cmdbuf(vcmd_core_str *subsys_core, bi_list_node *cmdbuf_node)
+ {
+ 	struct vcmd_dev *subsys_dev = subsys_core->parent_dev;
+ 	bi_list *list = &subsys_core->list_manager;
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0005-.gitignore-add-gitignore-file-to-exclude-compiler-ge.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0005-.gitignore-add-gitignore-file-to-exclude-compiler-ge.patch
@@ -1,7 +1,7 @@
 From b554a1da1502617d91c0e636568f2390fe68fe7d Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Sat, 18 Oct 2025 10:27:19 +0800
-Subject: [PATCH 5/9] .gitignore: add gitignore file to exclude compiler
+Subject: [PATCH 05/10] .gitignore: add gitignore file to exclude compiler
  generated files
 
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0005-.gitignore-add-gitignore-file-to-exclude-compiler-ge.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0005-.gitignore-add-gitignore-file-to-exclude-compiler-ge.patch
@@ -1,0 +1,30 @@
+From b554a1da1502617d91c0e636568f2390fe68fe7d Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Sat, 18 Oct 2025 10:27:19 +0800
+Subject: [PATCH 5/9] .gitignore: add gitignore file to exclude compiler
+ generated files
+
+---
+ .gitignore | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+ create mode 100644 .gitignore
+
+diff --git a/.gitignore b/.gitignore
+new file mode 100644
+index 0000000..e679420
+--- /dev/null
++++ b/.gitignore
+@@ -0,0 +1,10 @@
++/.cache
++/conftest
++
++*.o
++*.ko
++*.mod
++*.mod.c
++*.cmd
++*.symvers
++*.order
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,0 +1,26 @@
+From 4bc9a74961203e3da5b503463e35d7a4ee88b882 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu@aosc.io>
+Date: Tue, 30 Dec 2025 18:52:26 +0800
+Subject: [PATCH 6/9] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
+ switched to c23
+
+---
+ conftest.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index e1de359..2e92b0e 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -89,7 +89,7 @@ build_cflags() {
+     BASE_CFLAGS="-O2 -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM \
+--Wno-implicit-function-declaration -Wno-strict-prototypes"
++-Wno-implicit-function-declaration -Wno-strict-prototypes -std=gnu11"
+ 
+     if [ "$OUTPUT" != "$SOURCES" ]; then
+         OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0006-loonggpu-add-cflag-std-gnu11-to-conftest-as-gcc-15-s.patch
@@ -1,7 +1,7 @@
 From 4bc9a74961203e3da5b503463e35d7a4ee88b882 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu@aosc.io>
 Date: Tue, 30 Dec 2025 18:52:26 +0800
-Subject: [PATCH 6/9] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
+Subject: [PATCH 06/10] loonggpu: add cflag '-std=gnu11' to conftest as gcc-15
  switched to c23
 
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0007-fix-dkms.conf-drop-deprecated-DKMS-options.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0007-fix-dkms.conf-drop-deprecated-DKMS-options.patch
@@ -1,0 +1,26 @@
+From 666995e2267163439835f6838018d799aa3b2501 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 30 Dec 2025 22:09:04 +0800
+Subject: [PATCH 7/9] fix(dkms.conf): drop deprecated DKMS options
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ dkms.conf | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 384772e..7898d08 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -8,8 +8,6 @@ BUILT_MODULE_NAME[0]="ls2k3000_vpu"
+ DEST_MODULE_NAME[0]="$PACKAGE_NAME"
+ DEST_MODULE_LOCATION[0]="/updates/dkms"
+ AUTOINSTALL=yes
+-REMAKE_INITRD=yes
+ 
+ MAKE[0]="unset ARCH; env LG_VERBOSE=1 \
+     make ${parallel_jobs+-j$parallel_jobs} modules KERNEL_UNAME=${kernelver}"
+-CLEAN="make KERNEL_UNAME=${kernelver} clean"
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0007-fix-dkms.conf-drop-deprecated-DKMS-options.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0007-fix-dkms.conf-drop-deprecated-DKMS-options.patch
@@ -1,7 +1,7 @@
 From 666995e2267163439835f6838018d799aa3b2501 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Tue, 30 Dec 2025 22:09:04 +0800
-Subject: [PATCH 7/9] fix(dkms.conf): drop deprecated DKMS options
+Subject: [PATCH 07/10] fix(dkms.conf): drop deprecated DKMS options
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-add-cflag-fms-extensions-to-conftest.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-add-cflag-fms-extensions-to-conftest.patch
@@ -1,0 +1,25 @@
+From f2485aeb0445dbb5b672e44c8a7b3b9c7a557364 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Fri, 6 Mar 2026 13:27:30 +0800
+Subject: [PATCH 8/9] loonggpu: add cflag '-fms-extensions' to conftest
+
+---
+ conftest.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index 2e92b0e..c499031 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -89,7 +89,7 @@ build_cflags() {
+     BASE_CFLAGS="-O2 -D__KERNEL__ \
+ -DKBUILD_BASENAME=\"#conftest$$\" -DKBUILD_MODNAME=\"#conftest$$\" \
+ -nostdinc -isystem $ISYSTEM \
+--Wno-implicit-function-declaration -Wno-strict-prototypes -std=gnu11"
++-Wno-implicit-function-declaration -Wno-strict-prototypes -std=gnu11 -fms-extensions"
+ 
+     if [ "$OUTPUT" != "$SOURCES" ]; then
+         OUTPUT_CFLAGS="-I$OUTPUT/include2 -I$OUTPUT/include"
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-add-cflag-fms-extensions-to-conftest.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0008-loonggpu-add-cflag-fms-extensions-to-conftest.patch
@@ -1,7 +1,7 @@
 From f2485aeb0445dbb5b672e44c8a7b3b9c7a557364 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Fri, 6 Mar 2026 13:27:30 +0800
-Subject: [PATCH 8/9] loonggpu: add cflag '-fms-extensions' to conftest
+Subject: [PATCH 08/10] loonggpu: add cflag '-fms-extensions' to conftest
 
 ---
  conftest.sh | 2 +-

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0009-loongvpu-use-the-inline-lock-in-dma_fence-on-Linux-7.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0009-loongvpu-use-the-inline-lock-in-dma_fence-on-Linux-7.patch
@@ -1,0 +1,130 @@
+From d4fb9ce030bdea58d2aaea608141fb2a42d24df4 Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Mon, 8 Jun 2026 11:46:30 +0800
+Subject: [PATCH 9/9] loongvpu: use the inline lock in dma_fence on Linux 7.1+
+
+Link: https://lore.kernel.org/r/20260219160822.1529-5-christian.koenig@amd.com
+---
+ conftest.sh           | 12 ++++++++++++
+ hantro/hantro.Kbuild  |  1 +
+ hantro/hantro_fence.c | 20 ++++++++++++++++++--
+ include/hantro_priv.h |  3 ++-
+ 4 files changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/conftest.sh b/conftest.sh
+index c499031..c5c17b8 100644
+--- a/conftest.sh
++++ b/conftest.sh
+@@ -975,6 +975,18 @@ compile_test() {
+             rm -f conftest$$.c
+         ;;
+ 
++        dma_fence_has_per_fence_lock)
++            #
++            # Determine if dma_fence has per-fence lock.
++            #
++            CODE="#include <linux/dma-fence.h>
++            void conftest_dma_fence_has_per_fence_lock(struct dma_fence *fence) {
++                (void)&fence->inline_lock;
++            }"
++
++            compile_check_conftest "$CODE" "LG_DMA_FENCE_HAS_PER_FENCE_LOCK" "" "types"
++        ;;
++
+         # When adding a new conftest entry, please use the correct format for
+         # specifying the relevant upstream Linux kernel commit.  Please
+         # avoid specifying -rc kernels, and only use SHAs that actually exist
+diff --git a/hantro/hantro.Kbuild b/hantro/hantro.Kbuild
+index 628e430..b95a55c 100644
+--- a/hantro/hantro.Kbuild
++++ b/hantro/hantro.Kbuild
+@@ -176,3 +176,4 @@ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_gem_object_put_unlocked
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_driver_has_date
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_mode_config_funcs_fb_create_has_info
+ LG_CONFTEST_TYPE_COMPILE_TESTS += drm_get_format_info_has_pixel_format
++LG_CONFTEST_TYPE_COMPILE_TESTS += dma_fence_has_per_fence_lock
+diff --git a/hantro/hantro_fence.c b/hantro/hantro_fence.c
+index dbf2ac4..e0469cb 100644
+--- a/hantro/hantro_fence.c
++++ b/hantro/hantro_fence.c
+@@ -45,23 +45,32 @@ static bool hantro_fence_enable_signaling(hantro_fence_t *fence)
+ 		return false;
+ }
+ 
++#if !defined(LG_DMA_FENCE_HAS_PER_FENCE_LOCK)
++#define dma_fence_lock_irqsave(fence, flags)	\
++	spin_lock_irqsave(fence->lock, flags)
++#define dma_fence_unlock_irqrestore(fence, flags)	\
++	spin_unlock_irqrestore(fence->lock, flags)
++#endif
++
+ static bool hantro_fence_signaled(hantro_fence_t *fobj)
+ {
+ 	unsigned long irqflags;
+ 	bool ret;
+ 
+-	spin_lock_irqsave(fobj->lock, irqflags);
++	dma_fence_lock_irqsave(fobj, irqflags);
+ 	ret = (test_bit(HANTRO_FENCE_FLAG_SIGNAL_BIT, &fobj->flags) != 0);
+-	spin_unlock_irqrestore(fobj->lock, irqflags);
++	dma_fence_unlock_irqrestore(fobj, irqflags);
+ 	return ret;
+ }
+ 
++#if !defined(LG_DMA_FENCE_HAS_PER_FENCE_LOCK)
+ static void hantro_fence_free(hantro_fence_t *fence)
+ {
+ 	kfree(fence->lock);
+ 	fence->lock = NULL;
+ 	dma_fence_free(fence);
+ }
++#endif
+ 
+ const static hantro_fence_op_t hantro_fenceops = {
+ 	.get_driver_name = hantro_fence_get_driver_name,
+@@ -69,7 +78,9 @@ const static hantro_fence_op_t hantro_fenceops = {
+ 	.enable_signaling = hantro_fence_enable_signaling,
+ 	.signaled = hantro_fence_signaled,
+ 	.wait = hantro_fence_default_wait,
++#if !defined(LG_DMA_FENCE_HAS_PER_FENCE_LOCK)
+ 	.release = hantro_fence_free,
++#endif
+ };
+ 
+ static hantro_fence_t *alloc_fence(unsigned int ctxno)
+@@ -81,6 +92,9 @@ static hantro_fence_t *alloc_fence(unsigned int ctxno)
+ 	fobj = kzalloc(sizeof(hantro_fence_t), GFP_KERNEL);
+ 	if (!fobj)
+ 		return NULL;
++#if defined(LG_DMA_FENCE_HAS_PER_FENCE_LOCK)
++	lock = NULL;
++#else
+ 	lock = kzalloc(sizeof(*lock), GFP_KERNEL);
+ 	if (!lock) {
+ 		kfree(fobj);
+@@ -88,6 +102,8 @@ static hantro_fence_t *alloc_fence(unsigned int ctxno)
+ 	}
+ 
+ 	spin_lock_init(lock);
++#endif
++
+ 	hantro_fence_init(fobj, &hantro_fenceops, lock, ctxno, seqno++);
+ 	clear_bit(HANTRO_FENCE_FLAG_SIGNAL_BIT, &fobj->flags);
+ 	set_bit(HANTRO_FENCE_FLAG_ENABLE_SIGNAL_BIT, &fobj->flags);
+diff --git a/include/hantro_priv.h b/include/hantro_priv.h
+index f2adf16..4ed2883 100644
+--- a/include/hantro_priv.h
++++ b/include/hantro_priv.h
+@@ -183,7 +183,8 @@ static inline void hantro_fence_put(hantro_fence_t *fence)
+ 
+ static inline int hantro_fence_signal(hantro_fence_t *fence)
+ {
+-	return dma_fence_signal(fence);
++	dma_fence_signal(fence);
++	return 0;
+ }
+ 
+ static inline void ref_page(struct page *pp)
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0009-loongvpu-use-the-inline-lock-in-dma_fence-on-Linux-7.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0009-loongvpu-use-the-inline-lock-in-dma_fence-on-Linux-7.patch
@@ -1,7 +1,8 @@
 From d4fb9ce030bdea58d2aaea608141fb2a42d24df4 Mon Sep 17 00:00:00 2001
 From: liushuyu <liushuyu011@gmail.com>
 Date: Mon, 8 Jun 2026 11:46:30 +0800
-Subject: [PATCH 9/9] loongvpu: use the inline lock in dma_fence on Linux 7.1+
+Subject: [PATCH 09/10] loongvpu: use the inline lock in dma_fence on Linux
+ 7.1+
 
 Link: https://lore.kernel.org/r/20260219160822.1529-5-christian.koenig@amd.com
 ---

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0010-loongvpu-bump-version-to-1.0.0.patch
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/patches.deferred/0010-loongvpu-bump-version-to-1.0.0.patch
@@ -1,0 +1,25 @@
+From 7ceb6e6ef07c551aebd35ec8567844ee2cb2ea2b Mon Sep 17 00:00:00 2001
+From: liushuyu <liushuyu011@gmail.com>
+Date: Thu, 23 Jul 2026 18:58:59 +0800
+Subject: [PATCH 10/10] loongvpu: bump version to 1.0.0
+
+---
+ dkms.conf | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dkms.conf b/dkms.conf
+index 7898d08..90c3fe3 100644
+--- a/dkms.conf
++++ b/dkms.conf
+@@ -2,7 +2,7 @@
+ 
+ # The version is replaced at build time by dh_dkms invoked in debian/rules.
+ PACKAGE_NAME="ls2k3000_vpu"
+-PACKAGE_VERSION="0.1"
++PACKAGE_VERSION="1.0"
+ 
+ BUILT_MODULE_NAME[0]="ls2k3000_vpu"
+ DEST_MODULE_NAME[0]="$PACKAGE_NAME"
+-- 
+2.55.0
+

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/postinst.in
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/postinst.in
@@ -1,0 +1,16 @@
+VER=%PKGVER%
+unset ARCH
+
+echo "Installing LoongGPU (LS2K3000) kernel modules..."
+for i in `ls /usr/lib/modules | grep -v 'extramodules'`; do
+	if [ -f "/usr/lib/modules/${i}/modules.dep" -a \
+	     -f "/usr/lib/modules/${i}/modules.order" -a \
+	     -f "/usr/lib/modules/${i}/modules.builtin" ]; then
+		echo -e "\033[36m**\033[0m\tBuilding loongvpu-ls2k3000 kernel modules for $i ..."
+		dkms install loongvpu-ls2k3000/${VER} -k $i > /dev/null
+	else
+		echo -e "\033[33m**\033[0m\tSkipping incomplete kernel modules tree $i ..."
+	fi
+done
+
+update-initramfs

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/prepare
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/prepare
@@ -1,0 +1,7 @@
+for i in postinst prerm; do
+    abinfo "Generating $i ..."
+    sed -e \
+        "s/%PKGVER%/${PKGVER%%+*}/g" \
+        "${SRCDIR}/autobuild/${i}.in" > \
+        "${SRCDIR}/autobuild/${i}"
+done

--- a/runtime-kernel/loongvpu-kernel-dkms/autobuild/prerm.in
+++ b/runtime-kernel/loongvpu-kernel-dkms/autobuild/prerm.in
@@ -1,0 +1,4 @@
+VER=%PKGVER%
+unset ARCH
+
+dkms remove loongvpu-ls2k3000/${VER} --all || true > /dev/null

--- a/runtime-kernel/loongvpu-kernel-dkms/spec
+++ b/runtime-kernel/loongvpu-kernel-dkms/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.0-lnd25.1
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/+}
+SRCS="file::use-url-name=true::https://repo.aosc.io/aosc-repacks/loongvpu/loongvpu-kernel-dkms_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::91704fb862bb6e0944d2781636a70a4040aec3d07ca8fcd243e81d9c3b906627"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"

--- a/runtime-multimedia/loongvpu/autobuild/build
+++ b/runtime-multimedia/loongvpu/autobuild/build
@@ -1,0 +1,20 @@
+abinfo "Unpacking loonggl ..."
+dpkg -x "$SRCDIR"/loongvpu_${__UPSTREAM_VER}_loong64.deb \
+    "$PKGDIR"/
+
+abinfo "Moving libraries to the correct location ..."
+mv -v "$PKGDIR"/usr/lib/loongarch64-linux-gnu/* \
+    "$PKGDIR"/usr/lib/
+rm -rv "$PKGDIR"/usr/lib/loongarch64-linux-gnu
+
+abinfo "Correcting symlinks ..."
+rm -v "$PKGDIR"/usr/lib/dri/*_video.so
+mv -v "$PKGDIR"/usr/lib/dri/{ls2k3000_vpu,loonggpu_drv_video}.so
+
+abinfo "Setting executable bit for shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/dri/loonggpu_drv_video.so
+
+# FIXME: We have not tested 2K1000LA yet.
+abinfo "Removing unused driver files ..."
+rm -v "$PKGDIR"/usr/lib/dri/ls2k1000la_vpu.so
+rm -v "$PKGDIR"/usr/lib/libgsgpu_vdec.so

--- a/runtime-multimedia/loongvpu/autobuild/defines
+++ b/runtime-multimedia/loongvpu/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=loongvpu
+PKGSEC=libs
+PKGDEP="loonggpu-driver loongvpu-kernel-dkms ffmpeg x11-lib libva"
+PKGDES="VA-API runtime components for LoongVPU"
+
+# Note: Binary packaging.
+ABSTRIP=0
+ABSPIRAL=0
+
+# Note: LoongArch-specific.
+FAIL_ARCH="!(loongarch64)"

--- a/runtime-multimedia/loongvpu/autobuild/prerm
+++ b/runtime-multimedia/loongvpu/autobuild/prerm
@@ -1,0 +1,1 @@
+rm -f /usr/share/glvnd/egl_vendor.d/40_loonggpu.json

--- a/runtime-multimedia/loongvpu/spec
+++ b/runtime-multimedia/loongvpu/spec
@@ -1,0 +1,8 @@
+UPSTREAM_VER=1.0.0-lnd25.1
+# Note: For use in scripting.
+__UPSTREAM_VER=${UPSTREAM_VER}
+VER=${UPSTREAM_VER//\-/+}
+SRCS="file::use-url-name=true::https://repo.aosc.io/aosc-repacks/loongvpu/loongvpu_${UPSTREAM_VER}_loong64.deb"
+CHKSUMS="sha256::037d105227a6ee86140c483d01f33d3ee4811bfc7c432fe0634c7432f5bad5d0"
+SUBDIR=.
+CHKUPDATE="anitya::id=376483"


### PR DESCRIPTION
Topic Description
-----------------

- loongvpu: new, 1.0.0+lnd25.1
- loongvpu-kernel-dkms: new, 1.0.0+lnd25.1
    Track patches at AOSC-Tracking/loongvpu-kernel-dkms @ aosc/v1.0.0-lnd25.1
    \(HEAD: d4fb9ce030bdea58d2aaea608141fb2a42d24df4\).

Package(s) Affected
-------------------

- loongvpu: 1.0.0+lnd25.1
- loongvpu-kernel-dkms: 1.0.0+lnd25.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit loongvpu loongvpu-kernel-dkms
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] LoongArch 64-bit `loongarch64`
