### PR TITLE
vim: update to 9.2.0854

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0838
+VER=9.2.0854
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.0854.toml
+++ b/topics/vim-9.2.0854.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.0854"
+
+[caution]
+default = "Fixes 9 vulnerabilities (including 8 of Moderate severity)"
+zh_CN = "修复 9 个安全漏洞（含 8 个中危漏洞）"
+
+[packages-v2]
+"vim" = "< 9.2.0854"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.0854
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.0854
- vim: 9.2.0854

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
