### PR TITLE
fscrypt: new, 0.3.6

### DIFF
--- a/app-admin/fscrypt/autobuild/build
+++ b/app-admin/fscrypt/autobuild/build
@@ -1,0 +1,7 @@
+abinfo "Building fscrypt ..."
+make
+
+abinfo "Installing fscrypt ..."
+# NOTE: Leave PAM_CONFIG_DIR blank as it is a Ubuntu-specific configuration path
+# Link: https://wiki.ubuntu.com/PAMConfigFrameworkSpec
+make install PREFIX="$PKGDIR"/usr PAM_CONFIG_DIR=

--- a/app-admin/fscrypt/autobuild/defines
+++ b/app-admin/fscrypt/autobuild/defines
@@ -1,0 +1,14 @@
+PKGNAME=fscrypt
+PKGSEC=admin
+PKGDES="Tool to manage Linux filesystem-level encryption (fscrypt)"
+PKGDEP="linux-pam"
+BUILDDEP="go"
+
+ABTYPE=self
+
+# FIXME: FTBFS on loongson3:
+# -buildmode=c-shared not supported on linux/mips64le
+# Link: https://github.com/golang/go/issues/43264
+#
+# NOTE: Go compiler is only available on the following architectures
+FAIL_ARCH="!(amd64|armv6hf|armv7hf|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"

--- a/app-admin/fscrypt/spec
+++ b/app-admin/fscrypt/spec
@@ -1,0 +1,4 @@
+VER=0.3.6
+SRCS="git::commit=tags/v$VER::https://github.com/google/fscrypt.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=194605"


### PR DESCRIPTION
Topic Description
-----------------

- fscrypt: new, 0.3.6
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- fscrypt: 0.3.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit fscrypt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
