### PR TITLE
PostgreSQL security Survey

### DIFF
--- a/app-database/postgresql-14/spec
+++ b/app-database/postgresql-14/spec
@@ -1,5 +1,4 @@
-VER=14.23
+VER=14.24
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::cc7216822b546330e29c2f91e123c8734a4c41795082145bb962aa712e8c94a5"
+CHKSUMS="sha256::a7fa7ed3d558172355f51406097a7bd4f6b473be80f311ef7cda96bf383d8897"
 CHKUPDATE="anitya::id=236443"
-REL=1

--- a/app-database/postgresql-15/spec
+++ b/app-database/postgresql-15/spec
@@ -1,5 +1,4 @@
-VER=15.18
+VER=15.19
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::11df0df97fe3ea4ba9a791faaf39cee1d2fe571e78885b5b55d8517d27c323b4"
+CHKSUMS="sha256::e1a64a87a46b825b88c082e4518161a47aab53c45694964f8ba1df28f7859f89"
 CHKUPDATE="anitya::id=301832"
-REL=1

--- a/app-database/postgresql-16/spec
+++ b/app-database/postgresql-16/spec
@@ -1,5 +1,4 @@
-VER=16.14
+VER=16.15
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::f6d077142737920858ce958ccdb75c6ee137a63b5b0853c70693d401ac7e3471"
+CHKSUMS="sha256::c1575341fa7bd40f5274ea465b34390f4dc64cdd0770af327005caaeb9f6b7ed"
 CHKUPDATE="anitya::id=375691"
-REL=1

--- a/app-database/postgresql-17/spec
+++ b/app-database/postgresql-17/spec
@@ -1,5 +1,4 @@
-VER=17.10
+VER=17.11
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::078a03516dcdbdb705fecaf415ea3d13a956c589e46f09fed68a06fb00598c90"
+CHKSUMS="sha256::dd27f2b3c59e73ed14aa3324901242bf69a032a6347805f274e6260322d42979"
 CHKUPDATE="anitya::id=375014"
-REL=1

--- a/app-database/postgresql-18/spec
+++ b/app-database/postgresql-18/spec
@@ -1,5 +1,4 @@
-VER=18.4
+VER=18.6
 SRCS="tbl::https://ftp.postgresql.org/pub/source/v$VER/postgresql-$VER.tar.bz2"
-CHKSUMS="sha256::81a81ec695fb0c7901407defaa1d2f7973617154cf27ba74e3a7ab8e64436094"
+CHKSUMS="sha256::555610c24d53e4316da5b7d3fc25c279d96856d5e0e23ee308c328c5fa881d9f"
 CHKUPDATE="anitya::id=383697"
-REL=1

--- a/topics/postgresql-survey-20260814.toml
+++ b/topics/postgresql-survey-20260814.toml
@@ -1,0 +1,17 @@
+security = true
+must_match_all = false
+
+[name]
+default = "PostgreSQL Security Update: Version 18.6, 17.11, 16.15, 15.19 and 14.24"
+zh_CN = "PostgreSQL 安全更新：版本 18.6, 17.11, 16.15, 15.19 and 14.24"
+
+[caution]
+default = "Fixes 28 security vulnerabilities (including 18 of high severity and 7 of medium severity)"
+zh_CN = "修复了 28 个安全漏洞（包括 18 个高危漏洞和 7 个中危漏洞）"
+
+[packages-v2]
+"postgresql-14" = "< 14.24"
+"postgresql-15" = "< 15.19"
+"postgresql-16" = "< 16.15"
+"postgresql-17" = "< 17.11"
+"postgresql-18" = "< 18.6"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add postgresql-survey-20260814.toml
- postgresql-14: update to 14.24
- postgresql-15: update to 15.19
- postgresql-16: update to 16.15
- postgresql-17: update to 17.11
- postgresql-18: update to 18.6

Package(s) Affected
-------------------



Security Update?
----------------

Yes

Build Order
-----------

```
#buildit postgresql-18 postgresql-17 postgresql-16 postgresql-15 postgresql-14
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
