### PR TITLE
ab-download-manager: update to 1.10.1

### DIFF
--- a/app-web/ab-download-manager/autobuild/build
+++ b/app-web/ab-download-manager/autobuild/build
@@ -1,7 +1,9 @@
 abinfo "Building ab-download-manager..."
+export SKIP_ANDROID_BUILD=true
 echo "org.gradle.java.installations.auto-detect=true" >> "$SRCDIR"/gradle.properties
 echo "org.gradle.java.installations.auto-download=false" >> "$SRCDIR"/gradle.properties
-gradle createReleaseDistributable
+chmod +x "$SRCDIR"/gradlew
+"$SRCDIR"/gradlew createReleaseFolderForCi
 
 abinfo "Installing ab-download-manager..."
 install -dvm755 "$PKGDIR/usr/lib/ab-download-manager"

--- a/app-web/ab-download-manager/autobuild/defines
+++ b/app-web/ab-download-manager/autobuild/defines
@@ -2,7 +2,6 @@ PKGNAME=ab-download-manager
 PKGSEC=web
 PKGDES="A multifunctional file downloader"
 PKGDEP="gcc-runtime glibc libappindicator openjdk"
-BUILDDEP="gradle"
 
 PKGPROV=abdownloadmanager
 

--- a/app-web/ab-download-manager/spec
+++ b/app-web/ab-download-manager/spec
@@ -1,4 +1,4 @@
-VER=1.9.2
+VER=1.10.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/amir1376/ab-download-manager"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376269"


### PR DESCRIPTION
Topic Description
-----------------

- ab-download-manager: update to 1.10.1
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- ab-download-manager: 1.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ab-download-manager
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
