### PR TITLE
ayugram-desktop: new, 6.7.8

### DIFF
--- a/app-web/ayugram-desktop/autobuild/defines
+++ b/app-web/ayugram-desktop/autobuild/defines
@@ -1,0 +1,34 @@
+PKGNAME=ayugram-desktop
+PKGSEC=web
+PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
+    openal-soft openssl lz4 qt-6 xxhash hunspell crc32c glibmm-2.68 fmt \
+    libavif libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons ada sqlite"
+PKGDEP__MAINLINE_TIER2="${PKGDEP} libdispatch"
+BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm gperf \
+          extra-cmake-modules wayland-protocols plasma-wayland-protocols"
+PKGSUG="webkit2gtk"
+PKGRECOM="kimageformats"
+PKGDES="Telegram desktop client fork with ghost mode, message history, and extended customization"
+
+CMAKE_AFTER=(
+    '-DCMAKE_INSTALL_PREFIX=/usr'
+    '-DDESKTOP_APP_SPECIAL_TARGET='
+    '-DTDESKTOP_LAUNCHER_BASENAME=ayugramdesktop;'
+    '-DDESKTOP_APP_USE_PACKAGED=ON'
+    '-DDESKTOP_APP_USE_PACKAGED_FONTS=OFF'
+    '-DDESKTOP_APP_DISABLE_AUTOUPDATE=ON'
+    '-DQT_VERSION_MAJOR=6'
+    '-DTDESKTOP_API_ID=2040'
+    '-DTDESKTOP_API_HASH=b18441a1ff607e10a989891a5462e627'
+)
+
+CMAKE_AFTER__LOONGSON3=(
+    ${CMAKE_AFTER[@]}
+    '-DCMAKE_BUILD_TYPE=MinSizeRel'
+)
+
+ABTYPE=cmakeninja
+
+NOLTO__RISCV64=1
+NOLTO__LOONGSON3=1
+AB_FLAGS_OS__LOONGSON3=1

--- a/app-web/ayugram-desktop/autobuild/prepare
+++ b/app-web/ayugram-desktop/autobuild/prepare
@@ -1,0 +1,36 @@
+abinfo "Patching tg_owt ..."
+cd "$SRCDIR"/../tg_owt
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.owt.deferred
+
+abinfo "Building tg_owt ..."
+cmake -B build \
+      -G Ninja \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_INSTALL_PREFIX=/usr \
+      -DTG_OWT_DLOPEN_PIPEWIRE=OFF .
+ninja -C build -v
+ninja -C build install
+
+abinfo "Patching tdlib ..."
+cd "$SRCDIR"/../td
+ab_apply_patches "$SRCDIR"/autobuild/patches/*.td.deferred
+
+abinfo "Building tdlib ..."
+cmake -B build \
+      -G Ninja \
+      -DTD_INSTALL_SHARED_LIBRARIES=OFF \
+      -DTD_INSTALL_STATIC_LIBRARIES=ON \
+      -DTD_E2E_ONLY=ON \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCMAKE_INSTALL_PREFIX=/usr .
+ninja -C build -v
+ninja -C build install
+
+cd "$SRCDIR"
+
+if ab_match_arch riscv64; then
+    abinfo "Injecting -pthread and -latomic for RISCV64..."
+    export LDFLAGS="${LDFLAGS} -pthread -latomic"
+fi
+

--- a/app-web/ayugram-desktop/spec
+++ b/app-web/ayugram-desktop/spec
@@ -1,0 +1,10 @@
+VER=6.7.8
+OWTVER=89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4
+TDLIBVER=51743dfd01dff6179e2d8f7095729caa4e2222e9
+
+SRCS="git::commit=b25513a06ff88be0b3f4c928252b56c3da39cec7;submodule=recursive::https://github.com/AyuGram/AyuGramDesktop \
+      git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt \
+      git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
+CHKSUMS="SKIP SKIP SKIP"
+
+SUBDIR="ayugram-desktop"


### PR DESCRIPTION
Topic Description
-----------------

新增软件包 `ayugram-desktop` —— AyuGram Desktop,Telegram Desktop 的第三方 fork,
主要特性为 Ghost Mode(免已读)、本地消息历史与防撤回、字体自定义等。

- 上游:https://github.com/AyuGram/AyuGramDesktop
- 版本:v6.7.8(releases 页面的最新**正式发布版**)
- 许可:GPL-3.0(继承 tdesktop)
- 分类:`app-web/`,与 `telegram-desktop` 同级

> 上游 tag 列表中有 `v7.0.9`,但它**不是 release**,是 rebase 到 tdesktop 7.0.9
> 过程中的中间 tag,故未采用。

本包以现有 `app-web/telegram-desktop` 为模板,以下为差异及理由。

### 1. API_ID / API_HASH

AyuGram 上游仓库**不含** `snap/snapcraft.yaml`,因此无法沿用 `telegram-desktop`
在 `autobuild/prepare` 中从该文件 grep 凭据的做法。本包在 `autobuild/defines` 的
`CMAKE_AFTER` 里直接写入上游 `docs/building-linux.md` 公布的公开凭据:

```
-DTDESKTOP_API_ID=2040
-DTDESKTOP_API_HASH=b18441a1ff607e10a989891a5462e627
```

已在构建日志中确认该值正确进入编译命令行。

**请 reviewer 定夺**:是接受这组公开凭据,还是需要以 AOSC 名义申请专用凭据。

相应地删除了 `autobuild/prepare` 末尾两行(从 telegram-desktop 复制而来):

```bash
abinfo "Applying API ID from snapcraft.yml ..."
export CMAKE_AFTER=(${CMAKE_AFTER[@]} $(grep TDESKTOP_API_ "$SRCDIR"/snap/snapcraft.yaml | awk '{print $2}'))
```

对 AyuGram 而言这是死代码(目标文件不存在),且因它**追加**在 `CMAKE_AFTER` 之后,
一旦上游将来新增该文件反而会**覆盖**上面写死的凭据。

### 2. 未沿用 telegram-desktop 的补丁

现有 5 个补丁是针对 **7.0.8** 写的,套到 6.7.8 上下文对不上
(`0003` 的 hunk #1 直接失败)。这些补丁都只改外观默认值、不影响编译,故整体未采用。

其中 `0003-AOSCOS-fix-settings-use-system-fonts-by-default.patch` **建议对本包永久不采用**:
它强制 `_customFontFamily = style::SystemFontTag()`,而字体自定义正是 AyuGram
的招牌功能之一,两者设计意图冲突。

`0001`(默认窗口宽度)/ `0002`(系统窗口装饰)如认为有必要与官方包保持一致观感,
可手工 rebase 到 6.7.8 上下文后加回,请 reviewer 指示。

### 3. 与 telegram-desktop 无文件冲突,未添加 PKGCONFL

以 `dpkg -c` 对比双方文件列表,**交集为 0**(各 22 个文件),两包可共存:

| | ayugram-desktop | telegram-desktop 7.0.8 |
|---|---|---|
| 可执行文件 | `/usr/bin/AyuGram` | `/usr/bin/Telegram` |
| desktop / dbus / 图标 / metainfo | `com.ayugram.desktop.*` | `org.telegram.desktop.*` |

同时**删除了**模板中的 `PKGPROV="telegram tdesktop"` —— fork 不应冒充官方包,
否则会干扰依赖解析。

### 4. PKGDEP 中额外加入 libavif

对产物做了依赖闭包核对:取 `/usr/bin/AyuGram` 的 `NEEDED`(61 项),经仓库
`Contents-amd64` 映射到提供者,再对 `PKGDEP` 求传递闭包 —— 结果 60 项在闭包内,
仅 `libavif.so.16` 落在闭包外,故 `PKGDEP` 追加 `libavif`。

**现有的 `telegram-desktop` 存在完全相同的遗漏**(同样链接 `libavif.so.16`,
`PKGDEP` 中同样没有)。本 PR 只修本包,是否顺带修 `telegram-desktop`
请 reviewer 定夺(可另开 topic)。

另请注意:`libheif` / `libjxl` 虽在闭包内,但路径为
`libnotify → gtk-4 → gdk-pixbuf → glycin → libheif/libjxl`,较为脆弱,
上游调整 `glycin` 依赖即会断开。是否将这两者也显式写入 `PKGDEP`,同样请 reviewer 定夺。

> autobuild4 的 QA 不检出此类问题(AOSC 无 Debian 式 shlibs 自动依赖生成),
> 以上为手工核对结果。

### 5. 其他差异一览

| 改动 | 原因 |
|---|---|
| `PKGNAME` → `ayugram-desktop` | — |
| 删除 `PKGPROV="telegram tdesktop"` | fork 不应冒充官方包 |
| `TDESKTOP_LAUNCHER_BASENAME` → `ayugramdesktop` | 避免与官方包同名(实测上游本身即使用 `com.ayugram.desktop` 命名空间) |
| 新增 `TDESKTOP_API_ID` / `API_HASH` | 见第 1 节 |
| `PKGDEP` 追加 `sqlite` | AyuGram 使用 SQLite 存储消息历史 |
| `PKGDEP` 追加 `libavif` | 见第 4 节 |
| `SUBDIR="ayugram-desktop"` | 多源(3 个 git)时 ACBS 无法自动判定主目录;ACBS 对主 git 源按**包名**建目录,而非仓库名 |

`tg_owt` / `tdlib` 的 commit 取自 AyuGram 6.7.8 tag 下的
`Telegram/build/prepare/prepare.py`,**未**沿用 telegram-desktop 的值
(后者与 6.7.8 不兼容):

| 组件 | commit |
|---|---|
| tg_owt | `89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4` |
| tdlib (tde2e) | `51743dfd01dff6179e2d8f7095729caa4e2222e9` |

Package(s) Affected
-------------------

`ayugram-desktop`(新增)

Security Update?
----------------

No

Build Order
-----------

```
#buildit ayugram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

### amd64 构建结果

- 构建机:32 vCPU / 125 GB RAM,AOSC OS 13.3.1 BuildKit(20260621),ACBS 20260729 / autobuild4 4.20.0
- 耗时:约 26 分钟
- **带 LTO 全程构建通过**,未设置 `NOLTO__AMD64`,内存峰值远低于上限
- **autobuild4 QA 通过,零 `[WARN]` / `[ERROR]` / `[CRIT]`**
- 容器内 `dpkg` 安装成功,desktop-file-utils / xdg-menu / gtk-icon-cache /
  hicolor-icon-theme 触发器均正常执行
- 产物:`ayugram-desktop_6.7.8-0_amd64.deb`(50.7 MB)+ `-dbg`(1.6 GB)

### 实机安装测试(amd64)

在 AOSC OS 13.3.1 桌面环境上安装本包并实际运行,**可正常启动、基本功能正常**。
安装时需从仓库补入 `crc32c`、`glibmm-2.68`、`rnnoise`、`ada` 四个依赖,依赖解析无冲突。
与已安装的 `telegram-desktop` 共存,未观察到冲突。

### 尚未验证事项(请协助)

1. **仅在 amd64 上做过测试构建**,其余架构未测试 —— 手上没有对应硬件,
   烦请 maintainer 或 CI 补齐。`defines` 中沿用了模板里针对
   `riscv64` / `loongson3` 的 `NOLTO` 与 `AB_FLAGS_OS` 例外,未做改动。
2. **未做长期使用验证** —— 尚未系统性验证上述公开 API 凭据在长期登录下是否会
   触发 Telegram 侧限制,以及 Ghost Mode 等 AyuGram 特有功能的完整行为。
   欢迎 maintainer 与用户进一步测试。
