### PR TITLE
MariaDB, PostgreSQL: disable data CoW for new data directories

### DIFF
--- a/app-database/mariadb/autobuild/overrides/usr/lib/tmpfiles.d/mysql.conf
+++ b/app-database/mariadb/autobuild/overrides/usr/lib/tmpfiles.d/mysql.conf
@@ -1,3 +1,4 @@
 # See tmpfiles.d(5) for details
 d /var/lib/mysql 0700 mysql mysql -
+h /var/lib/mysql - - - - +C
 d /run/mysqld 0755 mysql mysql -

--- a/app-database/mariadb/spec
+++ b/app-database/mariadb/spec
@@ -1,4 +1,5 @@
 VER=13.0.1
+REL=1
 SRCS="git::commit=tags/mariadb-$VER;copy-repo=true::https://github.com/MariaDB/server"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1887"

--- a/app-database/postgresql-14/02-server/postgresqld.tmpfiles.in
+++ b/app-database/postgresql-14/02-server/postgresqld.tmpfiles.in
@@ -1,1 +1,2 @@
 d /var/lib/postgres 0775 postgres postgres -
+h /var/lib/postgres - - - - +C

--- a/app-database/postgresql-14/spec
+++ b/app-database/postgresql-14/spec
@@ -2,4 +2,4 @@ VER=14.23
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::cc7216822b546330e29c2f91e123c8734a4c41795082145bb962aa712e8c94a5"
 CHKUPDATE="anitya::id=236443"
-REL=1
+REL=2

--- a/app-database/postgresql-15/02-server/postgresqld.tmpfiles.in
+++ b/app-database/postgresql-15/02-server/postgresqld.tmpfiles.in
@@ -1,1 +1,2 @@
 d /var/lib/postgres 0775 postgres postgres -
+h /var/lib/postgres - - - - +C

--- a/app-database/postgresql-15/spec
+++ b/app-database/postgresql-15/spec
@@ -2,4 +2,4 @@ VER=15.18
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::11df0df97fe3ea4ba9a791faaf39cee1d2fe571e78885b5b55d8517d27c323b4"
 CHKUPDATE="anitya::id=301832"
-REL=1
+REL=2

--- a/app-database/postgresql-16/02-server/postgresqld.tmpfiles.in
+++ b/app-database/postgresql-16/02-server/postgresqld.tmpfiles.in
@@ -1,1 +1,2 @@
 d /var/lib/postgres 0775 postgres postgres -
+h /var/lib/postgres - - - - +C

--- a/app-database/postgresql-16/spec
+++ b/app-database/postgresql-16/spec
@@ -2,4 +2,4 @@ VER=16.14
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::f6d077142737920858ce958ccdb75c6ee137a63b5b0853c70693d401ac7e3471"
 CHKUPDATE="anitya::id=375691"
-REL=1
+REL=2

--- a/app-database/postgresql-17/02-server/postgresqld.tmpfiles.in
+++ b/app-database/postgresql-17/02-server/postgresqld.tmpfiles.in
@@ -1,1 +1,2 @@
 d /var/lib/postgres 0775 postgres postgres -
+h /var/lib/postgres - - - - +C

--- a/app-database/postgresql-17/spec
+++ b/app-database/postgresql-17/spec
@@ -2,4 +2,4 @@ VER=17.10
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::078a03516dcdbdb705fecaf415ea3d13a956c589e46f09fed68a06fb00598c90"
 CHKUPDATE="anitya::id=375014"
-REL=1
+REL=2

--- a/app-database/postgresql-18/02-server/postgresqld.tmpfiles.in
+++ b/app-database/postgresql-18/02-server/postgresqld.tmpfiles.in
@@ -1,1 +1,2 @@
 d /var/lib/postgres 0775 postgres postgres -
+h /var/lib/postgres - - - - +C

--- a/app-database/postgresql-18/spec
+++ b/app-database/postgresql-18/spec
@@ -2,4 +2,4 @@ VER=18.4
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
 CHKSUMS="sha256::81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094"
 CHKUPDATE="anitya::id=383697"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- postgresql-18: disable CoW for data directory
- postgresql-17: disable CoW for data directory
- postgresql-16: disable CoW for data directory
- postgresql-15: disable CoW for data directory
- postgresql-14: disable CoW for data directory
- mariadb: disable CoW for data directory

Package(s) Affected
-------------------

- mariadb: 13.0.1-1
- postgresql-14: 14.23-2
- postgresql-15: 15.18-2
- postgresql-16: 16.14-2
- postgresql-17: 17.10-2
- postgresql-18: 18.4-2
- postgresql-runtime-14: 14.23-2
- postgresql-runtime-15: 15.18-2
- postgresql-runtime-16: 16.14-2
- postgresql-runtime-17: 17.10-2
- postgresql-runtime-18: 18.4-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mariadb postgresql-14 postgresql-15 postgresql-16 postgresql-17 postgresql-18
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
