### PR TITLE
.NET SDK 10.0.111

### DIFF
--- a/lang-dotnet/dotnet10/01-source-built-artifacts/defines
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/defines
@@ -11,5 +11,5 @@ USECLANG=1
 # Note: source built artifact itself is a tarball
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/01-source-built-artifacts/defines.stage2
+++ b/lang-dotnet/dotnet10/01-source-built-artifacts/defines.stage2
@@ -11,5 +11,5 @@ USECLANG=1
 # Note: source built artifact itself is a tarball
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/02-runtime-deps/defines
+++ b/lang-dotnet/dotnet10/02-runtime-deps/defines
@@ -6,5 +6,5 @@ PKGDEP="glibc gcc-runtime krb5 zlib openssl icu"
 ABSTRIP=0
 ABTYPE=dummy
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/03-host/defines
+++ b/lang-dotnet/dotnet10/03-host/defines
@@ -6,5 +6,5 @@ PKGSEC=libs
 PKGDES="Microsoft .NET Host"
 PKGDEP="glibc gcc-runtime"
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/04-hostfxr/defines
+++ b/lang-dotnet/dotnet10/04-hostfxr/defines
@@ -3,5 +3,5 @@ PKGSEC=libs
 PKGDES="Microsoft .NET Host FX Resolver (version 10)"
 PKGDEP="dotnet-host"
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/05-runtime/defines
+++ b/lang-dotnet/dotnet10/05-runtime/defines
@@ -3,5 +3,5 @@ PKGSEC=libs
 PKGDES=".NET runtime (version 10)"
 PKGDEP="dotnet-hostfxr-10.0 dotnet-runtime-deps-10.0"
 
-# FIXME: no upstream support for loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/06-aspnet-runtime/defines
+++ b/lang-dotnet/dotnet10/06-aspnet-runtime/defines
@@ -3,5 +3,5 @@ PKGSEC=devel
 PKGDES="Microsoft ASP.NET Core runtime (version 10)"
 PKGDEP="dotnet-runtime-10.0"
 
-# FIXME: no upstream support for loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/07-apphost-pack/defines
+++ b/lang-dotnet/dotnet10/07-apphost-pack/defines
@@ -3,5 +3,5 @@ PKGSEC=libs
 PKGDES=".NET native application template (version 10)"
 PKGDEP=""
 
-# FIXME: no upstream support for loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/08-targeting-pack/defines
+++ b/lang-dotnet/dotnet10/08-targeting-pack/defines
@@ -6,5 +6,5 @@ PKGDEP=""
 # Note: No symbol
 ABSTRIP=0
 
-# FIXME: no upstream support for loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/09-aspnet-targeting-pack/defines
+++ b/lang-dotnet/dotnet10/09-aspnet-targeting-pack/defines
@@ -6,5 +6,5 @@ PKGDEP="dotnet-targeting-pack-10.0"
 # Note: No symbol
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/10-templates/defines
+++ b/lang-dotnet/dotnet10/10-templates/defines
@@ -6,5 +6,5 @@ PKGDEP=""
 # Note: No symbol
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/11-sdk/defines
+++ b/lang-dotnet/dotnet10/11-sdk/defines
@@ -12,5 +12,5 @@ PKGPROV="dotnet10"
 # PDB filter is manually called in build script
 ABSTRIP=0
 
-# FIXME: no upstream support on loongson3
-FAIL_ARCH="@(loongson3)"
+# FIXME: no upstream support on loongson3 and i486
+FAIL_ARCH="@(loongson3|i486)"

--- a/lang-dotnet/dotnet10/12-sdk-aot/defines
+++ b/lang-dotnet/dotnet10/12-sdk-aot/defines
@@ -9,5 +9,6 @@ ABSTRIP=0
 # Note: NativeAOT compiler ships static library to be linked with user program
 NOSTATIC=0
 
+# FIXME: no upstream support on loongson3 and i486
 # FIXME: no native aot support on ppc64el due to mono runtime
-FAIL_ARCH="@(loongson3|ppc64el)"
+FAIL_ARCH="@(loongson3|i486|ppc64el)"

--- a/lang-dotnet/dotnet10/spec
+++ b/lang-dotnet/dotnet10/spec
@@ -1,4 +1,4 @@
-VER=10.0.110
+VER=10.0.111
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/dotnet/dotnet.git"
 CHKSUMS="SKIP"
 CHKUPDATE="html::url=https://dotnetcli.azureedge.net/dotnet/release-metadata/releases-index.json;pattern=\"latest-sdk\": \"(10\.0\.1.+?)\""


### PR DESCRIPTION
Topic Description
-----------------

- dotnet10: update to 10.0.111

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit dotnet-sdk-10.0-source-built-artifacts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
