### PR TITLE
FAIL_ARCH Survey 20260715 Rework

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,5 @@
 VER=4.18.0
-SRCS="git::commit=tags/${VER}::https://github.com/AOSC-Dev/autobuild4"
+REL=1
+SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"


### PR DESCRIPTION
Topic Description
-----------------

- autobuild4: fix version prefix in tag name

Package(s) Affected
-------------------

- autobuild4: 4.18.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
