### PR TITLE
libreoffice: update to 26.8.0.1

### DIFF
--- a/app-productivity/libreoffice/autobuild/patches/1002-ArchRISCV-firebird-riscv64-support.patch.firebird-deferred.riscv64
+++ b/app-productivity/libreoffice/autobuild/patches/1002-ArchRISCV-firebird-riscv64-support.patch.firebird-deferred.riscv64
@@ -61,7 +61,7 @@ diff --git a/workdir/UnpackedTarball/firebird/configure.ac b/workdir/UnpackedTar
 index 9412b10..ed50d32 100644
 --- a/workdir/UnpackedTarball/firebird/configure.ac
 +++ b/workdir/UnpackedTarball/firebird/configure.ac
-@@ -251,6 +251,18 @@ dnl CPU_TYPE=ppc64
+@@ -251,6 +251,18 @@ STD_ICU=true
      libdir=/usr/lib64
      ;;
  
@@ -77,7 +77,7 @@ index 9412b10..ed50d32 100644
 +    libdir=/usr/lib64
 +    ;;
 +
-   powerpc64le-*-linux*)                           
+   powerpc64le-*-linux*)
      MAKEFILE_PREFIX=linux_powerpc64el
      INSTALL_PREFIX=linux
 diff --git a/workdir/UnpackedTarball/firebird/src/common/classes/DbImplementation.cpp b/workdir/UnpackedTarball/firebird/src/common/classes/DbImplementation.cpp
@@ -143,8 +143,8 @@ index 58abaaf..365b97e 100644
 --- a/workdir/UnpackedTarball/firebird/src/common/common.h
 +++ b/workdir/UnpackedTarball/firebird/src/common/common.h
 @@ -135,6 +135,10 @@
- #define FB_CPU CpuArm64
- #endif /* ARM64 */
+ #define FB_CPU CpuArm
+ #endif /* ARM */
  
 +#ifdef RISCV64
 +#define FB_CPU CpuRiscV64

--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,4 +1,4 @@
-VER=26.2.5.1
+VER=26.8.0.1
 SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://github.com/LibreOffice/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: update to 26.8.0.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libreoffice: 26.8.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
