### PR TITLE
deno: update to 2.9.5

### DIFF
--- a/lang-js/deno/autobuild/defines
+++ b/lang-js/deno/autobuild/defines
@@ -12,12 +12,11 @@ PKGDES="JavaScript and TypeScript runtime"
 ABTYPE=rust
 USECLANG=1
 CARGO_AFTER=(
-    '--no-default-features' # Disable the upgrade feature and vendor zlib
-    '-p' 'deno'
+    '--bin' 'deno'
 )
 
 # loongson3: Missing libclang_rt.builtins.a.
-FAIL_ARCH="@(loongson3)"
+FAIL_ARCH="@(loongson3|retro)"
 
 # FIXME:
 # ld.lld: error: undefined symbol: aws_lc_0_26_0_EVP_parse_private_key

--- a/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/lang-js/deno/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,7 +1,7 @@
-From 90578710abd5b90fee06d9f7fd0b3bb6209a6004 Mon Sep 17 00:00:00 2001
+From a41d3b0ee475cd45169edf9fa0cf14c46ed863a6 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 24 Jul 2026 20:23:18 +0800
-Subject: [PATCH] AOSCOS: use local patched rusty_v8
+Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
 
 ---
  Cargo.lock | 2 --
@@ -9,23 +9,23 @@ Subject: [PATCH] AOSCOS: use local patched rusty_v8
  2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/Cargo.lock b/Cargo.lock
-index 640923eb0c..c66237bb4e 100644
+index 8739cfa1c2..f812300546 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -11174,8 +11174,6 @@ dependencies = [
+@@ -11273,8 +11273,6 @@ dependencies = [
  [[package]]
  name = "v8"
- version = "150.2.0"
+ version = "150.4.0"
 -source = "registry+https://github.com/rust-lang/crates.io-index"
--checksum = "c7f4e905df70d6c00b95e69c5f0831fd5eb5889b0116ae2b30293578c19cd1bc"
+-checksum = "42a978ff11f15b24e5c05a7123cf2b68f41e763546699781a924ef4e2cf43a49"
  dependencies = [
   "bindgen 0.72.1",
   "bitflags 2.9.3",
 diff --git a/Cargo.toml b/Cargo.toml
-index ade71b26c4..4a3b71d99b 100644
+index 2b660a0bfd..9ff6f4b84c 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -635,3 +635,6 @@ opt-level = 3
+@@ -640,3 +640,6 @@ opt-level = 3
  opt-level = 3
  [profile.release.package.twox-hash]
  opt-level = 3

--- a/lang-js/deno/autobuild/patches/0002-AOSCOS-Disable-the-upgrade-feature-and-vendor-zlib.patch
+++ b/lang-js/deno/autobuild/patches/0002-AOSCOS-Disable-the-upgrade-feature-and-vendor-zlib.patch
@@ -1,0 +1,25 @@
+From af6826ea88a5bf874c366a765d16d84c5baca4d9 Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Fri, 7 Aug 2026 23:40:37 +0800
+Subject: [PATCH 2/2] AOSCOS: Disable the upgrade feature and vendor zlib
+
+---
+ cli/Cargo.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cli/Cargo.toml b/cli/Cargo.toml
+index dc50a26c8b..3b2f99931b 100644
+--- a/cli/Cargo.toml
++++ b/cli/Cargo.toml
+@@ -27,7 +27,7 @@ harness = false
+ default = ["v8"]
+ # The dependency named `v8` is the deno_v8 facade, retained under the existing
+ # crate name so the engine integration does not require source-level churn.
+-v8 = ["__runtime_defaults", "deno_core/v8", "v8/v8"]
++v8 = ["deno_core/v8", "v8/v8"]
+ quickjs = ["__runtime_defaults", "deno_core/quickjs", "v8/quickjs"]
+ __runtime_defaults = ["upgrade", "__vendored_zlib_ng"]
+ # A feature that enables heap profiling with dhat on Linux.
+-- 
+2.55.0
+

--- a/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0003-AOSCOS-Disable-cross-compilation-setup.patch.deferred
@@ -1,7 +1,7 @@
-From f914c2860b40e9938b4203d61990f2743ae85510 Mon Sep 17 00:00:00 2001
+From a8128af83f12804ee068f9fa69d7a1fffbc4137c Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 24 Jul 2026 20:16:21 +0800
-Subject: [PATCH 2/4] AOSCOS: Disable cross-compilation setup
+Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup
 
 Because we have native linux arm64 and riscv64 CI :)
 ---

--- a/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0004-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,7 +1,7 @@
-From d96d388fff3dcfcf44f53f63ddcd2dca32301e6f Mon Sep 17 00:00:00 2001
+From 49cad91d039a22739fc280e9e1f65ca5bf2f6b84 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
-Subject: [PATCH 3/4] AOSCOS: build: correct Clang builtins path
+Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
 
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 

--- a/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/lang-js/deno/autobuild/patches/0005-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,7 +1,7 @@
-From 832842c9fe89bb318da2869f2ce9d08570682c1c Mon Sep 17 00:00:00 2001
+From e44433cd4b0111e42f46b0aa2b496699f38c7b6f Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 23 May 2026 00:26:17 +0800
-Subject: [PATCH 4/4] AOSCOS: drop unknown argument
+Subject: [PATCH 5/5] AOSCOS: drop unknown argument
 
 Ref: https://github.com/cions/termux-deno/blob/7068f1fc4d8817045cbe4c65934df9646cd78368/rusty_v8-fix-unknown-options.patch
 ---

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.9.4
+VER=2.9.5
 # Note: This must match "v8" version in Cargo.lock.
-RUSTY_V8_VER=150.2.0
+RUSTY_V8_VER=150.4.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::95f9d8361809f2d2f3ee2d8a6955951dcf96c2f4bbeb540c2d6fdd9363e6dc94 \
+CHKSUMS="sha256::b3d1d66e47d74f5bda84d5a80282135b7d8f2e336fbcf98c75be32f18130864a \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.9.5
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.9.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
