### PR TITLE
Gitea and Forgejo security update (2026 July)

### DIFF
--- a/app-vcs/gitea/autobuild/defines
+++ b/app-vcs/gitea/autobuild/defines
@@ -21,4 +21,5 @@ ABTYPE=self
 # /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:1916:34: undefined: long
 # /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:2620:48: undefined: long
 # /root/go/pkg/mod/modernc.org/libc@v1.73.4/libc.go:2620:48: too many errors 
-FAIL_ARCH="@(loongson3)"
+# FIXME: no nodejs on i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/app-vcs/gitea/spec
+++ b/app-vcs/gitea/spec
@@ -1,4 +1,4 @@
-VER=1.27.0
+VER=1.27.1
 SRCS="tbl::https://dl.gitea.com/gitea/$VER/gitea-src-$VER.tar.gz"
-CHKSUMS="sha256::012df875bfa7764ade92301ac5e4225fc2c2aab7b3b40b4d6e7149a926253496"
+CHKSUMS="sha256::2a0b401ef7a00acc2ab64e7977c7d0997030a32499ef4690118c93a8f33c9f2d"
 CHKUPDATE="anitya::id=13537"

--- a/app-web/forgejo/autobuild/defines
+++ b/app-web/forgejo/autobuild/defines
@@ -5,3 +5,6 @@ PKGDEP="glibc git"
 PKGRECOM="openssh"
 BUILDDEP="go"
 ABTYPE=self
+
+# Note: limited by go
+FAIL_ARCH="!(mainline|i486)"

--- a/app-web/forgejo/autobuild/patches/0001-edit-systemd-service-file-to-met-need-of-AOSC-OS.patch
+++ b/app-web/forgejo/autobuild/patches/0001-edit-systemd-service-file-to-met-need-of-AOSC-OS.patch
@@ -1,4 +1,4 @@
-From 6cfffc107a070c8602a6512d426cd5ec28614d90 Mon Sep 17 00:00:00 2001
+From f9aa77b7ad0c01c786cc1eb46506236ff7aad92f Mon Sep 17 00:00:00 2001
 From: Student Main <studentmain@aosc.io>
 Date: Tue, 6 Aug 2024 17:19:57 +0000
 Subject: [PATCH] edit systemd service file to met need of AOSC OS
@@ -10,7 +10,7 @@ change user and group name to 'forgejo'
  1 file changed, 14 insertions(+), 17 deletions(-)
 
 diff --git a/contrib/systemd/forgejo.service b/contrib/systemd/forgejo.service
-index ee019e11ea78..6fa5b497e1eb 100644
+index 36dc2a3a5b..735e70a97c 100644
 --- a/contrib/systemd/forgejo.service
 +++ b/contrib/systemd/forgejo.service
 @@ -5,22 +5,19 @@ After=network.target
@@ -49,7 +49,7 @@ index ee019e11ea78..6fa5b497e1eb 100644
 @@ -53,15 +50,15 @@ After=network.target
  # LimitNOFILE=524288:524288
  RestartSec=2s
- Type=simple
+ Type=notify
 -User=git
 -Group=git
 +User=forgejo
@@ -66,8 +66,6 @@ index ee019e11ea78..6fa5b497e1eb 100644
  # If you install Git to directory prefix other than default PATH (which happens
  # for example if you install other versions of Git side-to-side with
  # distribution version), uncomment below line and add that prefix to PATH
-
-base-commit: 12a277ed65220cc152419242280f426e84ba0e61
 -- 
-2.47.0
+2.55.0
 

--- a/app-web/forgejo/spec
+++ b/app-web/forgejo/spec
@@ -1,5 +1,4 @@
-VER=14.0.2
-REL=3
+VER=16.0.2
 SRCS="tbl::https://codeberg.org/forgejo/forgejo/releases/download/v$VER/forgejo-src-$VER.tar.gz"
-CHKSUMS="sha256::422f04bfa0f615e4d686cfae9012693f821eaaf7efae8eb4905416c5633440af"
+CHKSUMS="sha256::570cb79e92bd2c906c329ff6019cffcb341a5e07ec4652c9c04c57c01beeb98f"
 CHKUPDATE="anitya::id=370527"

--- a/topics/gitea-forgejo-202607.toml
+++ b/topics/gitea-forgejo-202607.toml
@@ -1,0 +1,14 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Gitea and Forgejo security update (July, 2026)"
+zh_CN = "Gitea 与 Forgejo 安全更新（2026 年 7 月）"
+
+[caution]
+default = "Fixes a path traversal vulnerability (CVE-2026-59774, Severity: Critical) and a code injection vulnerability (CVE-2026-60004, Severity: Critical)"
+zh_CN = "修复 1 个路径遍历漏洞（CVE-2026-59774，严重性：严重）与 1 个代码注入漏洞（CVE-2026-60004，严重性：严重）"
+
+[packages-v2]
+"gitea" = "< 1.27.1"
+"forgejo" = "< 16.0.2"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add gitea-forgejo-202607.toml
- forgejo: update to 16.0.2
- gitea: update to 1.27.1

Package(s) Affected
-------------------

- forgejo: 16.0.2
- gitea: 1.27.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit gitea forgejo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
