### PR TITLE
glfw: update to 3.5.1

### DIFF
--- a/runtime-display/glfw/spec
+++ b/runtime-display/glfw/spec
@@ -1,4 +1,4 @@
-VER=3.4
+VER=3.5.1
 SRCS="git::commit=tags/$VER::https://github.com/glfw/glfw"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1180"


### PR DESCRIPTION
Topic Description
-----------------

- glfw: update to 3.5.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- glfw: 3.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit glfw
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
