### PR TITLE
uv: update to 0.12.4

### DIFF
--- a/lang-python/uv/autobuild/build
+++ b/lang-python/uv/autobuild/build
@@ -3,6 +3,12 @@ if ab_match_arch loongarch64; then
     python3 "$SRCDIR"/crates/uv-python/fetch-download-metadata.py
 fi
 
+if ab_match_arch loongarch64 || ab_match_arch loongarch64_nosimd; then
+    # https://github.com/sunfishcode/linux-raw-sys/issues/192
+    abinfo "Updating linux-raw-sys with a patched version ..."
+    cargo update --package linux-raw-sys
+fi
+
 abinfo "Building uv ..."
 export tripple="$(rustc --print host-tuple)"
 maturin build --locked --release --target "$tripple" --strip --compatibility linux

--- a/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
+++ b/lang-python/uv/autobuild/patches/0001-AOSCOS-Relax-ELF-parsing-mode.patch
@@ -1,7 +1,7 @@
-From 44e57f409848e84ac049a55e28804dd300011330 Mon Sep 17 00:00:00 2001
+From 820753dbca8872beb9d909a5cdba901c4989adb6 Mon Sep 17 00:00:00 2001
 From: Rong Bao <rong.bao@csmantle.top>
 Date: Sat, 28 Feb 2026 13:11:54 +0800
-Subject: [PATCH 1/2] AOSCOS: Relax ELF parsing mode
+Subject: [PATCH 1/3] AOSCOS: Relax ELF parsing mode
 
 uv finds the libc version on the current platform by looking at the
 name of dynamic linker (ld). It finds ld by parsing several well-known

--- a/lang-python/uv/autobuild/patches/0002-AOSCOS-Override-python-build-standalone-source-for-l.patch.loongarch64
+++ b/lang-python/uv/autobuild/patches/0002-AOSCOS-Override-python-build-standalone-source-for-l.patch.loongarch64
@@ -1,7 +1,7 @@
-From 4c408a064dd8a6782cd540bfb53d568d72e166e4 Mon Sep 17 00:00:00 2001
+From f226dfdf85186561f1f78c19a253eb1783e0058b Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Sun, 26 Jul 2026 19:03:57 +0800
-Subject: [PATCH 2/2] AOSCOS: Override python-build-standalone source for
+Subject: [PATCH 2/3] AOSCOS: Override python-build-standalone source for
  loongarch64
 
 Source: https://github.com/loong64/uv/blob/9f40378309f8d2c9191e4a96684d83a873e4d692/patch_loong64.patch#L12-L24
@@ -10,7 +10,7 @@ Source: https://github.com/loong64/uv/blob/9f40378309f8d2c9191e4a96684d83a873e4d
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/crates/uv-python/fetch-download-metadata.py b/crates/uv-python/fetch-download-metadata.py
-index 00c88d655..b405e023d 100755
+index ae0a4e2ce..2ac1ca83f 100755
 --- a/crates/uv-python/fetch-download-metadata.py
 +++ b/crates/uv-python/fetch-download-metadata.py
 @@ -194,7 +194,7 @@ class Finder:

--- a/lang-python/uv/autobuild/patches/0003-AOSCOS-Replace-linux-raw-sys-for-loongarch64.patch.loongarch64
+++ b/lang-python/uv/autobuild/patches/0003-AOSCOS-Replace-linux-raw-sys-for-loongarch64.patch.loongarch64
@@ -1,0 +1,24 @@
+From f2c31c8df4850ef04cdd98c055e4ee5e3ada477e Mon Sep 17 00:00:00 2001
+From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
+Date: Fri, 14 Aug 2026 15:19:36 +0800
+Subject: [PATCH 3/3] AOSCOS: Replace linux-raw-sys for loongarch64
+
+https://github.com/sunfishcode/linux-raw-sys/issues/192
+---
+ Cargo.toml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/Cargo.toml b/Cargo.toml
+index 710f34879..53d6ffaa0 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -468,3 +468,6 @@ codegen-units = 1
+ # The profile that 'cargo dist' will build with.
+ [profile.dist]
+ inherits = "release"
++
++[patch.crates-io]
++linux-raw-sys = { git = "https://github.com/loong64/linux-raw-sys", branch = "loong64-v0.12.1" }
+-- 
+2.55.0
+

--- a/lang-python/uv/autobuild/patches/0003-AOSCOS-Replace-linux-raw-sys-for-loongarch64.patch.loongarch64_nosimd
+++ b/lang-python/uv/autobuild/patches/0003-AOSCOS-Replace-linux-raw-sys-for-loongarch64.patch.loongarch64_nosimd
@@ -1,0 +1,1 @@
+0003-AOSCOS-Replace-linux-raw-sys-for-loongarch64.patch.loongarch64

--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.12.1
+VER=0.12.4
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.12.4
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.12.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
