### PR TITLE
udisks-2: update to 2.11.1

### DIFF
--- a/app-admin/udisks-2/spec
+++ b/app-admin/udisks-2/spec
@@ -1,5 +1,4 @@
-VER=2.11.0
-REL=3
+VER=2.11.1
 SRCS="tbl::https://github.com/storaged-project/udisks/releases/download/udisks-$VER/udisks-$VER.tar.bz2"
-CHKSUMS="sha256::0bf30151fe8d9d2fb59b57f6630739dfbbd16417dee69ec57d43b37335bd649a"
+CHKSUMS="sha256::e88c52bae02fa13414604bbef42c6bb91c2e24177ee0057ed55c6bd7451bcb6d"
 CHKUPDATE="anitya::id=5028"


### PR DESCRIPTION
Topic Description
-----------------

- udisks-2: update to 2.11.1
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- udisks-2: 2.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit udisks-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
