### PR TITLE
ayugram-desktop: new, 7.0.9

### DIFF
--- a/app-web/ayugram-desktop/autobuild/beyond
+++ b/app-web/ayugram-desktop/autobuild/beyond
@@ -1,0 +1,5 @@
+# Move the real binary aside; a first-run notice wrapper takes its
+# place at /usr/bin/AyuGram (see overrides).
+abinfo "Moving AyuGram binary for the first-run notice wrapper ..."
+mkdir -pv "$PKGDIR"/usr/lib/ayugram-desktop
+mv -v "$PKGDIR"/usr/bin/AyuGram "$PKGDIR"/usr/lib/ayugram-desktop/AyuGram

--- a/app-web/ayugram-desktop/autobuild/defines
+++ b/app-web/ayugram-desktop/autobuild/defines
@@ -1,0 +1,37 @@
+PKGNAME=ayugram-desktop
+PKGSEC=web
+PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
+    openal-soft openssl lz4 qt-6 xxhash hunspell crc32c glibmm-2.68 fmt \
+    libavif libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons ada \
+    zenity"
+BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm gperf \
+          extra-cmake-modules wayland-protocols plasma-wayland-protocols"
+PKGSUG="webkit2gtk"
+PKGDES="Telegram desktop client fork with ghost mode, message history, and extended customization"
+
+# API credentials published by upstream for AyuGram builds
+# https://github.com/AyuGram/AyuGramDesktop/blob/v7.0.9/docs/api_credentials.md
+# These credentials are shared by all builds that use them, so
+# Telegram may throttle or restrict clients under a shared api_id if
+# it is abused; accounts remain bound to Telegram's third-party client
+# policies either way.
+CMAKE_AFTER=(
+    '-DTDESKTOP_API_ID=2040'
+    '-DTDESKTOP_API_HASH=b18441a1ff607e10a989891a5462e627'
+)
+
+# FIXME: relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
+# CMake overrides our optimization flags, so pick a size-optimized build type
+# for loongson3.
+CMAKE_AFTER__LOONGSON3=(
+    ${CMAKE_AFTER[@]}
+    '-DCMAKE_BUILD_TYPE=MinSizeRel'
+)
+
+ABTYPE=cmakeninja
+
+# FIXME: LTO requires enormous amount of RAM
+NOLTO__LOONGSON3=1
+
+# FIXME: relocation truncated to fit: R_MIPS_GOT_PAGE against `.text'
+AB_FLAGS_OS__LOONGSON3=1

--- a/app-web/ayugram-desktop/autobuild/overrides/usr/bin/AyuGram
+++ b/app-web/ayugram-desktop/autobuild/overrides/usr/bin/AyuGram
@@ -1,0 +1,10 @@
+#!/bin/sh
+# One-time notice: AyuGram is an unofficial third-party Telegram client.
+NOTICE_STAMP="${XDG_DATA_HOME:-$HOME/.local/share}/ayugram-desktop/.aosc-first-run-notice"
+if [ ! -e "$NOTICE_STAMP" ]; then
+    zenity --warning --width=560 --title="AyuGram Desktop" \
+        --text="AyuGram Desktop is an unofficial, third-party Telegram client. It is not endorsed by Telegram, and using third-party clients may pose risks to your account's security. Proceed at your own discretion." \
+        || true
+    install -Dm644 /dev/null "$NOTICE_STAMP"
+fi
+exec /usr/lib/ayugram-desktop/AyuGram "$@"

--- a/app-web/ayugram-desktop/autobuild/patches/Telegram/codegen/0001-UPSTREAM-fix-lang-key-subsets-scanning-for-ayu-prefixed-keys.patch
+++ b/app-web/ayugram-desktop/autobuild/patches/Telegram/codegen/0001-UPSTREAM-fix-lang-key-subsets-scanning-for-ayu-prefixed-keys.patch
@@ -1,0 +1,29 @@
+From 8845d9d45ac754400e19cc2c706dba70a16ef0d5 Mon Sep 17 00:00:00 2001
+From: fractal <99148867+fractal-l@users.noreply.github.com>
+Date: Sat, 8 Aug 2026 14:41:46 +0300
+Subject: [PATCH] fix: lang key subsets scanning for ayu_ prefixed keys
+
+---
+ codegen/lang/subsets.cpp | 9 +++++----
+ 1 file changed, 5 insertions(+), 4 deletions(-)
+
+diff --git a/codegen/lang/subsets.cpp b/codegen/lang/subsets.cpp
+index c1a3373..dcb38a9 100644
+--- a/codegen/lang/subsets.cpp
++++ b/codegen/lang/subsets.cpp
+@@ -193,10 +193,11 @@ void Scan(const QByteArray &content, Scanned &result) {
+ 	const auto data = content.constData();
+ 	const auto size = content.size();
+ 	for (auto i = qsizetype(0); i + 4 < size; ++i) {
+-		if (data[i] != 'l'
+-			|| data[i + 1] != 'n'
+-			|| data[i + 2] != 'g'
+-			|| data[i + 3] != '_'
++		const auto isKeyPrefix = (data[i] == 'l' && data[i + 1] == 'n'
++			&& data[i + 2] == 'g' && data[i + 3] == '_')
++			|| (data[i] == 'a' && data[i + 1] == 'y'
++				&& data[i + 2] == 'u' && data[i + 3] == '_');
++		if (!isKeyPrefix
+ 			|| (i > 0 && IsIdentifierChar(data[i - 1]))) {
+ 			continue;
+ 		}

--- a/app-web/ayugram-desktop/autobuild/prepare
+++ b/app-web/ayugram-desktop/autobuild/prepare
@@ -1,0 +1,24 @@
+# Version-bound to this release, so bundled statically.
+abinfo "Building and installing tg_owt ..."
+(
+    export SRCDIR="$SRCDIR"/../tg_owt
+    export BLDDIR="$SRCDIR"/abbuild
+    export PKGDIR=/
+    export CMAKE_AFTER=('-DBUILD_SHARED_LIBS=OFF')
+    build_cmakeninja_configure
+    build_cmakeninja_build
+    build_cmakeninja_install
+)
+
+# tde2e only supports static installation upstream (its install rules
+# are gated on TD_INSTALL_STATIC_LIBRARIES, which defaults to ON).
+abinfo "Building and installing tde2e ..."
+(
+    export SRCDIR="$SRCDIR"/../td
+    export BLDDIR="$SRCDIR"/abbuild
+    export PKGDIR=/
+    export CMAKE_AFTER=('-DTD_E2E_ONLY=ON')
+    build_cmakeninja_configure
+    build_cmakeninja_build
+    build_cmakeninja_install
+)

--- a/app-web/ayugram-desktop/spec
+++ b/app-web/ayugram-desktop/spec
@@ -1,0 +1,22 @@
+VER=7.0.9
+# Note: tg_owt and tde2e are strictly version-bound to each release; upstream
+# pins its exact commits in Telegram/build/docker/centos_env/Dockerfile.
+#
+# FIXME: With 7.0.9, the upstream's tg_owt pin (5c5c7125) uses absl::Nonnull, removed
+# in abseil-cpp >= 20260526 (our system version), and fails to build.
+# Use the newer, API-compatible snapshots pinned by telegram-desktop
+# 7.0.8 instead (build- and runtime-verified against AyuGram 7.0.9).
+OWTVER=19d51d3c19632a63fdbe17c62f10332d978cb940
+TDLIBVER=022d60202e446ad1287b9fb68e687c8a0760788b
+
+SRCS="git::commit=tags/v$VER::https://github.com/AyuGram/AyuGramDesktop \
+      git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt \
+      git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
+CHKSUMS="SKIP SKIP SKIP"
+CHKUPDATE="anitya::id=390672"
+
+SUBDIR="ayugram-desktop"
+ENVREQ__ARM64="total_mem_per_core=3"
+ENVREQ__LOONGARCH64="total_mem_per_core=4"
+ENVREQ__LOONGSON3="total_mem_per_core=4"
+ENVREQ__PPC64EL="total_mem_per_core=4"


### PR DESCRIPTION
Topic Description
-----------------

- ayugram-desktop: new, 7.0.9
Package(s) Affected
-------------------

- ayugram-desktop: 7.0.9
Security Update?
----------------

No.

Build Order
-----------

```
#buildit tg-owt libtde2e ayugram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**


- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**



- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`


