### PR TITLE
fastfetch: remove xfconf from BUILDDEP for Afterglow

### DIFF
--- a/app-utils/fastfetch/autobuild/defines
+++ b/app-utils/fastfetch/autobuild/defines
@@ -6,5 +6,5 @@ BUILDDEP="libnma libpurple ddcutil gcc make xfconf imagemagick libclc libcl \
           opencl-registry-api opencl-clang vulkan-headers dbus zlib pkgconf \
           chafa"
 
-BUILDDEP__RETRO="ddcutil xfconf imagemagick vulkan-headers dbus zlib pkgconf"
+BUILDDEP__RETRO="ddcutil imagemagick vulkan-headers dbus zlib pkgconf"
 ABTYPE=cmakeninja

--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,5 +1,5 @@
 VER=2.66.0
-REL=1
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: remove xfconf from BUILDDEP for Afterglow

Package(s) Affected
-------------------

- xfconf: 4.20.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xfconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
