### PR TITLE
Python Packages Survey 20260804

### DIFF
--- a/app-doc/ocrmypdf/spec
+++ b/app-doc/ocrmypdf/spec
@@ -1,4 +1,4 @@
-VER=17.4.0
+VER=17.8.1
 SRCS="git::commit=tags/v$VER::https://github.com/ocrmypdf/OCRmyPDF"
 CHKSUMS="sha256::cd96bddfb3a986be7bf7857757919332e1db5dab780eb7b321fdea38f60127ac"
 CHKUPDATE="anitya::id=15744"

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -868,7 +868,6 @@ dephell-markers
 dephell-pythons
 dephell-shells
 dephell-venvs
-diff-match-patch
 dill
 ecdsa
 eyed3

--- a/groups/py3-rebuild
+++ b/groups/py3-rebuild
@@ -868,7 +868,6 @@ dephell-markers
 dephell-pythons
 dephell-shells
 dephell-venvs
-dill
 ecdsa
 eyed3
 mccabe

--- a/lang-python/diff-match-patch/autobuild/defines
+++ b/lang-python/diff-match-patch/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=diff-match-patch
-PKGSEC=python
-PKGDEP="python-3"
-BUILDDEP="flit-core"
-PKGDES="Robust algorithms to perform the operations required for synchronizing plain text"
-
-ABTYPE=pep517
-ABHOST=noarch

--- a/lang-python/diff-match-patch/spec
+++ b/lang-python/diff-match-patch/spec
@@ -1,5 +1,0 @@
-VER=20241021
-SRCS="tbl::https://pypi.io/packages/source/d/diff-match-patch/diff_match_patch-$VER.tar.gz"
-CHKSUMS="sha256::beae57a99fa48084532935ee2968b8661db861862ec82c6f21f4acdd6d835073"
-CHKUPDATE="anitya::id=12238"
-REL="1"

--- a/lang-python/dill/autobuild/defines
+++ b/lang-python/dill/autobuild/defines
@@ -1,8 +1,0 @@
-PKGNAME=dill
-PKGSEC=python
-PKGDEP="python-3"
-BUILDDEP="setuptools"
-PKGDES="Serializing and de-serializing python objects to the majority of the built-in python types"
-
-ABHOST=noarch
-NOPYTHON2=1

--- a/lang-python/dill/spec
+++ b/lang-python/dill/spec
@@ -1,5 +1,0 @@
-VER=0.4.0
-SRCS="tbl::https://pypi.io/packages/source/d/dill/dill-$VER.tar.gz"
-CHKSUMS="sha256::0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0"
-CHKUPDATE="anitya::id=7687"
-REL="1"

--- a/lang-python/distlib/spec
+++ b/lang-python/distlib/spec
@@ -1,5 +1,4 @@
-VER=0.3.9
+VER=0.4.3
 SRCS="pypi::version=${VER}::distlib"
-CHKSUMS="sha256::a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"
+CHKSUMS="sha256::f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed"
 CHKUPDATE="anitya::id=34504"
-REL="1"

--- a/lang-python/dukpy/autobuild/defines
+++ b/lang-python/dukpy/autobuild/defines
@@ -5,5 +5,4 @@ BUILDDEP="setuptools"
 PKGDES="Simple JavaScript interpreter for Python"
 
 NOPYTHON2=1
-ABTYPE=python
-ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/dukpy/spec
+++ b/lang-python/dukpy/spec
@@ -1,5 +1,4 @@
-VER=0.4.0
+VER=0.6.0
 SRCS="git::commit=tags/$VER::https://github.com/amol-/dukpy.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=309220"
-REL="1"

--- a/lang-python/exceptiongroup/autobuild/defines
+++ b/lang-python/exceptiongroup/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=exceptiongroup
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="wheel python-build python-installer flit-scm"
+BUILDDEP="flit-scm"
 PKGDES="Backport of PEP 654 (exception groups)"
 
 ABTYPE=pep517

--- a/lang-python/exceptiongroup/spec
+++ b/lang-python/exceptiongroup/spec
@@ -1,5 +1,4 @@
-VER=1.2.2
-SRCS="tbl::https://files.pythonhosted.org/packages/source/e/exceptiongroup/exceptiongroup-$VER.tar.gz"
-CHKSUMS="sha256::47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+VER=1.3.1
+SRCS="pypi::version=${VER}::exceptiongroup"
+CHKSUMS="sha256::8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219"
 CHKUPDATE="anitya::id=245950"
-REL="1"

--- a/lang-python/executing/spec
+++ b/lang-python/executing/spec
@@ -1,5 +1,4 @@
-VER=2.1.0
-SRCS="tbl::https://files.pythonhosted.org/packages/source/e/executing/executing-$VER.tar.gz"
-CHKSUMS="sha256::8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab"
+VER=2.2.1
+SRCS="pypi::version=$VER::executing"
+CHKSUMS="sha256::3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4"
 CHKUPDATE="anitya::id=24668"
-REL="1"

--- a/lang-python/expandvars/autobuild/defines
+++ b/lang-python/expandvars/autobuild/defines
@@ -1,8 +1,9 @@
 PKGNAME=expandvars
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="python-build hatchling python-installer"
+BUILDDEP="hatchling"
 PKGDES="Variable expansion library in Python"
 
+ABTYPE=pep517
 NOPYTHON2=1
 ABHOST=noarch

--- a/lang-python/expandvars/spec
+++ b/lang-python/expandvars/spec
@@ -1,5 +1,4 @@
-VER=0.12.0
-SRCS="tbl::https://pypi.io/packages/source/e/expandvars/expandvars-$VER.tar.gz"
-CHKSUMS="sha256::7d1adfa55728cf4b5d812ece3d087703faea953e0c0a1a78415de9df5024d844"
+VER=1.1.2
+SRCS="pypi::version=$VER::expandvars"
+CHKSUMS="sha256::6c5822b7b756a99a356b915dd1267f52ab8a4efaa135963bd7f4bd5d368f71d7"
 CHKUPDATE="anitya::id=95228"
-REL="1"

--- a/lang-python/eyed3/spec
+++ b/lang-python/eyed3/spec
@@ -1,5 +1,4 @@
-VER=0.9.5
-SRCS="tbl::https://pypi.io/packages/source/e/eyeD3/eyeD3-$VER.tar.gz"
-CHKSUMS="sha256::faf5806197f2093e82c2830d41f2378f07b3a9da07a16fafb14fc6fbdebac50a"
+VER=0.9.9
+SRCS="pypi::version=$VER::eyeD3"
+CHKSUMS="sha256::a8affaae19384aca66f6efef3babd705042a76e546f08e886f5f28691ac62a3b"
 CHKUPDATE="anitya::id=6547"
-REL="4"

--- a/lang-python/fastbencode/autobuild/defines
+++ b/lang-python/fastbencode/autobuild/defines
@@ -1,13 +1,8 @@
 PKGNAME=fastbencode
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="python-build python-installer wheel setuptools-python3 setuptools-rust llvm cython"
+BUILDDEP="setuptools setuptools-rust cython llvm"
 PKGDES="Implementation of Bencode, and encoding format used for peer-to-peer file transmission"
 
 ABTYPE=pep517
 NOPYTHON2=1
-
-# ld.lld does not support loongson3
-USECLANG=1
-USECLANG__LOONGSON3=0
-NOLTO__LOONGSON3=1

--- a/lang-python/fastbencode/spec
+++ b/lang-python/fastbencode/spec
@@ -1,5 +1,4 @@
-VER=0.3.2
-SRCS="tbl::https://github.com/breezy-team/fastbencode/archive/refs/tags/v$VER.tar.gz"
-CHKSUMS="sha256::98c5152ea30f103fc4b3d7b62a3e510cb87bf899a54775b619719a967749e295"
+VER=0.3.11
+SRCS="pypi::version=$VER::fastbencode"
+CHKSUMS="sha256::7e2be45bfe81167cd79986698a2cf270eaf61add5b1bc711378c2bb3f05396d5"
 CHKUPDATE="anitya::id=233299"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- fastbencode: update to 0.3.11
    Signed-off-by: stydxm <stydxm@outlook.com>
- eyed3: update to 0.9.9
    Signed-off-by: stydxm <stydxm@outlook.com>
- expandvars: update to 1.1.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- executing: update to 2.2.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- exceptiongroup: update to 1.3.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- dukpy: update to 0.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- distlib: update to 0.4.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- dill: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>
- diff-match-patch: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>
- deprecation: drop, orphaned
    Signed-off-by: stydxm <stydxm@outlook.com>

... and 1 more commits

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit ocrmypdf distlib dukpy exceptiongroup executing expandvars eyed3 fastbencode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
