### PR TITLE
Afterglow fixes 20260726

### DIFF
--- a/app-admin/apt/autobuild/defines
+++ b/app-admin/apt/autobuild/defines
@@ -13,7 +13,7 @@ PKGEPOCH_SPIRAL=2
 PKGDEP="aosc-os-keyring gnupg dpkg glibc zlib bzip2 lz4 \
         systemd gnutls zstd xxhash db libseccomp xz libgcrypt"
 PKGDEP__RETRO="dpkg glibc zlib bzip2 gnutls lz4 systemd zstd \
-               libunistring xxhash libgcrypt"
+               libunistring xxhash libgcrypt aosc-os-keyring"
 
 BUILDDEP="docbook-xsl po4a triehash"
 

--- a/app-admin/apt/spec
+++ b/app-admin/apt/spec
@@ -1,4 +1,5 @@
 VER=3.2.0
+REL=1
 SRCS="git::commit=tags/$VER::https://salsa.debian.org/apt-team/apt.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7208"

--- a/app-network/net-snmp/autobuild/patches/0001-DEBIAN-makefile-trap-needs-agent.patch
+++ b/app-network/net-snmp/autobuild/patches/0001-DEBIAN-makefile-trap-needs-agent.patch
@@ -1,0 +1,17 @@
+Description: Add libnetsnmpaget link to libnetsnmptrapd
+ Causes a linking issue otherwise 
+Author: Craig Small <csmall@debian.org>
+Reviewed-by: Craig Small <csmall@debian.org>
+Last-Update: 2023-08-19
+---
+--- a/apps/Makefile.in
++++ b/apps/Makefile.in
+@@ -237,7 +237,7 @@
+ 	$(LINK) ${CFLAGS} -o $@ snmppcap.$(OSUFFIX) ${LDFLAGS} ${USEAGENTLIBS} ${LIBS} -lpcap
+ 
+ libnetsnmptrapd.$(LIB_EXTENSION)$(LIB_VERSION): $(LLIBTRAPD_OBJS)
+-	$(LIB_LD_CMD) $@ ${LLIBTRAPD_OBJS} $(MIBLIB) $(MYSQL_LIBS) $(USELIBS) $(PERLLDOPTS_FOR_LIBS) $(LDFLAGS)
++	$(LIB_LD_CMD) $@ ${LLIBTRAPD_OBJS} $(MIBLIB) $(MYSQL_LIBS) $(USELIBS) $(USEAGENTLIBS) $(PERLLDOPTS_FOR_LIBS) $(LDFLAGS)
+ 	$(RANLIB) $@
+ 
+ snmpinforminstall:

--- a/app-network/net-snmp/spec
+++ b/app-network/net-snmp/spec
@@ -2,4 +2,4 @@ VER=5.9.5.2
 SRCS="git::commit=tags/v$VER::https://github.com/net-snmp/net-snmp"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2062"
-REL=1
+REL=2

--- a/app-network/networkmanager/autobuild/defines
+++ b/app-network/networkmanager/autobuild/defines
@@ -96,7 +96,7 @@ MESON_AFTER__RETRO=(
     '-Dfirewalld_zone=false'
     '-Dlibpsl=false'
     '-Dcrypto=gnutls'
-    '-Debpf=false'
+    '-Dclat=false'
 )
 
 PKGESS=1

--- a/app-network/networkmanager/spec
+++ b/app-network/networkmanager/spec
@@ -1,4 +1,5 @@
 VER=1.58.0
+REL=1
 SRCS="tbl::https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/releases/$VER/downloads/NetworkManager-$VER.tar.xz"
 CHKSUMS="sha256::0c6f2703a2c9b017cd68fbfe1d2e8a1a5d7ff05137c751ec421cba36e94546ba"
 CHKUPDATE="anitya::id=21197"


### PR DESCRIPTION
Topic Description
-----------------

- networkmanager: disable CLAT for Afterglow
- net-snmp: \(Debian patch\) Fix linkage of libnetsnmptrapd
- apt: add aosc-os-keyring as PKGDEP for Afterglow
    It went unnoticed for I really don't know how long.

Package(s) Affected
-------------------

- apt: 2:3.2.0-1
- net-snmp: 5.9.5.2-2
- networkmanager: 1.58.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit apt net-snmp networkmanager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
