### PR TITLE
latx: fix VER escape ~

### DIFF
--- a/app-emulation/latx/spec
+++ b/app-emulation/latx/spec
@@ -1,6 +1,6 @@
 UPSTREAM_VER=1.6.7
 # Note: 1.5.3-rc1 => 1.5.3~rc1
-VER=${UPSTREAM_VER/-/~}
+VER=${UPSTREAM_VER/-/\~}
 # Note: The last source is for installing documentation.
 SRCS="git::commit=tags/${UPSTREAM_VER};copy-repo=true;submodule=false::https://github.com/lat-opensource/lat"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- latx: fix VER escape \~
- simde: fix \`VER\` escape \`\~\`

Package(s) Affected
-------------------

- latx: 1.6.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit latx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] LoongArch 64-bit `loongarch64`
