### PR TITLE
gnu-efi: update to 4.0.4

### DIFF
--- a/app-devel/gnu-efi/autobuild/defines
+++ b/app-devel/gnu-efi/autobuild/defines
@@ -2,8 +2,13 @@ PKGNAME=gnu-efi
 PKGSEC=devel
 PKGDES="Libraries for building UEFI applications using the GNU toolchain"
 
+# This is a bare-metal SDK, so it shouldn't be stripped and only static
+# libraries are present.
 ABSTRIP=0
-NOPARALLEL=1
 NOSTATIC=0
+# The hand-written build system seems to be not robust enough
+NOPARALLEL=1
+# Stack protection leads to missing symbol
+AB_FLAGS_SSP=0
 
 FAIL_ARCH="!(amd64|arm64|armv7hf|riscv64|loongarch64|loongarch64_nosimd)"

--- a/app-devel/gnu-efi/autobuild/defines
+++ b/app-devel/gnu-efi/autobuild/defines
@@ -5,5 +5,7 @@ PKGDES="Libraries for building UEFI applications using the GNU toolchain"
 ABSTRIP=0
 NOPARALLEL=1
 NOSTATIC=0
+# Stack protection leads to missing symbol
+AB_FLAGS_SSP=0
 
 FAIL_ARCH="!(amd64|arm64|armv7hf|riscv64|loongarch64|loongarch64_nosimd)"

--- a/app-devel/gnu-efi/spec
+++ b/app-devel/gnu-efi/spec
@@ -1,5 +1,4 @@
-VER=3.0.18
-SRCS="tbl::https://sourceforge.net/projects/gnu-efi/files/gnu-efi-$VER.tar.bz2/download"
-CHKSUMS="sha256::7f212c96ee66547eeefb531267b641e5473d7d8529f0bd8ccdefd33cf7413f5c"
+VER=4.0.4
+SRCS="git::commit=tags/${VER}::https://github.com/ncroxon/gnu-efi.git"
+CHKSUMS="sha256::SKIP"
 CHKUPDATE="anitya::id=1202"
-REL=2


### PR DESCRIPTION
Topic Description
-----------------

- gnu-efi: update to 4.0.4
    The upstream is now moved to GitHub.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- gnu-efi: 4.0.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit gnu-efi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
