### PR TITLE
flit-scm: fix build with flit-core 4

### DIFF
--- a/lang-python/flit-scm/autobuild/defines
+++ b/lang-python/flit-scm/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=flit-scm
 PKGSEC=python
-PKGDEP="setuptools-scm python-3 flit-core tomli"
-BUILDDEP="wheel python-build python-installer"
+PKGDEP="setuptools-scm python-3 flit-core"
+BUILDDEP="tomli"
 PKGDES="PEP 518 build backend to generate a version file using setuptools_scm"
 
 ABTYPE=pep517

--- a/lang-python/flit-scm/autobuild/patches/0001-AOSC-flit-core-4.patch
+++ b/lang-python/flit-scm/autobuild/patches/0001-AOSC-flit-core-4.patch
@@ -1,0 +1,22 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 433de46..e50c713 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -18,7 +18,7 @@ classifiers = [
+     "Topic :: Software Development :: Build Tools",
+ ]
+ dependencies = [
+-    "flit-core~=3.5",
++    "flit-core>=3.5",
+     "setuptools_scm>=6.4",
+     "tomli; python_version < '3.11'",
+ ]
+@@ -33,7 +33,7 @@ repository = "https://gitlab.com/WillDaSilva/flit_scm"
+ 
+ [build-system]
+ requires = [
+-    "flit-core~=3.5",
++    "flit-core>=3.5",
+     "setuptools_scm>=6.4",
+     "tomli; python_version < '3.11'",
+ ]

--- a/lang-python/flit-scm/spec
+++ b/lang-python/flit-scm/spec
@@ -1,5 +1,5 @@
 VER=1.7.0
-REL="2"
-SRCS="tbl::https://files.pythonhosted.org/packages/source/f/flit_scm/flit_scm-$VER.tar.gz"
+REL=3
+SRCS="pypi::version=${VER}::flit_scm"
 CHKSUMS="sha256::961bd6fb24f31bba75333c234145fff88e6de0a90fc0f7e5e7c79deca69f6bb2"
 CHKUPDATE="anitya::id=250223"


### PR DESCRIPTION
Topic Description
-----------------

- flit-scm: fix build with flit-core 4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- flit-scm: 1.7.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit flit-scm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
