### PR TITLE
doggo: update to 1.3.0

### DIFF
--- a/app-network/doggo/spec
+++ b/app-network/doggo/spec
@@ -1,4 +1,4 @@
-VER=1.2.0
+VER=1.3.0
 SRCS="git::commit=tags/v$VER::https://github.com/mr-karan/doggo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373317"


### PR DESCRIPTION
Topic Description
-----------------

- doggo: update to 1.3.0
    Co-authored-by: Chi_Tang \(@chitang233\) <me@chitang.dev>

Package(s) Affected
-------------------

- doggo: 1.3.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit doggo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
