### PR TITLE
vscode: update to 1.133.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.132.1
+VER=1.133.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::da17f465d8c33add5affe157a2c0a0b8a2c0af11b63804d055b853be04ddbfc9"
-CHKSUMS__ARM64="sha256::cb4b5a0732eb85f8764933616ffdae922c9d160647b427f9409a5686ecc4a6bd"
+CHKSUMS__AMD64="sha256::d064e87e22f556b8a91e1354b5227e340597324e52886dbb288551596b00e34a"
+CHKSUMS__ARM64="sha256::b20bfb21c5b3656e3411391c5c18df1782aedd7cd3bda0b9c08363ea261fca4b"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.133.0
    Co-authored-by: LJL \(@ljlofficial\) <lkjmlk@aosc.io>

Package(s) Affected
-------------------

- vscode: 1.133.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
