### PR TITLE
pmbootstrap: update to 3.11.1

### DIFF
--- a/app-utils/pmbootstrap/autobuild/defines
+++ b/app-utils/pmbootstrap/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=pmbootstrap
 PKGSEC=utils
-PKGDEP="python-3 openssl tar git util-linux procps tomli" 
-PKGDES="Command-line tool to install a postmarketOS system environment" 
+PKGDEP="python-3 openssl tar git util-linux procps tomli"
+PKGDES="Command-line tool to install a postmarketOS system environment"
 ABHOST=noarch

--- a/app-utils/pmbootstrap/spec
+++ b/app-utils/pmbootstrap/spec
@@ -1,4 +1,4 @@
-VER=3.10.3
+VER=3.11.1
 SRCS="git::commit=tags/$VER;copy-repo=true::https://gitlab.postmarketos.org/postmarketOS/pmbootstrap"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21200"


### PR DESCRIPTION
Topic Description
-----------------

- pmbootstrap: update to 3.11.1

Package(s) Affected
-------------------

- pmbootstrap: 3.11.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit pmbootstrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
