### PR TITLE
godot: update to 4.7.1

### DIFF
--- a/app-devel/godot/01-editor/build
+++ b/app-devel/godot/01-editor/build
@@ -1,5 +1,6 @@
 abinfo "Building Godot Engine ..."
 
+has_dotnet=yes
 if ab_match_arch amd64; then
     GODOT_ARCH=x86_64
 elif ab_match_arch arm64; then
@@ -12,8 +13,15 @@ elif ab_match_arch loongarch64; then
     GODOT_ARCH=loongarch64
 elif ab_match_arch loongarch64_nosimd; then
     GODOT_ARCH=loongarch64
+elif ab_match_arch i486; then
+    GODOT_ARCH=x86_32
+    # Note: require lock free uint64_t atomic
+    #   static_assert(std::atomic<uint64_t>::is_always_lock_free)
+    abinfo "Set machine type to i586 ..."
+    CFLAGS="${CFLAGS/-march=i486/-march=i586}"
+    has_dotnet=no
 else
-    aberr "Unsupported architecture."
+    abdie "Unsupported architecture."
 fi
 
 abinfo "Use custom build name \"aosc\" ..."
@@ -27,33 +35,38 @@ ARGV=(
     production=yes
     debug_symbols=yes
     arch="$GODOT_ARCH"
-    module_mono_enabled=yes
+    module_mono_enabled="$has_dotnet"
 
     progress=no
     debug_paths_relative=yes
+    ccflags="$CFLAGS"
+    linkflags="$LDFLAGS"
 
     engine_update_check=no
 
     builtin_certs=no
     system_certs_path=/etc/ssl/ca-bundle.crt
 
+    use_static_cpp=no
+
     # use system libraries
     # commented libraries are using bundled version due to not in our repo unless specified otherwise
     builtin_brotli=no
     # clipper2
     # embree, godot use patched version, system version crashed when occlusion culling active
-    builtin_enet=no
+    # enet, "System-provided ENet has its functionality limited to IPv4 only and no DTLS support, unless patched for Godot."
     builtin_freetype=no
     # msdfgen
     # glslang, need specific version
     builtin_graphite=no
-    # harfbuzz, issue with extension
+    # harfbuzz, issue with extension, https://github.com/godotengine/godot/issues/91401
     builtin_sdl=no
-    # icu4c, issue with extension
+    # icu4c, issue with extension, https://github.com/godotengine/godot/issues/100301
     builtin_libjpeg_turbo=no
     builtin_libogg=no
     builtin_libpng=no
     builtin_libtheora=no
+    builtin_libvorbis=no
     builtin_libwebp=no
     # wslay
     builtin_mbedtls=no
@@ -66,54 +79,70 @@ ARGV=(
     # xatlas
     builtin_zlib=no
     builtin_zstd=no
-    use_static_cpp=no
 )
-scons ${ARGV[*]}
+if ab_match_arch i486; then
+    ARGV+=(
+        # FIXME: /usr/bin/ld: bin/obj/platform/linuxbsd/crash_handler_linuxbsd.linuxbsd.editor.x86_32.o: plugin needed to handle lto object
+        # Note: need disable LTO in both defines and scons parameter
+        lto=none
+        
+        # FIXME: OOM when build on BuildIt! i486 machine, which have 8 cores and 24 GiB memory
+        -j 4
+    )
+fi
 
-EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH.mono"
-abinfo "Building Godot C# binding ..."
-"$SRCDIR"/bin/"$EXE_NAME" \
-	--headless \
-	--generate-mono-glue "$SRCDIR"/modules/mono/glue
-"$SRCDIR"/modules/mono/build_scripts/build_assemblies.py \
-	--godot-output-dir="$SRCDIR"/bin \
-	--godot-platform=linuxbsd
+scons "${ARGV[@]}"
+
+EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH"
+if [[ $has_dotnet == "yes" ]]; then
+    EXE_NAME="$EXE_NAME.mono"
+    abinfo "Building Godot C# binding ..."
+    "$SRCDIR"/bin/"$EXE_NAME" \
+        --headless \
+        --generate-mono-glue "$SRCDIR"/modules/mono/glue
+    "$SRCDIR"/modules/mono/build_scripts/build_assemblies.py \
+        --godot-output-dir="$SRCDIR"/bin \
+        --godot-platform=linuxbsd
+fi
 
 abinfo "Installing Godot..."
 install -dv "$PKGDIR"/usr/lib/godot/
-mv -v "$SRCDIR"/bin/GodotSharp \
-	"$PKGDIR"/usr/lib/godot/
+if [[ $has_dotnet == "yes" ]]; then
+    mv -v "$SRCDIR"/bin/GodotSharp \
+        "$PKGDIR"/usr/lib/godot/
+fi
+
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/godot
 mkdir -pv "$PKGDIR"/usr/bin/
 ln -sv ../lib/godot/godot "$PKGDIR"/usr/bin/godot
 
 abinfo "Installing appdata ..."
 install -Dvm644 "$SRCDIR"/misc/dist/linux/org.godotengine.Godot.appdata.xml \
-	"$PKGDIR"/usr/share/appdata/org.godotengine.Godot.appdata.xml
+    "$PKGDIR"/usr/share/appdata/org.godotengine.Godot.appdata.xml
 
 abinfo "Installing desktop entry ..."
 install -Dvm644 "$SRCDIR"/misc/dist/linux/org.godotengine.Godot.desktop \
-	"$PKGDIR"/usr/share/applications/org.godotengine.Godot.desktop
+    "$PKGDIR"/usr/share/applications/org.godotengine.Godot.desktop
 install -Dvm644 "$SRCDIR"/misc/logo/icon.svg \
-	"$PKGDIR"/usr/share/icons/hicolor/scalable/apps/godot.svg
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/godot.svg
 
 abinfo "Installing MIME info ..."
 install -Dvm644 "$SRCDIR"/misc/dist/linux/org.godotengine.Godot.xml \
-	"$PKGDIR"/usr/share/mime/packages/org.godotengine.Godot.xml
+    "$PKGDIR"/usr/share/mime/packages/org.godotengine.Godot.xml
 install -Dvm644 "$SRCDIR"/misc/dist/document_icons/project.svg \
-	"$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-project.svg
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-project.svg
 install -Dvm644 "$SRCDIR"/misc/dist/document_icons/resource.svg \
-	"$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-resource.svg
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-resource.svg
 install -Dvm644 "$SRCDIR"/misc/dist/document_icons/scene.svg \
-	"$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-scene.svg
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-scene.svg
 install -Dvm644 "$SRCDIR"/misc/dist/document_icons/shader.svg \
-	"$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-shader.svg
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-godot-shader.svg
 install -Dvm644 "$SRCDIR"/misc/dist/document_icons/gdscript.svg \
-	"$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-gdscript.svg
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/mimetypes/x-gdscript.svg
 
 abinfo "Installing shell completions ..."
 install -Dvm644 "$SRCDIR"/misc/dist/shell/godot.bash-completion \
-	"$PKGDIR"/usr/share/bash-completion/completions/godot
+    "$PKGDIR"/usr/share/bash-completion/completions/godot
 install -Dvm644 "$SRCDIR"/misc/dist/shell/_godot.zsh-completion \
     "$PKGDIR"/usr/share/zsh/site-functions/_godot
 install -Dvm644 "$SRCDIR"/misc/dist/shell/godot.fish \

--- a/app-devel/godot/01-editor/build
+++ b/app-devel/godot/01-editor/build
@@ -1,5 +1,6 @@
 abinfo "Building Godot Engine ..."
 
+has_dotnet=yes
 if ab_match_arch amd64; then
     GODOT_ARCH=x86_64
 elif ab_match_arch arm64; then
@@ -12,8 +13,14 @@ elif ab_match_arch loongarch64; then
     GODOT_ARCH=loongarch64
 elif ab_match_arch loongarch64_nosimd; then
     GODOT_ARCH=loongarch64
+elif ab_match_arch i486; then
+    GODOT_ARCH=x86_32
+	# Note: require lock free uint64_t atomic
+	#   static_assert(std::atomic<uint64_t>::is_always_lock_free)
+	CFLAGS="${CFLAGS/-march=i486/-march=i586}"
+	has_dotnet=no
 else
-    aberr "Unsupported architecture."
+    abdie "Unsupported architecture."
 fi
 
 abinfo "Use custom build name \"aosc\" ..."
@@ -27,62 +34,80 @@ ARGV=(
     production=yes
     debug_symbols=yes
     arch="$GODOT_ARCH"
-    module_mono_enabled=yes
+    module_mono_enabled="$has_dotnet"
 
     progress=no
     debug_paths_relative=yes
+	ccflags="$CFLAGS"
+	linkflags="$LDFLAGS"
 
     engine_update_check=no
 
     builtin_certs=no
     system_certs_path=/etc/ssl/ca-bundle.crt
 
-    # use system libraries
-    # commented libraries are using bundled version due to not in our repo unless specified otherwise
-    builtin_brotli=no
-    # clipper2
-    # embree, godot use patched version, system version crashed when occlusion culling active
-    builtin_enet=no
-    builtin_freetype=no
-    # msdfgen
-    # glslang, need specific version
-    builtin_graphite=no
-    # harfbuzz, issue with extension
-    builtin_sdl=no
-    # icu4c, issue with extension
-    builtin_libjpeg_turbo=no
-    builtin_libogg=no
-    builtin_libpng=no
-    builtin_libtheora=no
-    builtin_libwebp=no
-    # wslay
-    builtin_mbedtls=no
-    builtin_miniupnpc=no
-    # openxr
-    builtin_pcre2=no
-    # recastnavigation
-    # rvo2_2d
-    # rvo2_3d
-    # xatlas
-    builtin_zlib=no
-    builtin_zstd=no
     use_static_cpp=no
-)
-scons ${ARGV[*]}
 
-EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH.mono"
-abinfo "Building Godot C# binding ..."
-"$SRCDIR"/bin/"$EXE_NAME" \
-	--headless \
-	--generate-mono-glue "$SRCDIR"/modules/mono/glue
-"$SRCDIR"/modules/mono/build_scripts/build_assemblies.py \
-	--godot-output-dir="$SRCDIR"/bin \
-	--godot-platform=linuxbsd
+	# use system libraries
+	# commented libraries are using bundled version due to not in our repo unless specified otherwise
+	builtin_brotli=no
+	# clipper2
+	# embree, godot use patched version, system version crashed when occlusion culling active
+	# enet, "System-provided ENet has its functionality limited to IPv4 only and no DTLS support, unless patched for Godot."
+	builtin_freetype=no
+	# msdfgen
+	# glslang, need specific version
+	builtin_graphite=no
+	# harfbuzz, issue with extension, https://github.com/godotengine/godot/issues/91401
+	builtin_sdl=no
+	# icu4c, issue with extension, https://github.com/godotengine/godot/issues/100301
+	builtin_libjpeg_turbo=no
+	builtin_libogg=no
+	builtin_libpng=no
+	builtin_libtheora=no
+	builtin_libvorbis=no
+	builtin_libwebp=no
+	# wslay
+	builtin_mbedtls=no
+	builtin_miniupnpc=no
+	# openxr
+	builtin_pcre2=no
+	# recastnavigation
+	# rvo2_2d
+	# rvo2_3d
+	# xatlas
+	builtin_zlib=no
+	builtin_zstd=no
+)
+if ab_match_arch i486; then
+	ARGV+=(
+		# FIXME: /usr/bin/ld: bin/obj/platform/linuxbsd/crash_handler_linuxbsd.linuxbsd.editor.x86_32.o: plugin needed to handle lto object
+		# Note: need disable LTO in both defines and scons parameter
+		lto=none
+	)
+fi
+
+scons "${ARGV[@]}"
+
+EXE_NAME="godot.linuxbsd.editor.$GODOT_ARCH"
+if [[ $has_dotnet == "yes" ]]; then
+	EXE_NAME="$EXE_NAME.mono"
+	abinfo "Building Godot C# binding ..."
+	"$SRCDIR"/bin/"$EXE_NAME" \
+		--headless \
+		--generate-mono-glue "$SRCDIR"/modules/mono/glue
+	"$SRCDIR"/modules/mono/build_scripts/build_assemblies.py \
+		--godot-output-dir="$SRCDIR"/bin \
+		--godot-platform=linuxbsd
+fi
 
 abinfo "Installing Godot..."
 install -dv "$PKGDIR"/usr/lib/godot/
-mv -v "$SRCDIR"/bin/GodotSharp \
-	"$PKGDIR"/usr/lib/godot/
+if [[ $has_dotnet == "yes" ]]; then
+	mv -v "$SRCDIR"/bin/GodotSharp \
+		"$PKGDIR"/usr/lib/godot/
+fi
+
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/godot
 mkdir -pv "$PKGDIR"/usr/bin/
 ln -sv ../lib/godot/godot "$PKGDIR"/usr/bin/godot

--- a/app-devel/godot/01-editor/defines
+++ b/app-devel/godot/01-editor/defines
@@ -2,10 +2,11 @@ PKGNAME=godot
 PKGDES="Multi-platform 2D and 3D game engine"
 PKGSEC=devel
 
-PKGDEP="x11-lib libglvnd glu alsa-lib pulseaudio systemd gcc-runtime \
-        brotli enet freetype glslang graphite libjpeg-turbo \
+PKGDEP="x11-lib wayland libglvnd glu alsa-lib pulseaudio systemd gcc-runtime \
+        brotli freetype glslang graphite libjpeg-turbo \
         libogg libpng libtheora libvorbis libwebp mbedtls miniupnpc \
         pcre2 sdl3 zlib zstd dotnet-sdk-10.0"
+PKGDEP__RETRO="${PKGDEP/dotnet-sdk-10.0/}"
 BUILDDEP="pkg-config gcc scons"
 
 PKGRECOM="\
@@ -15,6 +16,12 @@ godot-export-template-loongarch64 \
 godot-export-template-ppc64el \
 godot-export-template-riscv64 \
 "
+# Note: recommend nothing on retro to save disk space
+PKGRECOM__RETRO=""
 
-# FIXME: No support for these architecture(s) yet.
-FAIL_ARCH="loongson3"
+# FIXME: lto1: out of memory allocating 5831060 bytes after a total of 1261744128 bytes
+# Note: need disable LTO in both defines and scons parameter
+NOLTO__I486=1
+
+# FIXME: No support for loongson3
+FAIL_ARCH="@(loongson3)"

--- a/app-devel/godot/02-export-template-amd64/build
+++ b/app-devel/godot/02-export-template-amd64/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+    ccflags="$CFLAGS"
+    linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,10 +20,9 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 
 abinfo "Installing export template for $GODOT_ARCH ..."
-install -dv "$PKGDIR"/usr/lib/godot/templates/
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/templates/linux_release."$GODOT_ARCH"

--- a/app-devel/godot/02-export-template-amd64/build
+++ b/app-devel/godot/02-export-template-amd64/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+	ccflags="$CFLAGS"
+	linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,7 +20,7 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 

--- a/app-devel/godot/04-export-template-loongarch64/build
+++ b/app-devel/godot/04-export-template-loongarch64/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+    ccflags="$CFLAGS"
+    linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,10 +20,9 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 
 abinfo "Installing export template for $GODOT_ARCH ..."
-install -dv "$PKGDIR"/usr/lib/godot/templates/
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/templates/linux_release."$GODOT_ARCH"

--- a/app-devel/godot/04-export-template-loongarch64/build
+++ b/app-devel/godot/04-export-template-loongarch64/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+	ccflags="$CFLAGS"
+	linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,7 +20,7 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 

--- a/app-devel/godot/05-export-template-ppc64el/build
+++ b/app-devel/godot/05-export-template-ppc64el/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+    ccflags="$CFLAGS"
+    linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,10 +20,9 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 
 abinfo "Installing export template for $GODOT_ARCH ..."
-install -dv "$PKGDIR"/usr/lib/godot/templates/
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/templates/linux_release."$GODOT_ARCH"

--- a/app-devel/godot/05-export-template-ppc64el/build
+++ b/app-devel/godot/05-export-template-ppc64el/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+	ccflags="$CFLAGS"
+	linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,7 +20,7 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 

--- a/app-devel/godot/06-export-template-riscv64/build
+++ b/app-devel/godot/06-export-template-riscv64/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+    ccflags="$CFLAGS"
+    linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,10 +20,9 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 
 abinfo "Installing export template for $GODOT_ARCH ..."
-install -dv "$PKGDIR"/usr/lib/godot/templates/
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/templates/linux_release."$GODOT_ARCH"

--- a/app-devel/godot/06-export-template-riscv64/build
+++ b/app-devel/godot/06-export-template-riscv64/build
@@ -11,6 +11,8 @@ ARGV=(
     debug_symbols=yes
     arch="$GODOT_ARCH"
     module_mono_enabled=yes
+	ccflags="$CFLAGS"
+	linkflags="$LDFLAGS"
 
     progress=no
     debug_paths_relative=yes
@@ -18,7 +20,7 @@ ARGV=(
     builtin_certs=yes
     use_static_cpp=yes
 )
-scons ${ARGV[*]}
+scons "${ARGV[@]}"
 
 EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
 

--- a/app-devel/godot/07-export-template-i486/build
+++ b/app-devel/godot/07-export-template-i486/build
@@ -1,6 +1,11 @@
-GODOT_ARCH=arm64
+GODOT_ARCH=x86_32
 
 abinfo "Building Godot export template for $GODOT_ARCH ..."
+
+# Note: require lock free uint64_t atomic
+#   static_assert(std::atomic<uint64_t>::is_always_lock_free)
+abinfo "Set machine type to i586 ..."
+CFLAGS="${CFLAGS/-march=i486/-march=i586}"
 
 export BUILD_NAME=aosc
 
@@ -10,7 +15,7 @@ ARGV=(
     production=yes
     debug_symbols=yes
     arch="$GODOT_ARCH"
-    module_mono_enabled=yes
+    module_mono_enabled=no
     ccflags="$CFLAGS"
     linkflags="$LDFLAGS"
 
@@ -19,10 +24,13 @@ ARGV=(
     engine_update_check=no
     builtin_certs=yes
     use_static_cpp=yes
+
+    # FIXME: OOM when build on BuildIt! i486 machine, which have 8 cores and 24 GiB memory
+    -j 4
 )
 scons "${ARGV[@]}"
 
-EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
+EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH"
 
 abinfo "Installing export template for $GODOT_ARCH ..."
 install -Dvm755 "$SRCDIR"/bin/"$EXE_NAME" "$PKGDIR"/usr/lib/godot/templates/linux_release."$GODOT_ARCH"

--- a/app-devel/godot/07-export-template-i486/build
+++ b/app-devel/godot/07-export-template-i486/build
@@ -1,6 +1,10 @@
-GODOT_ARCH=arm64
+GODOT_ARCH=x86_32
 
 abinfo "Building Godot export template for $GODOT_ARCH ..."
+
+# Note: require lock free uint64_t atomic
+#   static_assert(std::atomic<uint64_t>::is_always_lock_free)
+CFLAGS="${CFLAGS/-march=i486/-march=i586}"
 
 export BUILD_NAME=aosc
 
@@ -10,7 +14,7 @@ ARGV=(
     production=yes
     debug_symbols=yes
     arch="$GODOT_ARCH"
-    module_mono_enabled=yes
+    module_mono_enabled=no
 	ccflags="$CFLAGS"
 	linkflags="$LDFLAGS"
 
@@ -22,7 +26,7 @@ ARGV=(
 )
 scons "${ARGV[@]}"
 
-EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH.mono"
+EXE_NAME="godot.linuxbsd.template_release.$GODOT_ARCH"
 
 abinfo "Installing export template for $GODOT_ARCH ..."
 install -dv "$PKGDIR"/usr/lib/godot/templates/

--- a/app-devel/godot/07-export-template-i486/defines
+++ b/app-devel/godot/07-export-template-i486/defines
@@ -1,0 +1,10 @@
+PKGNAME=godot-export-template-i486
+PKGDES="Godot engine export template (for i486 Linux target)"
+PKGSEC=devel
+
+PKGDEP="godot"
+BUILDDEP="pkg-config gcc scons"
+
+# Note: specify worker architecture while compiling noarch package
+FAIL_ARCH="!(i486)"
+DPKG_ARCH=noarch

--- a/app-devel/godot/spec
+++ b/app-devel/godot/spec
@@ -1,4 +1,4 @@
-VER=4.7
+VER=4.7.1
 SRCS="git::commit=tags/$VER-stable::https://github.com/godotengine/godot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373975"

--- a/app-network/miniupnpc/autobuild/defines
+++ b/app-network/miniupnpc/autobuild/defines
@@ -4,3 +4,5 @@ PKGDEP="glibc"
 PKGDES="UPnP client library/tool to access Internet Gateway Devices"
 
 PKGBREAK="0ad<=0.0.20 dante<=1.4.1-4 dolphin-emu<=5.0"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/app-network/miniupnpc/spec
+++ b/app-network/miniupnpc/spec
@@ -1,5 +1,4 @@
-VER=2.1
-REL=5
+VER=2.3.3
 SRCS="tbl::http://miniupnp.free.fr/files/miniupnpc-$VER.tar.gz"
-CHKSUMS="sha256::e19fb5e01ea5a707e2a8cb96f537fbd9f3a913d53d804a3265e3aeab3d2064c6"
+CHKSUMS="sha256::d52a0afa614ad6c088cc9ddff1ae7d29c8c595ac5fdd321170a05f41e634bd1a"
 CHKUPDATE="anitya::id=1986"

--- a/app-network/miniupnpd/autobuild/defines
+++ b/app-network/miniupnpd/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=miniupnpd
 PKGSEC=net
 PKGDEP="libnfnetlink iptables net-tools util-linux"
 PKGDES="Lightweight UPnP IGD daemon"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/app-network/miniupnpd/spec
+++ b/app-network/miniupnpd/spec
@@ -1,4 +1,4 @@
-VER=2.3.10
+VER=2.3.11
 SRCS="tbl::http://miniupnp.free.fr/files/miniupnpd-$VER.tar.gz"
-CHKSUMS="sha256::f9c34ed3632fb60cd248dd5897bd98479a103a75688b056ca2f069e68ab32987"
+CHKSUMS="sha256::91994b127da735b2c97f19992e34420648c0e8c4ace8a4bcb0596e7685c48678"
 CHKUPDATE="anitya::id=14608"

--- a/runtime-cryptography/mbedtls/autobuild/defines
+++ b/runtime-cryptography/mbedtls/autobuild/defines
@@ -18,16 +18,10 @@ CMAKE_AFTER=(
 
 NOSTATIC=0
 NOSTATIC__RETRO=1
-NOSTATIC__ARMV4="${NOSTATIC__RETRO}"
-NOSTATIC__ARMV6HF="${NOSTATIC__RETRO}"
-NOSTATIC__ARMV7HF="${NOSTATIC__RETRO}"
-NOSTATIC__I486="${NOSTATIC__RETRO}"
-NOSTATIC__LOONGSON2F="${NOSTATIC__RETRO}"
-NOSTATIC__M68K="${NOSTATIC__RETRO}"
-NOSTATIC__POWERPC="${NOSTATIC__RETRO}"
-NOSTATIC__PPC64="${NOSTATIC__RETRO}"
 
 PKGBREAK="bctoolbox<=0.6.0-4 belle-sip<=1.6.3-4 bzrtp<=1.0.6-4 dislocker<=0.7.3-1 \
           dolphin-emu<=1:2509-1 julia<=1.1.0-2 godot<=4.5.1 imhex<=1.37.4-2 \
           ncbi-vdb<=3.0.2-1 nng<=1.10.1 obs-studio<=32.0.3 openrgb<=0.9 \
           pkcs11-helper<=1.30.0 shadowsocks-libev<=3.3.5-3 thedarkmod<=2.06-1"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-network/libnfnetlink/autobuild/defines
+++ b/runtime-network/libnfnetlink/autobuild/defines
@@ -2,3 +2,5 @@ PKGNAME=libnfnetlink
 PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="Low level Netfilter kernel/user interface communication library"
+
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-network/libnfnetlink/spec
+++ b/runtime-network/libnfnetlink/spec
@@ -1,5 +1,4 @@
-VER=1.0.1
-REL=2
+VER=1.0.2
 SRCS="tbl::http://ftp.netfilter.org/pub/libnfnetlink/libnfnetlink-$VER.tar.bz2"
-CHKSUMS="sha256::f270e19de9127642d2a11589ef2ec97ef90a649a74f56cf9a96306b04817b51a"
+CHKSUMS="sha256::b064c7c3d426efb4786e60a8e6859b82ee2f2c5e49ffeea640cfe4fe33cbc376"
 CHKUPDATE="anitya::id=1682"


### PR DESCRIPTION
Topic Description
-----------------

- libnfnetlink: update to 1.0.2
- miniupnpd: update to 2.3.11
- miniupnpc: update to 2.3.3
- mbedtls: allow build on retro
- godot: update to 4.7.1

Package(s) Affected
-------------------

- godot: 4.7.1
- godot-export-template-amd64: 4.7.1
- godot-export-template-arm64: 4.7.1
- godot-export-template-i486: 4.7.1
- godot-export-template-loongarch64: 4.7.1
- godot-export-template-ppc64el: 4.7.1
- godot-export-template-riscv64: 4.7.1
- miniupnpd: 2.3.11

Security Update?
----------------

No

Build Order
-----------

```
#buildit godot miniupnpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
