### PR TITLE
unixbench: update to 6.0.1

### DIFF
--- a/app-benchmarks/unixbench/autobuild/defines
+++ b/app-benchmarks/unixbench/autobuild/defines
@@ -2,3 +2,4 @@ PKGNAME=unixbench
 PKGSEC=utils
 PKGDEP="perl"
 PKGDES="Open-Source Unix Benchmarking"
+FAIL_ARCH="!(mainline|retro)"

--- a/app-benchmarks/unixbench/spec
+++ b/app-benchmarks/unixbench/spec
@@ -1,5 +1,5 @@
-VER=6.0.0
+VER=6.0.1
 REL=1
-SRCS="tbl::https://github.com/kdlucas/byte-unixbench/archive/v$VER.tar.gz"
-CHKSUMS="sha256::c151d28b6f4f3f40faad19e877c1ab06fbd4b3da006ccfa26b36200c741fc3ba"
+SRCS="git::commit=tags/v${VER}::https://github.com/kdlucas/byte-unixbench.git"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=226943"


### PR DESCRIPTION
Topic Description
-----------------

- unixbench: update to 6.0.1

Trying to build for i486.

Package(s) Affected
-------------------

- unixbench: 6.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit unixbench
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`


**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`