### PR TITLE
Python Packages Survey 20260803 No.2

### DIFF
--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -859,7 +859,6 @@ cppheaderparser
 dephell-specifier
 dephell-pythons
 dephell-shells
-dephell-venvs
 ecdsa
 eyed3
 mccabe

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-licenses
 dephell-links
 dephell-specifier
 dephell-markers

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -456,7 +456,6 @@ pythran
 scipy
 networkx
 pypkgconfig
-contextlib2
 net-snmp
 reportlab
 hplip

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-discover
 dephell-licenses
 dephell-links
 dephell-specifier

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-argparse
 dephell-changelogs
 dephell-discover
 dephell-licenses

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-archive
 dephell-argparse
 dephell-changelogs
 dephell-discover

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-links
 dephell-specifier
 dephell-markers
 dephell-pythons

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -857,7 +857,6 @@ pastel
 pylev
 cppheaderparser
 dephell-specifier
-dephell-shells
 ecdsa
 eyed3
 mccabe

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-changelogs
 dephell-discover
 dephell-licenses
 dephell-links

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -856,7 +856,6 @@ cherrypy
 pastel
 pylev
 cppheaderparser
-dephell-specifier
 ecdsa
 eyed3
 mccabe

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -857,7 +857,6 @@ pastel
 pylev
 cppheaderparser
 dephell-specifier
-dephell-markers
 dephell-pythons
 dephell-shells
 dephell-venvs

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -857,7 +857,6 @@ pastel
 pylev
 cppheaderparser
 dephell-specifier
-dephell-pythons
 dephell-shells
 ecdsa
 eyed3

--- a/lang-python/contextlib2/autobuild/defines
+++ b/lang-python/contextlib2/autobuild/defines
@@ -1,7 +1,0 @@
-PKGNAME=contextlib2
-PKGSEC=python
-PKGDEP="python-3"
-PKGDES="A backport of the standard library’s contextlib module to earlier Python versions"
-
-ABHOST=noarch
-NOPYTHON2=1

--- a/lang-python/contextlib2/spec
+++ b/lang-python/contextlib2/spec
@@ -1,5 +1,0 @@
-VER=21.6.0
-SRCS="tbl::https://pypi.io/packages/source/c/contextlib2/contextlib2-$VER.tar.gz"
-CHKSUMS="sha256::ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"
-CHKUPDATE="anitya::id=6215"
-REL="1"

--- a/lang-python/cppheaderparser/spec
+++ b/lang-python/cppheaderparser/spec
@@ -1,4 +1,4 @@
 VER=2.7.4
-SRCS="tbl::https://files.pythonhosted.org/packages/3c/ba/d8d168a4b54cae66eaf13d1d9197ca9349c94653815e061f79e7eed86c01/CppHeaderParser-2.7.4.tar.gz"
+SRCS="pypi::version=$VER::CppHeaderParser"
 CHKSUMS="sha256::382b30416d95b0a5e8502b214810dcac2a56432917e2651447d3abe253e3cc42"
 REL="1"

--- a/lang-python/cryptography/spec
+++ b/lang-python/cryptography/spec
@@ -1,5 +1,4 @@
-VER=48.0.0
-REL=1
+VER=50.0.0
 SRCS="pypi::version=$VER::cryptography"
-CHKSUMS="sha256::5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"
+CHKSUMS="sha256::eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9"
 CHKUPDATE="anitya::id=5532"

--- a/lang-python/css-parser/autobuild/defines
+++ b/lang-python/css-parser/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=css-parser
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
+BUILDDEP="setuptools"
 PKGDES="CSS-related utilities (parsing, serialization, etc.) for Python"
 
 ABHOST=noarch

--- a/lang-python/css-parser/spec
+++ b/lang-python/css-parser/spec
@@ -1,4 +1,4 @@
-VER=1.0.10
+VER=1.1.1
 SRCS="pypi::version=$VER::css-parser"
-CHKSUMS="sha256::bf1e972ad33344e93206964fb4cd908d9ddef9fcd0c01fa93e0d734675394363"
+CHKSUMS="sha256::93c7fb08cf16d45bbb8b964b4f4899a4eb36d9be6ffef17f99ad280f4034b36c"
 CHKUPDATE="anitya::id=231082"

--- a/lang-python/cssselect2/autobuild/defines
+++ b/lang-python/cssselect2/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=cssselect2
 PKGSEC=python
-PKGDEP="tinycss2"
-BUILDDEP="python-build python-installer"
-PKGDES="A Python library that parses CSS3 Selectors and translates them to XPath 1.0 (version 2)"
+PKGDEP="tinycss2 webencodings"
+BUILDDEP="flit-core"
+PKGDES="CSS selectors for Python ElementTree"
 
+ABTYPE=pep517
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/cssselect2/autobuild/patches/0001-AOSC-flit-core-4.patch
+++ b/lang-python/cssselect2/autobuild/patches/0001-AOSC-flit-core-4.patch
@@ -1,0 +1,11 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 908849a..d109772 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core >=3.2']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]

--- a/lang-python/cssselect2/spec
+++ b/lang-python/cssselect2/spec
@@ -1,5 +1,4 @@
-VER=0.6.0
-SRCS="tbl::https://pypi.io/packages/source/c/cssselect2/cssselect2-$VER.tar.gz"
-CHKSUMS="sha256::5b5d6dea81a5eb0c9ca39f116c8578dd413778060c94c1f51196371618909325"
+VER=0.9.0
+SRCS="pypi::version=$VER::cssselect2"
+CHKSUMS="sha256::759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb"
 CHKUPDATE="anitya::id=86109"
-REL="1"

--- a/lang-python/dbus-python/autobuild/defines
+++ b/lang-python/dbus-python/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=dbus-python
 PKGSEC=python
 PKGDEP="dbus-glib python-3"
-BUILDDEP="meson"
+BUILDDEP="meson-python"
 PKGDES="Python bindings for DBus"
 
 NOPYTHON2=1

--- a/lang-python/dbus-python/spec
+++ b/lang-python/dbus-python/spec
@@ -1,5 +1,4 @@
-VER=1.3.2
-SRCS="tbl::https://dbus.freedesktop.org/releases/dbus-python/dbus-python-$VER.tar.gz"
-CHKSUMS="sha256::ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8"
+VER=1.4.0
+SRCS="pypi::version=$VER::dbus-python"
+CHKSUMS="sha256::991666e498f60dbf3e49b8b7678f5559b8a65034fdf61aae62cdecdb7d89c770"
 CHKUPDATE="anitya::id=63686"
-REL="2"

--- a/lang-python/debtcollector/autobuild/defines
+++ b/lang-python/debtcollector/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=debtcollector
 PKGSEC=python
 PKGDEP="wrapt"
 BUILDDEP="pbr"
-PKGDES="A collection of Python deprecation patterns and strategies"
+PKGDES="Collection of Python deprecation patterns and strategies"
 
 ABHOST=noarch
 ABTYPE=pep517

--- a/lang-python/debtcollector/spec
+++ b/lang-python/debtcollector/spec
@@ -1,5 +1,4 @@
-VER=3.0.0
-SRCS="tbl::https://pypi.io/packages/source/d/debtcollector/debtcollector-$VER.tar.gz"
-CHKSUMS="sha256::2a8917d25b0e1f1d0d365d3c1c6ecfc7a522b1e9716e8a1a4a915126f7ccea6f"
+VER=3.1.0
+SRCS="pypi::version=$VER::debtcollector"
+CHKSUMS="sha256::278a45608cf16e79c0ae10851d869185c6b78f86610df8f27a451a18c1fec732"
 CHKUPDATE="anitya::id=6107"
-REL="1"

--- a/lang-python/decorator/autobuild/defines
+++ b/lang-python/decorator/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=decorator
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
+BUILDDEP="setuptools"
 PKGDES="Python decorator module"
 
 ABHOST=noarch

--- a/lang-python/decorator/spec
+++ b/lang-python/decorator/spec
@@ -1,6 +1,4 @@
-VER=5.2.1
+VER=5.3.1
 SRCS="pypi::version=${VER}::decorator"
-CHKSUMS="sha256::65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"
-
+CHKSUMS="sha256::4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82"
 CHKUPDATE="anitya::id=3819"
-REL="1"

--- a/lang-python/dephell-archive/autobuild/defines
+++ b/lang-python/dephell-archive/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-archive
-PKGSEC=python
-PKGDEP="python-3"
-PKGDES="A Python module to work with files and directories in archive in pathlib style"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-archive/spec
+++ b/lang-python/dephell-archive/spec
@@ -1,5 +1,0 @@
-VER=0.1.7
-SRCS="https://pypi.io/packages/source/d/dephell-archive/dephell-archive-${VER}.tar.gz"
-CHKSUMS="sha256::bb263492a7d430f9e04cef9a0237b7752cc797ab364bf35e70196af09c73ea37"
-CHKUPDATE="anitya::id=231083"
-REL="2"

--- a/lang-python/dephell-argparse/autobuild/defines
+++ b/lang-python/dephell-argparse/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-argparse
-PKGSEC=python
-PKGDEP="python-3"
-PKGDES="A Python module powered argparse with fuzzy matching"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-argparse/spec
+++ b/lang-python/dephell-argparse/spec
@@ -1,5 +1,0 @@
-VER=0.1.3
-SRCS="https://pypi.io/packages/source/d/dephell-argparse/dephell_argparse-${VER}.tar.gz"
-CHKSUMS="sha256::2ab9b2441f808bb11c338c4849d22ded898cde8325946800ac9e39d2b138735d"
-CHKUPDATE="anitya::id=52260"
-REL="2"

--- a/lang-python/dephell-changelogs/autobuild/defines
+++ b/lang-python/dephell-changelogs/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-changelogs
-PKGSEC=python
-PKGDEP="python-3 requests"
-PKGDES="A Python module which can find changelog for github repository, local dir, parse changelog"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-changelogs/spec
+++ b/lang-python/dephell-changelogs/spec
@@ -1,5 +1,0 @@
-VER=0.0.1
-SRCS="https://pypi.io/packages/source/d/dephell-changelogs/dephell_changelogs-${VER}.tar.gz"
-CHKSUMS="sha256::e639a3d08d389e22fbac0cc64181dbe93c4b4ba9f0134e273e6dd3e26ae70b21"
-CHKUPDATE="anitya::id=231084"
-REL="2"

--- a/lang-python/dephell-discover/autobuild/defines
+++ b/lang-python/dephell-discover/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-discover
-PKGSEC=python
-PKGDEP="python-3 attrs"
-PKGDES="A Python module which can find project modules and data files"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-discover/spec
+++ b/lang-python/dephell-discover/spec
@@ -1,6 +1,0 @@
-VER=0.2.10
-SRCS="https://pypi.io/packages/source/d/dephell-discover/dephell_discover-${VER}.tar.gz"
-CHKSUMS="sha256::a2ad414e5e0fe16c82c537d6a3198afd9818c0c010760eccb23e2d60e5b66df6"
-
-CHKUPDATE="anitya::id=42330"
-REL="2"

--- a/lang-python/dephell-licenses/autobuild/defines
+++ b/lang-python/dephell-licenses/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-licenses
-PKGSEC=python
-PKGDEP="python-3 attrs requests"
-PKGDES="A Python module which getting info about OSS licenses"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-licenses/spec
+++ b/lang-python/dephell-licenses/spec
@@ -1,5 +1,0 @@
-VER=0.1.7
-SRCS="https://pypi.io/packages/source/d/dephell-licenses/dephell-licenses-${VER}.tar.gz"
-CHKSUMS="sha256::f175cec822a32bda5b56442f48dae39efbb5c3851275ecd41cfd7e849ddd2ea6"
-CHKUPDATE="anitya::id=231085"
-REL="2"

--- a/lang-python/dephell-links/autobuild/defines
+++ b/lang-python/dephell-links/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-links
-PKGSEC=python
-PKGDEP="python-3 attrs"
-PKGDES="A Python module for parsing dependency links"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-links/spec
+++ b/lang-python/dephell-links/spec
@@ -1,5 +1,0 @@
-VER=0.1.5
-SRCS="https://pypi.io/packages/source/d/dephell-links/dephell_links-${VER}.tar.gz"
-CHKSUMS="sha256::28d694142e2827a59d2c301e7185afb52fb8acdb950b1da38308d69e43418eaa"
-CHKUPDATE="anitya::id=231087"
-REL="2"

--- a/lang-python/dephell-markers/autobuild/defines
+++ b/lang-python/dephell-markers/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-markers
-PKGSEC=python
-PKGDEP="python-3 packaging attrs dephell-specifier"
-PKGDES="A Python module works with environment markers for dephell"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-markers/spec
+++ b/lang-python/dephell-markers/spec
@@ -1,5 +1,0 @@
-VER=1.0.3
-SRCS="https://pypi.io/packages/source/d/dephell-markers/dephell_markers-${VER}.tar.gz"
-CHKSUMS="sha256::525e17914e705acf8652dd8681fccdec912432a747d8def4720f49416817f2d4"
-CHKUPDATE="anitya::id=31735"
-REL="2"

--- a/lang-python/dephell-pythons/autobuild/defines
+++ b/lang-python/dephell-pythons/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-pythons
-PKGSEC=python
-PKGDEP="python-3 attrs dephell-specifier packaging"
-PKGDES="A Python module works with python versions for dephell"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-pythons/spec
+++ b/lang-python/dephell-pythons/spec
@@ -1,6 +1,0 @@
-VER=0.1.15
-SRCS="https://pypi.io/packages/source/d/dephell-pythons/dephell_pythons-${VER}.tar.gz"
-CHKSUMS="sha256::804c29afa2147322aa23e791f591d0204fd1e9983afa7d91e1d1452fc7be1c5c"
-
-CHKUPDATE="anitya::id=57877"
-REL="2"

--- a/lang-python/dephell-shells/autobuild/defines
+++ b/lang-python/dephell-shells/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-shells
-PKGSEC=python
-PKGDEP="python-3 attrs pexpect shellingham"
-PKGDES="A Python module activates virtual environment for current shell"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-shells/spec
+++ b/lang-python/dephell-shells/spec
@@ -1,5 +1,0 @@
-VER=0.1.5
-SRCS="https://pypi.io/packages/source/d/dephell-shells/dephell_shells-${VER}.tar.gz"
-CHKSUMS="sha256::77150b732db135d436f41c2c6f12694e6058a8609214117ee80f6c40234ac2d5"
-CHKUPDATE="anitya::id=57916"
-REL="2"

--- a/lang-python/dephell-specifier/autobuild/defines
+++ b/lang-python/dephell-specifier/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-specifier
-PKGSEC=python
-PKGDEP="python-3 packaging"
-PKGDES="A Python module Work with version specifiers for dephell"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-specifier/spec
+++ b/lang-python/dephell-specifier/spec
@@ -1,5 +1,0 @@
-VER=0.2.2
-SRCS="https://pypi.io/packages/source/d/dephell-specifier/dephell_specifier-${VER}.tar.gz"
-CHKSUMS="sha256::b5ec6409a1916980c4861da2cb7538246555bff4b95bef2c952c56bd19eb2de6"
-CHKUPDATE="anitya::id=96901"
-REL="2"

--- a/lang-python/dephell-venvs/autobuild/defines
+++ b/lang-python/dephell-venvs/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dephell-venvs
-PKGSEC=python
-PKGDEP="python-3 attrs dephell-pythons"
-PKGDES="A Python module manages virtual environments for dephell"
-
-ABHOST=noarch
-ABTYPE=python
-NOPYTHON2=1

--- a/lang-python/dephell-venvs/spec
+++ b/lang-python/dephell-venvs/spec
@@ -1,5 +1,0 @@
-VER=0.1.18
-SRCS="https://pypi.io/packages/source/d/dephell-venvs/dephell_venvs-${VER}.tar.gz"
-CHKSUMS="sha256::c7307291b754edba325ab27edeb05d85ee4dd2f1487c48872a1ebfc372bf7a2e"
-CHKUPDATE="anitya::id=231088"
-REL="2"

--- a/lang-python/llfuse/autobuild/defines
+++ b/lang-python/llfuse/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=llfuse
 PKGSEC=python
-PKGDES="a set of Python bindings for the low level FUSE API"
-PKGDEP="python-3 fuse contextlib2"
-BUILDDEP="setuptools-python3"
+PKGDES="Python bindings for FUSE API"
+PKGDEP="python-3 fuse"
+BUILDDEP="setuptools"
 
 ABTYPE=pep517
 

--- a/lang-python/llfuse/spec
+++ b/lang-python/llfuse/spec
@@ -1,5 +1,4 @@
-VER=1.5.1
-SRCS="tbl::https://pypi.io/packages/source/l/llfuse/llfuse-${VER}.tar.gz"
-CHKSUMS="sha256::7c9be52289cf647e3d735104531cc23a1a89fd1be3a621613a1cc0991f1b2699"
+VER=1.5.2
+SRCS="pypi::version=$VER::llfuse"
+CHKSUMS="sha256::3f7fdc86e3db433c48cb6505fe3000ec1b3e84a4a40a84ad67b8df3a847f0697"
 CHKUPDATE="anitya::id=3911"
-REL="2"


### PR DESCRIPTION
Topic Description
-----------------

- dephell-specifier: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-shells: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-pythons: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-venvs: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-markers: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-links: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-licenses: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-discover: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephellchangelogs-: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>
- dephell-argparse: drop, orphaned
    this packages was previously required by dephell, which has been dropped
    Signed-off-by: stydxm <stydxm@outlook.com>

... and 11 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit llfuse cryptography css-parser cssselect2 dbus-python debtcollector decorator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
