### PR TITLE
slock: update to 1.7

### DIFF
--- a/app-utils/slock/autobuild/defines
+++ b/app-utils/slock/autobuild/defines
@@ -1,5 +1,5 @@
 PKGNAME=slock
 PKGSEC=x11
-PKGDES="A simple screen locker for X"
-PKGDEP=x11-lib
+PKGDES="Simple screen locker for X"
+PKGDEP="x11-lib"
 ABTYPE=self

--- a/app-utils/slock/autobuild/patch
+++ b/app-utils/slock/autobuild/patch
@@ -1,2 +1,0 @@
-sed -i 's|static const char \*group = "nogroup";|static const char *group = "nobody";|' config.def.h
-sed -ri 's/((CPP|C|LD)FLAGS) =/\1 +=/g' config.mk

--- a/app-utils/slock/autobuild/patches/0001-AOSCOS-fix-flags-in-makefile.patch
+++ b/app-utils/slock/autobuild/patches/0001-AOSCOS-fix-flags-in-makefile.patch
@@ -1,0 +1,36 @@
+From ee88438e8f4cc6924dc5755f8a2e9f52c3c4d07f Mon Sep 17 00:00:00 2001
+From: Amenomiya_Ame <46444349+BillZhou233@users.noreply.github.com>
+Date: Wed, 19 Aug 2026 17:44:00 +0800
+Subject: [PATCH] AOSCOS: fix flags in makefile
+
+---
+ config.mk | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/config.mk b/config.mk
+index 9fe5bff..d754155 100644
+--- a/config.mk
++++ b/config.mk
+@@ -15,15 +15,15 @@ INCS = -I. -I/usr/include -I${X11INC}
+ LIBS = -L/usr/lib -lc -lcrypt -L${X11LIB} -lX11 -lXext -lXrandr
+ 
+ # flags
+-CPPFLAGS = -DVERSION=\"${VERSION}\" -D_DEFAULT_SOURCE -DHAVE_SHADOW_H
+-CFLAGS = -std=c99 -pedantic -Wall -Os ${INCS} ${CPPFLAGS}
+-LDFLAGS = -s ${LIBS}
++CPPFLAGS += -DVERSION=\"${VERSION}\" -D_DEFAULT_SOURCE -DHAVE_SHADOW_H
++CFLAGS += -std=c99 -pedantic -Wall -Os ${INCS} ${CPPFLAGS}
++LDFLAGS += -s ${LIBS}
+ COMPATSRC = explicit_bzero.c
+ 
+ # On OpenBSD and Darwin remove -lcrypt from LIBS
+ #LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 -lXext -lXrandr
+ # On *BSD remove -DHAVE_SHADOW_H from CPPFLAGS
+ # On NetBSD add -D_NETBSD_SOURCE to CPPFLAGS
+-#CPPFLAGS = -DVERSION=\"${VERSION}\" -D_BSD_SOURCE -D_NETBSD_SOURCE
++#CPPFLAGS += -DVERSION=\"${VERSION}\" -D_BSD_SOURCE -D_NETBSD_SOURCE
+ # On OpenBSD set COMPATSRC to empty
+ #COMPATSRC =
+-- 
+2.50.1 (Apple Git-155)
+

--- a/app-utils/slock/spec
+++ b/app-utils/slock/spec
@@ -1,4 +1,4 @@
-VER=1.4
+VER=1.7
 SRCS="tbl::https://dl.suckless.org/tools/slock-${VER}.tar.gz"
-CHKSUMS="sha256::b53849dbc60109a987d7a49b8da197305c29307fd74c12dc18af0d3044392e6a"
+CHKSUMS="sha256::99711e6b419b221ae9fc3e9c8f31e6b168db51154278996f3d02ce65cc198301"
 CHKUPDATE="anitya::id=4833"


### PR DESCRIPTION
Topic Description
-----------------

- slock: update to 1.7
    Co-authored-by: 雨ノ宮 あめ \(@BillZhou233\)
    Co-authored-by: xffish \(@xflcx1991\)

Package(s) Affected
-------------------

- slock: 1.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit slock
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
