### PR TITLE
[DO NOT MERGE]Autobuild4 patch sub directory survey

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,4 +1,5 @@
 VER=4.19.1
-SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/autobuild4"
+REL=1
+SRCS="git::commit=00e6914e67d676b6a1fee84735c2ab82d7ee2969::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-shells/powershell/autobuild/patch
+++ b/app-shells/powershell/autobuild/patch
@@ -1,3 +1,0 @@
-abinfo "Applying patches ..."
-cd "$SRCDIR"/powershell
-ab_apply_patches "$SRCDIR"/autobuild/patches/*

--- a/app-shells/powershell/autobuild/patches/powershell/0001-Support-build-on-LoongArch64-architecture.patch
+++ b/app-shells/powershell/autobuild/patches/powershell/0001-Support-build-on-LoongArch64-architecture.patch
@@ -1,4 +1,4 @@
-From 1177ffe1a0f1cda5b397a940b2de16a14765553a Mon Sep 17 00:00:00 2001
+From c1a7f19610d623b53c79d1a307d1ca8538808e96 Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Fri, 27 Mar 2026 21:43:05 +0800
 Subject: [PATCH 1/4] Support build on LoongArch64 architecture
@@ -40,5 +40,5 @@ index 42a202d94..da4551162 100644
              Write-Verbose -Message "$($script:Options.Runtime) is a fxdependent runtime, no cleanup needed in pwsh.deps.json" -Verbose
              return
 -- 
-2.52.0
+2.55.0
 

--- a/app-shells/powershell/autobuild/patches/powershell/0002-don-t-exit-when-dotnet-sdk-version-mismatch.patch
+++ b/app-shells/powershell/autobuild/patches/powershell/0002-don-t-exit-when-dotnet-sdk-version-mismatch.patch
@@ -1,4 +1,4 @@
-From 6a6f5eb5e08be30fd0ffbc8c968af2b7f61a0440 Mon Sep 17 00:00:00 2001
+From 059c2b7bb4685cc9e966884578185470fc661d20 Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Thu, 5 Mar 2026 17:15:13 +0800
 Subject: [PATCH 2/4] don't exit when dotnet sdk version mismatch
@@ -20,5 +20,5 @@ index da4551162..d796e523d 100644
  
      # set output options
 -- 
-2.52.0
+2.55.0
 

--- a/app-shells/powershell/autobuild/patches/powershell/0003-use-dotnet-sdk-10.0.110.patch
+++ b/app-shells/powershell/autobuild/patches/powershell/0003-use-dotnet-sdk-10.0.110.patch
@@ -1,23 +1,23 @@
-From 654607eb60e66bb5472bb12289b8071d39c6b4e6 Mon Sep 17 00:00:00 2001
+From 9ac32b821313f50d2d5cc405a040d3244383f882 Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Thu, 26 Mar 2026 01:18:16 +0800
-Subject: [PATCH 3/4] downgrade dotnet sdk to 108
+Subject: [PATCH 3/4] use dotnet sdk 10.0.110
 
 ---
  global.json | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/global.json b/global.json
-index 9769786b1..c2647eb3c 100644
+index 14b50cf15..cc056fe1d 100644
 --- a/global.json
 +++ b/global.json
 @@ -1,5 +1,5 @@
  {
    "sdk": {
--    "version": "10.0.300"
-+    "version": "10.0.108"
+-    "version": "10.0.302"
++    "version": "10.0.110"
    }
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-shells/powershell/autobuild/patches/powershell/0004-disable-nuget-audit.patch
+++ b/app-shells/powershell/autobuild/patches/powershell/0004-disable-nuget-audit.patch
@@ -1,4 +1,4 @@
-From 625c7f39f636e9234211c43db630cd09112ecea8 Mon Sep 17 00:00:00 2001
+From 04447f17d372d0017746c32a83345944f44b0dff Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Sun, 31 May 2026 01:04:08 +0800
 Subject: [PATCH 4/4] disable nuget audit
@@ -23,5 +23,5 @@ index 0b40b8d71..4a7b504cc 100644
        <!--
           DO NOT UPDATE without reviewing with the Microsoft update plan.
 -- 
-2.52.0
+2.55.0
 

--- a/app-shells/powershell/spec
+++ b/app-shells/powershell/spec
@@ -1,4 +1,4 @@
-VER=7.6.2
+VER=7.6.4
 # Use Git source to satisfy build system
 SRCS="git::commit=tags/v$VER;rename=powershell;copy-repo=true::https://github.com/PowerShell/PowerShell.git \
       git::commit=2c55e8fc288e31ce72974ad783151b06049591c4;rename=libpsl::https://github.com/PowerShell/PowerShell-Native.git"
@@ -6,4 +6,3 @@ CHKSUMS="SKIP \
          SKIP"
 CHKUPDATE="anitya::id=230574"
 SUBDIR="."
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- powershell: update to v7.6.4
- autobuild4: update to 4.19.1-1

Package(s) Affected
-------------------

- autobuild4: 4.19.1-1
- edit: 2.0.0
- powershell: 7.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 powershell edit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
