### PR TITLE
mark-shot: update to 0.1.48

### DIFF
--- a/app-utils/mark-shot/spec
+++ b/app-utils/mark-shot/spec
@@ -1,4 +1,4 @@
-VER=0.1.33
+VER=0.1.48
 SRCS="git::commit=tags/v$VER::https://github.com/jswysnemc/mark-shot.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=390990"


### PR DESCRIPTION
Topic Description
-----------------

- mark-shot: update to 0.1.48
    Co-authored-by: Chi_Tang \(@chitang233\) <me@chitang.dev>

Package(s) Affected
-------------------

- mark-shot: 0.1.48

Security Update?
----------------

No

Build Order
-----------

```
#buildit mark-shot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
