### PR TITLE
vscode: update to 1.132.1

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.132.0
+VER=1.132.1
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::b73e01a1a371eb7d57f2c01712c43e9cedd15d6bad9a44261c4473db946532ef"
-CHKSUMS__ARM64="sha256::599196c05788cf5d433556118eaa6a1b89a46683c6d1423aacf4279200533e82"
+CHKSUMS__AMD64="sha256::da17f465d8c33add5affe157a2c0a0b8a2c0af11b63804d055b853be04ddbfc9"
+CHKSUMS__ARM64="sha256::cb4b5a0732eb85f8764933616ffdae922c9d160647b427f9409a5686ecc4a6bd"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.132.1
    Co-authored-by: LJL \(@ljlofficial\) <lkjmlk@aosc.io>

Package(s) Affected
-------------------

- vscode: 1.132.1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
