### PR TITLE
nexttrace: update to 1.7.2

### DIFF
--- a/app-network/nexttrace/spec
+++ b/app-network/nexttrace/spec
@@ -1,4 +1,4 @@
-VER=1.7.1
+VER=1.7.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/nxtrace/NTrace-core.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=356726"


### PR DESCRIPTION
Topic Description
-----------------

- nexttrace: update to 1.7.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- nexttrace: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nexttrace
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
