### PR TITLE
libfprint: update to 1.94.100

### DIFF
--- a/runtime-devices/libfprint/autobuild/defines
+++ b/runtime-devices/libfprint/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=libfprint
 PKGSEC=libs
 PKGDEP="libgusb nss gdk-pixbuf"
-BUILDDEP="gobject-introspection gtk-doc"
+BUILDDEP="gobject-introspection"
 PKGDES="Library for fingerprint readers"
 
 PKGBREAK="fingerprint-gui<=1.09+git20181110 fprintd<=0.8.1-1"
@@ -13,6 +13,6 @@ MESON_AFTER=(
     '-Dudev_rules=enabled'
     '-Dudev_hwdb=enabled'
     '-Dgtk-examples=false'
-    '-Ddoc=true'
+    '-Ddoc=false'
     '-Dinstalled-tests=false'
 )

--- a/runtime-devices/libfprint/spec
+++ b/runtime-devices/libfprint/spec
@@ -1,4 +1,4 @@
-VER=1.94.10
+VER=1.94.100
 SRCS="https://gitlab.freedesktop.org/libfprint/libfprint/-/archive/v$VER/libfprint-v$VER.tar.gz"
-CHKSUMS="sha256::8d5b202e836f69076c90ead0a654b0ee275788922359ebc9d7706bb5cde7ca54"
+CHKSUMS="sha256::edc90e02f330a7595ceaf37f2c6ec32ed43541347fe936d3273b0bb2524fd19c"
 CHKUPDATE="anitya::id=1615"


### PR DESCRIPTION
Topic Description
-----------------

- libfprint: update to 1.94.100
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libfprint: 1.94.100

Security Update?
----------------

No

Build Order
-----------

```
#buildit libfprint
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
