### PR TITLE
topics: add severity for ntfs-3g-2026.7.7.toml

### DIFF
--- a/topics/ntfs-3g-2026.7.7.toml
+++ b/topics/ntfs-3g-2026.7.7.toml
@@ -5,8 +5,8 @@ must_match_all = false
 default = "NTFS-3G 2026.7.7"
 
 [caution]
-default = "Fixes 9 security vulnerabilities (severity details pending)"
-zh_CN = "修复 9 个安全漏洞（漏洞严重性细节待定）"
+default = "Fixes 9 security vulnerabilities (including 7 of high severity and 2 of moderate severity)"
+zh_CN = "修复 9 个安全漏洞（含 7 个高危漏洞, 2 个中危漏洞）"
 
 [packages-v2]
 "ntfs-3g" = "< 1:2026.7.7"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add severity for ntfs-3g-2026.7.7.toml
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
