### PR TITLE
86box: use qt6

### DIFF
--- a/app-emulation/86box/autobuild/defines
+++ b/app-emulation/86box/autobuild/defines
@@ -1,14 +1,14 @@
 PKGNAME=86box
 PKGSEC=utils
 PKGDEP="gcc-runtime fluidsynth glib jack libevdev libpng libserialport \
-        libslirp libsndfile libxcb openal-soft qt-5 rtmidi sdl2 wayland \
+        libslirp libsndfile libxcb openal-soft qt-6 rtmidi sdl2 wayland \
         x11-lib zlib"
 PKGRECOM="86box-assets 86box-roms"
 PKGDES="Emulator for x86-based machines"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
-    '-DUSE_QT6=OFF'
+    '-DUSE_QT6=ON'
     '-DSTATIC_BUILD=OFF'
     '-DRELEASE=ON'
     '-DDYNAREC=OFF'

--- a/app-emulation/86box/autobuild/defines
+++ b/app-emulation/86box/autobuild/defines
@@ -1,14 +1,14 @@
 PKGNAME=86box
 PKGSEC=utils
 PKGDEP="gcc-runtime fluidsynth glib jack libevdev libpng libserialport \
-        libslirp libsndfile libxcb openal-soft qt-5 rtmidi sdl2 wayland \
+        libslirp libsndfile libxcb openal-soft qt-6 rtmidi sdl2 wayland \
         x11-lib zlib"
 PKGRECOM="86box-roms"
 PKGDES="Emulator for x86-based machines"
 
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
-    '-DUSE_QT6=OFF'
+    '-DUSE_QT6=ON'
     '-DSTATIC_BUILD=OFF'
     '-DRELEASE=ON'
     '-DDYNAREC=OFF'

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,5 +1,5 @@
 VER=6.0
-REL=3
+REL=4
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,4 +1,5 @@
 VER=6.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
Topic Description
-----------------

- 86box: use qt6

Package(s) Affected
-------------------

- 86box: 6.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
