### PR TITLE
libwebp: disable all optional components for stage 2

### DIFF
--- a/runtime-imaging/libwebp/autobuild/defines.stage2
+++ b/runtime-imaging/libwebp/autobuild/defines.stage2
@@ -1,54 +1,23 @@
 PKGNAME=libwebp
 PKGDES="A library and support programs to encode and decode images in WebP format"
-PKGDEP="freeglut giflib libjpeg-turbo libpng libtiff"
+PKGDEP=""
 PKGSEC=libs
 
-# Note: Not specifying the ambiguous --enable-everything option.
-# Note: --disable-wic, WIC = Windows Imaging Component.
-AUTOTOOLS_AFTER="--enable-libwebpmux \
-                 --enable-libwebpdemux \
-                 --enable-libwebpdecoder \
-                 --enable-libwebpextras \
-                 --enable-asserts \
-                 --enable-threading \
-                 --disable-gl \
-                 --disable-sdl \
-                 --enable-png \
-                 --enable-jpeg \
-                 --enable-tiff \
-                 --enable-gif \
-                 --disable-wic \
-                 --disable-swap-16bit-csp \
-                 --enable-near-lossless"
-
-# Note: AMD64 requires SSE2.
-AUTOTOOLS_AFTER__AMD64=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-sse4.1 \
-                 --enable-sse2"
-
-AUTOTOOLS_AFTER__ARMV4=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-neon"
-AUTOTOOLS_AFTER__ARMV6HF=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-neon"
-# Note: --disable-neon-rtcd, NEON is not optional.
-AUTOTOOLS_AFTER__ARMV7HF=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --enable-neon \
-                 --disable-neon-rtcd"
-# Note: i486 targets actual 80486 compatibles.
-AUTOTOOLS_AFTER__I486=" \
-                 ${AUTOTOOLS_AFTER} \
-                 --disable-sse4.1 \
-                 --disable-sse2"
-
-PKGBREAK="amule<=1:2.3.2-1 darktable<=1:2.4.2 efl<=1.20.7 gst-plugins-bad-1-0<=1.12.4 \
-          gthumb<=3.6.1 imagemagick<=6.9.9+46 kde-runtime<=17.08.3 leptonica<=1.75.3 \
-          libgd<=2.2.5 librasterlite2<=1.0.0rc0 netsurf<=3.3-2 pillow<=5.0.0 qt-5<=1:5.10.1+wk5.212.0 \
-          sdl-image<=1.2.12-5 sdl2-image<=2.0.1-1 spatialite-gui<=2.0.0 telegram-purple<=1.3.1 \
-          webkit2gtk<=2.20.2 webkitgtk<=2.4.11-3 opencv<=3.4.1-2"
-
-# Note: Extra Provides for Spiral.
-PKGPROV="libwebp6_spiral"
+# NOTE: Disabling all optional components.
+AUTOTOOLS_AFTER=(
+	"--enable-libwebpmux"
+	"--enable-libwebpdemux"
+	"--enable-libwebpdecoder"
+	"--enable-libwebpextras"
+	"--enable-asserts"
+	"--enable-threading"
+	"--disable-gl"
+	"--disable-sdl"
+	"--disable-png"
+	"--disable-jpeg"
+	"--disable-tiff"
+	"--disable-gif"
+	"--disable-wic"
+	"--disable-swap-16bit-csp"
+	"--enable-near-lossless"
+)


### PR DESCRIPTION
Topic Description
-----------------

This PR removes all optional components from libwebp's stage2 recipe.

Package(s) Affected
-------------------

libwebp

Security Update?
----------------

No

Build Order
-----------

No build should be perfomed since it only affects stage2 recipe.

Test Build(s) Done
------------------

None