### PR TITLE
Package Styling Survey 20260816

### DIFF
--- a/app-devel/composer/autobuild/defines
+++ b/app-devel/composer/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=composer
 PKGSEC=devel
 PKGDES="Dependency manager for PHP"
-PKGDEP=php
+PKGDEP="php"
 
 ABHOST=noarch

--- a/app-devel/composer/spec
+++ b/app-devel/composer/spec
@@ -2,3 +2,4 @@ VER=2.9.5
 SRCS="file::rename=composer.phar::https://getcomposer.org/download/$VER/composer.phar"
 CHKSUMS="sha256::c86ce603fe836bf0861a38c93ac566c8f1e69ac44b2445d9b7a6a17ea2e9972a"
 CHKUPDATE="anitya::id=9710"
+REL=1

--- a/app-devel/dfu-util/autobuild/defines
+++ b/app-devel/dfu-util/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=dfu-util
 PKGDES="Host implementation of DFU protocol to flash device firmware via USB"
 PKGSEC=devel
-PKGDEP=libusb
+PKGDEP="libusb"

--- a/app-devel/dfu-util/spec
+++ b/app-devel/dfu-util/spec
@@ -2,3 +2,4 @@ VER=0.11
 SRCS="tbl::http://dfu-util.sourceforge.net/releases/dfu-util-$VER.tar.gz"
 CHKSUMS="sha256::b4b53ba21a82ef7e3d4c47df2952adf5fa494f499b6b0b57c58c5d04ae8ff19e"
 CHKUPDATE="anitya::id=10195"
+REL=1

--- a/app-shells/bash-completion/autobuild/defines
+++ b/app-shells/bash-completion/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=bash-completion
 PKGDES="Programmable completion for the Bash shell"
 PKGSEC=misc
-PKGDEP=bash
+PKGDEP="bash"
 
 PKGEPOCH=1
 ABHOST=noarch

--- a/app-shells/bash-completion/spec
+++ b/app-shells/bash-completion/spec
@@ -2,3 +2,4 @@ VER=2.17.0
 SRCS="git::commit=tags/$VER::https://github.com/scop/bash-completion"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5667"
+REL=1

--- a/lang-perl/perl-uri/autobuild/defines
+++ b/lang-perl/perl-uri/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=perl-uri
 PKGDES="Perl module that implements the URI class"
-PKGDEP=perl
+PKGDEP="perl"
 PKGSEC=perl
 
 ABHOST=noarch

--- a/lang-perl/perl-uri/spec
+++ b/lang-perl/perl-uri/spec
@@ -2,3 +2,4 @@ VER=5.35
 SRCS="tbl::https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-${VER}.tar.gz"
 CHKSUMS="sha256::89648964ce5ae006726951f42f718576fbefe9e98a41bd2212d57386163092d2"
 CHKUPDATE="anitya::id=3485"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- perl-uri: add quotation mark for PKGDEP
- bash-completion: add quotation mark for PKGDEP
- dfu-util: add quotation mark for PKGDEP
- composer: add quotation mark for PKGDEP

Package(s) Affected
-------------------

- bash-completion: 1:2.17.0-1
- composer: 2.9.5-1
- dfu-util: 0.11-1
- perl-uri: 5.35-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit bash-completion composer dfu-util perl-uri
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
