### PR TITLE
dankmaterialshell: update to 1.5.3

### DIFF
--- a/app-utils/danksearch/spec
+++ b/app-utils/danksearch/spec
@@ -1,4 +1,4 @@
-VER=0.3.1
+VER=0.3.2
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AvengeMedia/danksearch.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=106455"

--- a/app-utils/dgop/autobuild/defines
+++ b/app-utils/dgop/autobuild/defines
@@ -6,3 +6,4 @@ BUILDDEP="go"
 
 ABTYPE=gomod
 GO_PACKAGES=("cmd/dgop")
+GO_LDFLAGS=("-X main.Version=$PKGVER")

--- a/app-utils/dgop/spec
+++ b/app-utils/dgop/spec
@@ -1,5 +1,4 @@
-VER=0.2.2
-REL=1
+VER=0.2.3
 SRCS="git::commit=tags/v$VER::https://github.com/AvengeMedia/dgop.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388379"

--- a/runtime-desktop/dankmaterialshell/autobuild/build
+++ b/runtime-desktop/dankmaterialshell/autobuild/build
@@ -20,12 +20,9 @@ install -Dvm644 "$SRCDIR"/assets/dms-open.desktop -t "$PKGDIR"/usr/share/applica
 install -Dvm644 "$SRCDIR"/assets/danklogo.svg -t "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/
 
 abinfo "Installing shell completions ..."
-# FIXME: dms cannot be run as root, so we have to copy it to a temporary location and run it as nobody to generate the completions
-## Note: https://github.com/AvengeMedia/DankMaterialShell/issues/2233
-cp -av "$SRCDIR"/core/cmd/dms/dms /tmp/dms-abbs-dms
-runuser -u nobody -- /tmp/dms-abbs-dms completion bash > "$SRCDIR"/bash-completions
-runuser -u nobody -- /tmp/dms-abbs-dms completion fish > "$SRCDIR"/fish-completions
-runuser -u nobody -- /tmp/dms-abbs-dms completion zsh > "$SRCDIR"/zsh-completions
+"$SRCDIR"/core/cmd/dms/dms completion bash > "$SRCDIR"/bash-completions
+"$SRCDIR"/core/cmd/dms/dms completion fish > "$SRCDIR"/fish-completions
+"$SRCDIR"/core/cmd/dms/dms completion zsh > "$SRCDIR"/zsh-completions
 install -Dvm644 "$SRCDIR"/bash-completions "$PKGDIR"/usr/share/bash-completion/completions/dms
 install -Dvm644 "$SRCDIR"/fish-completions "$PKGDIR"/usr/share/fish/vendor_completions.d/dms.fish
 install -Dvm644 "$SRCDIR"/zsh-completions "$PKGDIR"/usr/share/zsh/site-functions/_dms

--- a/runtime-desktop/dankmaterialshell/autobuild/defines
+++ b/runtime-desktop/dankmaterialshell/autobuild/defines
@@ -4,6 +4,6 @@ PKGDES="Desktop shell for Wayland compositors built with Quickshell and Go"
 PKGDEP="quickshell glibc"
 PKGCRECCOM="cava cliphist wl-clipboard matugun dgop danksearch"
 PKGSUG="i2c-tools accountsservice tuned cups-pk-helper greetd"
-PKGPROV="dms"
+PKGPROV="dms dms-shell"
 
 BUILDDEP="go"

--- a/runtime-desktop/dankmaterialshell/spec
+++ b/runtime-desktop/dankmaterialshell/spec
@@ -1,5 +1,4 @@
-VER=1.4.6
-REL=1
+VER=1.5.3
 SRCS="git::commit=tags/v$VER::https://github.com/AvengeMedia/DankMaterialShell.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388076"


### PR DESCRIPTION
Topic Description
-----------------

- dankmaterialshell: update to 1.5.3
- dgop: update to 0.2.3
- danksearch: update to 0.3.2

Package(s) Affected
-------------------

- dankmaterialshell: 1.5.3
- danksearch: 0.3.2
- dgop: 0.2.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit dgop danksearch dankmaterialshell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
