### PR TITLE
86box: backport patch to change hard reset keybind to Ctrl+Shift+F12

### DIFF
--- a/app-emulation/86box/autobuild/patches/0001-Replace-hard-reset-keybind-with-Ctrl-Shift-F12.patch
+++ b/app-emulation/86box/autobuild/patches/0001-Replace-hard-reset-keybind-with-Ctrl-Shift-F12.patch
@@ -1,0 +1,25 @@
+From cf1236088b796a283c93554fee546cdfa7f25fe1 Mon Sep 17 00:00:00 2001
+From: Canadew <110163919+chun-awa@users.noreply.github.com>
+Date: Mon, 3 Aug 2026 19:56:59 +0800
+Subject: [PATCH] Replace hard reset keybind with Ctrl+Shift+F12
+
+---
+ src/86box.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/86box.c b/src/86box.c
+index 0f8793bd7..32263a9eb 100644
+--- a/src/86box.c
++++ b/src/86box.c
+@@ -292,7 +292,7 @@ struct accelKey def_acc_keys[NUM_ACCELS] = {
+     {
+         .name="hard_reset",
+         .desc="Hard reset",
+-        .seq="Ctrl+Alt+F12"
++        .seq="Ctrl+Shift+F12"
+     },
+     {
+         .name="pause",
+-- 
+2.55.0
+

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,4 +1,5 @@
 VER=6.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
Topic Description
-----------------

Backport patch from upstream commit [`cf12360`](https://github.com/86Box/86Box/commit/cf1236088b796a283c93554fee546cdfa7f25fe1).

Package(s) Affected
-------------------

- 86box: 6.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
