### PR TITLE
docbook-dsssl: workaround removal failure on OverlayFS

### DIFF
--- a/app-doc/docbook-dsssl/autobuild/postinst
+++ b/app-doc/docbook-dsssl/autobuild/postinst
@@ -1,7 +1,7 @@
 /usr/bin/install-catalog --add \
-                         /etc/sgml/dsssl-docbook-stylesheets.cat \
-                         /usr/share/sgml/docbook/dsssl-stylesheets-1.79/catalog
+	/etc/sgml/dsssl-docbook-stylesheets.cat \
+	/usr/share/sgml/docbook/dsssl-stylesheets-1.79/catalog
  
 /usr/bin/install-catalog --add \
-                         /etc/sgml/sgml-docbook.cat \
-                         /etc/sgml/dsssl-docbook-stylesheets.cat
+	/etc/sgml/sgml-docbook.cat \
+	/etc/sgml/dsssl-docbook-stylesheets.cat

--- a/app-doc/docbook-dsssl/autobuild/prerm
+++ b/app-doc/docbook-dsssl/autobuild/prerm
@@ -1,7 +1,25 @@
+# FIXME: Removal fails on OverlayFS for some reason. Allowing `|| true'.
+#
+# Removing docbook-xml (1:0-1) ...
+# Removing docbook-dtd (4.5-5) ...
+# Removing docbook-dsssl (1.79-1) ...
+# install-catalog: can not modify "/etc/sgml/catalog".
+# install-catalog: can not modify "/etc/sgml/catalog".
+# dpkg: error processing package docbook-dsssl (--remove):
+#  old docbook-dsssl package prerm maintainer script subprocess failed with exit status 2
+# dpkg: too many errors, stopping
+# install-catalog: addition of /usr/share/sgml/docbook/dsssl-stylesheets-1.79/catalog in /etc/sgml/dsssl-docbook-stylesheets.cat
+# Warning: /usr/share/sgml/docbook/dsssl-stylesheets-1.79/catalog is already installed in the centralized catalog /etc/sgml/dsssl-docbook-stylesheets.cat
+# install-catalog: addition of /etc/sgml/dsssl-docbook-stylesheets.cat in /etc/sgml/catalog
+# install-catalog: addition of /etc/sgml/dsssl-docbook-stylesheets.cat in /etc/sgml/sgml-docbook.cat
+# install-catalog: addition of /etc/sgml/sgml-docbook.cat in /etc/sgml/catalog
+# Errors were encountered while processing:
+#  docbook-dsssl
+# Processing was halted because there were too many errors.
 /usr/bin/install-catalog --remove \
-                         /etc/sgml/dsssl-docbook-stylesheets.cat \
-                         /usr/share/sgml/docbook/dsssl-stylesheets-1.79/catalog
+	/etc/sgml/dsssl-docbook-stylesheets.cat \
+	/usr/share/sgml/docbook/dsssl-stylesheets-1.79/catalog || true
   
 /usr/bin/install-catalog --remove \
-                         /etc/sgml/sgml-docbook.cat \
-                         /etc/sgml/dsssl-docbook-stylesheets.cat
+	/etc/sgml/sgml-docbook.cat \
+	/etc/sgml/dsssl-docbook-stylesheets.cat || true

--- a/app-doc/docbook-dsssl/spec
+++ b/app-doc/docbook-dsssl/spec
@@ -1,5 +1,5 @@
 VER=1.79
-REL=1
+REL=2
 SRCS="tbl::https://sourceforge.net/projects/docbook/files/docbook-dsssl/$VER/docbook-dsssl-$VER.tar.bz2"
 CHKSUMS="sha256::2f329e120bee9ef42fbdd74ddd60e05e49786c5a7953a0ff4c680ae6bdf0e2bc"
 CHKUPDATE="anitya::id=227306"

--- a/app-doc/sgml-common/autobuild/prerm
+++ b/app-doc/sgml-common/autobuild/prerm
@@ -1,4 +1,20 @@
+# FIXME: Removal fails on OverlayFS for some reason. Allowing `|| true'.
+#
+# Removing sgml-common (0.6.3-3) ...
+# install-catalog: can not modify "/etc/sgml/catalog".
+# install-catalog: can not modify "/etc/sgml/catalog".
+# dpkg: error processing package sgml-common (--remove):
+#  old sgml-common package prerm maintainer script subprocess failed with exit status 2
+# dpkg: too many errors, stopping
+# install-catalog: addition of /usr/share/sgml/sgml-iso-entities-8879.1986/catalog in /etc/sgml/sgml-ent.cat
+# Warning: /usr/share/sgml/sgml-iso-entities-8879.1986/catalog is already installed in the centralized catalog /etc/sgml/sgml-ent.cat
+# install-catalog: addition of /etc/sgml/sgml-ent.cat in /etc/sgml/catalog
+# install-catalog: addition of /etc/sgml/sgml-ent.cat in /etc/sgml/sgml-docbook.cat
+# install-catalog: addition of /etc/sgml/sgml-docbook.cat in /etc/sgml/catalog
+# Errors were encountered while processing:
+#  sgml-common
+# Processing was halted because there were too many errors.
 install-catalog --remove /etc/sgml/sgml-ent.cat \
-	/usr/share/sgml/sgml-iso-entities-8879.1986/catalog
+	/usr/share/sgml/sgml-iso-entities-8879.1986/catalog || true
 install-catalog --remove /etc/sgml/sgml-docbook.cat \
-	/etc/sgml/sgml-ent.cat
+	/etc/sgml/sgml-ent.cat || true

--- a/app-doc/sgml-common/spec
+++ b/app-doc/sgml-common/spec
@@ -1,5 +1,5 @@
 VER=0.6.3
-REL=3
+REL=4
 SRCS="tbl::https://sourceware.org/ftp/docbook-tools/new-trials/SOURCES/sgml-common-$VER.tgz"
 CHKSUMS="sha256::7dc418c1d361123ffc5e45d61f1b97257940a8eb35d0bfbbc493381cc5b1f959"
 CHKUPDATE="anitya::id=227355"


### PR DESCRIPTION
Topic Description
-----------------

- sgml-common: workaround removal failure on OverlayFS
    Investigation pending, this is but a hotfix for Ciel stalls.
- docbook-dsssl: workaround removal failure on OverlayFS
    Investigation pending, this is but a hotfix for Ciel stalls.

Package(s) Affected
-------------------

- docbook-dsssl: 1.79-2
- sgml-common: 0.6.3-5

Security Update?
----------------

No

Build Order
-----------

```
#buildit docbook-dsssl sgml-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
