### PR TITLE
cinny-desktop: update to 4.12.6

### DIFF
--- a/app-web/cinny-desktop/autobuild/defines
+++ b/app-web/cinny-desktop/autobuild/defines
@@ -1,7 +1,9 @@
 PKGNAME=cinny-desktop
 PKGSEC=web
 PKGDEP="webkit2gtk openssl gtk-3"
-BUILDDEP="nodejs rustc llvm-20"
+BUILDDEP="nodejs rustc llvm"
+# FIXME: nodejs 26 npm segmentation fault on loongson3
+BUILDDEP__LOONGSON3="nodejs-24 rustc llvm"
 PKGDES="Matrix client for desktop"
 
 USECLANG=1
@@ -11,4 +13,5 @@ ABTYPE=rust
 # on riscv64.
 #
 # FIXME: stuck at `vite v5.4.19 building for production...` on ppc64el
-FAIL_ARCH="@(riscv64|ppc64el)"
+# Note: webkit2gtk is not available on retro architectures
+FAIL_ARCH="@(riscv64|ppc64el|retro)"

--- a/app-web/cinny-desktop/autobuild/patches/0001-AOSCOS-remove-tauri-updater.patch.cinny-desktop
+++ b/app-web/cinny-desktop/autobuild/patches/0001-AOSCOS-remove-tauri-updater.patch.cinny-desktop
@@ -1,16 +1,35 @@
-From 8aefbf905a3ce578f72d81a8f4b18ed7310bd41c Mon Sep 17 00:00:00 2001
+From 8bef8a848f7cf1058359563d7273dc4ac205f7d5 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
-Date: Thu, 25 Jun 2026 11:17:45 +0800
+Date: Wed, 5 Aug 2026 19:57:09 +0800
 Subject: [PATCH] AOSCOS: remove tauri updater
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
- src-tauri/Cargo.lock | 276 +------------------------------------------
- src-tauri/Cargo.toml |   5 +-
- 2 files changed, 7 insertions(+), 274 deletions(-)
+ 0001-disable-tauri-updater.patch |  10 --
+ src-tauri/Cargo.lock             | 276 +------------------------------
+ src-tauri/Cargo.toml             |   5 +-
+ 3 files changed, 7 insertions(+), 284 deletions(-)
+ delete mode 100644 0001-disable-tauri-updater.patch
 
+diff --git a/0001-disable-tauri-updater.patch b/0001-disable-tauri-updater.patch
+deleted file mode 100644
+index 88f4167..0000000
+--- a/0001-disable-tauri-updater.patch
++++ /dev/null
+@@ -1,10 +0,0 @@
+-diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
+-index c998577..c92139e 100644
+---- a/src-tauri/Cargo.toml
+-+++ b/src-tauri/Cargo.toml
+-@@ -35,3 +35,3 @@ tauri-plugin-dialog = "2.7.1"
+- # when `tauri dev` runs it is executed with `cargo run --no-default-features` if `devPath` is an URL
+--default = [ "custom-protocol", "updater" ]
+-+default = [ "custom-protocol" ]
+- # this feature is used used for production builds where `devPath` points to the filesystem
+- 
+\ No newline at end of file
 diff --git a/src-tauri/Cargo.lock b/src-tauri/Cargo.lock
-index a5cb37b..c99e093 100644
+index 5529274..36b7ebc 100644
 --- a/src-tauri/Cargo.lock
 +++ b/src-tauri/Cargo.lock
 @@ -47,15 +47,6 @@ version = "1.0.102"
@@ -474,7 +493,7 @@ index a5cb37b..c99e093 100644
  name = "zmij"
  version = "1.0.21"
 diff --git a/src-tauri/Cargo.toml b/src-tauri/Cargo.toml
-index 1fbda39..f40580d 100644
+index a87425e..52f6339 100644
 --- a/src-tauri/Cargo.toml
 +++ b/src-tauri/Cargo.toml
 @@ -33,15 +33,14 @@ tauri-plugin-dialog = "2.7.1"
@@ -496,5 +515,5 @@ index 1fbda39..f40580d 100644
  [lib]
  name = "app_lib"
 -- 
-2.52.0
+2.55.0
 

--- a/app-web/cinny-desktop/autobuild/patches/0001-AOSCOS-update-vite-plugin-top-level-await-to-1.6.0.patch.cinny
+++ b/app-web/cinny-desktop/autobuild/patches/0001-AOSCOS-update-vite-plugin-top-level-await-to-1.6.0.patch.cinny
@@ -1,18 +1,18 @@
-From 4f5b9c285987391b63a2f0be9dd84a6463e33918 Mon Sep 17 00:00:00 2001
+From ebb8a0e9d6e9552dbf439ffc063a4a7ff90188a6 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
-Date: Thu, 25 Jun 2026 11:18:36 +0800
+Date: Wed, 5 Aug 2026 19:44:09 +0800
 Subject: [PATCH 1/2] AOSCOS: update vite-plugin-top-level-await to 1.6.0
 
 Fix build on architectures without native bindings, fallback to WASM.
 
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
- package-lock.json | 20 ++++++++++++++------
- package.json      |  2 +-
- 2 files changed, 15 insertions(+), 7 deletions(-)
+ package-lock.json | 190 ++++++++++++++++++++++++++++++++--------------
+ package.json      |   2 +-
+ 2 files changed, 134 insertions(+), 58 deletions(-)
 
 diff --git a/package-lock.json b/package-lock.json
-index 1dd202b..fc680ec 100644
+index b01cf47..2473ec6 100644
 --- a/package-lock.json
 +++ b/package-lock.json
 @@ -99,7 +99,7 @@
@@ -24,21 +24,330 @@ index 1dd202b..fc680ec 100644
        },
        "engines": {
          "node": ">=16.0.0"
-@@ -4699,6 +4699,13 @@
+@@ -4352,14 +4352,15 @@
+       }
+     },
+     "node_modules/@swc/core": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.7.tgz",
+-      "integrity": "sha512-py91kjI1jV5D5W/Q+PurBdGsdU5TFbrzamP7zSCqLdMcHkKi3rQEM5jkQcZr0MXXSJTaayLxS3MWYTBIkzPDrg==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.47.tgz",
++      "integrity": "sha512-FbsO5JcfOjfH38W/rohBRBweJeERsAuIP4f377lmkmxTcq9exjtx4SkRuZY5CdfhR2CBVwDIJegBpJDffwNsOg==",
+       "dev": true,
+       "hasInstallScript": true,
++      "license": "Apache-2.0",
+       "dependencies": {
+         "@swc/counter": "^0.1.3",
+-        "@swc/types": "^0.1.17"
++        "@swc/types": "^0.1.27"
+       },
+       "engines": {
+         "node": ">=10"
+@@ -4369,19 +4370,21 @@
+         "url": "https://opencollective.com/swc"
+       },
+       "optionalDependencies": {
+-        "@swc/core-darwin-arm64": "1.10.7",
+-        "@swc/core-darwin-x64": "1.10.7",
+-        "@swc/core-linux-arm-gnueabihf": "1.10.7",
+-        "@swc/core-linux-arm64-gnu": "1.10.7",
+-        "@swc/core-linux-arm64-musl": "1.10.7",
+-        "@swc/core-linux-x64-gnu": "1.10.7",
+-        "@swc/core-linux-x64-musl": "1.10.7",
+-        "@swc/core-win32-arm64-msvc": "1.10.7",
+-        "@swc/core-win32-ia32-msvc": "1.10.7",
+-        "@swc/core-win32-x64-msvc": "1.10.7"
+-      },
+-      "peerDependencies": {
+-        "@swc/helpers": "*"
++        "@swc/core-darwin-arm64": "1.15.47",
++        "@swc/core-darwin-x64": "1.15.47",
++        "@swc/core-linux-arm-gnueabihf": "1.15.47",
++        "@swc/core-linux-arm64-gnu": "1.15.47",
++        "@swc/core-linux-arm64-musl": "1.15.47",
++        "@swc/core-linux-ppc64-gnu": "1.15.47",
++        "@swc/core-linux-s390x-gnu": "1.15.47",
++        "@swc/core-linux-x64-gnu": "1.15.47",
++        "@swc/core-linux-x64-musl": "1.15.47",
++        "@swc/core-win32-arm64-msvc": "1.15.47",
++        "@swc/core-win32-ia32-msvc": "1.15.47",
++        "@swc/core-win32-x64-msvc": "1.15.47"
++      },
++      "peerDependencies": {
++        "@swc/helpers": ">=0.5.17"
+       },
+       "peerDependenciesMeta": {
+         "@swc/helpers": {
+@@ -4390,13 +4393,14 @@
+       }
+     },
+     "node_modules/@swc/core-darwin-arm64": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.7.tgz",
+-      "integrity": "sha512-SI0OFg987P6hcyT0Dbng3YRISPS9uhLX1dzW4qRrfqQdb0i75lPJ2YWe9CN47HBazrIA5COuTzrD2Dc0TcVsSQ==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.47.tgz",
++      "integrity": "sha512-GsoMtan3ojGGMGFbl31mmRu5ctZ56re8grGE8mO/OHJ8O+JRkzod02fe7X6ZQ8JvamA3imkEkx/h3u+vsOgPgA==",
+       "cpu": [
+         "arm64"
+       ],
+       "dev": true,
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "darwin"
+@@ -4406,13 +4410,14 @@
+       }
+     },
+     "node_modules/@swc/core-darwin-x64": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.7.tgz",
+-      "integrity": "sha512-RFIAmWVicD/l3RzxgHW0R/G1ya/6nyMspE2cAeDcTbjHi0I5qgdhBWd6ieXOaqwEwiCd0Mot1g2VZrLGoBLsjQ==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.47.tgz",
++      "integrity": "sha512-leTi7Rx3KF4zcC637iqWgk9SoV8VXAD8ppQYXsep63px5A/UftOcxLN1pmr8Z1si/YvX90ompP/rHgpYkgwXWg==",
+       "cpu": [
+         "x64"
+       ],
+       "dev": true,
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "darwin"
+@@ -4422,13 +4427,14 @@
+       }
+     },
+     "node_modules/@swc/core-linux-arm-gnueabihf": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.7.tgz",
+-      "integrity": "sha512-QP8vz7yELWfop5mM5foN6KkLylVO7ZUgWSF2cA0owwIaziactB2hCPZY5QU690coJouk9KmdFsPWDnaCFUP8tg==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.47.tgz",
++      "integrity": "sha512-hBqHuoWKKIsKmDBn9qVeWqj5GWZhtlcczVaqQmNRXsDfq+voR5CxKRfamA367QjJXtceYuliLFfEL8QsskRM2g==",
+       "cpu": [
+         "arm"
+       ],
+       "dev": true,
++      "license": "Apache-2.0",
+       "optional": true,
+       "os": [
+         "linux"
+@@ -4438,13 +4444,17 @@
+       }
+     },
+     "node_modules/@swc/core-linux-arm64-gnu": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.7.tgz",
+-      "integrity": "sha512-NgUDBGQcOeLNR+EOpmUvSDIP/F7i/OVOKxst4wOvT5FTxhnkWrW+StJGKj+DcUVSK5eWOYboSXr1y+Hlywwokw==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.47.tgz",
++      "integrity": "sha512-TBxvRz+B4K205TWHHZxWVxkC2RFNP/Mz3PNcECBos5PsKwxjg3QSJzdoebr0VCf0Bfh8HOPldKxAP/8XkFe9gA==",
+       "cpu": [
+         "arm64"
+       ],
+       "dev": true,
++      "libc": [
++        "glibc"
++      ],
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "linux"
+@@ -4454,13 +4464,57 @@
+       }
+     },
+     "node_modules/@swc/core-linux-arm64-musl": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.7.tgz",
+-      "integrity": "sha512-gp5Un3EbeSThBIh6oac5ZArV/CsSmTKj5jNuuUAuEsML3VF9vqPO+25VuxCvsRf/z3py+xOWRaN2HY/rjMeZog==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.47.tgz",
++      "integrity": "sha512-3Yu3Uq/VgytqsPjTMbkPU1ExADytbdWbruJYhA584E9jrpE2Ki+R6VVPoZCeAVk1Cb7QxcRTgblw6bSa6a/R+w==",
+       "cpu": [
+         "arm64"
+       ],
+       "dev": true,
++      "libc": [
++        "musl"
++      ],
++      "license": "Apache-2.0 AND MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=10"
++      }
++    },
++    "node_modules/@swc/core-linux-ppc64-gnu": {
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.47.tgz",
++      "integrity": "sha512-wfdMi5IaOaNtmh2/6geRoxIdNfqylUZFdtzTKS655y1axWfIWyx7As74vv0wVdjeCIZ3WmCI9odDd4rUttXOSQ==",
++      "cpu": [
++        "ppc64"
++      ],
++      "dev": true,
++      "libc": [
++        "glibc"
++      ],
++      "license": "Apache-2.0 AND MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=10"
++      }
++    },
++    "node_modules/@swc/core-linux-s390x-gnu": {
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.47.tgz",
++      "integrity": "sha512-3hHYBY0yx8Ez7GMRrkhXHQzMdR5IZA6Wq5Ee4svlgwvSECLpnAJ9+0AimEGUFDvuLwE7nV/2+PYe8+Nm4rvNcQ==",
++      "cpu": [
++        "s390x"
++      ],
++      "dev": true,
++      "libc": [
++        "glibc"
++      ],
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "linux"
+@@ -4470,13 +4524,17 @@
+       }
+     },
+     "node_modules/@swc/core-linux-x64-gnu": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.7.tgz",
+-      "integrity": "sha512-k/OxLLMl/edYqbZyUNg6/bqEHTXJT15l9WGqsl/2QaIGwWGvles8YjruQYQ9d4h/thSXLT9gd8bExU2D0N+bUA==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.47.tgz",
++      "integrity": "sha512-TjfhjgP/jGCfFHYC3JQPhJA1HwErbIJ9JfREDc1KNkvY6P0LodCgKVIlQ5deeTbkG7ih3bF5PHJLuLpaZjdRyQ==",
+       "cpu": [
+         "x64"
+       ],
+       "dev": true,
++      "libc": [
++        "glibc"
++      ],
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "linux"
+@@ -4486,13 +4544,17 @@
+       }
+     },
+     "node_modules/@swc/core-linux-x64-musl": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.7.tgz",
+-      "integrity": "sha512-XeDoURdWt/ybYmXLCEE8aSiTOzEn0o3Dx5l9hgt0IZEmTts7HgHHVeRgzGXbR4yDo0MfRuX5nE1dYpTmCz0uyA==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.47.tgz",
++      "integrity": "sha512-CQpS8Ge/avfjZd0UEwG/sds83Uu32deQXcV1Jo3jD0mmvQQqtYAjpsDZXugmheeAwmt+YIuoVtVHro8LMYHqsQ==",
+       "cpu": [
+         "x64"
+       ],
+       "dev": true,
++      "libc": [
++        "musl"
++      ],
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "linux"
+@@ -4502,13 +4564,14 @@
+       }
+     },
+     "node_modules/@swc/core-win32-arm64-msvc": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.7.tgz",
+-      "integrity": "sha512-nYAbi/uLS+CU0wFtBx8TquJw2uIMKBnl04LBmiVoFrsIhqSl+0MklaA9FVMGA35NcxSJfcm92Prl2W2LfSnTqQ==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.47.tgz",
++      "integrity": "sha512-0W8IKHsUTYiT7G2RqtOoVWk+89yzZikIiDUb/sCK6BmQDBhN91hQSfyUtW12jhEWLzYgcfmisfsZrmZE+84U1A==",
+       "cpu": [
+         "arm64"
+       ],
+       "dev": true,
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "win32"
+@@ -4518,13 +4581,14 @@
+       }
+     },
+     "node_modules/@swc/core-win32-ia32-msvc": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.7.tgz",
+-      "integrity": "sha512-+aGAbsDsIxeLxw0IzyQLtvtAcI1ctlXVvVcXZMNXIXtTURM876yNrufRo4ngoXB3jnb1MLjIIjgXfFs/eZTUSw==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.47.tgz",
++      "integrity": "sha512-ZIp49d2Z4/ka2jO9otOg4hDvTdPmp86kVOgS2M5FCPI7eKKZ1W0boxWn+8XeZrfERtFGW0AlMRm4JhlJa7l3NA==",
+       "cpu": [
+         "ia32"
+       ],
+       "dev": true,
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "win32"
+@@ -4534,13 +4598,14 @@
+       }
+     },
+     "node_modules/@swc/core-win32-x64-msvc": {
+-      "version": "1.10.7",
+-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.7.tgz",
+-      "integrity": "sha512-TBf4clpDBjF/UUnkKrT0/th76/zwvudk5wwobiTFqDywMApHip5O0VpBgZ+4raY2TM8k5+ujoy7bfHb22zu17Q==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.47.tgz",
++      "integrity": "sha512-2h8Iek95vnixkBRCo+H8p09+Q5ll2NgSMFrWTy0iKt7+/t+8/T5mBpiT6c0ZxSS7wcWjwZ9sGZkK70tTSYHdDw==",
+       "cpu": [
+         "x64"
+       ],
+       "dev": true,
++      "license": "Apache-2.0 AND MIT",
+       "optional": true,
+       "os": [
+         "win32"
+@@ -4553,7 +4618,8 @@
+       "version": "0.1.3",
+       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+-      "dev": true
++      "dev": true,
++      "license": "Apache-2.0"
+     },
+     "node_modules/@swc/helpers": {
+       "version": "0.5.15",
+@@ -4564,14 +4630,22 @@
+       }
+     },
+     "node_modules/@swc/types": {
+-      "version": "0.1.17",
+-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
++      "version": "0.1.28",
++      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.28.tgz",
++      "integrity": "sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==",
+       "dev": true,
++      "license": "Apache-2.0",
+       "dependencies": {
          "@swc/counter": "^0.1.3"
        }
      },
 +    "node_modules/@swc/wasm": {
-+      "version": "1.15.43",
-+      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.43.tgz",
-+      "integrity": "sha512-jYqeckrzZGAU+9OSfmL15MWfhkKWRCC8QMssL/MZu/MaIP76mU3VHjzqxlwKIz9DOSR/9jCqi1+QlWE0ILNehA==",
++      "version": "1.15.47",
++      "resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.15.47.tgz",
++      "integrity": "sha512-AdcxrBWz13mPnXxzxr5Lkxkgknwi0fAaArdehpYENB/iIds+WEWVcof3FJKfYAPP7TOeCsaSTKFTSsP3/YX7iw==",
 +      "dev": true,
 +      "license": "Apache-2.0"
 +    },
      "node_modules/@tanstack/query-core": {
        "version": "5.24.1",
        "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.24.1.tgz",
-@@ -13822,15 +13829,16 @@
+@@ -13052,14 +13126,16 @@
        }
      },
      "node_modules/vite-plugin-top-level-await": {
@@ -49,7 +358,7 @@ index 1dd202b..fc680ec 100644
 +      "resolved": "https://registry.npmjs.org/vite-plugin-top-level-await/-/vite-plugin-top-level-await-1.6.0.tgz",
 +      "integrity": "sha512-bNhUreLamTIkoulCR9aDXbTbhLk6n1YE8NJUTTxl5RYskNRtzOR0ASzSjBVRtNdjIfngDXo11qOsybGLNsrdww==",
        "dev": true,
-       "license": "MIT",
++      "license": "MIT",
        "dependencies": {
          "@rollup/plugin-virtual": "^3.0.2",
 -        "@swc/core": "^1.7.0",
@@ -61,7 +370,7 @@ index 1dd202b..fc680ec 100644
        "peerDependencies": {
          "vite": ">=2.8"
 diff --git a/package.json b/package.json
-index d687097..58c0f21 100644
+index aa3e17d..036b6fc 100644
 --- a/package.json
 +++ b/package.json
 @@ -123,6 +123,6 @@
@@ -73,5 +382,5 @@ index d687097..58c0f21 100644
    }
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-web/cinny-desktop/autobuild/patches/0002-AOSCOS-use-rollup-wasm-node-to-fix-build-on-unsuppor.patch.cinny.wasm
+++ b/app-web/cinny-desktop/autobuild/patches/0002-AOSCOS-use-rollup-wasm-node-to-fix-build-on-unsuppor.patch.cinny.wasm
@@ -1,4 +1,4 @@
-From 9bf2e46bd5987c3354a44f62c656fd729416ccb3 Mon Sep 17 00:00:00 2001
+From 9e79a5ec3f8c9872af53e06fa4f2a4c958fd0478 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <origincode@aosc.io>
 Date: Thu, 7 May 2026 17:52:56 +0800
 Subject: [PATCH 2/2] AOSCOS: use `@rollup/wasm-node` to fix build on
@@ -10,7 +10,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  1 file changed, 5 insertions(+)
 
 diff --git a/package.json b/package.json
-index 58c0f21..61356b5 100644
+index 036b6fc..1efedaa 100644
 --- a/package.json
 +++ b/package.json
 @@ -124,5 +124,10 @@
@@ -25,5 +25,5 @@ index 58c0f21..61356b5 100644
    }
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-web/cinny-desktop/spec
+++ b/app-web/cinny-desktop/spec
@@ -1,6 +1,5 @@
-VER=4.12.5
+VER=4.12.6
 SRCS="git::commit=tags/v$VER::https://github.com/cinnyapp/cinny-desktop"
 CHKSUMS="SKIP"
 SUBDIR="cinny-desktop/src-tauri"
 CHKUPDATE="anitya::id=324698"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- cinny-desktop: update to 4.12.6
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- cinny-desktop: 4.12.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit cinny-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
