### PR TITLE
binutils: set GNUTARGET for cross tools

### DIFF
--- a/app-devel/binutils/01-main/defines
+++ b/app-devel/binutils/01-main/defines
@@ -38,10 +38,6 @@ AUTOTOOLS_AFTER__LOONGSON3=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-mips-fix-loongson3-llsc'
 )
-AUTOTOOLS_AFTER__PPC64EL=(
-    "${AUTOTOOLS_AFTER[@]}"
-    '--enable-targets=powerpc-linux'
-)
 
 # Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
 FAIL_ARCH="!(mainline|retro)"

--- a/app-devel/binutils/02-amd64/build
+++ b/app-devel/binutils/02-amd64/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/03-arm64/build
+++ b/app-devel/binutils/03-arm64/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/04-loongarch64/build
+++ b/app-devel/binutils/04-loongarch64/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/05-loongson3/build
+++ b/app-devel/binutils/05-loongson3/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/06-ppc64el/build
+++ b/app-devel/binutils/06-ppc64el/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/07-riscv64/build
+++ b/app-devel/binutils/07-riscv64/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/08-arm-none-eabi/build
+++ b/app-devel/binutils/08-arm-none-eabi/build
@@ -71,13 +71,19 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m $targ_emul --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
-abinfo "Creating symlinks for other tools (target: $targ) ..."
+output_format=$("$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-ld --print-output-format)
+
+abinfo "Creating wrapper scripts for other tools (target: $targ) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-${output_format}} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: $targ)"

--- a/app-devel/binutils/09-i486/build
+++ b/app-devel/binutils/09-i486/build
@@ -8,7 +8,7 @@ cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-as << EOF
 #!/bin/sh
 exec x86_64-aosc-linux-gnu-as --32 "$@"
 EOF
-chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-as
+chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-as
 
 abinfo "Creating wrapper script for the linker (target: i486-aosc-linux-gnu) ..."
 for i in ld ld.bfd; do
@@ -16,13 +16,17 @@ for i in ld ld.bfd; do
 #!/bin/sh
 exec /usr/bin/$i -m elf_i386 --sysroot=/var/ab/cross-root/${__CROSS} "\$@"
 EOF
-  chmod 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-$i
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-$i
 done
 
-abinfo "Creating symlinks for other tools (target: i486-aosc-linux-gnu) ..."
+abinfo "Creating wrapper scripts for other tools (target: i486-aosc-linux-gnu) ..."
 for i in addr2line ar c++filt elfedit gprof nm objcopy objdump ranlib \
          readelf size strings strip; do
-  ln -svr "$PKGDIR"/usr/bin/$i "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-$i
+  cat > "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-$i << EOF
+#!/bin/sh
+GNUTARGET=\${GNUTARGET:-elf32-i386} exec /usr/bin/$i "\$@"
+EOF
+  chmod -v 755 "$PKGDIR"/opt/abcross/${__CROSS}/bin/i486-aosc-linux-gnu-$i
 done
 
 abinfo "Creating symlinks in the tooldir (target: i486-aosc-linux-gnu)"

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,5 @@
 VER=2.47
-REL=1
+REL=2
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::154ab23b60070e8f27013c22977f1129425d67d1e8acd6e13010e617811e4cff"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION


<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

binutils: set GNUTARGET for cross tools and remove AUTOTOOLS_AFTER__PPC64EL
    
Without GNUTARGET, the tools guesses the input format but sometimes the
guess is incorrect.  For example, a elf64-tradlittlemips object can be
guessed as elf64-littlemips and then objcopy will fail with "not enough
room for program headers."
    
And AUTOTOOLS_AFTER__PPC64EL overrides --enable-targets=all, causing the
cross toolchain on ppc64el fail to work at all.


Package(s) Affected
-------------------

- binutils: `2.47-2`
- binutils+cross-amd64: `2.47-2`
- binutils+cross-arm64: `2.47-2`
- binutils+cross-loongarch64: `2.47-2`
- binutils+cross-loongson3: `2.47-2`
- binutils+cross-ppc64el: `2.47-2`
- binutils+cross-riscv64: `2.47-2`
- binutils+cross-arm-none-eabi: `2.47-2`
- binutils+cross-i486: `2.47-2`

Security Update?
----------------

<!-- If this topic contains security update(s), please uncomment "Yes,"
     mark with the `security` label and make sure to mark your commits to
     relevant issue numbers.

     Please see GitHub's documentation on "Linking a pull request to an issue":

     https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

<!-- Yes, #ISSUENUMBER -->
No

Build Order
-----------

<!-- Please describe in what order the packages affected by this pull request
     should be built. Please use the following template, making sure to keep
     the `#buildit` prefix, and use space to separate packages. -->

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
