### PR TITLE
lutris: update to 0.5.22

### DIFF
--- a/app-games/lutris/spec
+++ b/app-games/lutris/spec
@@ -1,5 +1,4 @@
-VER=0.5.18
+VER=0.5.22
 SRCS="tbl::https://lutris.net/releases/lutris_$VER.tar.xz"
-CHKSUMS="sha256::fe93437cc0e68b8117e1b28147807c0c6c6db9bb19c2320fc8d3a963719770a5"
+CHKSUMS="sha256::9bfdd758362400c0f34d5d514b167fcda7e3f23ebe6067e2871cfbbccbe787e1"
 CHKUPDATE="anitya::id=12270"
-REL="2"


### PR DESCRIPTION
Topic Description
-----------------

- lutris: update to 0.5.22
    Co-authored-by: Cinhi Young \(@Cyanoxygen\) <cyan@cyano.uk>

Package(s) Affected
-------------------

- lutris: 0.5.22

Security Update?
----------------

No

Build Order
-----------

```
#buildit lutris
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
