### PR TITLE
time: allow build for Afterglow

### DIFF
--- a/app-utils/time/autobuild/defines
+++ b/app-utils/time/autobuild/defines
@@ -7,3 +7,6 @@ ABTYPE=autotools
 # FIXME: [...]/time-1.10/bootstrap: Bootstrapping from a non-checked-out distribution is risky.
 ABNOBOOTSTRAP=1
 ABNOAUTOGEN=1
+
+# Note: Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"


### PR DESCRIPTION
Topic Description
-----------------

- time: allow build for Afterglow
- linux-kernel: mark Zenscape as High severity
- topics: add libheif-1.23.1.toml

Package(s) Affected
-------------------

- time: 1.10

Security Update?
----------------

No

Build Order
-----------

```
#buildit time
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
