### PR TITLE
redis: update to 8.10.0

### DIFF
--- a/app-database/redis/autobuild/build
+++ b/app-database/redis/autobuild/build
@@ -1,7 +1,8 @@
 abinfo "Building and installing redis ..."
 make all \
     BUILD_TLS=yes \
-    USE_SYSTEMD=yes
+    USE_SYSTEMD=yes \
+    IGNORE_MISSING_DEPS=1
 
 abinfo "Installing redis ..."
 make install \

--- a/app-database/redis/autobuild/defines
+++ b/app-database/redis/autobuild/defines
@@ -1,6 +1,11 @@
 PKGNAME=redis
 PKGSEC=database
 PKGDEP="jemalloc grep shadow lua"
+BUILDDEP="rustc llvm"
 PKGDES="Advanced key-value store"
 
 ABTYPE=self
+# FIXME: Error: LTO requires clang as the C compiler
+USECLANG=1
+# FIXME: (.text.unlikely.stats_general_print+0xea): undefined reference to `je_mallctl'/usr/bin/ld: /var/cache/acbs/build/acbs.qypayso3/redis-8.10.0/deps/jemalloc/src/stats.c:1404
+NOLTO=1

--- a/app-database/redis/autobuild/defines
+++ b/app-database/redis/autobuild/defines
@@ -1,6 +1,11 @@
 PKGNAME=redis
 PKGSEC=database
 PKGDEP="jemalloc grep shadow lua"
+BUILDDEP="rustc llvm-21"
 PKGDES="Advanced key-value store"
 
 ABTYPE=self
+# FIXME: Error: LTO requires clang as the C compiler
+USECLANG=1
+# FIXME: (.text.unlikely.stats_general_print+0xea): undefined reference to `je_mallctl'/usr/bin/ld: /var/cache/acbs/build/acbs.qypayso3/redis-8.10.0/deps/jemalloc/src/stats.c:1404
+NOLTO=1

--- a/app-database/redis/autobuild/patches/0002-AUR-use-system-jemalloc.patch
+++ b/app-database/redis/autobuild/patches/0002-AUR-use-system-jemalloc.patch
@@ -1,0 +1,15 @@
+diff --git a/src/Makefile b/src/Makefile
+index 5cb4f67..7f652fd 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -317,8 +317,8 @@ endif
+ 
+ ifeq ($(MALLOC),jemalloc)
+ 	DEPENDENCY_TARGETS+= jemalloc
+-	FINAL_CFLAGS+= -DUSE_JEMALLOC -I../deps/jemalloc/include
+-	FINAL_LIBS := ../deps/jemalloc/lib/libjemalloc.a $(FINAL_LIBS)
++	FINAL_CFLAGS+= -DUSE_JEMALLOC -DJEMALLOC_NO_DEMANGLE -I/usr/include/jemalloc
++	FINAL_LIBS := -ljemalloc $(FINAL_LIBS)
+ endif
+ 
+ # LIBSSL & LIBCRYPTO

--- a/app-database/redis/spec
+++ b/app-database/redis/spec
@@ -1,4 +1,4 @@
-VER=8.8.1
+VER=8.10.0
 SRCS="tbl::https://download.redis.io/releases/redis-$VER.tar.gz"
-CHKSUMS="sha256::1d1e423c9c808de3cb01dd3300d2b8d305b7691382e31a847ec17b66d3157477"
+CHKSUMS="sha256::f1baa4b28befd417aa6577ebeedde9e9fc7814cfcc299b2a6d2fd99ef7420a6c"
 CHKUPDATE="anitya::id=4181"


### PR DESCRIPTION
Topic Description
-----------------

- redis: update to 8.10.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- redis: 8.10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit redis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
