### PR TITLE
openssh: update to 10.5p1

### DIFF
--- a/app-network/openssh/spec
+++ b/app-network/openssh/spec
@@ -1,5 +1,4 @@
-VER=10.4p1
-REL=1
+VER=10.5p1
 SRCS="tbl::https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$VER.tar.gz"
-CHKSUMS="sha256::ef6026dd2aea8d56059638d5d3262902c892ceba9f88395835e0d06d3fb63238"
+CHKSUMS="sha256::d44d28a839ea9daf969cc69150fde59910b2b39361dad81a3bd6cbd19218db11"
 CHKUPDATE="anitya::id=2565"

--- a/topics/openssh-10.5p1.toml
+++ b/topics/openssh-10.5p1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "OpenSSH 10.5p1"
+
+[caution]
+default = "Fixes 3 security vulnerabilities"
+zh_CN = "修复 3 个安全漏洞"
+
+[packages-v2]
+"openssh" = "< 10.5p1"


### PR DESCRIPTION
Topic Description
-----------------

- openssh: update to 10.5p1
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- openssh: 10.5p1

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
