### PR TITLE
gradle: update to 9.6.1

### DIFF
--- a/lang-java/gradle/autobuild/build
+++ b/lang-java/gradle/autobuild/build
@@ -2,7 +2,7 @@ abinfo "Initializing the output dir ..."
 install -dv "$SRCDIR"/temp
 
 abinfo "Building gradle ..."
-"$SRCDIR"/gradlew installAll -Pgradle_installPath="$SRCDIR"/temp -PfinalRelease=true --no-configuration-cache --no-daemon
+"$SRCDIR"/gradlew installAll -Pgradle_installPath="$SRCDIR"/temp -PfinalRelease=true -Dorg.gradle.unsafe.isolated-projects=false --no-configuration-cache --no-daemon
 
 abinfo "Creating directories ..."
 install -dv "$PKGDIR"/usr/{bin,share,lib}

--- a/lang-java/gradle/spec
+++ b/lang-java/gradle/spec
@@ -1,4 +1,4 @@
-VER=9.3.0
+VER=9.6.1
 SRCS="git::commit=tags/v$VER::https://github.com/gradle/gradle"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6088"


### PR DESCRIPTION
Topic Description
-----------------

- gradle: update to 9.6.1
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- gradle: 9.6.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit gradle
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
