### PR TITLE
udisks-2: update to 2.11.2

### DIFF
--- a/app-admin/udisks-2/spec
+++ b/app-admin/udisks-2/spec
@@ -1,5 +1,4 @@
-VER=2.11.0
-REL=3
+VER=2.11.2
 SRCS="tbl::https://github.com/storaged-project/udisks/releases/download/udisks-$VER/udisks-$VER.tar.bz2"
-CHKSUMS="sha256::0bf30151fe8d9d2fb59b57f6630739dfbbd16417dee69ec57d43b37335bd649a"
+CHKSUMS="sha256::18630a8aad806bea0bc626ce97e71e50ec82c742956ac1c834a4275f8f22207b"
 CHKUPDATE="anitya::id=5028"

--- a/topics/udisks-2-2.11.2.toml
+++ b/topics/udisks-2-2.11.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "UDisks 2.11.2"
+
+[caution]
+default = "Fixes a Local Privilege Escalation vulnerability, codenamed \"disk2root\" (CVE-2026-7867, severity: High)"
+zh_CN = "修复代号为 \"disk2root\" 的本地提权漏洞（CVE-2026-7867，严重性：高）"
+
+[packages-v2]
+"udisks-2" = "< 2.11.2"


### PR DESCRIPTION
Topic Description
-----------------

- udisks-2: update to 2.11.2
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- udisks-2: 2.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit udisks-2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
