### PR TITLE
[FLIGHT] oma: test fix for no-logind envs

### DIFF
--- a/app-admin/oma/autobuild/defines
+++ b/app-admin/oma/autobuild/defines
@@ -5,7 +5,7 @@ PKGDEP="aosc-os-feature-data apt bzip2 gcc-runtime gmp nettle openssl \
         aosc-os-repository-template aosc-os-keyring"
 PKGDEP__RETRO="${PKGDEP} openssl"
 PKGRECOM="amo"
-BUILDDEP="rustc llvm"
+BUILDDEP="llvm"
 PKGSEC="admin"
 PKGBREAK="mirrormgr<=0.11.1"
 PKGREP="mirrormgr<=0.11.1"
@@ -20,3 +20,5 @@ CARGO_AFTER=(
 )
 
 FAIL_ARCH="!(mainline|i486)"
+
+NOLTO=1

--- a/app-admin/oma/autobuild/prepare
+++ b/app-admin/oma/autobuild/prepare
@@ -1,2 +1,5 @@
 abinfo "Set ZSTD_SYS_USE_PKG_CONFIG=1 to use system zstd ..."
 export ZSTD_SYS_USE_PKG_CONFIG=1
+
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+export PATH="$HOME"/.cargo/bin:"$PATH"

--- a/app-admin/oma/spec
+++ b/app-admin/oma/spec
@@ -1,5 +1,5 @@
 VER=1.27.3
-REL=1
-SRCS="git::commit=tags/v${VER/\~/-}::https://github.com/AOSC-Dev/oma"
+REL=2
+SRCS="git::commit=89cbc500d3eecf6c63714129582aef753eb84d7f::https://github.com/AOSC-Dev/oma"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=328412"


### PR DESCRIPTION
Topic Description
-----------------

- \[FLIGHT\] oma: test fix for no-logind envs

Package(s) Affected
-------------------

- oma: 1.27.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit oma
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
