### PR TITLE
xz: add xz-utils spiral marker

### DIFF
--- a/app-utils/xz/autobuild/defines
+++ b/app-utils/xz/autobuild/defines
@@ -3,6 +3,7 @@ PKGDES="General-purpose data compression software with a high compression ratio"
 PKGDEP="glibc"
 BUILDDEP="po4a"
 PKGSEC=utils
+PKGPROV="xz-utils_spiral"
 
 ABTYPE=autotools
 # Note: --enable-assume-ram=SIZE

--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,4 +1,5 @@
 VER=5.8.3
+REL=1
 SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
 CHKSUMS="sha256::fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
 CHKUPDATE="anitya::id=5277"


### PR DESCRIPTION
Topic Description
-----------------

- xz: add xz-utils spiral marker

Package(s) Affected
-------------------

- xz: 5.8.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
