### PR TITLE
nushell: update to 0.114.1

### DIFF
--- a/app-shells/nushell/spec
+++ b/app-shells/nushell/spec
@@ -1,4 +1,4 @@
-VER=0.113.1
+VER=0.114.1
 SRCS="git::commit=tags/$VER::https://github.com/nushell/nushell"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=31106"


### PR DESCRIPTION
Topic Description
-----------------

- nushell: update to 0.114.1
    Co-authored-by: Gray David \(@grayawa\)

Package(s) Affected
-------------------

- nushell: 0.114.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nushell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
