### PR TITLE
public-inbox: new, 2.1.0

### DIFF
--- a/app-network/public-inbox/autobuild/beyond
+++ b/app-network/public-inbox/autobuild/beyond
@@ -1,0 +1,15 @@
+#!/bin/bash
+abinfo "Installing example files ..."
+mkdir -pv "$PKGDIR"/usr/share/doc/public-inbox
+cp -av "$SRCDIR"/examples \
+    "$PKGDIR"/usr/share/doc/public-inbox/
+
+abinfo "Installing systemd units for long-standing daemons ..."
+for daemon in httpd imapd nntpd; do
+    install -v -Dm644 \
+        "$SRCDIR"/examples/public-inbox-$daemon.socket \
+        "$SRCDIR"/examples/public-inbox-$daemon@.service \
+        -t "$PKGDIR"/usr/lib/systemd/system/
+done
+install -v -Dm644 "$SRCDIR"/examples/public-inbox-watch.service \
+    -t "$PKGDIR"/usr/lib/systemd/system/

--- a/app-network/public-inbox/autobuild/beyond
+++ b/app-network/public-inbox/autobuild/beyond
@@ -1,4 +1,3 @@
-#!/bin/bash
 abinfo "Installing example files ..."
 mkdir -pv "$PKGDIR"/usr/share/doc/public-inbox
 cp -av "$SRCDIR"/examples \

--- a/app-network/public-inbox/autobuild/build
+++ b/app-network/public-inbox/autobuild/build
@@ -1,7 +1,15 @@
 #!/bin/bash
 abinfo "Building public-inbox ..."
-perl Makefile.PL PREFIX=/usr
+perl Makefile.PL PREFIX=/usr INSTALLDIRS=vendor
 make
 
 abinfo "Installing public-inbox ..."
 make install DESTDIR="$PKGDIR"
+
+abinfo "Moving executables /usr/bin/vendor_perl/* => /usr/bin ..."
+mv -v "$PKGDIR"/usr/bin/vendor_perl/* \
+    "$PKGDIR"/usr/bin/
+rmdir -v "$PKGDIR"/usr/bin/vendor_perl
+
+abinfo "Removing MakeMaker metadata ..."
+find "$PKGDIR" \( -name perllocal.pod -o -name .packlist \) -delete

--- a/app-network/public-inbox/autobuild/build
+++ b/app-network/public-inbox/autobuild/build
@@ -1,4 +1,3 @@
-#!/bin/bash
 abinfo "Building public-inbox ..."
 perl Makefile.PL PREFIX=/usr INSTALLDIRS=vendor
 make

--- a/app-network/public-inbox/autobuild/build
+++ b/app-network/public-inbox/autobuild/build
@@ -1,0 +1,7 @@
+#!/bin/bash
+abinfo "Building public-inbox ..."
+perl Makefile.PL PREFIX=/usr
+make
+
+abinfo "Installing public-inbox ..."
+make install DESTDIR="$PKGDIR"

--- a/app-network/public-inbox/autobuild/defines
+++ b/app-network/public-inbox/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=public-inbox
 PKGSEC=net
-PKGDEP="git perl perl-dbd-sqlite perl-uri"
+PKGDEP="git perl perl-dbd-sqlite perl-uri xapian-bindings"
 PKGDES="Git-based public email archive with NNTP, IMAP, and HTTP interfaces"
 
 ABHOST=noarch

--- a/app-network/public-inbox/autobuild/defines
+++ b/app-network/public-inbox/autobuild/defines
@@ -1,6 +1,7 @@
 PKGNAME=public-inbox
 PKGSEC=net
 PKGDEP="git perl perl-dbd-sqlite perl-uri xapian-bindings"
+PKGSUG="perl-mail-imapclient perl-net-server perl-parse-recdescent perl-timedate"
 PKGDES="Git-based public email archive with NNTP, IMAP, and HTTP interfaces"
 
 ABHOST=noarch

--- a/app-network/public-inbox/autobuild/defines
+++ b/app-network/public-inbox/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=public-inbox
 PKGSEC=net
 PKGDEP="git perl perl-dbd-sqlite perl-uri"
 PKGDES="Git-based public email archive with NNTP, IMAP, and HTTP interfaces"
+
+ABHOST=noarch

--- a/app-network/public-inbox/autobuild/defines
+++ b/app-network/public-inbox/autobuild/defines
@@ -1,5 +1,4 @@
 PKGNAME=public-inbox
 PKGSEC=net
 PKGDEP="git perl perl-dbd-sqlite perl-uri"
-BUILDDEP="perl perl-extutils-makemaker"
 PKGDES="Git-based public email archive with NNTP, IMAP, and HTTP interfaces"

--- a/app-network/public-inbox/autobuild/defines
+++ b/app-network/public-inbox/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=public-inbox
+PKGSEC=net
+PKGDEP="git perl perl-dbd-sqlite perl-uri"
+BUILDDEP="perl perl-extutils-makemaker"
+PKGDES="Git-based public email archive with NNTP, IMAP, and HTTP interfaces"

--- a/app-network/public-inbox/spec
+++ b/app-network/public-inbox/spec
@@ -1,3 +1,4 @@
 VER=2.1.0
 SRCS="git::commit=tags/v$VER::https://public-inbox.org/public-inbox.git"
 CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=283613"

--- a/app-network/public-inbox/spec
+++ b/app-network/public-inbox/spec
@@ -1,0 +1,3 @@
+VER=2.1.0
+SRCS="git::commit=tags/v$VER::https://public-inbox.org/public-inbox.git"
+CHKSUMS="SKIP"

--- a/runtime-common/xapian-bindings/autobuild/defines
+++ b/runtime-common/xapian-bindings/autobuild/defines
@@ -1,0 +1,28 @@
+PKGNAME=xapian-bindings
+PKGSEC=devel
+PKGDEP="xapian-core"
+PKGSUG="python-3 ruby tcl perl lua mono"
+BUILDDEP="${PKGSUG} sphinx"
+BUILDDEP__NOMONO="${BUILDDEP/mono/}"
+BUILDDEP__LOONGSON3="${BUILDDEP__NOMONO}"
+BUILDDEP__RISCV64="${BUILDDEP__NOMONO}"
+BUILDDEP__RETRO="${BUILDDEP__NOMONO}"
+PKGDES="Language bindings for Xapian"
+
+AUTOTOOLS_AFTER="--with-python3 \
+                 --with-ruby \
+                 --with-tcl \
+                 --without-java \
+                 --with-perl \
+                 --with-lua \
+                 --with-csharp"
+AUTOTOOLS_AFTER__NOMONO="--with-python3 \
+                 --with-ruby \
+                 --with-tcl \
+                 --without-java \
+                 --with-perl \
+                 --with-lua \
+                 --without-csharp"
+AUTOTOOLS_AFTER__LOONGSON3="${AUTOTOOLS_AFTER__NOMONO}"
+AUTOTOOLS_AFTER__RISCV64="${AUTOTOOLS_AFTER__NOMONO}"
+AUTOTOOLS_AFTER__RETRO="${AUTOTOOLS_AFTER__NOMONO}"

--- a/runtime-common/xapian-bindings/autobuild/defines
+++ b/runtime-common/xapian-bindings/autobuild/defines
@@ -2,12 +2,14 @@ PKGNAME=xapian-bindings
 PKGSEC=devel
 PKGDEP="xapian-core"
 PKGSUG="python-3 ruby tcl perl lua mono"
-BUILDDEP="${PKGSUG} sphinx"
+BUILDDEP="${PKGSUG} pkg-config sphinx"
 BUILDDEP__NOMONO="${BUILDDEP/mono/}"
 BUILDDEP__LOONGSON3="${BUILDDEP__NOMONO}"
 BUILDDEP__RISCV64="${BUILDDEP__NOMONO}"
 BUILDDEP__RETRO="${BUILDDEP__NOMONO}"
 PKGDES="Language bindings for Xapian"
+
+ABTYPE=autotools
 
 AUTOTOOLS_AFTER="--with-python3 \
                  --with-ruby \

--- a/runtime-common/xapian-bindings/spec
+++ b/runtime-common/xapian-bindings/spec
@@ -1,0 +1,4 @@
+VER=2.0.0
+SRCS="tbl::https://oligarchy.co.uk/xapian/$VER/xapian-bindings-$VER.tar.xz"
+CHKSUMS="sha256::9a544b69c31355a92edbcd4102cf0f1ec4407fd0a4645f4870fb52300b736910"
+CHKUPDATE="anitya::id=15919"


### PR DESCRIPTION
Topic Description
-----------------

- public-inbox: add xapian-bindings to PKGDEP
    V2 inbox indexing loads Search::Xapian at runtime; without it
    public-inbox-init dies with "failed to load Xapian".
    This commit is authored with assistance from AI/LLM:
    - Model: Kimi K3 \(k3\)
    - Platform: Kimi \(kimi.com\)
    - Agent platform: Kimi Code CLI \(code.kimi.com\)
    - Prompt:
    public-inbox-init fails with the following error, fix it: failed to
    load Xapian: Can't locate Search/Xapian.pm in @INC \(you may need to
    install the Search::Xapian module\)
    Assisted-by: Kimi K3 \(k3\)
- xapian-bindings: new, 2.0.0
    Restore the bindings package dropped in a22f4a6ba3 \("drop, orphaned"\),
    now at 2.0.0 to match xapian-core. Provides the Perl Search::Xapian
    module required by public-inbox's search indexing \(public-inbox-init
    fails with "Can't locate Search/Xapian.pm in @INC" without it\).
    C# bindings are disabled where mono is unavailable \(Loongson 3,
    RISC-V 64, retro ports\), following the NOMONO pattern used by
    graphviz/tdebindings.
    This commit is authored with assistance from AI/LLM:
    - Model: Kimi K3 \(k3\)
    - Platform: Kimi \(kimi.com\)
    - Agent platform: Kimi Code CLI \(code.kimi.com\)
    - Prompt:
    public-inbox-init fails with the following error, fix it: failed to
    load Xapian: Can't locate Search/Xapian.pm in @INC \(you may need to
    install the Search::Xapian module\)
    Assisted-by: Kimi K3 \(k3\)
- public-inbox: set ABHOST=noarch for pure Perl package
    public-inbox is a pure Perl package with no compiled ELF binaries,
    so it should not generate debug symbol packages.
    This commit is authored with assistance from AI/LLM:
    - Model: mimo-v2.5-pro
    - Platform: MiMo \(mimo.xiaomi.com\)
    - Agent platform: MiMoCode \(mimocode.com\)
    - Prompt:
    Fix build error: ABSPLITDBG set but no symbol files found
- public-inbox: remove invalid BUILDDEP
    ExtUtils::MakeMaker ships with Perl core and is not a separate
    package in the tree. Remove the non-existent perl-extutils-makemaker
    build dependency.
    This commit is authored with assistance from AI/LLM:
    - Model: mimo-v2.5-pro
    - Platform: MiMo \(mimo.xiaomi.com\)
    - Agent platform: MiMoCode \(mimocode.com\)
    - Prompt:
    Fix build error: perl-extutils-makemaker package not found
- public-inbox: new, 2.1.0
    public-inbox is a git-based public email archive with NNTP, IMAP,
    and HTTP interfaces. It allows users to read and search mailing
    list archives using standard email clients and web browsers.
    This commit is authored with assistance from AI/LLM:
    - Model: mimo-v2.5-pro
    - Platform: MiMo \(mimo.xiaomi.com\)
    - Agent platform: MiMoCode \(mimocode.com\)
    - Prompt:
    Add new package public-inbox, upstream https://public-inbox.org/

Package(s) Affected
-------------------

- public-inbox: 2.1.0
- xapian-bindings: 2.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit xapian-bindings public-inbox
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
