### PR TITLE
oxideterm: new, 2.0.28

### DIFF
--- a/app-utils/oxideterm/autobuild/defines
+++ b/app-utils/oxideterm/autobuild/defines
@@ -1,0 +1,12 @@
+PKGNAME=oxideterm
+PKGDES="All-in-one terminal workspace"
+PKGSEC=devel
+PKGDEP="alsa-lib gstreamer libxkbcommon"
+BUILDDEP="rustc llvm"
+
+ABTYPE=rust
+
+# FIXME: lto fail with rustc>=1.90
+# mold: error: undefined symbol: aws_lc_0_29_0_AES_set_decrypt_key
+# = note: ld.lld: error: undefined symbol: aws_lc_0_29_0_EVP_parse_private_key
+NOLTO=1

--- a/app-utils/oxideterm/spec
+++ b/app-utils/oxideterm/spec
@@ -1,0 +1,6 @@
+VER=2.0.12
+SRCS="git::commit=v$VER::https://github.com/AnalyseDeCircuit/oxideterm"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391393"
+
+ENVREQ="total_mem_per_core=3"

--- a/app-utils/oxideterm/spec
+++ b/app-utils/oxideterm/spec
@@ -1,0 +1,6 @@
+VER=2.0.28
+SRCS="git::commit=v$VER::https://github.com/AnalyseDeCircuit/oxideterm"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391393"
+
+ENVREQ="total_mem_per_core=3"


### PR DESCRIPTION
Topic Description
-----------------

- oxideterm: new, 2.0.12
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- oxideterm: 2.0.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit oxideterm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
