### PR TITLE
openless: new, 1.3.18

### DIFF
--- a/app-productivity/openless/01-openless-fcitx5-plugin/build
+++ b/app-productivity/openless/01-openless-fcitx5-plugin/build
@@ -1,0 +1,7 @@
+abinfo "Building OpenLess fcitx5 plugin  ..."
+export SRCDIR="$SRCDIR"/openless-all/scripts/linux-fcitx5-plugin
+export CMAKE_AFTER=""
+build_cmakeninja_configure
+build_cmakeninja_build
+build_cmakeninja_install
+export SRCDIR="$SRCDIR"/../../..

--- a/app-productivity/openless/01-openless-fcitx5-plugin/defines
+++ b/app-productivity/openless/01-openless-fcitx5-plugin/defines
@@ -1,0 +1,7 @@
+PKGNAME=openless-fcitx5-plugin
+PKGSEC=doc
+PKGDEP="fcitx5"
+PKGDES="Open-source voice input method with AI-polished text (fcitx5 plugin)"
+
+ABTYPE=cmakeninja
+NOLTO=1

--- a/app-productivity/openless/01-openless-fcitx5-plugin/defines
+++ b/app-productivity/openless/01-openless-fcitx5-plugin/defines
@@ -3,5 +3,5 @@ PKGSEC=doc
 PKGDEP="fcitx5"
 PKGDES="Open-source voice input method with AI-polished text (fcitx5 plugin)"
 
-ABTYPE=cmakeninja
+ABTYPE=self
 NOLTO=1

--- a/app-productivity/openless/02-openless/build
+++ b/app-productivity/openless/02-openless/build
@@ -1,0 +1,16 @@
+cd "$SRCDIR"/../../app
+
+abinfo "Fetching dependencies and assets ..."
+npm i
+
+abinfo "Building OpenLess ..."
+npm run build
+npm run tauri build -- --no-bundle
+
+abinfo "Installing OpenLess ..."
+install -Dvm755 "$SRCDIR"/../../app/src-tauri/target/release/openless \
+    "$PKGDIR"/usr/bin/openless
+
+abinfo "Installing icon ..."
+install -Dvm644 "$SRCDIR"/../../app/src-tauri/icons/icon.png \
+    "$PKGDIR"/usr/share/pixmaps/openless.png

--- a/app-productivity/openless/02-openless/build
+++ b/app-productivity/openless/02-openless/build
@@ -1,16 +1,25 @@
-cd "$SRCDIR"/../../app
+cd "$SRCDIR"/openless-all/app
 
 abinfo "Fetching dependencies and assets ..."
 npm i
+if ab_match_arch loongarch64; then
+    npm install -D lightningcss@npm:lightningcss-wasm@latest
+    rm -r ./node_modules/@tailwindcss/node/node_modules/lightningcss/
+    cp -r ./node_modules/lightningcss/ ./node_modules/@tailwindcss/node/node_modules/
+
+    npm install -D @tailwindcss/oxide@npm:@esm.sh/oxide-wasm@latest
+    rm -r ./node_modules/@tailwindcss/vite/node_modules/@tailwindcss/oxide
+    cp -r ./node_modules/@tailwindcss/oxide/ ./node_modules/@tailwindcss/vite/node_modules/@tailwindcss/
+fi
 
 abinfo "Building OpenLess ..."
 npm run build
 npm run tauri build -- --no-bundle
 
 abinfo "Installing OpenLess ..."
-install -Dvm755 "$SRCDIR"/../../app/src-tauri/target/release/openless \
+install -Dvm755 "$SRCDIR"/openless-all/app/src-tauri/target/release/openless \
     "$PKGDIR"/usr/bin/openless
 
 abinfo "Installing icon ..."
-install -Dvm644 "$SRCDIR"/../../app/src-tauri/icons/icon.png \
+install -Dvm644 "$SRCDIR"/openless-all/app/src-tauri/icons/icon.png \
     "$PKGDIR"/usr/share/pixmaps/openless.png

--- a/app-productivity/openless/02-openless/defines
+++ b/app-productivity/openless/02-openless/defines
@@ -1,0 +1,12 @@
+PKGNAME=openless
+PKGSEC=doc
+PKGDEP="libsoup-3 webkit2gtk xdotool openless-fcitx5-plugin"
+BUILDDEP="nodejs rustc llvm tauri-cli"
+PKGDES="Open-source voice input method with AI-polished text"
+
+ABTYPE=self
+
+# FIXME: lto fail with rustc>=1.90
+# mold: error: undefined symbol: aws_lc_0_29_0_AES_set_decrypt_key
+# = note: ld.lld: error: undefined symbol: aws_lc_0_29_0_EVP_parse_private_key
+NOLTO=1

--- a/app-productivity/openless/spec
+++ b/app-productivity/openless/spec
@@ -1,0 +1,6 @@
+VER=1.3.14
+SRCS="git::commit=tags/v$VER-tauri::https://github.com/Open-Less/openless"
+CHKSUMS="SKIP"
+SUBDIR=openless/openless-all/scripts/linux-fcitx5-plugin
+CHKUPDATE="anitya::id=390918"
+ENVREQ="total_mem=30"

--- a/app-productivity/openless/spec
+++ b/app-productivity/openless/spec
@@ -1,0 +1,6 @@
+VER=1.3.18
+SRCS="git::commit=tags/v$VER-tauri::https://github.com/Open-Less/openless"
+CHKSUMS="SKIP"
+SUBDIR=openless/openless-all/scripts/linux-fcitx5-plugin
+CHKUPDATE="anitya::id=390918"
+ENVREQ="total_mem=30"

--- a/app-productivity/openless/spec
+++ b/app-productivity/openless/spec
@@ -1,6 +1,5 @@
 VER=1.3.18
 SRCS="git::commit=tags/v$VER-tauri::https://github.com/Open-Less/openless"
 CHKSUMS="SKIP"
-SUBDIR=openless/openless-all/scripts/linux-fcitx5-plugin
 CHKUPDATE="anitya::id=390918"
 ENVREQ="total_mem=30"


### PR DESCRIPTION
Topic Description
-----------------

- openless: new, 1.3.14
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- openless: 1.3.14
- openless-fcitx5-plugin: 1.3.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit openless
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
