### PR TITLE
86box: introduce assets

### DIFF
--- a/app-emulation/86box-assets/autobuild/build
+++ b/app-emulation/86box-assets/autobuild/build
@@ -1,0 +1,4 @@
+abinfo "Installing assets ..."
+mkdir -pv "$PKGDIR"/usr/share/86Box/assets
+cp -rv "$SRCDIR"/{fonts,sounds} \
+    "$PKGDIR"/usr/share/86Box/assets/

--- a/app-emulation/86box-assets/autobuild/defines
+++ b/app-emulation/86box-assets/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=86box-assets
+PKGSEC=non-free/misc
+PKGDES="Sound and font assets for use with 86Box"
+
+ABHOST=noarch
+ABTYPE=self

--- a/app-emulation/86box-assets/spec
+++ b/app-emulation/86box-assets/spec
@@ -1,0 +1,5 @@
+VER=6.0+git20260704
+SRCS="git::commit=f06840ba5cb7cd3d42f1faa7fe418871a3b3be52::https://github.com/86Box/assets"
+CHKSUMS="SKIP"
+# Note: We will just follow master, there is no point in following tags.
+#CHKUPDATE="anitya::id=268433"

--- a/app-emulation/86box/autobuild/defines
+++ b/app-emulation/86box/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=utils
 PKGDEP="gcc-runtime fluidsynth glib jack libevdev libpng libserialport \
         libslirp libsndfile libxcb openal-soft qt-5 rtmidi sdl2 wayland \
         x11-lib zlib"
-PKGRECOM="86box-roms"
+PKGRECOM="86box-assets 86box-roms"
 PKGDES="Emulator for x86-based machines"
 
 ABTYPE=cmakeninja

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,5 +1,5 @@
 VER=6.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
Topic Description
-----------------

- 86box: add 86box-assets RECOM
- 86box-assets: new, 6.0+git20260704

Package(s) Affected
-------------------

- 86box: 6.0-1
- 86box-assets: 6.0+git20260704

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box-assets 86box
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
