### PR TITLE
noto-fonts: update to 2026.08.01+emoji2.051+cjksans2.004+cjkserif2.003

### DIFF
--- a/desktop-fonts/noto-fonts/spec
+++ b/desktop-fonts/noto-fonts/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=2026.07.01
+UPSTREAM_VER=2026.08.01
 # Note: For the main version number, go with NotoSans- prefixed tags at
 # https://github.com/notofonts/notofonts.github.io/.
 EMOJI_VER=2.051
@@ -15,7 +15,7 @@ CJK_COMMIT="4efc595762d1f4b4fa504bccfe8e59de91fda063"
 SRCS="tbl::https://github.com/notofonts/notofonts.github.io/archive/refs/tags/noto-monthly-release-${UPSTREAM_VER}.tar.gz \
       tbl::https://github.com/googlefonts/noto-emoji/archive/refs/tags/v${EMOJI_VER}.tar.gz \
       git::commit=${CJK_COMMIT};rename=noto-cjk::https://github.com/googlefonts/noto-cjk"
-CHKSUMS="sha256::b614152147d67bfceaaf3409600353e582a477fa64bef4da6a8ca2e370aaf531 \
+CHKSUMS="sha256::ef269bd42da0cd1c602c69c9edd81c655662babf495f69cd66d01842a1b7bbb2 \
          sha256::04f3d1e5605edebebac00a7a0becb390a4a3ead015066905b27935b30c18e745 \
          SKIP"
 CHKUPDATE="anitya::id=10671"


### PR DESCRIPTION
Topic Description
-----------------

- noto-fonts: update to 2026.08.01+emoji2.051+cjksans2.004+cjkserif2.003
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- noto-cjk-fonts: 2026.08.01+emoji2.051+cjksans2.004+cjkserif2.003
- noto-fonts: 2026.08.01+emoji2.051+cjksans2.004+cjkserif2.003

Security Update?
----------------

No

Build Order
-----------

```
#buildit noto-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
