### PR TITLE
box64: update to 0.4.5+1

### DIFF
--- a/app-emulation/box64/autobuild/alternatives
+++ b/app-emulation/box64/autobuild/alternatives
@@ -1,2 +1,2 @@
-alternative /usr/lib/binfmt.d/emu-x86_64.conf /usr/lib/binfmt.alternatives/box64.conf 70
-alternative /usr/lib/binfmt.d/emu-i386.conf /usr/lib/binfmt.alternatives/box32.conf 70
+alternative /usr/lib/binfmt.d/emu-x86_64.conf /usr/lib/binfmt.alternatives/box64.conf 90
+alternative /usr/lib/binfmt.d/emu-i386.conf /usr/lib/binfmt.alternatives/box32.conf 90

--- a/app-emulation/box64/spec
+++ b/app-emulation/box64/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=0.4.4
+UPSTREAM_VER=0.4.5-1
 VER=${UPSTREAM_VER//\-/+}
 # Note: copy-repo is required for "box64 -v" to show the commit hash
 SRCS="git::commit=tags/v${UPSTREAM_VER};copy-repo=true::https://github.com/ptitSeb/box64.git"


### PR DESCRIPTION
Topic Description
-----------------

- box64: update to 0.4.5+1

Package(s) Affected
-------------------

- box64: 0.4.5+1

Security Update?
----------------

No

Build Order
-----------

```
#buildit box64
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
