### PR TITLE
vscode: fix arm64 sha256 (FTBFS) 

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -2,7 +2,7 @@ VER=1.131.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
 CHKSUMS__AMD64="sha256::fe2ed2d94ccc694f49d9084846c0be78ba56c42810355fa3999160079bb53c9a"
-CHKSUMS__ARM64="sha256::43db51d7d37565e887b5a3947f32a2369c841389842686028f4fdb406d077c8e"
+CHKSUMS__ARM64="sha256::b57f73e4a8a4524bf2a796757f64bd7b594515dd8dabae9b8cd07b1beb204d9c"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------
vscode: fix arm64 sha256 (FTBFS) 

Package(s) Affected
-------------------

vscode

Security Update?
----------------
No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------
- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

