### PR TITLE
autobuild4: update to 4.19.2, fix spiral marks

### DIFF
--- a/app-devel/autobuild4/spec
+++ b/app-devel/autobuild4/spec
@@ -1,5 +1,4 @@
-VER=4.19.1
-REL=1
+VER=4.19.2
 SRCS="git::commit=tags/v${VER}::https://github.com/AOSC-Dev/autobuild4"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372345"

--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,5 @@
 VER=2.42
-REL=1
+REL=2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
 CHKSUMS="sha256::3452b260bbaa775d6e749ac3bb22111785003fc1f444970025c8da26dfa758e9"
 CHKUPDATE="anitya::id=8179"


### PR DESCRIPTION
Topic Description
-----------------

- binutils: bump REL to re-generate spiral marks
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- autobuild4: update to 4.19.2, fix spiral marks
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- autobuild4: 4.19.2
- util-linux: 2.42-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit autobuild4 util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
