### PR TITLE
deb-installer: update to 0.3.5

### DIFF
--- a/app-admin/deb-installer/spec
+++ b/app-admin/deb-installer/spec
@@ -1,4 +1,4 @@
-VER=0.3.4
+VER=0.3.5
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/deb-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375467"

--- a/topics/deb-installer-0.3.5.toml
+++ b/topics/deb-installer-0.3.5.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Package Installation Wizard (deb-installer) 0.3.5"
+zh_CN = "软件包安装向导 (deb-installer) 0.3.5"
+
+[caution]
+default = "Fixes a Missing Authorization vulnerability (Severity: High)"
+zh_CN = "修复 1 个越权 (Missing Authorization) 漏洞（严重性：高）"
+
+[packages-v2]
+"deb-installer" = "< 0.3.5"


### PR DESCRIPTION
Topic Description
-----------------

- deb-installer: update to 0.3.5
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- deb-installer: 0.3.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit deb-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
