### PR TITLE
pandoc: update to 3.10.1

### DIFF
--- a/app-doc/pandoc/spec
+++ b/app-doc/pandoc/spec
@@ -1,4 +1,4 @@
-VER=3.10
+VER=3.10.1
 SRCS="git::commit=tags/$VER::https://github.com/jgm/pandoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2589"


### PR DESCRIPTION
Topic Description
-----------------

- pandoc: update to 3.10.1

Package(s) Affected
-------------------

- pandoc: 3.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pandoc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
