### PR TITLE
greetd-tuigreet: update to 0.11.0

### DIFF
--- a/desktop-displaymanagers/greetd-tuigreet/autobuild/patches/0001-fix-build-on-loongarch64.patch
+++ b/desktop-displaymanagers/greetd-tuigreet/autobuild/patches/0001-fix-build-on-loongarch64.patch
@@ -1,0 +1,11 @@
+diff --git a/Cargo.toml b/Cargo.toml
+index 0b1e895..196de9b 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -62,3 +62,6 @@ unicode-width = "0.2.2"
+ 
+ [profile.release]
+ lto = true
++
++[patch.crates-io]
++utmp-raw = { git = "https://github.com/ChinsaaWei/utmp-rs", rev = "32a09a2bd30380ec7885bbe0da32fdc4844d8a98" }

--- a/desktop-displaymanagers/greetd-tuigreet/spec
+++ b/desktop-displaymanagers/greetd-tuigreet/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-REL=1
-SRCS="git::commit=tags/$VER::https://github.com/apognu/tuigreet"
+VER=0.11.0
+SRCS="git::commit=tags/$VER::https://github.com/tuigreet/tuigreet"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=266462"

--- a/desktop-displaymanagers/greetd-tuigreet/spec
+++ b/desktop-displaymanagers/greetd-tuigreet/spec
@@ -1,5 +1,4 @@
-VER=0.9.1
-REL=1
-SRCS="git::commit=tags/$VER::https://github.com/apognu/tuigreet"
+VER=0.11.0
+SRCS="git::commit=tags/$VER::https://github.com/NotAShelf/tuigreet"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=266462"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

greetd-tuigreet: update to 0.11.0

Package(s) Affected
-------------------

greetd-tuigreet

Security Update?
----------------

No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit greetd-tuigreet
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
