### PR TITLE
linux-kernel: mark Zenscape as High severity

### DIFF
--- a/topics/linux-kernel-7.1.7.toml
+++ b/topics/linux-kernel-7.1.7.toml
@@ -6,8 +6,8 @@ default = "Linux Kernel 7.1.7"
 zh_CN = "Linux 内核，版本 7.1.7"
 
 [caution]
-default = "Fixes a KVM escape vulnerability, codenamed \"Zapscape\" (CVE-2026-64561, severity: Pending)"
-zh_CN = "修复代号为 \"Zapscape\" 的 KVM 逃逸漏洞（CVE-2026-64561，严重性：待定）"
+default = "Fixes a KVM escape vulnerability, codenamed \"Zapscape\" (CVE-2026-64561, severity: High)"
+zh_CN = "修复代号为 \"Zapscape\" 的 KVM 逃逸漏洞（CVE-2026-64561，严重性：高）"
 
 [packages-v2]
 "linux+kernel" = "< 3:7.1.7"


### PR DESCRIPTION
Topic Description
-----------------

- linux-kernel: mark Zenscape as High severity
- topics: add libheif-1.23.1.toml

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
