### PR TITLE
cage: update to 0.3.1

### DIFF
--- a/desktop-wm/cage/spec
+++ b/desktop-wm/cage/spec
@@ -1,4 +1,4 @@
-VER=0.2.1
+VER=0.3.1
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/cage-kiosk/cage"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya=21171"

--- a/runtime-display/wlroots/autobuild/defines
+++ b/runtime-display/wlroots/autobuild/defines
@@ -21,4 +21,4 @@ MESON_AFTER=(
     "-Dlibliftoff=enabled"
 )
 
-PKGBREAK="sway<=1.11 scenefx<=0.4.1 swayfx<=0.5.3 labwc<=0.9.7"
+PKGBREAK="cage<=0.2.1 sway<=1.11 scenefx<=0.4.1 swayfx<=0.5.3 labwc<=0.9.7"

--- a/runtime-display/wlroots/spec
+++ b/runtime-display/wlroots/spec
@@ -1,4 +1,5 @@
 VER=0.20.2
+REL=1
 SRCS="git::commit=tags/${VER/\~/-}::https://gitlab.freedesktop.org/wlroots/wlroots.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18357"


### PR DESCRIPTION
Topic Description
-----------------

- cage: update to 0.3.1
    Co-authored-by: SkyBird \(@SkyBird233\)
- wlroots: break cage<=0.2.1 due to its dependency on wlroots 0.19
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- cage: 0.3.1
- wlroots: 0.20.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wlroots cage
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
