### PR TITLE
simde: fix VER escape ~

### DIFF
--- a/runtime-common/simde/spec
+++ b/runtime-common/simde/spec
@@ -1,5 +1,5 @@
 UPSTREAM_VER=0.8.4-rc3
-VER=${UPSTREAM_VER/-/~}
+VER=${UPSTREAM_VER/-/\~}
 SRCS="git::commit=tags/v${UPSTREAM_VER}::https://github.com/simd-everywhere/simde"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=180908"


### PR DESCRIPTION
Topic Description
-----------------

- simde: fix \`VER\` escape \`\~\`

Package(s) Affected
-------------------

- simde: 0.8.4~rc3

Security Update?
----------------

No

Build Order
-----------

```
#buildit simde
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
