### PR TITLE
wine: update to 11.15+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

### DIFF
--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -2,7 +2,7 @@ __GECKO_VER=2.47.4
 __MONO_VER=11.2.0
 __DXVK_VER=3.0.2
 __VKD3D_PROTON_VER=3.0.1
-UPSTREAM_VER=11.14
+UPSTREAM_VER=11.15
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}+dxvk${__DXVK_VER}+vkd3dproton${__VKD3D_PROTON_VER}
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
@@ -11,7 +11,7 @@ SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTRE
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz \
       tbl::rename=dxvk-${__DXVK_VER}.tar.gz::https://github.com/doitsujin/dxvk/releases/download/v${__DXVK_VER}/dxvk-${__DXVK_VER}.tar.gz \
       tbl::rename=vkd3d-proton-${__VKD3D_PROTON_VER}.tar.zst::https://github.com/HansKristian-Work/vkd3d-proton/releases/download/v${__VKD3D_PROTON_VER}/vkd3d-proton-${__VKD3D_PROTON_VER}.tar.zst"
-CHKSUMS="sha256::06b3bd872ae0d4d454b9a0c00772727701720de184d36c68597088038113edc4 \
+CHKSUMS="sha256::5046f36dae210b198ea69792774d4401feed975d465eca6c251c9394400ec272 \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 11.15+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wine: 3:11.15+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
