### PR TITLE
clash-verge-rev: update to 2.5.2-2

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -1,16 +1,19 @@
 PKGNAME=clash-verge-rev
 PKGSEC=net
+# FIXME: Add libjxl to fix the issue with linking to libjxl.so.0.11
+#        although this rarely occurs.
 PKGDEP="bzip2 cairo gcc-runtime gdk-pixbuf glib \
         glibc gtk-3 libsoup-3 openssl pango webkit2gtk \
         libayatana-appindicator libappindicator \
-        xz mihomo clash-verge-service-ipc mihomo-rules-dat"
+        xz mihomo clash-verge-service-ipc mihomo-rules-dat \
+        libjxl"
 BUILDDEP="nodejs rustc llvm tauri-cli"
 PKGDES="GUI configuration manager for the Clash rule-based proxy"
 PKGPROV="clash-verge"
 PKGEPOCH=1
 
 # FIXME: Vite not supported.
-FAIL_ARCH="@(loongson3|riscv64)"
+FAIL_ARCH="@(loongson3|riscv64|i486)"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_0_17_8_LIMBS_are_zero
 NOLTO=1

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -3,4 +3,4 @@ SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"
 ENVREQ="total_mem=30"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------
clash-verge-rev: rebuild with libjxl 0.12

Package(s) Affected
-------------------

clash-verge-rev: 1:2.5.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`