### PR TITLE
fwupd: update to 2.1.7

### DIFF
--- a/app-admin/fwupd/spec
+++ b/app-admin/fwupd/spec
@@ -1,4 +1,4 @@
-VER=2.1.6
+VER=2.1.7
 SRCS="tbl::https://github.com/fwupd/fwupd/releases/download/${VER//+/-}/fwupd-${VER%%+*}.tar.xz"
-CHKSUMS="sha256::517a0d9d4b00f3dbd72c36f55085bd5dbdc20e7a2d6cfc341c4be60a903bcd8d"
+CHKSUMS="sha256::472e9426f7a1b18fa9d199666c15482d4ee51ea35e916ca53bb3ca25919edb10"
 CHKUPDATE="anitya::id=5833"


### PR DESCRIPTION
Topic Description
-----------------

- fwupd: update to 2.1.7
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- fwupd: 2.1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit fwupd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
