### PR TITLE
tsukimi: update to 26.8.1

### DIFF
--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=tsukimi
 PKGSEC=video
 PKGDES="Third-party Jellyfin client"
-BUILDDEP="meson llvm rustc"
+BUILDDEP="meson llvm rustc blueprint-compiler"
 PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv \
-        openssl pango gtk-update-icon-cache"
+        openssl pango gtk-update-icon-cache glycin"
 
 ABTYPE=meson
 

--- a/app-multimedia/tsukimi/autobuild/patches/0001-fix-build-use-local-patched-uapi.patch.loongarch64
+++ b/app-multimedia/tsukimi/autobuild/patches/0001-fix-build-use-local-patched-uapi.patch.loongarch64
@@ -1,0 +1,73 @@
+From 063094689d5f36e533282ad57e123a1fa1dee5ef Mon Sep 17 00:00:00 2001
+From: MutsukiC <mutsuki@kmi.moe>
+Date: Sat, 1 Aug 2026 09:44:48 +0800
+Subject: [PATCH] fix(build): use local patched uapi
+
+Signed-off-by: MutsukiC <mutsuki@kmi.moe>
+---
+ Cargo.lock | 17 +----------------
+ Cargo.toml |  3 +++
+ 2 files changed, 4 insertions(+), 16 deletions(-)
+
+diff --git a/Cargo.lock b/Cargo.lock
+index 33d25dd..c706a6d 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -3192,17 +3192,6 @@ version = "2.6.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+ 
+-[[package]]
+-name = "syn"
+-version = "1.0.109"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+-dependencies = [
+- "proc-macro2",
+- "quote",
+- "unicode-ident",
+-]
+-
+ [[package]]
+ name = "syn"
+ version = "2.0.119"
+@@ -3633,8 +3622,6 @@ dependencies = [
+ [[package]]
+ name = "uapi"
+ version = "0.2.13"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3bf073840d1b16485bfe28b4e752eccee38d9ac53f152adf869708e3136561e6"
+ dependencies = [
+  "cc",
+  "cfg-if",
+@@ -3645,15 +3632,13 @@ dependencies = [
+ [[package]]
+ name = "uapi-proc"
+ version = "0.0.5"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "54de46f980cea7b2ae8d8f7f9f1c35cf7062c68343e99345ef73758f8e60975a"
+ dependencies = [
+  "lazy_static",
+  "libc",
+  "proc-macro2",
+  "quote",
+  "regex",
+- "syn 1.0.109",
++ "syn 2.0.119",
+ ]
+ 
+ [[package]]
+diff --git a/Cargo.toml b/Cargo.toml
+index a23115b..486649e 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -81,3 +81,6 @@ codegen-units = 1
+ 
+ [profile.dev]
+ debug = true
++
++[patch.crates-io]
++uapi = { path = "../uapi/uapi" }
+-- 
+2.55.0
+

--- a/app-multimedia/tsukimi/autobuild/patches/0001-fix-build-use-local-patched-uapi.patch.loongarch64_nosimd
+++ b/app-multimedia/tsukimi/autobuild/patches/0001-fix-build-use-local-patched-uapi.patch.loongarch64_nosimd
@@ -1,0 +1,1 @@
+0001-fix-build-use-local-patched-uapi.patch.loongarch64

--- a/app-multimedia/tsukimi/autobuild/patches/Add-ioctl-defs-for-loongarch64.patch.uapi.deferred
+++ b/app-multimedia/tsukimi/autobuild/patches/Add-ioctl-defs-for-loongarch64.patch.uapi.deferred
@@ -1,0 +1,27 @@
+From 65481f84fe448a1c879541b0a26223034650718f Mon Sep 17 00:00:00 2001
+From: MutsukiC <mutsuki@aosc.io>
+Date: Sat, 1 Aug 2026 09:25:04 +0800
+Subject: [PATCH] Add ioctl defs for loongarch64
+
+Signed-off-by: MutsukiC <mutsuki@kmi.moe>
+---
+ uapi/src/ioctl/linux.rs | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/uapi/src/ioctl/linux.rs b/uapi/src/ioctl/linux.rs
+index 5eb1448..f1b6ea2 100644
+--- a/uapi/src/ioctl/linux.rs
++++ b/uapi/src/ioctl/linux.rs
+@@ -18,7 +18,8 @@ cfg_if! {
+     }
+ }
+ cfg_if! {
+-    if #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "s390x", target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64"))] {
++    if #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "s390x", target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64",
++                 target_arch = "loongarch64"))] {
+         /// [`_IOC_NONE`](https://github.com/torvalds/linux/blob/v5.6/include/uapi/asm-generic/ioctl.h)
+         pub const _IOC_NONE: u64 = 0;
+         /// [`_IOC_READ`](https://github.com/torvalds/linux/blob/v5.6/include/uapi/asm-generic/ioctl.h)
+-- 
+2.55.0
+

--- a/app-multimedia/tsukimi/autobuild/prepare
+++ b/app-multimedia/tsukimi/autobuild/prepare
@@ -1,0 +1,7 @@
+if ab_match_arch loongarch64 || \
+   ab_match_arch loongarch64_nosimd; then
+    abinfo "Applying uapi patches for loongarch64"
+    pushd "$SRCDIR"/../uapi
+    ab_apply_patches "$SRCDIR"/autobuild/patches/*.uapi.deferred
+    popd
+fi

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,12 @@
-VER=26.7.1
-SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
+VER=26.8.1
+UAPI_CRATE_VER=0.2.13
+SRCS="git::commit=tags/v$VER;rename=tsukimi::https://github.com/tsukinaha/tsukimi"
+SRCS__LOONGARCH64="${SRCS} \
+    git::commit=tags/v$UAPI_CRATE_VER;rename=uapi::https://github.com/mahkoh/uapi"
+SRCS__LOONGARCH64_NOSIMD="${SRCS__LOONGARCH64}"
 CHKSUMS="SKIP"
+CHKSUMS__LOONGARCH64="$CHKSUMS \
+  SKIP"
+CHKSUMS__LOONGARCH64_NOSIMD="${CHKSUMS__LOONGARCH64}"
 CHKUPDATE="anitya::id=376111"
+SUBDIR=tsukimi


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: update to 26.8.1
    Co-authored-by: \(@MutsukiC\) <mutsuki@aosc.io>

Package(s) Affected
-------------------

- tsukimi: 26.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
