### PR TITLE
passim: update to 0.1.12

### DIFF
--- a/app-network/passim/autobuild/beyond
+++ b/app-network/passim/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "Removing HELLO.md ..."
+rm -v "$PKGDIR"/var/lib/passim/data/*

--- a/app-network/passim/autobuild/defines
+++ b/app-network/passim/autobuild/defines
@@ -4,3 +4,7 @@ PKGDEP="gcc-runtime glib glibc libsoup-3"
 PKGDES="Local caching service"
 
 ABTYPE=meson
+MESON_AFTER=(
+    '-Dintrospection=enabled'
+    '-Dinstalled_tests=false'
+)

--- a/app-network/passim/spec
+++ b/app-network/passim/spec
@@ -1,4 +1,4 @@
-VER=0.1.11
+VER=0.1.12
 SRCS="tbl::https://github.com/hughsie/passim/releases/download/$VER/passim-$VER.tar.xz"
-CHKSUMS="sha256::2ada050658dca16aba7dd7772617227f13a388107966d87637a7760250acd32b"
+CHKSUMS="sha256::400de22e7425930e50d4ae21005b39baf4a511b382378293aa255d20faf215c2"
 CHKUPDATE="anitya::id=377308"


### PR DESCRIPTION
Topic Description
-----------------

- passim: update to 0.1.12
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- passim: 0.1.12

Security Update?
----------------

No

Build Order
-----------

```
#buildit passim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
