### PR TITLE
lyrica: new, 0.24

### DIFF
--- a/app-multimedia/lyrica/autobuild/beyond
+++ b/app-multimedia/lyrica/autobuild/beyond
@@ -1,0 +1,4 @@
+abinfo "Install KDE widget ..."
+LYRICA_WIDGET_HOME="${PKGDIR}/usr/share/plasma/plasmoids/ink.chyk.lyricakde"
+mkdir -pv "${LYRICA_WIDGET_HOME}"
+cp -rv "${SRCDIR}/frontend/kde/"* "${LYRICA_WIDGET_HOME}/"

--- a/app-multimedia/lyrica/autobuild/defines
+++ b/app-multimedia/lyrica/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME="lyrica"
+PKGDES="Desktop lyrics widget for KDE"
+PKGSEC="kde"
+PKGDEP="qt-6 curl zstd"
+BUILDDEP="jq rustc llvm"
+ABTYPE="rust"
+USECLANG=1

--- a/app-multimedia/lyrica/autobuild/patches/0001-package-use-system-package-location.patch
+++ b/app-multimedia/lyrica/autobuild/patches/0001-package-use-system-package-location.patch
@@ -1,0 +1,25 @@
+From 1c18818b4354460b1a7d7908976caaa74ebab2dc Mon Sep 17 00:00:00 2001
+From: Kirikaze Chiyuki <me@chyk.ink>
+Date: Sat, 15 Aug 2026 14:35:41 +0800
+Subject: [PATCH] [package] use system package location
+
+---
+ frontend/kde/contents/ui/main.qml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/frontend/kde/contents/ui/main.qml b/frontend/kde/contents/ui/main.qml
+index a419ca5..6ef4b0f 100644
+--- a/frontend/kde/contents/ui/main.qml
++++ b/frontend/kde/contents/ui/main.qml
+@@ -186,7 +186,7 @@ PlasmoidItem {
+ 
+ 	    Plasma5Support.DataSource {
+ 	        id: backendExecutable
+-	        readonly property string command: "bash -c '$HOME/.local/share/plasma/plasmoids/ink.chyk.lyricakde/contents/bin/lyrica'"
++	        readonly property string command: "bash -c '/usr/bin/lyrica'"
+ 		    engine: "executable"
+ 		    connectedSources: []
+ 		    onSourceConnected: {
+-- 
+2.55.0
+

--- a/app-multimedia/lyrica/autobuild/prepare
+++ b/app-multimedia/lyrica/autobuild/prepare
@@ -1,0 +1,10 @@
+abinfo "Write version number to KDE widget metadata ..."
+METADATA_FILE="${SRCDIR}/frontend/kde/metadata.json"
+METADATA_NEW="${SRCDIR}/frontend/kde/metadata_new.json"
+export LYRICA_VERSION="$(grep -E '^version\s*=\s*".*"' Cargo.toml | sed -E 's/version\s*=\s*"(.*)"/\1/')"
+jq '.KPlugin.Version = env.LYRICA_VERSION' "${METADATA_FILE}" > "${METADATA_NEW}"
+if [ -n "$(grep null "${METADATA_NEW}")" ]; then
+    aberr "Could not read version number!"
+    exit 1
+fi
+mv "${METADATA_NEW}" "${METADATA_FILE}"

--- a/app-multimedia/lyrica/spec
+++ b/app-multimedia/lyrica/spec
@@ -1,0 +1,4 @@
+VER=0.24
+SRCS="git::commit=tags/v${VER}::https://github.com/chiyuki0325/lyrica"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=391780"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

- lyrica: new, 0.24

Package(s) Affected
-------------------

lyrica

Security Update?
----------------

No

Build Order
-----------

```
#buildit lyrica
```

Test Build(s) Done
------------------

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
