### PR TITLE
nodejs-26: update to 26.5.1

### DIFF
--- a/lang-js/nodejs-26/spec
+++ b/lang-js/nodejs-26/spec
@@ -1,4 +1,4 @@
-VER=26.5.0
+VER=26.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/nodejs/node"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8251"


### PR DESCRIPTION
Topic Description
-----------------

- nodejs-26: update to 26.5.1
    Co-authored-by: Kexy Biscuit a.k.a. るる \(@KexyBiscuit\) <kexybiscuit@outlook.com>

Package(s) Affected
-------------------

- nodejs-26: 26.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nodejs-26
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
