### PR TITLE
linux-kernel: backport patch to use .balign for system certificates

### DIFF
--- a/runtime-kernel/linux-kernel/autobuild/patches/0438-UPSTREAM-certs-specify-byte-alignment-with-balign.patch
+++ b/runtime-kernel/linux-kernel/autobuild/patches/0438-UPSTREAM-certs-specify-byte-alignment-with-balign.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Giuliano Procida <gprocida@google.com>
+Date: Fri, 12 Sep 2025 10:00:27 +0000
+Subject: [PATCH] AOSCOS: certs: specify byte alignment with .balign
+
+The .align macro is architecture dependent. On arm64 it behaves as
+.p2align. The various alignments in this file are all bytes.
+
+So use the .balign macro to avoid unnecessary padding due to
+over-alignment.
+
+Signed-off-by: Giuliano Procida <gprocida@google.com>
+---
+ certs/system_certificates.S | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/certs/system_certificates.S b/certs/system_certificates.S
+index 003e25d4a17e..ea6984b427c9 100644
+--- a/certs/system_certificates.S
++++ b/certs/system_certificates.S
+@@ -4,7 +4,7 @@
+ 
+ 	__INITRODATA
+ 
+-	.align 8
++	.balign 8
+ 	.globl system_certificate_list
+ system_certificate_list:
+ __cert_list_start:
+@@ -20,14 +20,14 @@ __cert_list_end:
+ system_extra_cert:
+ 	.fill CONFIG_SYSTEM_EXTRA_CERTIFICATE_SIZE, 1, 0
+ 
+-	.align 4
++	.balign 4
+ 	.globl system_extra_cert_used
+ system_extra_cert_used:
+ 	.int 0
+ 
+ #endif /* CONFIG_SYSTEM_EXTRA_CERTIFICATE */
+ 
+-	.align 8
++	.balign 8
+ 	.globl system_certificate_list_size
+ system_certificate_list_size:
+ #ifdef CONFIG_64BIT
+@@ -36,7 +36,7 @@ system_certificate_list_size:
+ 	.long __cert_list_end - __cert_list_start
+ #endif
+ 
+-	.align 8
++	.balign 8
+ 	.globl module_cert_size
+ module_cert_size:
+ #ifdef CONFIG_64BIT
+-- 
+2.51.0.384.g4c02a37b29-goog
+

--- a/runtime-kernel/linux-kernel/spec
+++ b/runtime-kernel/linux-kernel/spec
@@ -4,7 +4,7 @@ VER=7.1.5
 __VER="${VER}"
 
 # Use this for stable releases.
-REL=3
+REL=4
 # Note: In specific cases, `www.kernel.org` is faster than `cdn.kernel.org`. Change the host when appropriate.
 SRCS="tbl::https://cdn.kernel.org/pub/linux/kernel/v${VER%%.*}.x/linux-${VER%%.0}.tar.xz"
 


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: backport patch to use .balign for system certificates
    Backport a patch from Giuliano Procida to use .balign instead of
    .align in certs/system_certificates.S. The .align macro is
    architecture dependent and on arm64 behaves as .p2align, which can
    cause unnecessary padding due to over-alignment. Using .balign
    ensures consistent byte-level alignment across all architectures.
    Link: https://lore.kernel.org/all/20250923081344.1657783-1-gprocida@google.com/
    This commit is authored with assistance from AI/LLM:
    - Model: MiMo-v2.5-pro
    - Platform: Xiaomi \(mimo.xiaomi.com\)
    - Agent platform: MiMoCode \(mimocode.xiaomi.com\)
    - Prompt:
    Create a new topic with patch from
    https://lore.kernel.org/all/20250923081344.1657783-1-gprocida@google.com/,
    fetch and switch to latest stable first.
    Assisted-by: MiMo <noreply@xiaomi.com>

Package(s) Affected
-------------------

- linux-kernel-${__VER}: 7.1.5-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit linux-kernel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
