### PR TITLE
tsukimi: update to 26.8.2

### DIFF
--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,4 @@
-VER=26.8.1
+VER=26.8.2
 UAPI_CRATE_VER=0.2.13
 SRCS="git::commit=tags/v$VER;rename=tsukimi::https://github.com/tsukinaha/tsukimi"
 SRCS__LOONGARCH64="${SRCS} \


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: update to 26.8.2
    Co-authored-by: \(@MutsukiC\) <mutsuki@aosc.io>

Package(s) Affected
-------------------

- tsukimi: 26.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
