### PR TITLE
libvpl: update to 2.17.0

### DIFF
--- a/runtime-multimedia/libvpl/spec
+++ b/runtime-multimedia/libvpl/spec
@@ -1,4 +1,4 @@
-VER=2.16.0
+VER=2.17.0
 SRCS="git::commit=tags/v$VER::https://github.com/intel/libvpl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242664"


### PR DESCRIPTION
Topic Description
-----------------

- libvpl: update to 2.17.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libvpl: 2.17.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libvpl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
