### PR TITLE
rocm: Libraries without MachineLearning update to 7.14[2/3]

### DIFF
--- a/runtime-rocm/rocm-hipfft/spec
+++ b/runtime-rocm/rocm-hipfft/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipfft"

--- a/runtime-rocm/rocm-hipsparse/spec
+++ b/runtime-rocm/rocm-hipsparse/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipsparse"

--- a/runtime-rocm/rocm-rccl/autobuild/patches/0001-rccl-loongarch.patch
+++ b/runtime-rocm/rocm-rccl/autobuild/patches/0001-rccl-loongarch.patch
@@ -1,9 +1,9 @@
 diff --git a/src/include/gdrwrap.h b/src/include/gdrwrap.h
-index b3508a4..2af1d84 100644
+index 162373be19..b713574520 100644
 --- a/src/include/gdrwrap.h
 +++ b/src/include/gdrwrap.h
-@@ -43,7 +43,7 @@ static inline void wc_store_fence(void) { asm volatile("sync") ; }
- #elif defined(__x86_64__)
+@@ -40,7 +40,7 @@ static inline void wc_store_fence(void) { asm volatile("sync" : : : "memory"); }
+ #elif defined(__x86_64__) || (defined(_MSC_VER) && (defined(_M_X64) || defined(_M_AMD64)))
  #include <immintrin.h>
  static inline void wc_store_fence(void) { _mm_sfence(); }
 -#elif defined(__aarch64__) || defined(__riscv)

--- a/runtime-rocm/rocm-rccl/autobuild/patches/0003-rccl-nonx8664-arch.patch
+++ b/runtime-rocm/rocm-rccl/autobuild/patches/0003-rccl-nonx8664-arch.patch
@@ -1,21 +1,20 @@
 diff --git a/src/init.cc b/src/init.cc
-index a5fd77de92..c88eb0d9d4 100644
+index 689ea77764..055ae90537 100644
 --- a/src/init.cc
 +++ b/src/init.cc
-@@ -72,7 +72,12 @@
-
- #include "latency_profiler/CollTrace.h"
+@@ -77,7 +77,11 @@
  #include "latency_profiler/CollTraceFunc.h"
+ #include "dda_all_reduce_ipc.h"
+ #include "ipc_init.h"
++
 +#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
 +#define IS_X86_64
-+#endif
-+#ifdef IS_X86_64
  #include  <cpuid.h>
 +#endif
-
+ 
  #ifndef STR2
    #define STR2(v) #v
-@@ -250,6 +255,7 @@ static ncclResult_t ncclInit() {
+@@ -283,6 +287,7 @@ static ncclResult_t ncclInit() {
        if (verStr == NULL) break;
      }
      INFO(NCCL_INIT, "Kernel version: %s", verStr);
@@ -23,7 +22,7 @@ index a5fd77de92..c88eb0d9d4 100644
      if (strstr(verStr, "cray") == NULL) {
        unsigned int eax, ebx, ecx, edx;
        if (!__get_cpuid(1, &eax, &ebx, &ecx, &edx))
-@@ -274,6 +280,7 @@ static ncclResult_t ncclInit() {
+@@ -307,6 +312,7 @@ static ncclResult_t ncclInit() {
          WARN("Missing \"HSA_FORCE_FINE_GRAIN_PCIE=1\" from environment which can lead to low RCCL performance, system instablity or hang!");
  #endif
      }

--- a/runtime-rocm/rocm-rccl/spec
+++ b/runtime-rocm/rocm-rccl/spec
@@ -1,5 +1,5 @@
-VER=7.13
-SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
+VER=7.14
+SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 ENVREQ="total_mem=70"
 # Note: Disable iGPU/CDNA on ARM64. Reduce build pressure.

--- a/runtime-rocm/rocm-rocprim/spec
+++ b/runtime-rocm/rocm-rocprim/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocprim"

--- a/runtime-rocm/rocm-rocsolver/spec
+++ b/runtime-rocm/rocm-rocsolver/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsolver"

--- a/runtime-rocm/rocm-rocsparse/spec
+++ b/runtime-rocm/rocm-rocsparse/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/rocsparse"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rocsolver: update to 7.14
- rocm-hipsparse: update to 7.14
- rocm-hipfft: update to 7.14
- rocm-rocsparse: update to 7.14
- rocm-rocprim: update to 7.14
- rocm-rccl: update to 7.14

Package(s) Affected
-------------------

- rocm-hipfft: 7.14
- rocm-hipsparse: 7.14
- rocm-rccl: 7.14
- rocm-rocprim: 7.14
- rocm-rocsolver: 7.14
- rocm-rocsparse: 7.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-rccl rocm-rocprim rocm-rocsparse rocm-hipfft rocm-hipsparse rocm-rocsolver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
