### PR TITLE
papirus-icon-theme: update to 20260801

### DIFF
--- a/desktop-themes/papirus-icon-theme/autobuild/defines
+++ b/desktop-themes/papirus-icon-theme/autobuild/defines
@@ -6,3 +6,4 @@ PKGBREAK="papirus-icon-theme-kde<=20161102 papirus-icon-theme-gtk<=20161102"
 PKGREP="papirus-icon-theme-kde<=20161102 papirus-icon-theme-gtk<=20161102"
 
 ABHOST=noarch
+ABTYPE=self

--- a/desktop-themes/papirus-icon-theme/spec
+++ b/desktop-themes/papirus-icon-theme/spec
@@ -1,4 +1,4 @@
-VER=20250501
+VER=20260801
 SRCS="git::commit=tags/$VER;copy-repo=true::https://github.com/PapirusDevelopmentTeam/papirus-icon-theme.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18645"


### PR DESCRIPTION
Topic Description
-----------------

- papirus-icon-theme: update to 20260801
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- papirus-icon-theme: 20260801

Security Update?
----------------

No

Build Order
-----------

```
#buildit papirus-icon-theme
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
