### PR TITLE
topics: fix zh-CN version in linux-kernel-7.1.5-3.toml

### DIFF
--- a/topics/linux-kernel-7.1.5-3.toml
+++ b/topics/linux-kernel-7.1.5-3.toml
@@ -2,7 +2,7 @@ security = false
 
 [name]
 default = "Linux Kernel 7.1.5-3"
-zh_CN = "Linux 内核，版本 6.17.7-3"
+zh_CN = "Linux 内核，版本 7.1.5-3"
 
 [caution]
 default = "Introduces support for i486 (Afterglow) and a pre-upstream version of LoongArch CPU/SoC dynamic frequency and voltage scaling driver"


### PR DESCRIPTION
Topic Description
-----------------

- topics: fix zh-CN version in linux-kernel-7.1.5-3.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
