### PR TITLE
obs-studio: update to 32.2.1

### DIFF
--- a/app-multimedia/obs-studio/spec
+++ b/app-multimedia/obs-studio/spec
@@ -1,4 +1,4 @@
-VER=32.1.2
+VER=32.2.1
 # __OBS_CEF_VER: Find the build version on https://cef-builds.spotifycdn.com/index.html#linux64
 # Check https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Linux#obs-browser
 # for upstream required CEF version for reference.


### PR DESCRIPTION
Topic Description
-----------------

- obs-studio: update to 32.2.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- obs-studio: 32.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit obs-studio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
