### PR TITLE
deb-installer: update to 0.4.1

### DIFF
--- a/app-admin/deb-installer/autobuild/beyond
+++ b/app-admin/deb-installer/autobuild/beyond
@@ -1,7 +1,3 @@
-abinfo "Installing D-Bus service file ..."
-install -Dvm644 "$SRCDIR"/data/io.aosc.deb_installer.conf \
-    "$PKGDIR"/usr/share/dbus-1/system.d/io.aosc.deb_installer.conf
-
 abinfo "Installing icon files ..."
 install -Dvm644 \
     "$SRCDIR"/data/io.aosc.deb_installer.svg \

--- a/app-admin/deb-installer/spec
+++ b/app-admin/deb-installer/spec
@@ -1,5 +1,4 @@
-VER=0.3.5
-REL=1
+VER=0.4.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/deb-installer"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375467"


### PR DESCRIPTION
Topic Description
-----------------

- deb-installer: update to 0.4.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- deb-installer: 0.4.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit deb-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
