### PR TITLE
go: update to 1.26.5+tools0.48.0

### DIFF
--- a/lang-golang/go/01-compiler/build
+++ b/lang-golang/go/01-compiler/build
@@ -8,6 +8,8 @@ export GOROOT_BOOTSTRAP="/usr/lib/go"
 
 if ab_match_arch amd64; then
     export GOARCH="amd64" GOAMD64=v1
+elif ab_match_arch i486; then
+    export GOARCH="386" GO386=softfloat
 elif ab_match_arch arm64; then
     export GOARCH="arm64"
 elif ab_match_arch armv6hf; then
@@ -29,7 +31,7 @@ pushd "$GOROOT"/src
 bash make.bash -v
 popd
 # NOTE: Only amd64, arm64 and ppc64el support `-buildmode=shared`.
-if ab_match_arch amd64 || ab_match_arch arm64 || ab_match_arch ppc64el; then
+if ab_match_arch amd64 || ab_match_arch i486 || ab_match_arch arm64 || ab_match_arch ppc64el; then
     "$GOROOT"/bin/go install -v -buildmode=shared std
     # Prepare to build `go-runtime`.
     mv -v "$SRCDIR"/pkg/"$GOOS"_"$GOARCH"_dynlink \

--- a/lang-golang/go/01-compiler/build.stage2
+++ b/lang-golang/go/01-compiler/build.stage2
@@ -8,6 +8,8 @@ export GOROOT_BOOTSTRAP="$SRCDIR/go"
 
 if ab_match_arch amd64; then
     export GOARCH="amd64" GOAMD64=v1
+elif ab_match_arch i486; then
+    export GOARCH="386" GO386=softfloat
 elif ab_match_arch arm64; then
     export GOARCH="arm64"
 elif ab_match_arch armv6hf; then
@@ -25,17 +27,17 @@ elif ab_match_arch riscv64; then
 fi
 
 abinfo "Downloading Go binary distribution for bootstrapping ..."
-wget https://go.dev/dl/go${PKGVER%%+*}.linux-${buildarch}.tar.gz
+wget https://go.dev/dl/go"${PKGVER%%+*}".linux-"$GOARCH".tar.gz
 
 abinfo "Deploying Go binary distribution ..."
-tar xvf "$SRCDIR"/go${PKGVER%%+*}.linux-${buildarch}.tar.gz
+tar xvf "$SRCDIR"/go"${PKGVER%%+*}".linux-"$GOARCH".tar.gz
 
 abinfo "Building Go toolchain ..."
 pushd "$GOROOT"/src
 bash make.bash -v
 popd
 # NOTE: Only amd64, arm64 and ppc64el support `-buildmode=shared`.
-if ab_match_arch amd64 || ab_match_arch arm64 || ab_match_arch ppc64el; then
+if ab_match_arch amd64 || ab_match_arch i486 || ab_match_arch arm64 || ab_match_arch ppc64el; then
     "$GOROOT"/bin/go install -v -buildmode=shared std
     # Prepare to build `go-runtime`.
     mv -v "$SRCDIR"/pkg/"$GOOS"_"$GOARCH"_dynlink \

--- a/lang-golang/go/01-compiler/defines
+++ b/lang-golang/go/01-compiler/defines
@@ -7,7 +7,7 @@ BUILDDEP__LOONGSON3="${BUILDDEP/llvm/}"
 PKGDES="The Go language compiler and tools"
 
 NOSTATIC=0
-FAIL_ARCH="!(amd64|armv6hf|armv7hf|arm64|loongarch64|loongarch64_nosimd|loongson3|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|i486|armv6hf|armv7hf|arm64|loongarch64|loongarch64_nosimd|loongson3|ppc64el|riscv64)"
 
 USECLANG=1
 USECLANG__LOONGSON3=0

--- a/lang-golang/go/01-compiler/defines.stage2
+++ b/lang-golang/go/01-compiler/defines.stage2
@@ -7,7 +7,7 @@ BUILDDEP__LOONGSON3="${BUILDDEP/llvm/}"
 PKGDES="The Go language compiler and tools"
 
 NOSTATIC=0
-FAIL_ARCH="!(amd64|armv6hf|armv7hf|arm64|loongarch64|loongarch64_nosimd|loongson3|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|i486|armv6hf|armv7hf|arm64|loongarch64|loongarch64_nosimd|loongson3|ppc64el|riscv64)"
 
 USECLANG=1
 USECLANG__LOONGSON3=0

--- a/lang-golang/go/02-runtime/build
+++ b/lang-golang/go/02-runtime/build
@@ -4,6 +4,9 @@ export GOOS=linux
 if ab_match_arch amd64; then
     export GOARCH="amd64" GOAMD64=v1
 fi
+if ab_match_arch i486; then
+    export GOARCH="386" GO386=softfloat
+fi
 if ab_match_arch arm64; then
     export GOARCH="arm64"
 fi

--- a/lang-golang/go/02-runtime/build.stage2
+++ b/lang-golang/go/02-runtime/build.stage2
@@ -4,6 +4,9 @@ export GOOS=linux
 if ab_match_arch amd64; then
     export GOARCH="amd64" GOAMD64=v1
 fi
+if ab_match_arch i486; then
+    export GOARCH="386" GO386=softfloat
+fi
 if ab_match_arch arm64; then
     export GOARCH="arm64"
 fi

--- a/lang-golang/go/02-runtime/defines
+++ b/lang-golang/go/02-runtime/defines
@@ -4,7 +4,7 @@ PKGDEP="glibc go"
 PKGDES="The Go language compiler and tools (runtime)"
 
 NOSTATIC=0
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+FAIL_ARCH="!(amd64|i486|arm64|ppc64el)"
 
 PKGBREAK="go<=1.24.2+tools0.31.0+net0.38.0-3"
 PKGREP="go<=1.24.2+tools0.31.0+net0.38.0-3"

--- a/lang-golang/go/02-runtime/defines.stage2
+++ b/lang-golang/go/02-runtime/defines.stage2
@@ -4,7 +4,7 @@ PKGDEP="glibc go"
 PKGDES="The Go language compiler and tools (runtime)"
 
 NOSTATIC=0
-FAIL_ARCH="!(amd64|arm64|ppc64el)"
+FAIL_ARCH="!(amd64|i486|arm64|ppc64el)"
 
 PKGBREAK="go<=1.24.2+tools0.31.0+net0.38.0-3"
 PKGREP="go<=1.24.2+tools0.31.0+net0.38.0-3"

--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,6 +1,6 @@
 GO_VER=1.26.5
 # Go tools can be updated independently.
-TOOLS_VER=0.45.0
+TOOLS_VER=0.48.0
 
 VER="${GO_VER}+tools${TOOLS_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \


### PR DESCRIPTION
Topic Description
-----------------

- go: update to 1.26.5+tools0.48.0

Package(s) Affected
-------------------

- go: 1.26.5+tools0.48.0
- go-runtime: 1.26.5+tools0.48.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit go:+stage2 go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
