### PR TITLE
fonts Survey

### DIFF
--- a/desktop-fonts/fantasque-sans-mono-nerd-fonts/autobuild/defines
+++ b/desktop-fonts/fantasque-sans-mono-nerd-fonts/autobuild/defines
@@ -3,5 +3,5 @@ PKGDES="Fantasque Sans Mono Nerd Fonts Version"
 PKGDEP="fontconfig x11-font"
 PKGSEC=fonts
 
+ABTYPE=self
 ABHOST=noarch
-

--- a/desktop-fonts/fantasque-sans-mono-nerd-fonts/spec
+++ b/desktop-fonts/fantasque-sans-mono-nerd-fonts/spec
@@ -1,4 +1,4 @@
-VER=3.3.0
+VER=3.4.0
 SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/FantasqueSansMono.zip"
-CHKSUMS="sha256::849a660ce68cfba5b63dd8ee9cf90ed572f50579b8a098c2a2218559e6293fe5"
+CHKSUMS="sha256::29c6fe2420a61fff58a78c689e27d8b984ccef2990d6ed9c1a7f3661136acd41"
 CHKUPDATE="anitya::id=227412"

--- a/desktop-fonts/font-awesome/autobuild/defines
+++ b/desktop-fonts/font-awesome/autobuild/defines
@@ -1,7 +1,8 @@
 PKGNAME=font-awesome
 PKGSEC=fonts
 PKGDEP=fontconfig
-PKGDES="A set of iconic fonts"
+PKGDES="Set of iconic fonts"
 
+ABTYPE=self
 ABHOST=noarch
 PKGEPOCH=1

--- a/desktop-fonts/font-awesome/spec
+++ b/desktop-fonts/font-awesome/spec
@@ -1,4 +1,4 @@
-VER=7.3.0
+VER=7.3.1
 SRCS="git::commit=tags/$VER::https://github.com/FortAwesome/Font-Awesome"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=826"

--- a/desktop-fonts/genryu-font/autobuild/defines
+++ b/desktop-fonts/genryu-font/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=genryu-font
 PKGSEC=fonts
 PKGDEP="fontconfig"
-PKGDES="A free font family derived from Source Han Serif"
+PKGDES="Free font family derived from Source Han Serif"
+
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-fonts/genryu-font/spec
+++ b/desktop-fonts/genryu-font/spec
@@ -1,5 +1,4 @@
-VER=1.501
-SRCS="tbl::https://github.com/ButTaiwan/genryu-font/archive/v$VER.tar.gz"
-CHKSUMS="sha256::9571cf9ada3d1bb8dfc355df3478f521928434fcc98083e887a845f7f813c26c"
+VER=2.100
+SRCS="git::commit=tags/v$VER::https://github.com/ButTaiwan/genryu-font"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227572"
-REL=1

--- a/desktop-fonts/genwan-font/autobuild/defines
+++ b/desktop-fonts/genwan-font/autobuild/defines
@@ -1,5 +1,7 @@
 PKGNAME=genwan-font
 PKGSEC=fonts
 PKGDEP="fontconfig"
-PKGDES="A free font family derived from Source Han Serif"
+PKGDES="Free font family derived from Source Han Serif"
+
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-fonts/genwan-font/spec
+++ b/desktop-fonts/genwan-font/spec
@@ -1,4 +1,4 @@
-VER=2.000
-SRCS="tbl::https://github.com/ButTaiwan/genwan-font/archive/v$VER.tar.gz"
-CHKSUMS="sha256::04b59926dcad0f0cdd7da49e6323b2a7f57c8eb2880438bf89cd2e65f836ab2e"
+VER=2.100
+SRCS="git::commit=tags/v$VER::https://github.com/ButTaiwan/genwan-font"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227573"

--- a/desktop-fonts/genyo-font/autobuild/defines
+++ b/desktop-fonts/genyo-font/autobuild/defines
@@ -2,4 +2,6 @@ PKGNAME=genyo-font
 PKGSEC=fonts
 PKGDEP="fontconfig"
 PKGDES="Free font derived from Source Han Serif"
+
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-fonts/genyo-font/spec
+++ b/desktop-fonts/genyo-font/spec
@@ -1,5 +1,4 @@
-VER=1.501
-SRCS="tbl::https://github.com/ButTaiwan/genyo-font/archive/v$VER.tar.gz"
-CHKSUMS="sha256::aedaa3f63aff101eada1422290a886b0134c2dc23915fc57f1eecfc9b9ee8876"
+VER=2.100
+SRCS="git::commit=tags/v$VER::https://github.com/ButTaiwan/genyo-font"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=227574"
-REL=1

--- a/desktop-fonts/kose-font/01-kose-font/build
+++ b/desktop-fonts/kose-font/01-kose-font/build
@@ -3,5 +3,5 @@ install -Dvm644 "$SRCDIR"/"TTF (Japanese)"/*.ttf \
     -t "$PKGDIR"/usr/share/fonts/TTF/
 
 abinfo "Installing LICENSE..."
-install -Dvm644 "$SRCDIR"/License.txt \
+install -Dvm644 "$SRCDIR"/OFL.txt \
     "$PKGDIR"/usr/share/doc/kose-font/SIL_Open_Font_License_1.1.txt

--- a/desktop-fonts/kose-font/01-kose-font/defines
+++ b/desktop-fonts/kose-font/01-kose-font/defines
@@ -1,7 +1,7 @@
-PKGNAME="kose-font"
-PKGDES="A Kanji/Kana font derived from SetoFont/Naikai Font/cjkFonts-AllSeto (Japanese version)"
+PKGNAME=kose-font
+PKGDES="Kanji/Kana font derived from SetoFont/Naikai Font/cjkFonts-AllSeto (Japanese version)"
 PKGDEP="fontconfig"
-PKGSEC="fonts"
+PKGSEC=fonts
 
-ABHOST="noarch"
-
+ABTYPE=self
+ABHOST=noarch

--- a/desktop-fonts/kose-font/02-xiaolai-font/build
+++ b/desktop-fonts/kose-font/02-xiaolai-font/build
@@ -3,5 +3,5 @@ install -Dvm644 "$SRCDIR"/../*.ttf \
     -t "$PKGDIR"/usr/share/fonts/TTF/
 
 abinfo "Installing LICENSE..."
-install -Dvm644 "$SRCDIR"/License.txt \
+install -Dvm644 "$SRCDIR"/OFL.txt \
     "$PKGDIR"/usr/share/doc/xiaolai-font/SIL_Open_Font_License_1.1.txt

--- a/desktop-fonts/kose-font/02-xiaolai-font/defines
+++ b/desktop-fonts/kose-font/02-xiaolai-font/defines
@@ -1,7 +1,7 @@
-PKGNAME="xiaolai-font"
-PKGDES="A Simplified Chinese font dervied from Kose Font"
+PKGNAME=xiaolai-font
+PKGDES="Simplified Chinese font dervied from Kose Font"
 PKGDEP="fontconfig"
-PKGSEC="fonts"
+PKGSEC=fonts
 
-ABHOST="noarch"
-
+ABTYPE=self
+ABHOST=noarch

--- a/desktop-fonts/kose-font/spec
+++ b/desktop-fonts/kose-font/spec
@@ -1,8 +1,8 @@
-VER=3.120
+VER=3.126
 SRCS="git::commit=tags/v$VER::https://github.com/lxgw/kose-font \
-      file::rename=XiaolaiMonoSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiMonoSC-Regular.ttf \
-      file::rename=XiaolaiSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiSC-Regular.ttf"
+      file::rename=XiaolaiMonoSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/XiaolaiMono-Regular.ttf \
+      file::rename=XiaolaiSC-Regular.ttf::https://github.com/lxgw/kose-font/releases/download/v$VER/Xiaolai-Regular.ttf"
 CHKSUMS="SKIP \
-         sha256::a1e0bbdf369bd8a49d02d95ef2fba9f7d75ea5b685e662a2513be566da96b2f3 \
-         sha256::65e0c689eb0aff0782cc5a2adba97127bf2843fc302bfbc92e3cdf21ed20207f"
+         sha256::802b658db492e02ae5b659f5b56d7d4ef8f77609515bdcc82f462ae912888c33 \
+         sha256::e2f68daf0e72777a8cf58bc83de1b98634b251e537ddbfca24b0ae50d1802da2"
 CHKUPDATE="anitya::id=374941"

--- a/desktop-fonts/lxgwcleargothic-font/autobuild/defines
+++ b/desktop-fonts/lxgwcleargothic-font/autobuild/defines
@@ -1,6 +1,7 @@
-PKGNAME="lxgwcleargothic-font"
-PKGDES="A Sans Serif font derived from IPAex Gothic"
+PKGNAME=lxgwcleargothic-font
+PKGDES="Sans Serif font derived from IPAex Gothic"
 PKGDEP="fontconfig"
-PKGSEC="fonts"
+PKGSEC=fonts
 
-ABHOST="noarch"
+ABTYPE=self
+ABHOST=noarch

--- a/desktop-fonts/lxgwcleargothic-font/spec
+++ b/desktop-fonts/lxgwcleargothic-font/spec
@@ -1,8 +1,8 @@
-VER=0.508
+VER=1.001
 SRCS="file::rename=LXGWXiHeiCL.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiCL.ttf \
       file::rename=LXGWXiHeiMN.ttf::https://github.com/lxgw/LxgwXiHei/releases/download/v$VER/LXGWXiHeiMN.ttf
       file::rename=LICENSE.md::https://raw.githubusercontent.com/lxgw/LxgwXiHei/v$VER/LICENSE.md"
-CHKSUMS="sha256::9e46fb41dad3e94a289a706d9899e6c554e822ace24aa8648f169a86d8967c16 \
-         sha256::b2ce4b7cf1f4f0121719e039abc79888ac0582ba6bbace3f7c2cb55757ab4531 \
+CHKSUMS="sha256::da5de5e1c742864fd41634ad12c76eeea047a135a04b7695e6ec702b0126bdcd \
+         sha256::e29b6388cff06d2c9f665a5f8bb2e2d832793a4f3a5aeaeb74622bf14a27eb5b \
          sha256::a186b1f3ad4b8d56a43dc96637ce55f5aa4f4446025d6247641d4ef13c4bb29b"
 CHKUPDATE="anitya::id=234782"

--- a/desktop-fonts/lxgwneoxihei-font/autobuild/defines
+++ b/desktop-fonts/lxgwneoxihei-font/autobuild/defines
@@ -1,9 +1,10 @@
-PKGNAME="lxgwneoxihei-font"
-PKGDES="A Chinese sans-serif font derived from IPAex Gothic"
+PKGNAME=lxgwneoxihei-font
+PKGDES="Chinese sans-serif font derived from IPAex Gothic"
 PKGDEP="fontconfig"
-PKGSEC="fonts"
+PKGSEC=fonts
 
-ABHOST="noarch"
+ABTYPE=self
+ABHOST=noarch
 
 PKGBREAK="lxgwnewcleargothic-font<=1.124"
 PKGREP="lxgwnewcleargothic-font<=1.124"

--- a/desktop-fonts/lxgwneoxihei-font/spec
+++ b/desktop-fonts/lxgwneoxihei-font/spec
@@ -1,7 +1,7 @@
-VER=1.226
+VER=1.304
 SRCS="file::rename=LxgwNeoXiHei-Book.ttf::https://github.com/lxgw/LxgwNeoXiHei/releases/download/v$VER/LxgwNeoXiHei.ttf \
       git::commit=v$VER::https://github.com/lxgw/LxgwNeoXiHei.git"
-CHKSUMS="sha256::aca8449cd6ea4119537a96533ccf4d69abbbe185915382b6da3ac761339728e1 \
+CHKSUMS="sha256::5965dd992290861c6d62285098dc5ca7f6c669930765fd11d5d0fd4912d816e7 \
          SKIP"
 CHKUPDATE="anitya::id=234778"
 SUBDIR="."

--- a/desktop-fonts/lxgwwenkai-font/autobuild/defines
+++ b/desktop-fonts/lxgwwenkai-font/autobuild/defines
@@ -1,6 +1,7 @@
-PKGNAME="lxgwwenkai-font"
-PKGDES="An open-source Chinese font derived from Fontworks' Klee One"
+PKGNAME=lxgwwenkai-font
+PKGDES="open-source Chinese font derived from Fontworks' Klee One"
 PKGDEP="fontconfig"
-PKGSEC="fonts"
+PKGSEC=fonts
 
-ABHOST="noarch"
+ABTYPE=self
+ABHOST=noarch

--- a/desktop-fonts/lxgwwenkai-font/spec
+++ b/desktop-fonts/lxgwwenkai-font/spec
@@ -1,4 +1,4 @@
-VER=1.521
+VER=1.522
 SRCS="tbl::https://github.com/lxgw/LxgwWenKai/releases/download/v$VER/lxgw-wenkai-v$VER.tar.gz"
-CHKSUMS="sha256::e0658248c97e81dc6710f6bc24fcfb73e6d69b13fb1da6478fe0f4c940ea8157"
+CHKSUMS="sha256::681a77d5d002175e3a9e1af0fc6fa220164cc9ad6c14f1e842a539878e7ce1a4"
 CHKUPDATE="anitya::id=227594"

--- a/desktop-fonts/mengshen-pinyin-font/autobuild/build
+++ b/desktop-fonts/mengshen-pinyin-font/autobuild/build
@@ -4,4 +4,4 @@ install -vm644 "$SRCDIR"/*.ttf "$PKGDIR"/usr/share/fonts/TTF
 
 abinfo "Installing LICENSE..."
 install -dvm755 "$PKGDIR"/usr/share/doc/mengshen-pinyin-font
-install -vm644 "$SRCDIR"/Mengshen-pinyin-font-"$PKGVER"/LICENSE "$PKGDIR"/usr/share/doc/mengshen-pinyin-font
+install -vm644 "$SRCDIR"/Mengshen-pinyin-font-"${PKGVER/\+/-}"/LICENSE "$PKGDIR"/usr/share/doc/mengshen-pinyin-font

--- a/desktop-fonts/mengshen-pinyin-font/autobuild/defines
+++ b/desktop-fonts/mengshen-pinyin-font/autobuild/defines
@@ -1,6 +1,7 @@
-PKGNAME="mengshen-pinyin-font"
+PKGNAME=mengshen-pinyin-font
 PKGDES="Open source Pinyin font that supports homograph"
 PKGDEP="fontconfig"
+PKGSEC=fonts
 
-PKGSEC="fonts"
-ABHOST="noarch"
+ABTYPE=self
+ABHOST=noarch

--- a/desktop-fonts/mengshen-pinyin-font/spec
+++ b/desktop-fonts/mengshen-pinyin-font/spec
@@ -1,7 +1,10 @@
-VER=1.03
-SRCS="tbl::https://github.com/MaruTama/Mengshen-pinyin-font/releases/download/$VER/Mengshen.zip \
-      tbl::https://github.com/MaruTama/Mengshen-pinyin-font/archive/$VER.tar.gz"
-CHKSUMS="sha256::421350caee9dfc6b9a90c61a02dcb2743ee0b2f09d229cb3e15177aa0d092e9f \
-         sha256::bed9994cc92b335cfe28b72c189185a7a85ecd53501882637ca2ed3f885f673c"
+UPSTREAM_VER=20260721-150022
+VER=${UPSTREAM_VER/\-/+}
+SRCS="file::https://github.com/MaruTama/Mengshen-pinyin-font/releases/download/v$UPSTREAM_VER/Mengshen-Handwritten.ttf \
+      file::https://github.com/MaruTama/Mengshen-pinyin-font/releases/download/v$UPSTREAM_VER/Mengshen-HanSerif.ttf \
+      tbl::https://github.com/MaruTama/Mengshen-pinyin-font/archive/v$UPSTREAM_VER.tar.gz"
+CHKSUMS="sha256::53087a7b6d57cc782afac793c24162bcdd434a15dfc5db7a183b0e6a5ba28166 \
+      sha256::c3588a2087ca17f085f1acb42a6cccd5a48a720351f4766d744100c96160fff3 \
+      sha256::9a0f3018194507b38caca30189ea68f092516ed0a743d7b90cee88240ed1f5da"
 CHKUPDATE="anitya::id=227596"
 SUBDIR=.

--- a/desktop-fonts/noto-fonts/01-noto/defines
+++ b/desktop-fonts/noto-fonts/01-noto/defines
@@ -1,7 +1,7 @@
 PKGNAME=noto-fonts
 PKGSEC=fonts
 PKGDEP="adobe-source-code-pro"
-PKGDES="A font family aiming to support all languages with a harmonious look"
+PKGDES="Font family aiming to support all languages with a harmonious look"
 
 PKGREP="fonts-noto"
 PKGPROV="ttf-noto"

--- a/desktop-fonts/noto-fonts/02-cjk/defines
+++ b/desktop-fonts/noto-fonts/02-cjk/defines
@@ -1,7 +1,7 @@
 PKGNAME=noto-cjk-fonts
 PKGSEC=fonts
 PKGDEP="fontconfig"
-PKGDES="A font family aiming to support all languages with a harmonious look (Pan-CJK fonts)"
+PKGDES="Font family aiming to support all languages with a harmonious look (Pan-CJK fonts)"
 
 PKGREP="fonts-noto"
 PKGPROV="fonts-noto-cjk ttf-noto-cjk"

--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=2026.06.01
+UPSTREAM_VER=2026.07.01
 # Note: For the main version number, go with NotoSans- prefixed tags at
 # https://github.com/notofonts/notofonts.github.io/.
 EMOJI_VER=2.051
@@ -15,7 +15,7 @@ CJK_COMMIT="4efc595762d1f4b4fa504bccfe8e59de91fda063"
 SRCS="tbl::https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${UPSTREAM_VER}.tar.gz \
       tbl::https://github.com/googlefonts/noto-emoji/archive/refs/tags/v${EMOJI_VER}.tar.gz \
       git::commit=${CJK_COMMIT};rename=noto-cjk::https://github.com/googlefonts/noto-cjk"
-CHKSUMS="sha256::2f8539d08b9b6c73e86dce670eaa46e1d47d2330137ccb11ef4c69b27c865601 \
+CHKSUMS="sha256::b614152147d67bfceaaf3409600353e582a477fa64bef4da6a8ca2e370aaf531 \
          sha256::04f3d1e5605edebebac00a7a0becb390a4a3ead015066905b27935b30c18e745 \
          SKIP"
 CHKUPDATE="anitya::id=10671"

--- a/desktop-fonts/roboto-fonts/autobuild/build
+++ b/desktop-fonts/roboto-fonts/autobuild/build
@@ -1,3 +1,5 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/TTF
-cp -v *.ttf "$PKGDIR"/usr/share/fonts/TTF/
-chmod 0644 "$PKGDIR"/usr/share/fonts/TTF/*
+abinfo "Installing roboto-fonts ..."
+install -Dvm644 "$SRCDIR"/hinted/static/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF/
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/OFL.txt -t "$PKGDIR"/usr/share/doc/roboto-fonts

--- a/desktop-fonts/roboto-fonts/autobuild/defines
+++ b/desktop-fonts/roboto-fonts/autobuild/defines
@@ -3,4 +3,5 @@ PKGSEC=fonts
 PKGDEP="fontconfig"
 PKGDES="The Roboto family of fonts"
 
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-fonts/roboto-fonts/spec
+++ b/desktop-fonts/roboto-fonts/spec
@@ -1,6 +1,7 @@
-VER=2.138
-REL=2
-SRCS="tbl::https://github.com/google/roboto/releases/download/v$VER/roboto-android.zip"
-CHKSUMS="sha256::c825453253f590cfe62557733e7173f9a421fff103b00f57d33c4ad28ae53baf"
+VER=3.016
+SRCS="tbl::https://github.com/googlefonts/roboto-3-classic/releases/download/v$VER/Roboto_v$VER.zip \
+    file::rename=OFL.txt::https://github.com/googlefonts/roboto-3-classic/raw/refs/tags/v$VER/OFL.txt"
+CHKSUMS="sha256::1653dbe12f248da8fb0b9920db7b9496cd677ed3981154f6f15285c8bd4e334f \
+    sha256::061402327a96aadb0bfb694a960ed289ecd38d383e396243831ab81feb109c41"
 CHKUPDATE="anitya::id=12041"
 SUBDIR=.

--- a/desktop-fonts/sil-gentium/autobuild/build
+++ b/desktop-fonts/sil-gentium/autobuild/build
@@ -1,2 +1,5 @@
-mkdir -p "$PKGDIR"/usr/share/fonts/TTF
-cp -v *.ttf "$PKGDIR"/usr/share/fonts/TTF/
+abinfo "Installing sil-gentium ..."
+install -Dvm644 "$SRCDIR"/*.ttf -t "$PKGDIR"/usr/share/fonts/TTF
+
+abinfo "Installing LICENSE..."
+install -Dvm644 "$SRCDIR"/OFL.txt -t "$PKGDIR"/usr/share/doc/sil-gentium

--- a/desktop-fonts/sil-gentium/autobuild/defines
+++ b/desktop-fonts/sil-gentium/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="fontconfig"
 PKGDES="Extended smart font family for Latin, Greek and Cyrillic"
 
 PKGPROV="ttf-sil-gentium ttf-gentium ttf-sil-gentiumplus sil-gentiumplus"
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-fonts/sil-gentium/spec
+++ b/desktop-fonts/sil-gentium/spec
@@ -1,4 +1,4 @@
-VER=6.200
-SRCS="tbl::https://github.com/silnrsi/font-gentium/releases/download/v$VER/GentiumPlus-$VER.tar.xz"
-CHKSUMS="sha256::88453e8ca45591479f7e9776983131befe59ea47e898be7004d8c2436a189563"
+VER=7.000
+SRCS="tbl::https://github.com/silnrsi/font-gentium/releases/download/v$VER/Gentium-$VER.tar.xz"
+CHKSUMS="sha256::85f3f40bce2d4e1ba7f8656e13bc82a40624946f6177f6a65ef7425a0a7231cd"
 CHKUPDATE="anitya::id=10086"

--- a/desktop-fonts/symbols-nerd-font/autobuild/build
+++ b/desktop-fonts/symbols-nerd-font/autobuild/build
@@ -3,7 +3,7 @@ install -Dvm644 -t "$PKGDIR"/usr/share/fonts/TTF "$SRCDIR"/*.ttf
 
 abinfo "Installing fontconfig file for Nerd Font"
 install -Dvm644 \
-  "$SRCDIR"/symbols-nerd-font-3.2.1-1.conf \
+  "$SRCDIR"/10-nerd-font-symbols.conf \
   "$PKGDIR"/etc/fonts/conf.avail/10-nerd-font-symbols.conf
 
 abinfo "Enabling fontconfig file for Nerd Font"

--- a/desktop-fonts/symbols-nerd-font/autobuild/defines
+++ b/desktop-fonts/symbols-nerd-font/autobuild/defines
@@ -3,4 +3,5 @@ PKGDES="Nerd Font icons"
 PKGDEP="fontconfig x11-font"
 PKGSEC=fonts
 
+ABTYPE=self
 ABHOST=noarch

--- a/desktop-fonts/symbols-nerd-font/spec
+++ b/desktop-fonts/symbols-nerd-font/spec
@@ -1,7 +1,4 @@
-VER=3.2.1
-REL=1
-SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/NerdFontsSymbolsOnly.zip \
-      file::https://raw.githubusercontent.com/ryanoasis/nerd-fonts/v$VER/10-nerd-font-symbols.conf"
-CHKSUMS="sha256::bc59c2ea74d022a6262ff9e372fde5c36cd5ae3f82a567941489ecfab4f03d66 \
-         sha256::6601e431c5c43d80dfce375147b297df0b36bb4d465948f8f2178c1da89ace76"
+VER=3.4.0
+SRCS="tbl::https://github.com/ryanoasis/nerd-fonts/releases/download/v$VER/NerdFontsSymbolsOnly.zip"
+CHKSUMS="sha256::8e617904b980fe3648a4b116808788fe50c99d2d495376cb7c0badbd8a564c47"
 CHKUPDATE="anitya::id=227412"


### PR DESCRIPTION
Topic Description
-----------------

- symbols-nerd-font: update to 3.4.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- sil-gentium: update to 7.000
    Signed-off-by: stydxm <stydxm@outlook.com>
- roboto-fonts: update to 3.016
    Signed-off-by: stydxm <stydxm@outlook.com>
- noto-fonts: update to 2026.07.01+emoji2.051+cjksans2.004+cjkserif2.003
    Signed-off-by: stydxm <stydxm@outlook.com>
- mengshen-pinyin-font: update to 20260721+150022
    Signed-off-by: stydxm <stydxm@outlook.com>
- lxgwwenkai-font: update to 1.522
    Signed-off-by: stydxm <stydxm@outlook.com>
- lxgwneoxihei-font: update to 1.304
    Signed-off-by: stydxm <stydxm@outlook.com>
- lxgwcleargothic-font: update to 1.001
    Signed-off-by: stydxm <stydxm@outlook.com>
- kose-font: update to 3.126
    Signed-off-by: stydxm <stydxm@outlook.com>
- genyo-font: update to 2.100
    Signed-off-by: stydxm <stydxm@outlook.com>

... and 4 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit fantasque-sans-mono-nerd-fonts font-awesome genryu-font genwan-font genyo-font kose-font lxgwcleargothic-font lxgwneoxihei-font lxgwwenkai-font mengshen-pinyin-font noto-fonts roboto-fonts sil-gentium symbols-nerd-font
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
