### PR TITLE
[ci] scilab: new, 2026.1.0

### DIFF
--- a/app-scientific/scilab/autobuild/beyond
+++ b/app-scientific/scilab/autobuild/beyond
@@ -1,0 +1,7 @@
+find "$PKGDIR/usr/share/scilab" -type d -name .deps -prune -exec rm -rv {} +
+
+rm -v \
+    "$PKGDIR"/usr/share/applications/scilab-adv-cli.desktop \
+    "$PKGDIR"/usr/share/applications/scilab.desktop \
+    "$PKGDIR"/usr/share/applications/scinotes.desktop \
+    "$PKGDIR"/usr/share/applications/xcos.desktop

--- a/app-scientific/scilab/autobuild/defines
+++ b/app-scientific/scilab/autobuild/defines
@@ -1,0 +1,23 @@
+PKGNAME=scilab
+PKGSEC=math
+PKGDEP="apache-arrow arpack-ng curl fftw hdf5 libarchive libxml2 libxslt \
+        matio ncurses openblas pcre2 suitesparse tcl tk xlnt"
+BUILDDEP="eigen rapidjson"
+PKGDES="A high-level language for numerical computation (CLI)"
+
+ABTYPE=autotools
+ABSHADOW=0
+AUTOTOOLS_AFTER=(
+    --disable-build-help
+    --disable-static-system-lib
+    --enable-build-localization
+    --with-fftw
+    --with-matio
+    --with-tcl-library=/usr/lib
+    --with-tk-library=/usr/lib
+    --with-umfpack
+    --without-gui
+    --without-javasci
+    --without-modelica
+    --without-xcos
+)

--- a/app-scientific/scilab/autobuild/patches/0001-AOSCOS-build-with-CXX20.patch
+++ b/app-scientific/scilab/autobuild/patches/0001-AOSCOS-build-with-CXX20.patch
@@ -1,0 +1,31 @@
+From 39daf472f954d8a0568912064adc9494d29ca2ed Mon Sep 17 00:00:00 2001
+From: guanzi008 <20619190+guanzi008@users.noreply.github.com>
+Date: Tue, 28 Jul 2026 15:55:00 +0800
+Subject: [PATCH] AOSCOS: build with C++20
+
+Apache Arrow 23 exposes std::span in its public Parquet headers. Scilab's
+spreadsheet module includes those headers, so C++17 is no longer sufficient.
+---
+ configure.ac | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 7ae57b2..6828cbb 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -809,10 +809,10 @@ fi
+ 
+ AM_CONDITIONAL(IS_64_BITS_CPU, test $IS_64_BITS_CPU = true)
+ 
+-# check if the compiler supports c++17
++# check if the compiler supports c++20
+ saved_cppflags="$CXXFLAGS"
+ CXXFLAGS=""
+-AX_CXX_COMPILE_STDCXX(17, noext, mandatory)
++AX_CXX_COMPILE_STDCXX(20, noext, mandatory)
+ STDCXX_CXXFLAGS="$CXXFLAGS"
+ CXXFLAGS="$saved_cppflags"
+ 
+-- 
+2.55.0
+

--- a/app-scientific/scilab/autobuild/patches/0002-BACKPORT-fix-CXX20-string-conversions.patch
+++ b/app-scientific/scilab/autobuild/patches/0002-BACKPORT-fix-CXX20-string-conversions.patch
@@ -1,0 +1,39 @@
+From 23613542bc4ad90a419c876a89fdcae001d6c2c6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Cl=C3=A9ment=20DAVID?= <clement.david@3ds.com>
+Date: Fri, 5 Jun 2026 15:10:32 +0000
+Subject: [PATCH] C++20: fix implicit u8string to string conversion
+
+This modification fixes the implicit conversion from u8string to string. Calling `std::path::string()` makes it system-dependent but typesafe.
+
+The `test-types.cpp` file also contains an invalid wchar_t* to std::cout conversion.
+
+See https://gitlab.com/scilab/scilab/-/merge_requests/1770
+
+diff --git a/modules/ast/src/cpp/types/test-types.cpp b/modules/ast/src/cpp/types/test-types.cpp
+index 7b0f36f1f..40b67c8fc 100644
+--- a/modules/ast/src/cpp/types/test-types.cpp
++++ b/modules/ast/src/cpp/types/test-types.cpp
+@@ -43,7 +43,7 @@ int main(void)
+     ** types::String
+     */
+     types::String s42(L"42");
+-    std::cout << "s42 = " << s42.get(0, 0) << std::endl;
++    std::wcout << L"s42 = " << s42.get(0, 0) << std::endl;
+     assert(wcscmp(s42.get(0, 0), L"42") == 0);
+     assert(s42.isInt() == false);
+     assert(s42.isDouble() == false);
+diff --git a/modules/core/src/cpp/inlinehelp.cpp b/modules/core/src/cpp/inlinehelp.cpp
+index d2b10528e..41da5f0df 100644
+--- a/modules/core/src/cpp/inlinehelp.cpp
++++ b/modules/core/src/cpp/inlinehelp.cpp
+@@ -657,7 +657,7 @@ int generate_inline_links(const std::wstring& lang, const std::wstring& path)
+                     }
+                     else
+                     {
+-                        storedPath = replaceToolboxRoot(normalizedXmlPath, toolboxBase.u8string());
++                        storedPath = replaceToolboxRoot(normalizedXmlPath, toolboxBase.string());
+                     }
+                     links[id] = storedPath;
+                 }
+-- 
+2.51.0

--- a/app-scientific/scilab/autobuild/patches/0003-FIXED-initialize-symbol-table-on-first-use.patch
+++ b/app-scientific/scilab/autobuild/patches/0003-FIXED-initialize-symbol-table-on-first-use.patch
@@ -1,0 +1,74 @@
+From 6638b379e9653f7e227bcf92a41b87fef005a2be Mon Sep 17 00:00:00 2001
+From: guanzi008 <20619190+guanzi008@users.noreply.github.com>
+Date: Tue, 28 Jul 2026 19:10:00 +0800
+Subject: [PATCH] FIXED: initialize symbol table on first use
+
+The default ExecVisitor is initialized globally and constructs a Symbol.
+With LTO, its initializer may run before the global Symbol string set has
+been constructed, causing a crash in std::_Rb_tree_decrement at startup.
+
+Use a function-local static for the set so it is initialized before the
+first Symbol inserts into it.
+---
+ modules/ast/includes/symbol/symbol.hxx     |  2 +-
+ modules/ast/src/cpp/symbol/symbol.cpp      | 12 ++++++++----
+ 2 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/modules/ast/includes/symbol/symbol.hxx b/modules/ast/includes/symbol/symbol.hxx
+index c61b92173..328291f83 100644
+--- a/modules/ast/includes/symbol/symbol.hxx
++++ b/modules/ast/includes/symbol/symbol.hxx
+@@ -96,7 +96,7 @@ public:
+ 
+ private:
+     /** \brief Static (global to all instance of Symbol) strings container. */
+-    static string_set_type _set;
++    static string_set_type& getSet();
+     /** \brief Pointer to the node containing the unique referenced wstring. */
+     const string_set_type::const_iterator _set_node;
+ };
+diff --git a/modules/ast/src/cpp/symbol/symbol.cpp b/modules/ast/src/cpp/symbol/symbol.cpp
+index 29b6daf3e..95ea01c33 100644
+--- a/modules/ast/src/cpp/symbol/symbol.cpp
++++ b/modules/ast/src/cpp/symbol/symbol.cpp
+@@ -18,13 +18,17 @@
+ 
+ #include "symbol.hxx"
+ 
+-symbol::Symbol::string_set_type symbol::Symbol::_set;
+-
+ namespace symbol
+ {
++Symbol::string_set_type& Symbol::getSet()
++{
++    static string_set_type set;
++    return set;
++}
++
+ // Constructor
+ Symbol::Symbol (const std::wstring &s):
+-    _set_node (_set.insert(s).first)
++    _set_node (getSet().insert(s).first)
+ {
+ }
+ 
+@@ -37,7 +40,7 @@ const std::wstring& Symbol::getName () const
+ // Return the size of the Symbol map.
+ Symbol::size_type Symbol::getSize()
+ {
+-    return _set.size();
++    return getSet().size();
+ }
+ 
+ // Operators for better performances.
+@@ -68,7 +71,7 @@ wchar_t **Symbol::getAll()
+     wchar_t **resultVector = new wchar_t*[getSize()];
+     int i = 0;
+ 
+-    for (it = _set.begin() ; it != _set.end() ; ++it, ++i)
++    for (it = getSet().begin() ; it != getSet().end() ; ++it, ++i)
+     {
+         resultVector[i] = const_cast<wchar_t*>(it->c_str());
+     }
+-- 
+2.51.0

--- a/app-scientific/scilab/spec
+++ b/app-scientific/scilab/spec
@@ -1,0 +1,6 @@
+VER=2026.1.0
+SRCS="git::commit=tags/$VER::https://gitlab.com/scilab/scilab.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=6367"
+
+SUBDIR="scilab/scilab"

--- a/runtime-scientific/xlnt/autobuild/beyond
+++ b/runtime-scientific/xlnt/autobuild/beyond
@@ -1,0 +1,1 @@
+rm -v "$PKGDIR"/usr/include/xlnt/xlnt_config.hpp.orig

--- a/runtime-scientific/xlnt/autobuild/defines
+++ b/runtime-scientific/xlnt/autobuild/defines
@@ -1,0 +1,11 @@
+PKGNAME=xlnt
+PKGSEC=libs
+PKGDEP="gcc-runtime glibc"
+PKGDES="C++ library for reading and writing XLSX files"
+
+ABTYPE=cmakeninja
+CMAKE_AFTER=(
+    -DTESTS=OFF
+    -DSAMPLES=OFF
+    -DBENCHMARKS=OFF
+)

--- a/runtime-scientific/xlnt/autobuild/patches/0001-FIXED-include-cstdint-in-public-configuration.patch
+++ b/runtime-scientific/xlnt/autobuild/patches/0001-FIXED-include-cstdint-in-public-configuration.patch
@@ -1,0 +1,28 @@
+From 6ddbde4f126724ec2a19d562e416cd956112309b Mon Sep 17 00:00:00 2001
+From: guanzi008 <20619190+guanzi008@users.noreply.github.com>
+Date: Tue, 28 Jul 2026 13:20:00 +0800
+Subject: [PATCH] FIXED: include cstdint in public configuration
+
+GCC 15 no longer exposes fixed-width integer types through unrelated
+standard headers. Include their defining header in the public configuration
+used by the affected xlnt headers.
+---
+ include/xlnt/xlnt_config.hpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/xlnt/xlnt_config.hpp b/include/xlnt/xlnt_config.hpp
+index 09de8d7..04720ad 100644
+--- a/include/xlnt/xlnt_config.hpp
++++ b/include/xlnt/xlnt_config.hpp
+@@ -22,6 +22,8 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
++
+ #ifndef XLNT_API
+ #if !defined(XLNT_STATIC) && defined(_MSC_VER)
+ #ifdef XLNT_EXPORT
+-- 
+2.55.0
+

--- a/runtime-scientific/xlnt/autobuild/patches/0002-BACKPORT-include-limits-in-number-formatter.patch
+++ b/runtime-scientific/xlnt/autobuild/patches/0002-BACKPORT-include-limits-in-number-formatter.patch
@@ -1,0 +1,28 @@
+From 4da810eaef28b393a718f7587232c3ca7a6df079 Mon Sep 17 00:00:00 2001
+From: Darrell Wright <beached@users.noreply.github.com>
+Date: Fri, 18 Mar 2022 18:46:27 -0400
+Subject: [PATCH] BACKPORT: include limits in number formatter
+
+Limits is not guaranteed to be transitively included and its absence causes
+an error with current GCC.
+
+(cherry picked from commit 4da810eaef28b393a718f7587232c3ca7a6df079)
+---
+ source/detail/number_format/number_formatter.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/source/detail/number_format/number_formatter.cpp b/source/detail/number_format/number_formatter.cpp
+index 82341d3..21834cf 100644
+--- a/source/detail/number_format/number_formatter.cpp
++++ b/source/detail/number_format/number_formatter.cpp
+@@ -24,6 +24,7 @@
+ #include <algorithm>
+ #include <cctype>
+ #include <cmath>
++#include <limits>
+ 
+ #include <xlnt/utils/exceptions.hpp>
+ #include <detail/default_case.hpp>
+-- 
+2.55.0
+

--- a/runtime-scientific/xlnt/autobuild/patches/0003-FIXED-generate-absolute-pkg-config-paths.patch
+++ b/runtime-scientific/xlnt/autobuild/patches/0003-FIXED-generate-absolute-pkg-config-paths.patch
@@ -1,0 +1,31 @@
+From 32cb711402a8539542035213149647cc6537f4ba Mon Sep 17 00:00:00 2001
+From: guanzi008 <20619190+guanzi008@users.noreply.github.com>
+Date: Tue, 28 Jul 2026 17:02:00 +0800
+Subject: [PATCH] FIXED: generate absolute pkg-config paths
+
+The GNUInstallDirs variables used here are relative by default. Prefix them
+with the pkg-config prefix variables so consumers do not receive -Llib and
+-Iinclude.
+---
+ source/CMakeLists.txt | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/source/CMakeLists.txt b/source/CMakeLists.txt
+index 0dd77b7..9d8a105 100644
+--- a/source/CMakeLists.txt
++++ b/source/CMakeLists.txt
+@@ -295,8 +295,9 @@ endif()
+ 
+ if(NOT MSVC)
+   # Set pkg-config variables
+-  set(PKG_CONFIG_LIBDIR ${XLNT_LIB_DEST_DIR})
+-  set(PKG_CONFIG_INCLUDEDIR ${XLNT_INC_DEST_DIR})
++  set(PKG_CONFIG_EXEC_PREFIX "\${prefix}")
++  set(PKG_CONFIG_LIBDIR "\${exec_prefix}/${XLNT_LIB_DEST_DIR}")
++  set(PKG_CONFIG_INCLUDEDIR "\${prefix}/${XLNT_INC_DEST_DIR}")
+   set(PKG_CONFIG_LIBS "-L\${libdir} -lxlnt")
+   set(PKG_CONFIG_CFLAGS "-I\${includedir}")
+ 
+-- 
+2.51.0
+

--- a/runtime-scientific/xlnt/spec
+++ b/runtime-scientific/xlnt/spec
@@ -1,0 +1,4 @@
+VER=1.5.0
+SRCS="git::commit=tags/v$VER::https://github.com/tfussell/xlnt.git"
+CHKSUMS="SKIP"
+CHKUPDATE="github::repo=tfussell/xlnt"


### PR DESCRIPTION
Topic Description
-----------------

Introduce Scilab 2026.1.0 as a command-line numerical computing environment.

The Java GUI, Xcos, JavaSci, Modelica, and Java help are disabled because their Java and JCEF dependencies are not currently packaged in AOSC OS. Numerical computing, FFTW, HDF5, MATIO, UMFPACK, spreadsheet, Arrow/Parquet, and Tcl/Tk support remain enabled where applicable.

`xlnt` is added for Scilab XLSX support.

Package(s) Affected
-------------------

- `xlnt` 1.5.0 (new)
- `scilab` 2026.1.0 (new)

Security Update?
----------------

No

Build Order
-----------

```
#buildit xlnt scilab
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`

Built both packages from scratch in clean containers based on AOSC OS 13.3.1 on July 28, 2026. The resulting packages were installed through APT in a separate container.

Post-install tests covered Scilab startup and version reporting, matrix operations, FFT, HDF5 save/load, MATIO save/load, XLSX read/write, and Arrow/Parquet read/write. All packaged Scilab ELF files were also checked with `ldd`; no unresolved shared libraries were found.