### PR TITLE
wine: add built-in DXVK and vkd3d-proton

### DIFF
--- a/app-emulation/wine/autobuild/beyond
+++ b/app-emulation/wine/autobuild/beyond
@@ -13,6 +13,32 @@ mkdir -pv "$PKGDIR"/usr/share/wine/mono
 cp -av "$SRCDIR"/../wine-mono-${__MONO_VER} \
     "$PKGDIR"/usr/share/wine/mono/
 
+abinfo "Patching DXVK DLLs as built-in Wine libraries ..."
+for dir in "$SRCDIR"/../dxvk-${__DXVK_VER}/{x32,x64}; do
+    for file in "$dir"/*; do
+        [ -f "$file" ] && printf 'Wine builtin DLL\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' | dd of="$file" bs=1 seek=64 conv=notrunc
+    done
+done
+
+abinfo "Installing DXVK DLLs ..."
+cp -av "$SRCDIR"/../dxvk-${__DXVK_VER}/x64/. \
+    "$PKGDIR"/usr/lib/wine/x86_64-windows/
+cp -av "$SRCDIR"/../dxvk-${__DXVK_VER}/x32/. \
+    "$PKGDIR"/usr/lib/wine/i386-windows/
+
+abinfo "Patching vkd3d-proton DLLs as built-in Wine libraries ..."
+for dir in "$SRCDIR"/../vkd3d-proton-${__VKD3D_PROTON_VER}/{x86,x64}; do
+    for file in "$dir"/*; do 
+        [ -f "$file" ] && printf 'Wine builtin DLL\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' | dd of="$file" bs=1 seek=64 conv=notrunc
+    done
+done
+
+abinfo "Installing vkd3d-proton DLLs ..."
+cp -av "$SRCDIR"/../vkd3d-proton-${__VKD3D_PROTON_VER}/x64/. \
+    "$PKGDIR"/usr/lib/wine/x86_64-windows/
+cp -av "$SRCDIR"/../vkd3d-proton-${__VKD3D_PROTON_VER}/x86/. \
+    "$PKGDIR"/usr/lib/wine/i386-windows/ 
+
 # Routine adapted from Fedora.
 #
 # Ref: https://src.fedoraproject.org/rpms/wine/blob/b6dbe710ac007feb968c471054f0235cc8ca01b7/f/wine.spec#_841

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,16 +1,22 @@
 __GECKO_VER=2.47.4
 __MONO_VER=11.2.0
+__DXVK_VER=3.0.2
+__VKD3D_PROTON_VER=3.0.1
 UPSTREAM_VER=11.14
-VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
+VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}+dxvk${__DXVK_VER}+vkd3dproton${__VKD3D_PROTON_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86_64.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86_64.tar.xz \
-      tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz"
+      tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz \
+      tbl::rename=dxvk-${__DXVK_VER}.tar.gz::https://github.com/doitsujin/dxvk/releases/download/v${__DXVK_VER}/dxvk-${__DXVK_VER}.tar.gz \
+      tbl::rename=vkd3d-proton-${__VKD3D_PROTON_VER}.tar.zst::https://github.com/HansKristian-Work/vkd3d-proton/releases/download/v${__VKD3D_PROTON_VER}/vkd3d-proton-${__VKD3D_PROTON_VER}.tar.zst"
 CHKSUMS="sha256::06b3bd872ae0d4d454b9a0c00772727701720de184d36c68597088038113edc4 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::c9fb2e2823acf30b000b8806177db0f40751786136dd3f8fb2be7897b1643d06"
+         sha256::c9fb2e2823acf30b000b8806177db0f40751786136dd3f8fb2be7897b1643d06 \
+         sha256::9c538924110a7cdef871ca36dee218c0774124374ffdeb38af4b76be55bdf7c2 \
+         sha256::3cf2315522af5e43605ef6d3c41dad91387040bf97199934f3f7ab76caaa2f0c"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${UPSTREAM_VER}"


### PR DESCRIPTION
Topic Description
-----------------

- wine: add built-in DXVK and vkd3d-proton

Package(s) Affected
-------------------

- wine: 3:11.14+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
