### PR TITLE
libgpiod: update to 2.3.1

### DIFF
--- a/app-devel/avrdude/spec
+++ b/app-devel/avrdude/spec
@@ -1,5 +1,5 @@
 VER=6.3
-REL=2
+REL=3
 SRCS="tbl::https://download.savannah.gnu.org/releases/avrdude/avrdude-$VER.tar.gz"
 CHKSUMS="sha256::0f9f731b6394ca7795b88359689a7fa1fba818c6e1d962513eb28da670e0a196"
 CHKUPDATE="anitya::id=10751"

--- a/app-devel/openocd/autobuild/defines
+++ b/app-devel/openocd/autobuild/defines
@@ -1,25 +1,32 @@
 PKGNAME=openocd
 PKGSEC=devel
-PKGDEP="capstone hidapi libftdi libgpiod libjaylink libusb"
-PKGDES="An open-source JTAG On-Chip Debugging tool"
+PKGDEP="capstone hidapi libftdi libjaylink libusb"
+PKGDES="Open-source JTAG On-Chip Debugging tool"
 
+ABTYPE=autotools
 ABSHADOW=0
 AUTOTOOLS_STRICT=0
-AUTOTOOLS_AFTER="--enable-static \
-                 --disable-shared \
-                 --enable-remote-bitbang \
-                 --disable-werror \
-                 --enable-sysfsgpio \
-                 --enable-buspirate"
-AUTOTOOLS_AFTER__ARM64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-bcm2835gpio"
-AUTOTOOLS_AFTER__ARMV4=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-bcm2835gpio"
-AUTOTOOLS_AFTER__ARMV6HF=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-bcm2835gpio"
-AUTOTOOLS_AFTER__ARMV7HF=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-bcm2835gpio"
+AUTOTOOLS_AFTER=(
+    '--enable-static'
+    '--disable-shared'
+    '--enable-remote-bitbang'
+    '--disable-werror'
+    '--enable-sysfsgpio'
+    '--enable-buspirate'
+)
+AUTOTOOLS_AFTER__ARM64=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--enable-bcm2835gpio'
+)
+AUTOTOOLS_AFTER__ARMV4=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--enable-bcm2835gpio'
+)
+AUTOTOOLS_AFTER__ARMV6HF=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--enable-bcm2835gpio'
+)
+AUTOTOOLS_AFTER__ARMV7HF=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--enable-bcm2835gpio'
+)

--- a/app-devel/openocd/autobuild/prepare
+++ b/app-devel/openocd/autobuild/prepare
@@ -1,1 +1,0 @@
-acbs_copy_git

--- a/app-devel/openocd/spec
+++ b/app-devel/openocd/spec
@@ -1,5 +1,5 @@
 VER=0.12.0
 REL=1
-SRCS="git::commit=v${VER}::http://repo.or.cz/openocd.git"
+SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/openocd-org/openocd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2557"

--- a/app-electronics/openfpgaloader/autobuild/defines
+++ b/app-electronics/openfpgaloader/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=openfpgaloader
 PKGDES="Open-source FPGA programmer that supports multiple FPGAs and cables"
 PKGSEC=electronics
 PKGDEP="libftdi libusb hidapi libgpiod systemd"
+
+ABTYPE=cmakeninja

--- a/app-electronics/openfpgaloader/spec
+++ b/app-electronics/openfpgaloader/spec
@@ -1,4 +1,4 @@
-VER=0.12.1
+VER=1.1.1
 SRCS="git::commit=tags/v${VER}::https://github.com/trabucayre/openFPGALoader"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=trabucayre/openFPGALoader"

--- a/runtime-devices/libgpiod/autobuild/defines
+++ b/runtime-devices/libgpiod/autobuild/defines
@@ -4,4 +4,8 @@ PKGDEP="glibc"
 BUILDDEP="autoconf-archive"
 PKGDES="C library and tools for interacting with the linux GPIO character device"
 
-AUTOTOOLS_AFTER="--enable-tools"
+ABTYPE=meson
+MESON_AFTER=(
+    '-Dtests=disabled'
+)
+PKGBREAK="avrdude<=6.3-2 openfpgaloader<=0.12.1 openocd<=0.12.0-1"

--- a/runtime-devices/libgpiod/spec
+++ b/runtime-devices/libgpiod/spec
@@ -1,4 +1,4 @@
-VER=1.4.2
-SRCS="tbl::https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git/snapshot/libgpiod-$VER.tar.gz"
-CHKSUMS="sha256::e0ccad3c0cddf5660e07e9cc324a5c18e8d8caa362c23ad40ef11adf6c6c1064"
+VER=2.3.1
+SRCS="git::commit=tags/v$VER::https://git.kernel.org/pub/scm/libs/libgpiod/libgpiod.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20640"


### PR DESCRIPTION
Topic Description
-----------------

- openocd: rebuild for libgpiod
    Signed-off-by: stydxm <stydxm@outlook.com>
- openfpgaloader: update to 1.1.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- avrdude: rebuild for libgpiod
    Signed-off-by: stydxm <stydxm@outlook.com>
- libgpiod: update to 2.3.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit libgpiod avrdude openfpgaloader openocd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
