### PR TITLE
wine-emukit: add built-in DXVK and vkd3d-proton

### DIFF
--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -2,9 +2,11 @@
 EPOCH=3
 __GECKO_VER=2.47.4
 __MONO_VER=11.2.0
+__DXVK_VER=3.0.2
+__VKD3D_PROTON_VER=3.0.1
 UPSTREAM_VER=11.14
-VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}
+VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}+dxvk${__DXVK_VER}+vkd3dproton${__VKD3D_PROTON_VER}
 SRCS="file::rename=wine.deb::https://repo.aosc.io/anthon/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::bc195b19395e5d2dc7b2d9273249c018123a911442299bf472c28bc8ef2dd4a9"
+CHKSUMS="sha256::744877466cd49ea01dff524c20041cd83f7dfe58a889f7ad34fcb1a1a18d7ba2"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- wine-emukit: add built-in DXVK and vkd3d-proton

Package(s) Affected
-------------------

- wine: 11.14+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine-emukit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
