### PR TITLE
elfutils: update to 0.195

### DIFF
--- a/app-utils/elfutils/autobuild/defines
+++ b/app-utils/elfutils/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=utils
 PKGDEP="bzip2 curl libarchive libmicrohttpd xz zlib zstd"
 PKGDES="Libraries and utilities to handle ELF object files and DWARF debugging information"
 
+ABTYPE=autotools
 # Note:  --disable-thread-safety, this option causes poor and inconsistent
 #        performance when running Pahole across multiple cores. This feature
 #        is also marked as EXPERIMENTAL.
@@ -18,45 +19,35 @@ PKGDES="Libraries and utilities to handle ELF object files and DWARF debugging i
 #
 #     relocation R_X86_64_32 against `predict_data' can not be used when making
 #     a PIE object
-AUTOTOOLS_AFTER="--program-prefix=eu- \
-                 --enable-deterministic-archives \
-                 --disable-thread-safety \
-                 --enable-largefile \
-                 --disable-debugpred \
-                 --disable-gprof \
-                 --disable-gcov \
-                 --disable-sanitize-undefined \
-                 --disable-sanitize-address \
-                 --disable-valgrind \
-                 --disable-valgrind-annotations \
-                 --disable-install-elfh \
-                 --disable-textrelcheck \
-                 --enable-symbol-versioning \
-                 --enable-nls \
-                 --disable-rpath \
-                 --enable-libdebuginfod \
-                 --enable-debuginfod \
-                 --without-valgrind \
-                 --with-zlib \
-                 --with-bzlib \
-                 --with-lzma \
-                 --with-zstd \
-                 --without-biarch"
-
-ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--program-prefix=eu-'
+    '--enable-deterministic-archives'
+    '--disable-thread-safety'
+    '--enable-largefile'
+    '--disable-debugpred'
+    '--disable-gprof'
+    '--disable-gcov'
+    '--disable-sanitize-undefined'
+    '--disable-sanitize-address'
+    '--disable-valgrind'
+    '--disable-valgrind-annotations'
+    '--disable-install-elfh'
+    '--disable-textrelcheck'
+    '--enable-symbol-versioning'
+    '--enable-nls'
+    '--disable-rpath'
+    '--enable-libdebuginfod'
+    '--enable-debuginfod'
+    '--without-valgrind'
+    '--with-zlib'
+    '--with-bzlib'
+    '--with-lzma'
+    '--with-zstd'
+    '--without-biarch'
+)
 
 NOSTATIC=0
 NOSTATIC__RETRO=1
-NOSTATIC__ARMV4="$NOSTATIC__RETRO"
-NOSTATIC__ARMV6HF="$NOSTATIC__RETRO"
-NOSTATIC__ARMV7HF="$NOSTATIC__RETRO"
-NOSTATIC__I486="$NOSTATIC__RETRO"
-NOSTATIC__LOONGSON2F="$NOSTATIC__RETRO"
-NOSTATIC__M68K="$NOSTATIC__RETRO"
-NOSTATIC__POWERPC="$NOSTATIC__RETRO"
-NOSTATIC__PPC64="$NOSTATIC__RETRO"
-
-NOLTO=1
 
 PKGCONFL="libelf"
 PKGBREAK="libelf libdwarf<=20180706"

--- a/app-utils/elfutils/autobuild/defines.stage2
+++ b/app-utils/elfutils/autobuild/defines.stage2
@@ -3,6 +3,7 @@ PKGSEC=utils
 PKGDEP="bzip2 curl xz zlib zstd"
 PKGDES="Libraries and utilities to handle ELF object files and DWARF debugging information"
 
+ABTYPE=autotools
 # Note:  --disable-thread-safety, this option causes poor and inconsistent
 #        performance when running Pahole across multiple cores. This feature
 #        is also marked as EXPERIMENTAL.
@@ -18,45 +19,35 @@ PKGDES="Libraries and utilities to handle ELF object files and DWARF debugging i
 #
 #     relocation R_X86_64_32 against `predict_data' can not be used when making
 #     a PIE object
-AUTOTOOLS_AFTER="--program-prefix=eu- \
-                 --enable-deterministic-archives \
-                 --disable-thread-safety \
-                 --enable-largefile \
-                 --disable-debugpred \
-                 --disable-gprof \
-                 --disable-gcov \
-                 --disable-sanitize-undefined \
-                 --disable-sanitize-address \
-                 --disable-valgrind \
-                 --disable-valgrind-annotations \
-                 --disable-install-elfh \
-                 --disable-textrelcheck \
-                 --enable-symbol-versioning \
-                 --enable-nls \
-                 --disable-rpath \
-                 --disable-libdebuginfod \
-                 --disable-debuginfod \
-                 --without-valgrind \
-                 --with-zlib \
-                 --with-bzlib \
-                 --with-lzma \
-                 --with-zstd \
-                 --without-biarch"
-
-ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    '--program-prefix=eu-'
+    '--enable-deterministic-archives'
+    '--disable-thread-safety'
+    '--enable-largefile'
+    '--disable-debugpred'
+    '--disable-gprof'
+    '--disable-gcov'
+    '--disable-sanitize-undefined'
+    '--disable-sanitize-address'
+    '--disable-valgrind'
+    '--disable-valgrind-annotations'
+    '--disable-install-elfh'
+    '--disable-textrelcheck'
+    '--enable-symbol-versioning'
+    '--enable-nls'
+    '--disable-rpath'
+    '--disable-libdebuginfod'
+    '--disable-debuginfod'
+    '--without-valgrind'
+    '--with-zlib'
+    '--with-bzlib'
+    '--with-lzma'
+    '--with-zstd'
+    '--without-biarch'
+)
 
 NOSTATIC=0
 NOSTATIC__RETRO=1
-NOSTATIC__ARMV4="$NOSTATIC__RETRO"
-NOSTATIC__ARMV6HF="$NOSTATIC__RETRO"
-NOSTATIC__ARMV7HF="$NOSTATIC__RETRO"
-NOSTATIC__I486="$NOSTATIC__RETRO"
-NOSTATIC__LOONGSON2F="$NOSTATIC__RETRO"
-NOSTATIC__M68K="$NOSTATIC__RETRO"
-NOSTATIC__POWERPC="$NOSTATIC__RETRO"
-NOSTATIC__PPC64="$NOSTATIC__RETRO"
-
-NOLTO=1
 
 PKGCONFL="libelf"
 PKGBREAK="libelf libdwarf<=20180706"

--- a/app-utils/elfutils/spec
+++ b/app-utils/elfutils/spec
@@ -1,6 +1,4 @@
-VER=0.191
-REL=2
+VER=0.195
 SRCS="tbl::https://sourceware.org/elfutils/ftp/$VER/elfutils-$VER.tar.bz2"
-# checksum: https://sourceware.org/elfutils/ftp/$VER/sha512.sum
-CHKSUMS="sha256::df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871"
+CHKSUMS="sha256::37629fdf7f1f3dc2818e138fca2b8094177d6c2d0f701d3bb650a561218dc026"
 CHKUPDATE="anitya::id=5679"

--- a/runtime-optenv32/elfutils+32/autobuild/defines
+++ b/runtime-optenv32/elfutils+32/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=elfutils+32
 PKGSEC=utils
-PKGDEP="aosc-aaa+32 bzip2+32 zlib+32"
+PKGDEP="aosc-aaa+32 bzip2+32 zlib+32 libarchive+32"
 BUILDDEP="devel-base+32"
 PKGDES="Libraries and utilities to handle ELF object files and DWARF debugging information (32-bit x86 runtime)"
 
 ABHOST=optenv32
 
+ABTYPE=autotools
 # Note: Minimise dependency.
 AUTOTOOLS_AFTER=(
     '--disable-debuginfod'

--- a/runtime-optenv32/elfutils+32/spec
+++ b/runtime-optenv32/elfutils+32/spec
@@ -1,4 +1,4 @@
-VER=0.191
+VER=0.195
 SRCS="tbl::https://sourceware.org/elfutils/ftp/$VER/elfutils-$VER.tar.bz2"
-CHKSUMS="sha256::df76db71366d1d708365fc7a6c60ca48398f14367eb2b8954efc8897147ad871"
+CHKSUMS="sha256::37629fdf7f1f3dc2818e138fca2b8094177d6c2d0f701d3bb650a561218dc026"
 CHKUPDATE="anitya::id=5679"

--- a/runtime-optenv32/libarchive+32/autobuild/defines
+++ b/runtime-optenv32/libarchive+32/autobuild/defines
@@ -1,0 +1,35 @@
+PKGNAME=libarchive+32
+PKGDES="Library and utility to work with multiple compression formats (32-bit x86 runtime)"
+PKGDEP="acl+32 attr+32 bzip2+32 expat+32 lzo+32 openssl+32 xz+32 zlib+32 zstd+32"
+BUILDDEP="gcc+32"
+PKGSEC=libs
+
+# Note: Mutually exclusive feature sets.
+#     (1) mbedtls, nettle, or openssl for cryptography support.
+#     (2) [lib]xml2 or expat for xar support.
+AUTOTOOLS_AFTER=(
+    '--enable-bsdtar=shared'
+    '--enable-bsdcat=shared'
+    '--enable-bsdcpio=shared'
+    '--disable-rpath'
+    '--enable-posix-regex-lib=libc'
+    '--enable-xattr'
+    '--enable-acl'
+    '--enable-largefile'
+    '--with-zlib'
+    '--with-bz2lib'
+    '--with-iconv'
+    '--with-zstd'
+    '--with-lzma'
+    '--with-lzo2'
+    '--with-cng'
+    '--without-mbedtls'
+    '--without-nettle'
+    '--with-openssl'
+    '--without-xml2'
+    '--with-expat'
+)
+
+AB_FLAGS_O3=1
+
+ABHOST=optenv32

--- a/runtime-optenv32/libarchive+32/spec
+++ b/runtime-optenv32/libarchive+32/spec
@@ -1,0 +1,4 @@
+VER=3.8.5
+SRCS="tbl::https://www.libarchive.org/downloads/libarchive-$VER.tar.gz"
+CHKSUMS="sha256::8a60f3a7bfd59c54ce82ae805a93dba65defd04148c3333b7eaa2102f03b7ffd"
+CHKUPDATE="anitya::id=1558"


### PR DESCRIPTION
Topic Description
-----------------

- elfutils+32: update to 0.195
    Signed-off-by: stydxm <stydxm@outlook.com>
- libarchive+32: new, 3.8.5
    Signed-off-by: stydxm <stydxm@outlook.com>
- elfutils: update to 0.195
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- elfutils: 0.195

Security Update?
----------------

No

Build Order
-----------

```
#buildit elfutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
