### PR TITLE
samba: security update to 4.24.5

### DIFF
--- a/app-network/samba/spec
+++ b/app-network/samba/spec
@@ -1,5 +1,4 @@
-VER=4.24.3
-REL=1
+VER=4.24.5
 SRCS="tbl::https://download.samba.org/pub/samba/stable/samba-$VER.tar.gz"
-CHKSUMS="sha256::4a5e0ed1ea192b798c873d9957c50a5767c10c2767cccb00d56ecc427e94f8e9"
+CHKSUMS="sha256::6d5d7ee82f5ce9da4135086c9b184e47a58b4b023565f58abbb1f8c8a922306b"
 CHKUPDATE="anitya::id=4758"

--- a/topics/samba-4.24.5.toml
+++ b/topics/samba-4.24.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Samba 4.24.5"
+
+[caution]
+default = "Fixes 6 security vulnerabilities (including 4 of high severity and 2 of medium severity)"
+zh_CN = "修复 6 个安全漏洞（含 4 个高危漏洞和 2 个中危漏洞）"
+
+[packages-v2]
+"samba" = "< 4.24.5"


### PR DESCRIPTION
Topic Description
-----------------

- samba: security update to 4.24.5

Package(s) Affected
-------------------

- ldb: 2:4.24.5
- samba: 4.24.5

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit samba
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
