### PR TITLE
php: security update to 8.5.9

### DIFF
--- a/app-devel/php/spec
+++ b/app-devel/php/spec
@@ -1,5 +1,5 @@
-VER=8.5.8
+VER=8.5.9
 EPOCH=1
 SRCS="tbl::https://www.php.net/distributions/php-$VER.tar.xz"
-CHKSUMS="sha256::58910198d19e873048fe87cdfe16bc790025417ede3d1651bfa1c4b533d573f2"
+CHKSUMS="sha256::0db7855f25bcd0ab1d592cdb35e284d6f6a5d2ae0f6f621122e364cc39b708f4"
 CHKUPDATE="anitya::id=3627"

--- a/topics/php-8.5.9.toml
+++ b/topics/php-8.5.9.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "PHP 8.5.9"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (including 2 of high severity and 1 of medium severity)"
+zh_CN = "修复 4 个安全漏洞（含 2 个高危漏洞和 1 个中危漏洞）"
+
+[packages-v2]
+"php" = "< 1:8.5.9"


### PR DESCRIPTION
Topic Description
-----------------

- php: security update to 8.5.9

Package(s) Affected
-------------------

- php: 8.5.9

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit php
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
