### PR TITLE
intel-media-driver: update to 26.2.4

### DIFF
--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0001-LOONGARCH64-ARM64-FROMEXT-use-simde-to-support-loong.am.loongarch64
@@ -1,4 +1,4 @@
-From 22ca859d258359d0d38fb5c0e426d1c08b2ecaea Mon Sep 17 00:00:00 2001
+From 61d0184e770664b4f6c1964c4cbf12f674449dd0 Mon Sep 17 00:00:00 2001
 From: shangyatsen <429839446@qq.com>
 Date: Sun, 24 Mar 2024 11:23:27 +0800
 Subject: [PATCH 1/3] LOONGARCH64: ARM64: FROMEXT: use simde to support
@@ -16,9 +16,9 @@ Signed-off-by: Kexy Biscuit <kexybiscuit@aosc.io>
  .../linux/media_compile_flags_linux.cmake     |  3 +-
  .../common/cm/hal/osservice/cm_mem_os.cpp     | 11 ++-----
  .../linux/common/cm/hal/osservice/cm_mem_os.h | 22 +++----------
- media_driver/media_top_cmake.cmake            | 15 ++-------
+ media_driver/media_top_cmake.cmake            | 18 ++---------
  third_party/simde                             |  1 +
- 9 files changed, 24 insertions(+), 78 deletions(-)
+ 9 files changed, 24 insertions(+), 81 deletions(-)
  create mode 100644 .gitmodules
  create mode 160000 third_party/simde
 
@@ -223,7 +223,7 @@ index e911e4e7e..6aab19339 100644
  
  void CmFastMemCopyFromWC( void* dst, const void* src, const size_t bytes, CPU_INSTRUCTION_LEVEL cpuInstructionLevel );
 diff --git a/media_driver/media_top_cmake.cmake b/media_driver/media_top_cmake.cmake
-index 9d1c9b482..88236e4a7 100755
+index 2dcd0fb40..5eb8fbe15 100755
 --- a/media_driver/media_top_cmake.cmake
 +++ b/media_driver/media_top_cmake.cmake
 @@ -46,6 +46,8 @@ if(NOT DEFINED SKIP_GMM_CHECK)
@@ -235,7 +235,7 @@ index 9d1c9b482..88236e4a7 100755
  message("-- media -- PLATFORM = ${PLATFORM}")
  message("-- media -- ARCH = ${ARCH}")
  message("-- media -- CMAKE_CURRENT_LIST_DIR = ${CMAKE_CURRENT_LIST_DIR}")
-@@ -246,8 +248,6 @@ set_source_files_properties(${CP_COMMON_SHARED_SOURCES_} PROPERTIES LANGUAGE "CX
+@@ -253,8 +255,6 @@ set_source_files_properties(${CP_COMMON_SHARED_SOURCES_} PROPERTIES LANGUAGE "CX
  set_source_files_properties(${CP_COMMON_NEXT_SOURCES_} PROPERTIES LANGUAGE "CXX")
  set_source_files_properties(${CP_SOURCES_} PROPERTIES LANGUAGE "CXX")
  set_source_files_properties(${SOFTLET_DDI_SOURCES_} PROPERTIES LANGUAGE "CXX")
@@ -244,21 +244,24 @@ index 9d1c9b482..88236e4a7 100755
  
  # MHW settings
  set(SOFTLET_MHW_PRIVATE_INCLUDE_DIRS_
-@@ -419,13 +419,6 @@ set (VP_PRIVATE_INCLUDE_DIRS_
+@@ -426,16 +426,6 @@ set (VP_PRIVATE_INCLUDE_DIRS_
      ${VP_PRIVATE_INCLUDE_DIRS_}
      ${SOFTLET_VP_PRIVATE_INCLUDE_DIRS_})
  
 -add_library(${LIB_NAME}_SSE2 OBJECT ${SOURCES_SSE2})
--target_compile_options(${LIB_NAME}_SSE2 PRIVATE -msse2)
--target_include_directories(${LIB_NAME}_SSE2 BEFORE PRIVATE ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_} ${MOS_PUBLIC_INCLUDE_DIRS_} ${SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_} ${COMMON_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_MHW_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_})
+-    target_compile_options(${LIB_NAME}_SSE2 PRIVATE -msse2)
+-    target_include_directories(${LIB_NAME}_SSE2 BEFORE PRIVATE ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_} ${MOS_PUBLIC_INCLUDE_DIRS_} ${SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_} ${COMMON_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_MHW_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_})
+-    target_link_libraries(${LIB_NAME}_SSE2 ${MEDIA_GMM_INTERFACE_LIBS})
 -
 -add_library(${LIB_NAME}_SSE4 OBJECT ${SOURCES_SSE4})
--target_compile_options(${LIB_NAME}_SSE4 PRIVATE -msse4.1)
--target_include_directories(${LIB_NAME}_SSE4 BEFORE PRIVATE ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_} ${MOS_PUBLIC_INCLUDE_DIRS_} ${SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_} ${COMMON_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_MHW_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_})
- 
+-    target_compile_options(${LIB_NAME}_SSE4 PRIVATE -msse4.1)
+-    target_include_directories(${LIB_NAME}_SSE4 BEFORE PRIVATE ${SOFTLET_MOS_PREPEND_INCLUDE_DIRS_} ${MOS_PUBLIC_INCLUDE_DIRS_} ${SOFTLET_MOS_PUBLIC_INCLUDE_DIRS_} ${COMMON_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_MHW_PRIVATE_INCLUDE_DIRS_} ${SOFTLET_DDI_PUBLIC_INCLUDE_DIRS_})
+-    target_link_libraries(${LIB_NAME}_SSE4 ${MEDIA_GMM_INTERFACE_LIBS})
+-
  add_library(${LIB_NAME}_COMMON OBJECT ${COMMON_SOURCES_} ${SOFTLET_DDI_SOURCES_})
  set_property(TARGET ${LIB_NAME}_COMMON PROPERTY POSITION_INDEPENDENT_CODE 1)
-@@ -582,8 +575,6 @@ add_library(${LIB_NAME} SHARED
+ MediaAddCommonTargetDefines(${LIB_NAME}_COMMON)
+@@ -599,8 +589,6 @@ add_library(${LIB_NAME} SHARED
      $<TARGET_OBJECTS:${LIB_NAME}_CODEC>
      $<TARGET_OBJECTS:${LIB_NAME}_VP>
      $<TARGET_OBJECTS:${LIB_NAME}_CP>
@@ -267,7 +270,7 @@ index 9d1c9b482..88236e4a7 100755
      $<TARGET_OBJECTS:${LIB_NAME}_SOFTLET_VP>
      $<TARGET_OBJECTS:${LIB_NAME}_SOFTLET_CODEC>
      $<TARGET_OBJECTS:${LIB_NAME}_SOFTLET_COMMON>)
-@@ -595,8 +586,6 @@ add_library(${LIB_NAME_STATIC} STATIC
+@@ -612,8 +600,6 @@ add_library(${LIB_NAME_STATIC} STATIC
      $<TARGET_OBJECTS:${LIB_NAME}_CODEC>
      $<TARGET_OBJECTS:${LIB_NAME}_VP>
      $<TARGET_OBJECTS:${LIB_NAME}_CP>
@@ -284,5 +287,5 @@ index 000000000..87cd663a9
 @@ -0,0 +1 @@
 +Subproject commit 87cd663a92e78a38b203a9aaa082c8fbd67781d8
 -- 
-2.52.0
+2.55.0
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0002-LOONGARCH64-ARM64-AOSCOS-bump-simde-to-0.8.4-rc3.am.loongarch64
@@ -1,4 +1,4 @@
-From 5efc9f6f3e6f197c2cf337d418127788de3898b5 Mon Sep 17 00:00:00 2001
+From 90f090a7c12b62a8cb851dd2845b16149c7f0843 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Wed, 22 Apr 2026 16:00:55 +0800
 Subject: [PATCH 2/3] LOONGARCH64: ARM64: AOSCOS: bump simde to 0.8.4-rc3
@@ -15,5 +15,5 @@ index 87cd663a9..c86a433df 160000
 -Subproject commit 87cd663a92e78a38b203a9aaa082c8fbd67781d8
 +Subproject commit c86a433df3086512b0b12240defa9d9ddcc9decf
 -- 
-2.52.0
+2.55.0
 

--- a/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
+++ b/runtime-multimedia/intel-media-driver/autobuild/patches/0003-ARM64-AOSCOS-fix-__stdcall-and-__cdecl-redefined-on-.am.arm64
@@ -1,4 +1,4 @@
-From b57ab666fbde45eee715abdba0e258905273f036 Mon Sep 17 00:00:00 2001
+From 99308953834e88d643dfdb21214fee45f7fc45b9 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Fri, 18 Apr 2025 09:21:59 +0800
 Subject: [PATCH 3/3] ARM64: AOSCOS: fix __stdcall and __cdecl redefined on
@@ -24,5 +24,5 @@ index d5f04d1f8..396ec89b1 100644
      #define __cdecl         __attribute__((__cdecl__))
      #define __stdcall       __attribute__((__stdcall__))
 -- 
-2.52.0
+2.55.0
 

--- a/runtime-multimedia/intel-media-driver/spec
+++ b/runtime-multimedia/intel-media-driver/spec
@@ -1,4 +1,4 @@
-VER=26.1.5
+VER=26.2.4
 SRCS="git::commit=tags/intel-media-$VER;copy-repo=true::https://github.com/intel/media-driver"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20341"


### PR DESCRIPTION
Topic Description
-----------------

- intel-media-driver: update to 26.2.4
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- intel-media-driver: 26.2.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit intel-media-driver
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
