### PR TITLE
iosevka-fonts: update to 34.8.0

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,5 +1,4 @@
-VER=34.7.0
-REL=1
+VER=34.8.0
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -25,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::aaab707b399828783341c7668ffca5e6e6bbe99ff418efed0bd1ee38ed5d143a \
-         sha256::c4cb3c20cce151e805813a595175242b9f67562f98cd7d68e298af9e26830a25 \
-         sha256::d1736e247d4db21e6c988c034e61fb15ba62be32696a42a11a73d774d970b709 \
-         sha256::afe3262e90e754f3947be785667783d6f89875a739c02145b538c4507c05f78d \
-         sha256::5ccd6ec85544dde53721fd500f2db02a25d02309f815b77a4e46d19c485cf0ad \
-         sha256::b27df29cd04f1800f135bb1ae8d0e45c08dbd6548d28c403b945e4747c9fe2f9 \
-         sha256::700c66b12d78c6b70bc21bc7235781e2f3371613924d9fc5cdf99ee225934dcd \
-         sha256::5e52c9589775dff8d43c78c8f217ec7e809115c70912c2574ea5709e00a722f5 \
-         sha256::6464d4abecf782ba3f8d0ae9d81956136cd85db27afbcbd08b5f80cb018834b8 \
-         sha256::d3917bec91a157186ab06779cd2afde496c00af7aa382dda2e4204b9cc22e582 \
-         sha256::94a8298abba875f35b29efac23730395d0b84c29596c1566fc00837eee8eb227 \
-         sha256::96321951ae324e1697c26848623a787a235061546adc0c7bc69392f78411a55b \
-         sha256::fcf552ff7a533c486ddc773bb062691990c38c1d8d0ea698c674242840aedb3b \
-         sha256::51f56abdaf3b42df977328e1dc4cd8f9e2e1eac4735925ebcdd4def02912f186 \
-         sha256::533c09a121d8da5e83e618c3ab6fd56fc36149a74a804ff629f347ef6ca09fd3 \
-         sha256::3755d4d563f6e91e2686375a6cbc69adc394b701a008a0092cb24d273404ff17 \
-         sha256::1389c32abfa62e26d9cbca51f3be6a124d670e3194d08127d95154dbd2873b4d \
-         sha256::2c9cfdbade7d2fee86c6c918ceb5a98408f88032c4ee1483ee80fe9bfef6d56f \
-         sha256::e43d87fea0339b9196b872edb7650ff36c1e49dfdb5490423c2e25f57271d06c \
-         sha256::d24d80a82455ab94295b06bb59f8571b0b4fba70b56881e5a194c77c9f9208ee \
-         sha256::121823088abb76b103e5f3320302eaf35813bf65e362813e7a7f7b540fd8ad55 \
-         sha256::680c9c3a690cc184779f0ce5f2127b9c3db94d425923f81196493b5d616868e0 \
-         sha256::d72bb739abe40cdd5e3dd4d521124502bf0b0b460dc745203a1f1e7cd6f754fd \
-         sha256::bc532fc003b07a986f65993f86190c618238fd2b84811ed4e2c07eb2738d044e \
+CHKSUMS="sha256::fd64d3e261225a53029775c755451bce89a20030afa19711f547677c0845025c \
+         sha256::5993bc2675eda5062e962a7d336b6637ec25b1cbf61de287e6f08025b41ba9ad \
+         sha256::ac18dc2c3acc45420d27e32b4c78b1afa8c61ffaefefbbc90f8e4c8b5ed5a7b1 \
+         sha256::7fb1d48f6f0e6ca483d914d9dc25a492aff00b428badac923703ac19d4be5628 \
+         sha256::b4c7040112b239a1f8365461232cff67f5c2c4823c48e2526d04edce8f2161cd \
+         sha256::dbb695e1c0b684eb376af60bbc73e78390e0d900ffe00305052165b819648e6e \
+         sha256::43a58b72608c9f97f1d8d6f5a32395e9f9fb8b6c560695a2f9660994bc4a9470 \
+         sha256::419f0f5dc6909564459588d510a2c8a316c9999b775d704d3b0043fafc1969db \
+         sha256::c484b269e04b49efd6863feeeb3a0ba5809864789eb0d5a79efb363161dcce6b \
+         sha256::18cad13ea2d8a6c49c1a3a0c638be8ff0e7fca42c6692af538e89847e23ebd91 \
+         sha256::2b9550c5376e1e5b9314653a1662747fe21bfd82b390a64354e15bcc6bac6e04 \
+         sha256::e151267a86c4966fc695c518769e674fbcf3f1c89bf096c9979db05dd6d0a0a3 \
+         sha256::050234ff3f87959b9a1ec15e76922701d24756b9e526dfe56add35930019cd13 \
+         sha256::7a8094e6f005e76fef141f993febc2b130c11b47d8cc36dddb403d0ea00cc635 \
+         sha256::14a7ca5adcb0648890ed5e3a0cb07355f296a6e654d6f542f22db8edaf97ca54 \
+         sha256::04f06395721d8606278fd80121ffa0ed1ea89cd5dd82abc6aa2ebde3e11f95ce \
+         sha256::83b82346d4424f5446c66685640fad099934a6cfb18e948a2feaa5cc5023a350 \
+         sha256::a2821272de39bcfd90d9b8875e10107282dd54f2f9587198ec8f8479b8745951 \
+         sha256::37b74ec4207c6bbdb3e94a6fbd64cf7af99a21f108f8eac0a7344122bcfdc00a \
+         sha256::5e3d523d808acc48426fb1b63b43825b57fadcc7bdde532c8985e0fe7bc70be8 \
+         sha256::e6e9fa6ce10ab8b3d042315c55830bbce6903026c45cd8180c3f4543e0ebe697 \
+         sha256::7ae62d54ca412e1f4fff09461c3227426affae84d87f689068de168d9e9d4046 \
+         sha256::c4104880d96b38cbc65441673e1fd4033efb8bf0844f6343fca212d13e4cadde \
+         sha256::9b9881ecd895775a56f0c236043cecf8c63e0ae82a559a6dd1db2c7bcdc5c551 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.8.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
