### PR TITLE
latx: update to 1.6.7

### DIFF
--- a/app-emulation/latx/autobuild/build
+++ b/app-emulation/latx/autobuild/build
@@ -19,14 +19,10 @@ cd "$SRCDIR"/build64
     ${AUTOTOOLS_DEF[@]} \
     --target-list=x86_64-linux-user \
     --enable-latx \
+    --enable-guest-base-zero \
     --disable-debug-info \
     --optimize-O1 \
-    --extra-ldflags=-ldl \
-    --enable-kzt \
-    --disable-blobs \
-    --disable-docs \
-    --disable-werror \
-    --disable-linux-io-uring
+    --enable-latx-avx-opt
 ninja -v
 DESTDIR="$PKGDIR" ninja install
 
@@ -39,14 +35,7 @@ cd "$SRCDIR"/build32
     --enable-guest-base-zero \
     --disable-debug-info \
     --optimize-O1 \
-    --extra-ldflags=-ldl \
-    --disable-blobs \
-    --disable-docs \
-    --disable-werror \
-    --disable-pie \
-    --disable-gcrypt \
-    --static \
-    --disable-linux-io-uring
+    --enable-latx-avx-opt
 ninja -v
 DESTDIR="$PKGDIR" ninja install
 

--- a/app-emulation/latx/autobuild/defines
+++ b/app-emulation/latx/autobuild/defines
@@ -4,9 +4,6 @@ PKGSEC=utils
 # Note: Zenity is required for /usr/bin/runapp, an LATX requirement.
 PKGDEP="systemd zenity nettle pcre2 libffi gnutls glib zlib"
 PKGRECOM="emukit wine"
-# The following is needed for latx-i386
-BUILDDEP="glib-static libgcrypt-static libgpg-error-static \
-          libnfs-static pcre-static zlib-static zstd-static openssl-static"
 PKGDES="Loongson Architecture Translator for x86 applications"
 
 # Note: Extra Provides for Spiral (Debian compatibility).

--- a/app-emulation/latx/autobuild/patches/0001-FROMLIST-LATX-make-raw-LBT-assembly-compatible-with-.patch
+++ b/app-emulation/latx/autobuild/patches/0001-FROMLIST-LATX-make-raw-LBT-assembly-compatible-with-.patch
@@ -1,0 +1,208 @@
+From 5287826f83b14c71d3752fac260204853dfa5f1a Mon Sep 17 00:00:00 2001
+From: Hanlu Li <heuleehanlu@gmail.com>
+Date: Fri, 7 Aug 2026 09:13:45 +0800
+Subject: [PATCH] FROMLIST: LATX: make raw LBT assembly compatible with LTO
+
+Signed-off-by: Hanlu Li <heuleehanlu@gmail.com>
+
+Link: https://github.com/lat-opensource/lat/pull/375
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ target/i386/latx/include/reg-alloc.h     | 20 ------
+ target/i386/latx/translator/tr-pattern.c | 87 +++++++++++++++++-------
+ 2 files changed, 63 insertions(+), 44 deletions(-)
+
+diff --git a/target/i386/latx/include/reg-alloc.h b/target/i386/latx/include/reg-alloc.h
+index 4c996d3dd3..4cf28af1f8 100644
+--- a/target/i386/latx/include/reg-alloc.h
++++ b/target/i386/latx/include/reg-alloc.h
+@@ -188,24 +188,4 @@ void imm_cache_free_temp_helper(IR2_OPND dest_op);
+ IR2_OPND ra_alloc_st(int);
+ IR2_OPND ra_alloc_mda(void);
+ 
+-#define _IFC_REG(n)				\
+-	".ifc	\\r, $r" #n "\n\t"		\
+-	"\\var	= " #n "\n\t"			\
+-	".endif\n\t"
+-
+-    __asm__(".macro	parse_r var r, imm\n\t"
+-	"\\var	= -1\n\t"
+-	_IFC_REG(0)  _IFC_REG(1)  _IFC_REG(2)  _IFC_REG(3)
+-	_IFC_REG(4)  _IFC_REG(5)  _IFC_REG(6)  _IFC_REG(7)
+-	_IFC_REG(8)  _IFC_REG(9)  _IFC_REG(10) _IFC_REG(11)
+-	_IFC_REG(12) _IFC_REG(13) _IFC_REG(14) _IFC_REG(15)
+-	_IFC_REG(16) _IFC_REG(17) _IFC_REG(18) _IFC_REG(19)
+-	_IFC_REG(20) _IFC_REG(21) _IFC_REG(22) _IFC_REG(23)
+-	_IFC_REG(24) _IFC_REG(25) _IFC_REG(26) _IFC_REG(27)
+-	_IFC_REG(28) _IFC_REG(29) _IFC_REG(30) _IFC_REG(31)
+-	".iflt	\\var\n\t"
+-	".error	\"Unable to parse register name \\r\"\n\t"
+-	".endif\n\t"
+-	".endm");
+-
+ #endif
+diff --git a/target/i386/latx/translator/tr-pattern.c b/target/i386/latx/translator/tr-pattern.c
+index 886807d759..228ec9a9d7 100644
+--- a/target/i386/latx/translator/tr-pattern.c
++++ b/target/i386/latx/translator/tr-pattern.c
+@@ -16,6 +16,37 @@
+ #ifdef CONFIG_LATX_INSTS_PATTERN
+ 
+ #define WRAP(ins) (dt_X86_INS_##ins)
++#define PARSE_R_IFC_REG(n)                     \
++    ".ifc \\r, $r" #n "\n\t"                 \
++    "\\var = " #n "\n\t"                     \
++    ".endif\n\t"
++/*
++ * LTO may duplicate or reorder file-scope assembly.  Keep the assembler
++ * macro with its users and give each extended asm statement a unique name.
++ */
++#define DEFINE_PARSE_R                         \
++    ".macro parse_r_%= var r\n\t"              \
++    "\\var = -1\n\t"                          \
++    PARSE_R_IFC_REG(0)  PARSE_R_IFC_REG(1)  \
++    PARSE_R_IFC_REG(2)  PARSE_R_IFC_REG(3)  \
++    PARSE_R_IFC_REG(4)  PARSE_R_IFC_REG(5)  \
++    PARSE_R_IFC_REG(6)  PARSE_R_IFC_REG(7)  \
++    PARSE_R_IFC_REG(8)  PARSE_R_IFC_REG(9)  \
++    PARSE_R_IFC_REG(10) PARSE_R_IFC_REG(11) \
++    PARSE_R_IFC_REG(12) PARSE_R_IFC_REG(13) \
++    PARSE_R_IFC_REG(14) PARSE_R_IFC_REG(15) \
++    PARSE_R_IFC_REG(16) PARSE_R_IFC_REG(17) \
++    PARSE_R_IFC_REG(18) PARSE_R_IFC_REG(19) \
++    PARSE_R_IFC_REG(20) PARSE_R_IFC_REG(21) \
++    PARSE_R_IFC_REG(22) PARSE_R_IFC_REG(23) \
++    PARSE_R_IFC_REG(24) PARSE_R_IFC_REG(25) \
++    PARSE_R_IFC_REG(26) PARSE_R_IFC_REG(27) \
++    PARSE_R_IFC_REG(28) PARSE_R_IFC_REG(29) \
++    PARSE_R_IFC_REG(30) PARSE_R_IFC_REG(31) \
++    ".iflt \\var\n\t"                         \
++    ".error \"Unable to parse register name \\r\"\n\t" \
++    ".endif\n\t"                                \
++    ".endm\n\t"
+ #define EFLAGS_CACULATE(opnd0, opnd1, inst, i, flags)            \
+     do {                                                             \
+         bool need_calc_flag = ir1_need_calculate_any_flag(inst);     \
+@@ -2445,10 +2476,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 {
+                 case 8:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f0008 | (__src << 10) | (__dst << 5))\n\t" /*x86sub.b*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2458,10 +2490,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 break;
+                 case 16:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f0009 | (__src << 10) | (__dst << 5))\n\t" /*x86sub.h*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2471,10 +2504,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 break;
+                 case 32:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f000a | (__src << 10) | (__dst << 5))\n\t" /*x86sub.w*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2484,10 +2518,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 break;
+                 case 64:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f000b | (__src << 10) | (__dst << 5))\n\t" /*x86sub.d*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2516,10 +2551,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 {
+                 case 8:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f8010 | (__src << 10) | (__dst << 5))\n\t" /*x86and.b*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2529,10 +2565,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 break;
+                 case 16:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f8011 | (__src << 10) | (__dst << 5))\n\t" /*x86and.h*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2542,10 +2579,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 break;
+                 case 32:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f8012 | (__src << 10) | (__dst << 5))\n\t" /*x86and.w*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+@@ -2555,10 +2593,11 @@ void opt_instptn_fix(CPUState *cpu, TranslationBlock *tb, int index)
+                 break;
+                 case 64:
+                     asm volatile (
+-                        "parse_r __src, %[src]  \n\t"
+-                        "parse_r __dst, %[dst]  \n\t"
++                        DEFINE_PARSE_R
++                        "parse_r_%= __src, %[src]  \n\t"
++                        "parse_r_%= __dst, %[dst]  \n\t"
+                         ".word (0x003f8013 | (__src << 10) | (__dst << 5))\n\t" /*x86and.d*/
+-                        "parse_r __flags, %[flags]  \n\t"
++                        "parse_r_%= __flags, %[flags]  \n\t"
+                         ".word (0x005c0000 | (0x3f << 10) | __flags)\n\t"  /*x86mfflag*/
+                         : [dst]"+r"(a0),
+                         [flags]"=r"(eflags)
+-- 
+2.55.0
+

--- a/app-emulation/latx/spec
+++ b/app-emulation/latx/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=1.6.1
+UPSTREAM_VER=1.6.7
 # Note: 1.5.3-rc1 => 1.5.3~rc1
 VER=${UPSTREAM_VER/-/~}
 # Note: The last source is for installing documentation.


### PR DESCRIPTION
Topic Description
-----------------

- latx: update to 1.6.7
    Track patches at AOSC-Tracking/latx @ aosc/1.6.7
    \(HEAD: 5287826f83b14c71d3752fac260204853dfa5f1a\).

Package(s) Affected
-------------------

- latx: 1.6.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit latx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`
