### PR TITLE
vscode: update to 1.132.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.131.0
+VER=1.132.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::fe2ed2d94ccc694f49d9084846c0be78ba56c42810355fa3999160079bb53c9a"
-CHKSUMS__ARM64="sha256::b57f73e4a8a4524bf2a796757f64bd7b594515dd8dabae9b8cd07b1beb204d9c"
+CHKSUMS__AMD64="sha256::b73e01a1a371eb7d57f2c01712c43e9cedd15d6bad9a44261c4473db946532ef"
+CHKSUMS__ARM64="sha256::599196c05788cf5d433556118eaa6a1b89a46683c6d1423aacf4279200533e82"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.132.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- vscode: 1.132.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
