### PR TITLE
xf86-video-rdc: new, 0.1.y

### DIFF
--- a/runtime-display/xf86-video-rdc/autobuild/defines
+++ b/runtime-display/xf86-video-rdc/autobuild/defines
@@ -1,0 +1,10 @@
+PKGNAME=xf86-video-rdc
+PKGDEP="xorg-server"
+PKGDES="XF86 driver for RDC GPU (M2012/M2015)"
+PKGSEC=x11
+
+AB_FLAGS_RRO=0
+AB_FLAGS_NOW=0
+
+# Note: RDC's GPU is used only on Vortex86
+FAIL_ARCH="!(i486)"

--- a/runtime-display/xf86-video-rdc/spec
+++ b/runtime-display/xf86-video-rdc/spec
@@ -1,0 +1,4 @@
+VER=0.1.1
+SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/xf86-video-rdc"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391673"


### PR DESCRIPTION
Topic Description
-----------------

- xf86-video-rdc: new, 0.1.y

More info: https://github.com/AOSC-Dev/xf86-video-rdc/tree/main/misc

Package(s) Affected
-------------------

- xf86-video-rdc: 0.1.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xf86-video-rdc
```

Test Build(s) Done
------------------


**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
