### PR TITLE
taisei: update to 1.4.6

### DIFF
--- a/app-games/taisei/autobuild/defines
+++ b/app-games/taisei/autobuild/defines
@@ -6,3 +6,5 @@ PKGSUG="gamemode"
 PKGDES="Open source Touhou clone"
 
 PKGEPOCH=1
+
+FAIL_ARCH="!(mainline|retro)"

--- a/app-games/taisei/spec
+++ b/app-games/taisei/spec
@@ -1,5 +1,5 @@
-VER=1.4.5
-SRCS="git::commit=tags/v$VER::https://github.com/laochailan/taisei"
+VER=1.4.6
+SRCS="git::commit=tags/v$VER::https://github.com/taisei-project/taisei.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141668"
 REL=1

--- a/app-scientific/cglm/autobuild/defines
+++ b/app-scientific/cglm/autobuild/defines
@@ -5,3 +5,5 @@ BUILDDEP="meson ninja"
 PKGDES="Optmised 2D/3D OpenGL Mathematics (GLM) library"
 
 ABTYPE=meson
+
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-common/libunibreak/autobuild/defines
+++ b/runtime-common/libunibreak/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libunibreak
 PKGDES="Implementation of the line breaking algorithm"
 PKGSEC=libs
 PKGDEP="glibc"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-multimedia/opusfile/autobuild/defines
+++ b/runtime-multimedia/opusfile/autobuild/defines
@@ -1,5 +1,6 @@
 PKGNAME=opusfile
 PKGSEC=libs
 PKGDEP="libogg opus openssl"
-BUILDDEP="doxygen"
-PKGDES="Library for opening, seeking, and recording .opus files"
+PKGDES="Library to open, seek, and record .opus files"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-multimedia/opusfile/spec
+++ b/runtime-multimedia/opusfile/spec
@@ -1,5 +1,5 @@
 VER=0.11
-REL=2
+REL=3
 SRCS="tbl::https://downloads.xiph.org/releases/opus/opusfile-$VER.tar.gz"
 CHKSUMS="sha256::74ce9b6cf4da103133e7b5c95df810ceb7195471e1162ed57af415fabf5603bf"
 CHKUPDATE="anitya::id=10353"

--- a/runtime-multimedia/sdl3-image/autobuild/defines
+++ b/runtime-multimedia/sdl3-image/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=sdl3-image
 PKGSEC=x11
 PKGDEP="libpng libjpeg-turbo libtiff libwebp sdl3"
 PKGDES="Image loader for the Simple Directmedia Layer (version 3)"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-multimedia/sdl3-ttf/autobuild/defines
+++ b/runtime-multimedia/sdl3-ttf/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=sdl3-ttf
 PKGSEC=libs
 PKGDEP="sdl3 freetype"
 PKGDES="TrueType (.ttf) font support for the Simple Directmedia Layer (version 3)"
+
+FAIL_ARCH="!(mainline|retro)"


### PR DESCRIPTION
Topic Description
-----------------

- libopusfile: allow building on Afterglow; disable Doxygen
- libunibreak: allow building on Afterglow
- cglm: allow building on Afterglow
- sdl3-ttf: allow building on Afterglow
- sdl3-image: allow building on Afterglow
- taisei: update to 1.4.6
    Signed-off-by: LiarOnce <liaronce@hotmail.com>

Package(s) Affected
-------------------

- taisei: 1:1.4.6-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit taisei
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
