### PR TITLE
uv: update to 0.11.32

### DIFF
--- a/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
+++ b/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
@@ -1,7 +1,7 @@
-From 64cf284f0b8fb83475cebdb1c040b38e690fcedb Mon Sep 17 00:00:00 2001
+From 44e57f409848e84ac049a55e28804dd300011330 Mon Sep 17 00:00:00 2001
 From: Rong Bao <rong.bao@csmantle.top>
 Date: Sat, 28 Feb 2026 13:11:54 +0800
-Subject: [PATCH] AOSCOS: Relax ELF parsing mode
+Subject: [PATCH 1/2] AOSCOS: Relax ELF parsing mode
 
 uv finds the libc version on the current platform by looking at the
 name of dynamic linker (ld). It finds ld by parsing several well-known
@@ -23,7 +23,7 @@ Signed-off-by: Rong Bao <rong.bao@csmantle.top>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/crates/uv-platform/src/libc.rs b/crates/uv-platform/src/libc.rs
-index 3a4e13343..0e49b4995 100644
+index 12881fd49..16e644f91 100644
 --- a/crates/uv-platform/src/libc.rs
 +++ b/crates/uv-platform/src/libc.rs
 @@ -6,6 +6,7 @@
@@ -31,10 +31,10 @@ index 3a4e13343..0e49b4995 100644
  use fs_err as fs;
  use goblin::elf::Elf;
 +use goblin::options::ParseOptions as ElfParseOptions;
- use regex::Regex;
+ use regex::regex;
  use std::fmt::Display;
  use std::io;
-@@ -432,7 +433,7 @@ fn find_ld_path_at(path: impl AsRef<Path>) -> Option<PathBuf> {
+@@ -437,7 +438,7 @@ fn find_ld_path_at(path: impl AsRef<Path>) -> Option<PathBuf> {
      let path = path.as_ref();
      // Not all linux distributions have all of these paths.
      let buffer = fs::read(path).ok()?;
@@ -44,5 +44,5 @@ index 3a4e13343..0e49b4995 100644
          Err(err) => {
              trace!(
 -- 
-2.52.0
+2.55.0
 

--- a/lang-python/uv/autobuild/patches/0002-AOSCOS-Override-python-build-standalone-source-for-l.patch.loongarch64
+++ b/lang-python/uv/autobuild/patches/0002-AOSCOS-Override-python-build-standalone-source-for-l.patch.loongarch64
@@ -1,15 +1,27 @@
+From 4c408a064dd8a6782cd540bfb53d568d72e166e4 Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Sun, 26 Jul 2026 19:03:57 +0800
+Subject: [PATCH 2/2] AOSCOS: Override python-build-standalone source for
+ loongarch64
+
 Source: https://github.com/loong64/uv/blob/9f40378309f8d2c9191e4a96684d83a873e4d692/patch_loong64.patch#L12-L24
+---
+ crates/uv-python/fetch-download-metadata.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/crates/uv-python/fetch-download-metadata.py b/crates/uv-python/fetch-download-metadata.py
-index 13ddfb9..ebfbdea 100755
+index 00c88d655..b405e023d 100755
 --- a/crates/uv-python/fetch-download-metadata.py
 +++ b/crates/uv-python/fetch-download-metadata.py
-@@ -191,7 +191,7 @@ class Finder:
+@@ -194,7 +194,7 @@ class Finder:
  class CPythonFinder(Finder):
      implementation = ImplementationName.CPYTHON
  
 -    NDJSON_URL = "https://releases.astral.sh/github/versions/main/v1/python-build-standalone.ndjson"
 +    NDJSON_URL = "https://github.com/loong64/versions/raw/refs/heads/main/v1/python-build-standalone.ndjson"
  
-     FLAVOR_PREFERENCES = [
+     FLAVOR_PREFERENCES: ClassVar[list[str]] = [
          "install_only_stripped",
+-- 
+2.55.0
+

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.11.30
+VER=0.11.32
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.11.32
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.11.32

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
