### PR TITLE
rocm: Libraries MachineLearning update to 7.14

### DIFF
--- a/runtime-rocm/rocm-composable-kernel/autobuild/defines
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/defines
@@ -36,7 +36,6 @@ CMAKE_AFTER=(
     '-DCMAKE_FIND_ROOT_PATH=/usr/lib/rocm/;/usr/lib/rocm/lib/llvm/'
     '-DCMAKE_INSTALL_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
     '-DCMAKE_BUILD_RPATH=/usr/lib/rocm/lib/llvm/lib;/usr/lib/rocm/lib'
-    '-DDPP_KERNELS=ON'
     '-DCK_USE_FP8_ON_UNSUPPORTED_ARCH=OFF'
     '-DBUILD_DEV=OFF'
     '-DROCM_WARN_TOOLCHAIN_VAR=OFF'

--- a/runtime-rocm/rocm-composable-kernel/autobuild/patches/0001-composable-kernel-default-gpu_targets.patch
+++ b/runtime-rocm/rocm-composable-kernel/autobuild/patches/0001-composable-kernel-default-gpu_targets.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c01d2ad..14106e5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -383,10 +383,8 @@ if(NOT ENABLE_ASAN_PACKAGING)
+         set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201")
+     elseif(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER_EQUAL 600400000 AND ${hip_VERSION_FLAT} LESS 600443483)
+         set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1200;gfx1201;gfx950")
+-    elseif(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER_EQUAL 600443483 AND ${hip_VERSION_FLAT} LESS 700200000)
++    elseif(NOT WIN32)
+         set(CK_GPU_TARGETS "gfx908;gfx90a;gfx942;gfx950;gfx10-3-generic;gfx11-generic;gfx12-generic")
+-    elseif(NOT WIN32 AND ${hip_VERSION_FLAT} GREATER_EQUAL 700200000)
+-        set(CK_GPU_TARGETS "")
+     endif()
+ else()
+     #build CK only for xnack-supported targets when using ASAN

--- a/runtime-rocm/rocm-composable-kernel/spec
+++ b/runtime-rocm/rocm-composable-kernel/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 ENVREQ="total_mem=100"
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"

--- a/runtime-rocm/rocm-miopen/autobuild/patches/0001-replace-ciso646-version.patch
+++ b/runtime-rocm/rocm-miopen/autobuild/patches/0001-replace-ciso646-version.patch
@@ -1,0 +1,13 @@
+diff --git a/src/include/miopen/serializable.hpp b/src/include/miopen/serializable.hpp
+index f7563f50be..ccd4ecc24a 100644
+--- a/src/include/miopen/serializable.hpp
++++ b/src/include/miopen/serializable.hpp
+@@ -27,7 +27,7 @@
+ #ifndef GUARD_MLOPEN_SERIALIZABLE_HPP
+ #define GUARD_MLOPEN_SERIALIZABLE_HPP
+ 
+-#include <ciso646>
++#include <version>
+ #include <miopen/config.h>
+ #include <iostream>
+ #include <sstream>

--- a/runtime-rocm/rocm-miopen/spec
+++ b/runtime-rocm/rocm-miopen/spec
@@ -1,4 +1,4 @@
-VER=7.13
+VER=7.14
 ENVREQ="total_mem=100"
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries;copy-repo=true::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-miopen: update to 7.14
- rocm-composable-kernel: update to 7.14

Package(s) Affected
-------------------

- rocm-composable-kernel: 7.14
- rocm-miopen: 7.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-composable-kernel rocm-miopen
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] LoongArch 64-bit `loongarch64`
