### PR TITLE
zsh-syntax-highlighting: fix missing files

### DIFF
--- a/app-shells/zsh-syntax-highlighting/autobuild/beyond
+++ b/app-shells/zsh-syntax-highlighting/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Adding the missing files..."
+install -Dvm644 "$SRCDIR"/zsh-syntax-highlighting.plugin.zsh \
+    "$PKGDIR"/usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.plugin.zsh

--- a/app-shells/zsh-syntax-highlighting/spec
+++ b/app-shells/zsh-syntax-highlighting/spec
@@ -1,5 +1,5 @@
 VER=0.8.0
-REL=1
+REL=2
 SRCS="git::commit=$VER::https://github.com/zsh-users/zsh-syntax-highlighting"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=7552"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------
Fix the issue of the zsh-syntax-highlighting package built without zsh-syntax-highlighting.plugin.zsh.

<!-- Please input topic description here. -->

Package(s) Affected
-------------------
zsh-syntax-highlighting: 0.8.0-2

<!-- Please list all package(s) affected by this topic here. -->

Security Update?
----------------
No

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
<!-- No -->

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit zsh-syntax-highlighting
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
