### PR TITLE
ipython: update to 9.16.1

### DIFF
--- a/lang-python/ipython/spec
+++ b/lang-python/ipython/spec
@@ -1,4 +1,4 @@
-VER=9.15.0
+VER=9.16.1
 SRCS="tbl::https://pypi.io/packages/source/i/ipython/ipython-$VER.tar.gz"
-CHKSUMS="sha256::da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756"
+CHKSUMS="sha256::5a3d1f9a47ff216d6cf9cf863124f6a2c1a198d1354c546a4d24a370a283b64c"
 CHKUPDATE="anitya::id=1399"


### PR DESCRIPTION
Topic Description
-----------------

- ipython: update to 9.16.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ipython: 9.16.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ipython
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
