### PR TITLE
deb-installer: install missing polkit policy

### DIFF
--- a/app-admin/deb-installer/autobuild/beyond
+++ b/app-admin/deb-installer/autobuild/beyond
@@ -15,3 +15,7 @@ abinfo "Installing localisation data ..."
 mkdir -pv "$PKGDIR"/usr/share/locale/
 cp -av "$SRCDIR"/mo/* \
     "$PKGDIR"/usr/share/locale/
+
+abinfo "Installing polkit policy ..."
+install -Dvm644 "$SRCDIR"/data/io.aosc.deb_installer.policy \
+    "$PKGDIR"/usr/share/polkit-1/actions/io.aosc.deb_installer.policy

--- a/app-admin/deb-installer/spec
+++ b/app-admin/deb-installer/spec
@@ -1,4 +1,5 @@
 VER=0.3.5
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/deb-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375467"


### PR DESCRIPTION
Topic Description
-----------------

- deb-installer: install missing polkit policy

Package(s) Affected
-------------------

- deb-installer: 0.3.5-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deb-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
