### PR TITLE
heroicgameslauncher: update to 2.22.1

### DIFF
--- a/app-games/heroic-gogdl/spec
+++ b/app-games/heroic-gogdl/spec
@@ -1,4 +1,4 @@
-VER=1.2.1
+VER=1.3.0
 SRCS="git::copy-repo=true;submodule=false;commit=tags/v$VER::https://github.com/Heroic-Games-Launcher/heroic-gogdl"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=Heroic-Games-Launcher/heroic-gogdl"

--- a/app-games/heroicgameslauncher/autobuild/patches/0001-Use-system-legendary-gogdl-nile-and-comet.patch
+++ b/app-games/heroicgameslauncher/autobuild/patches/0001-Use-system-legendary-gogdl-nile-and-comet.patch
@@ -1,4 +1,4 @@
-From 082cb3c8f854eefc0cec8e0cac54fb61727414e3 Mon Sep 17 00:00:00 2001
+From 1c604e9b37f8df4a9dca822253f95cf15cc6198c Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Thu, 29 Jan 2026 18:01:18 +0800
 Subject: [PATCH 1/5] Use system legendary, gogdl, nile and comet
@@ -14,7 +14,7 @@ Subject: [PATCH 1/5] Use system legendary, gogdl, nile and comet
  create mode 100644 src/common/constants.ts
 
 diff --git a/meta/downloadHelperBinaries.ts b/meta/downloadHelperBinaries.ts
-index 31821f22..dc40b48d 100644
+index 91729311..5d7a3edd 100644
 --- a/meta/downloadHelperBinaries.ts
 +++ b/meta/downloadHelperBinaries.ts
 @@ -167,7 +167,8 @@ async function downloadComet() {
@@ -46,10 +46,10 @@ index 31821f22..dc40b48d 100644
      console.log('Nothing to download, binaries are up-to-date')
      return
 diff --git a/src/backend/utils.ts b/src/backend/utils.ts
-index f2f07678..0a1faaf6 100644
+index 983acbde..f49a3fce 100644
 --- a/src/backend/utils.ts
 +++ b/src/backend/utils.ts
-@@ -82,6 +82,7 @@ import {
+@@ -81,6 +81,7 @@ import {
    windowIcon
  } from './constants/paths'
  import { parse } from '@node-steam/vdf'
@@ -57,7 +57,7 @@ index f2f07678..0a1faaf6 100644
  
  import type LogWriter from 'backend/logger/log_writer'
  import { isRunning } from './downloadmanager/downloadqueue'
-@@ -456,7 +457,7 @@ function archSpecificBinary(binaryName: string) {
+@@ -452,7 +453,7 @@ function archSpecificBinary(binaryName: string) {
    return join(publicDir, 'bin', 'x64', process.platform, binaryName)
  }
  
@@ -66,7 +66,7 @@ index f2f07678..0a1faaf6 100644
  function getLegendaryBin(): { dir: string; bin: string } {
    const settings = GlobalConfig.get().getSettings()
    if (settings?.altLegendaryBin) {
-@@ -469,7 +470,7 @@ function getLegendaryBin(): { dir: string; bin: string } {
+@@ -465,7 +466,7 @@ function getLegendaryBin(): { dir: string; bin: string } {
    return splitPathAndName(fixAsarPath(defaultLegendaryPath))
  }
  
@@ -75,7 +75,7 @@ index f2f07678..0a1faaf6 100644
  function getGOGdlBin(): { dir: string; bin: string } {
    const settings = GlobalConfig.get().getSettings()
    if (settings?.altGogdlBin) {
-@@ -481,7 +482,7 @@ function getGOGdlBin(): { dir: string; bin: string } {
+@@ -477,7 +478,7 @@ function getGOGdlBin(): { dir: string; bin: string } {
    return splitPathAndName(fixAsarPath(defaultGogdlPath))
  }
  
@@ -84,7 +84,7 @@ index f2f07678..0a1faaf6 100644
  function getCometBin(): { dir: string; bin: string } {
    const settings = GlobalConfig.get().getSettings()
    if (settings?.altCometBin) {
-@@ -493,7 +494,7 @@ function getCometBin(): { dir: string; bin: string } {
+@@ -489,7 +490,7 @@ function getCometBin(): { dir: string; bin: string } {
    return splitPathAndName(fixAsarPath(defaultCometPath))
  }
  
@@ -183,5 +183,5 @@ index f970e23a..5da6a930 100644
          'box.choose-nile-binary',
          'Select Nile Binary (needs restart)'
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/autobuild/patches/0002-Disable-auto-updates.patch
+++ b/app-games/heroicgameslauncher/autobuild/patches/0002-Disable-auto-updates.patch
@@ -1,4 +1,4 @@
-From 91e1f176ae8b77425bf9d37c83f0c52efa83e991 Mon Sep 17 00:00:00 2001
+From 796909f5cfcc14fc188e7e31914a771adc213a6d Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Thu, 29 Jan 2026 22:37:13 +0800
 Subject: [PATCH 2/5] Disable auto updates
@@ -9,7 +9,7 @@ Subject: [PATCH 2/5] Disable auto updates
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/backend/config.ts b/src/backend/config.ts
-index 601e265e..83ad7be7 100644
+index a4509313..35e04123 100644
 --- a/src/backend/config.ts
 +++ b/src/backend/config.ts
 @@ -335,7 +335,7 @@ class GlobalConfigV0 extends GlobalConfig {
@@ -22,12 +22,12 @@ index 601e265e..83ad7be7 100644
        customWinePaths: [],
        defaultInstallPath: heroicInstallPath,
 diff --git a/src/backend/main.ts b/src/backend/main.ts
-index 644b3e5f..247ff6da 100644
+index 61dcfa4b..ba76c0dd 100644
 --- a/src/backend/main.ts
 +++ b/src/backend/main.ts
-@@ -678,7 +678,7 @@ addHandler('isFullscreen', () => isSteamDeckGameMode || isCLIFullscreen)
- addHandler('getGameOverride', async () => getGameOverride())
- addHandler('getGameSdl', async (event, appName) => getGameSdl(appName))
+@@ -684,7 +684,7 @@ addHandler('getGameSdl', async (event, appName) =>
+   libraryManagerMap['legendary'].getGameSdl(appName)
+ )
  
 -addHandler('showUpdateSetting', () => !isFlatpak)
 +addHandler('showUpdateSetting', () => false)
@@ -35,5 +35,5 @@ index 644b3e5f..247ff6da 100644
  addHandler('getLatestReleases', async () => {
    const { checkForUpdatesOnStartup } = GlobalConfig.get().getSettings()
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/autobuild/patches/0003-Remove-analytics-opt-in-dialog-and-setting-entrance.patch
+++ b/app-games/heroicgameslauncher/autobuild/patches/0003-Remove-analytics-opt-in-dialog-and-setting-entrance.patch
@@ -1,4 +1,4 @@
-From 647d4e55049b41f9552f4fa741a3658fb6d9450a Mon Sep 17 00:00:00 2001
+From 82eff4cf0688b22d436131eb73161ebd10b4b1f3 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Fri, 30 Jan 2026 15:13:22 +0800
 Subject: [PATCH 3/5] Remove analytics opt-in dialog and setting entrance
@@ -52,5 +52,5 @@ index 80db7918..4f9342b2 100644
  
        <MaxRecentGames />
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/autobuild/patches/0004-loongarch64-enable-WoW64-by-default.patch.loongarch64
+++ b/app-games/heroicgameslauncher/autobuild/patches/0004-loongarch64-enable-WoW64-by-default.patch.loongarch64
@@ -1,4 +1,4 @@
-From 5ad75e09c4c52375fb9caf8ca3bec8202210843d Mon Sep 17 00:00:00 2001
+From 2e8a68ea9fb788ebb975416bb4ee12b36f4eac55 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Fri, 30 Jan 2026 15:24:53 +0800
 Subject: [PATCH 4/5] loongarch64: enable WoW64 by default
@@ -8,7 +8,7 @@ Subject: [PATCH 4/5] loongarch64: enable WoW64 by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/backend/config.ts b/src/backend/config.ts
-index 83ad7be7..a09f91a7 100644
+index 35e04123..b83b4079 100644
 --- a/src/backend/config.ts
 +++ b/src/backend/config.ts
 @@ -360,7 +360,7 @@ class GlobalConfigV0 extends GlobalConfig {
@@ -18,8 +18,8 @@ index 83ad7be7..a09f91a7 100644
 -      enableWoW64: false,
 +      enableWoW64: true,
        eacRuntime: isLinux,
-       battlEyeRuntime: isLinux,
-       framelessWindow: false,
+       gamepadRepeatDelay: 50,
+       gamepadInitialRepeatDelay: 300,
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/autobuild/patches/0004-riscv64-enable-WoW64-by-default.patch.riscv64
+++ b/app-games/heroicgameslauncher/autobuild/patches/0004-riscv64-enable-WoW64-by-default.patch.riscv64
@@ -1,4 +1,4 @@
-From 81c8aad59c31efb4721ea12252674b36d32484e9 Mon Sep 17 00:00:00 2001
+From 7559800551b70425f6ff075bbbf276342afaf6c5 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Fri, 30 Jan 2026 15:24:53 +0800
 Subject: [PATCH 4/5] riscv64: enable WoW64 by default
@@ -8,7 +8,7 @@ Subject: [PATCH 4/5] riscv64: enable WoW64 by default
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/backend/config.ts b/src/backend/config.ts
-index 83ad7be7..a09f91a7 100644
+index 35e04123..b83b4079 100644
 --- a/src/backend/config.ts
 +++ b/src/backend/config.ts
 @@ -360,7 +360,7 @@ class GlobalConfigV0 extends GlobalConfig {
@@ -18,8 +18,8 @@ index 83ad7be7..a09f91a7 100644
 -      enableWoW64: false,
 +      enableWoW64: true,
        eacRuntime: isLinux,
-       battlEyeRuntime: isLinux,
-       framelessWindow: false,
+       gamepadRepeatDelay: 50,
+       gamepadInitialRepeatDelay: 300,
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/autobuild/patches/0005-AOSCOS-add-support-for-riscv64.patch.riscv64
+++ b/app-games/heroicgameslauncher/autobuild/patches/0005-AOSCOS-add-support-for-riscv64.patch.riscv64
@@ -1,4 +1,4 @@
-From b7704c401bed6a23df39a0a910f33b0be67af203 Mon Sep 17 00:00:00 2001
+From 07925c28cc3f502b633c4bb9adc639c2a2f004d6 Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
 Date: Thu, 29 Jan 2026 15:19:20 +0800
 Subject: [PATCH 5/5] AOSCOS: add support for riscv64
@@ -8,7 +8,7 @@ Subject: [PATCH 5/5] AOSCOS: add support for riscv64
  1 file changed, 7 insertions(+)
 
 diff --git a/package.json b/package.json
-index eea7b0c9..dfac1752 100644
+index 72e62092..191a9a6b 100644
 --- a/package.json
 +++ b/package.json
 @@ -152,5 +152,12 @@
@@ -18,12 +18,12 @@ index eea7b0c9..dfac1752 100644
 +  },
 +  "pnpm": {
 +    "overrides": {
-+      "electron": "41.1.1",
++      "electron": "43.1.1",
 +      "electron-builder": "npm:@riscv-forks/electron-builder",
 +      "@vitejs/plugin-react-swc": "npm:@vitejs/plugin-react@^5.1.2"
 +    }
    }
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/autobuild/patches/0005-loongarch64-override-platform-related-dependencies.patch.loongarch64
+++ b/app-games/heroicgameslauncher/autobuild/patches/0005-loongarch64-override-platform-related-dependencies.patch.loongarch64
@@ -1,4 +1,4 @@
-From 6ce084dabd02c169fae4b8b371140b4876759876 Mon Sep 17 00:00:00 2001
+From 19c7b59e6eb31931e79ff278fee26a89444bce68 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Thu, 29 Jan 2026 15:49:13 +0800
 Subject: [PATCH 5/5] loongarch64: override platform-related dependencies
@@ -8,7 +8,7 @@ Subject: [PATCH 5/5] loongarch64: override platform-related dependencies
  1 file changed, 7 insertions(+)
 
 diff --git a/package.json b/package.json
-index eea7b0c9..85697431 100644
+index 72e62092..b0e7c090 100644
 --- a/package.json
 +++ b/package.json
 @@ -152,5 +152,12 @@
@@ -18,12 +18,12 @@ index eea7b0c9..85697431 100644
 +  },
 +  "pnpm": {
 +    "overrides": {
-+      "electron": "39.2.7",
-+      "electron-builder": "npm:@loongdotjs/electron-builder",
++      "electron": "42.3.0",
++      "electron-builder": "npm:@loongdotjs/electron-builder@26.8.2-3",
 +      "@vitejs/plugin-react-swc": "npm:@vitejs/plugin-react@^5.1.2"
 +    }
    }
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-games/heroicgameslauncher/spec
+++ b/app-games/heroicgameslauncher/spec
@@ -1,4 +1,4 @@
-VER=2.21.0
+VER=2.22.1
 SRCS="git::commit=tags/v${VER}::https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=241490"

--- a/app-games/umu-launcher/spec
+++ b/app-games/umu-launcher/spec
@@ -1,4 +1,4 @@
-VER=1.4.0
+VER=1.4.4
 SRCS="git::commit=tags/$VER::https://github.com/Open-Wine-Components/umu-launcher"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=375259"


### PR DESCRIPTION
Topic Description
-----------------

- heroicgameslauncher: update to 2.22.1
    - Track patches at AOSC-Tracking/HeroicGamesLauncher @ aosc/v2.22.1
    \(HEAD: 82eff4cf0688b22d436131eb73161ebd10b4b1f3\).
    - Track patches at AOSC-Tracking/HeroicGamesLauncher @ aosc/v2.22.1-loonogarch64
    \(HEAD: 19c7b59e6eb31931e79ff278fee26a89444bce68\).
    - Track patches at AOSC-Tracking/HeroicGamesLauncher @ aosc/v2.22.1-riscv64
    \(HEAD: 07925c28cc3f502b633c4bb9adc639c2a2f004d6\).
- umu-launcher: update to 1.4.4
- heroic-gogdl: update to 1.3.0

Package(s) Affected
-------------------

- heroic-gogdl: 1.3.0
- heroicgameslauncher: 2.22.1
- umu-launcher: 1.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit heroic-gogdl umu-launcher heroicgameslauncher
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
