### PR TITLE
fcitx5-pinyin-moegirl: update to 20260812

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,9 @@
-VER=20260713
+VER=20260812
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::666a5372894a4e32418a7a3ece454aea106fffeca5940881891e89cb8481755b \
-         sha256::15c6b9bd6766a9a4673fa89de13a95185b13c67ca70284133200169ed179798d \
+CHKSUMS="sha256::24ddcf2404b6c7616cbf1da2419f8ad0c60e4787ac1c61ceb13565fba7596551 \
+         sha256::5836c87507415f4dcdb0fc45aecf4dd7ae82183a650cdd7930e1e663e32e3a24 \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
 CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260812

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260812
- rime-pinyin-moegirl: 20260812

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
