### PR TITLE
binutils: fix broken glib on Cortex-A53 triggering ARM erratum 843419

### DIFF
--- a/app-devel/binutils/01-main/defines
+++ b/app-devel/binutils/01-main/defines
@@ -33,9 +33,6 @@ AUTOTOOLS_AFTER=(
     '--enable-64-bit-bfd'
     '--enable-default-hash-style=gnu'
     '--enable-targets=all'
-)
-AUTOTOOLS_AFTER__LOONGSON3=(
-    "${AUTOTOOLS_AFTER[@]}"
     '--enable-mips-fix-loongson3-llsc'
 )
 

--- a/app-devel/binutils/01-main/patches/0001-AOSCOS-Revert-aarch64-Fix-out-of-range-branch-veneer.patch
+++ b/app-devel/binutils/01-main/patches/0001-AOSCOS-Revert-aarch64-Fix-out-of-range-branch-veneer.patch
@@ -1,0 +1,98 @@
+From 4ba2cbb370beeb68141f94133cdaed37fd21748f Mon Sep 17 00:00:00 2001
+From: Icenowy Zheng <uwu@icenowy.me>
+Date: Tue, 18 Aug 2026 15:27:01 +0800
+Subject: [PATCH] AOSCOS: Revert "aarch64: Fix out-of-range branch veneers when
+ --fix-cortex-a53-843419"
+
+This reverts commit d3af4016a645db372ba6812eee651ac5e3eb9159.
+
+With this commit some 843419 sequence will be leaked to the final binary
+because of code being moved after being checked.
+
+Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
+---
+ bfd/elfnn-aarch64.c | 44 +++++++++++++++++++-------------------------
+ 1 file changed, 19 insertions(+), 25 deletions(-)
+
+diff --git a/bfd/elfnn-aarch64.c b/bfd/elfnn-aarch64.c
+index cbd4abea122..2e8ec4d075d 100644
+--- a/bfd/elfnn-aarch64.c
++++ b/bfd/elfnn-aarch64.c
+@@ -4777,55 +4777,49 @@ elfNN_aarch64_size_stubs (bfd *output_bfd,
+       stub_group_size = 127 * 1024 * 1024;
+     }
+ 
+-  /* The 843419 erratum fix inserts stub sections in place, not in
+-     the section groups.  Running this after we have created the stub
+-     groups can perturb the calculations and cause the stub groups
+-     that have been created to be out of range.  Avoid this by running
+-     this pass first and then creating the groups once we know how much
+-     code this mitigation will insert.  */
+-  if (htab->fix_erratum_843419 != ERRAT_NONE)
++  group_sections (htab, stub_group_size, stubs_always_before_branch);
++
++  (*htab->layout_sections_again) ();
++
++  if (htab->fix_erratum_835769)
+     {
+       bfd *input_bfd;
+ 
+       for (input_bfd = info->input_bfds;
+-	   input_bfd != NULL;
+-	   input_bfd = input_bfd->link.next)
++	   input_bfd != NULL; input_bfd = input_bfd->link.next)
+ 	{
+-	  asection *section;
+-
+ 	  if (!is_aarch64_elf (input_bfd)
+ 	      || (input_bfd->flags & BFD_LINKER_CREATED) != 0)
+ 	    continue;
+ 
+-	  for (section = input_bfd->sections;
+-	       section != NULL;
+-	       section = section->next)
+-	    if (!_bfd_aarch64_erratum_843419_scan (input_bfd, section, info))
+-	      return false;
++	  if (!_bfd_aarch64_erratum_835769_scan (input_bfd, info,
++						 &num_erratum_835769_fixes))
++	    return false;
+ 	}
+ 
+       _bfd_aarch64_resize_stubs (htab);
+       (*htab->layout_sections_again) ();
+     }
+ 
+-  group_sections (htab, stub_group_size, stubs_always_before_branch);
+-
+-  (*htab->layout_sections_again) ();
+-
+-  if (htab->fix_erratum_835769)
++  if (htab->fix_erratum_843419 != ERRAT_NONE)
+     {
+       bfd *input_bfd;
+ 
+       for (input_bfd = info->input_bfds;
+-	   input_bfd != NULL; input_bfd = input_bfd->link.next)
++	   input_bfd != NULL;
++	   input_bfd = input_bfd->link.next)
+ 	{
++	  asection *section;
++
+ 	  if (!is_aarch64_elf (input_bfd)
+ 	      || (input_bfd->flags & BFD_LINKER_CREATED) != 0)
+ 	    continue;
+ 
+-	  if (!_bfd_aarch64_erratum_835769_scan (input_bfd, info,
+-						 &num_erratum_835769_fixes))
+-	    return false;
++	  for (section = input_bfd->sections;
++	       section != NULL;
++	       section = section->next)
++	    if (!_bfd_aarch64_erratum_843419_scan (input_bfd, section, info))
++	      return false;
+ 	}
+ 
+       _bfd_aarch64_resize_stubs (htab);
+-- 
+2.52.0
+

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,5 @@
 VER=2.47
-REL=2
+REL=3
 SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::154ab23b60070e8f27013c22977f1129425d67d1e8acd6e13010e617811e4cff"
 CHKUPDATE="anitya::id=7981"

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,5 @@
 VER=2.47
 REL=3
-SRCS="tbl::https://mirrors.tuna.tsinghua.edu.cn/gnu/binutils/binutils-$VER.tar.xz"
+SRCS="tbl::https://ftp.gnu.org/pub/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::154ab23b60070e8f27013c22977f1129425d67d1e8acd6e13010e617811e4cff"
 CHKUPDATE="anitya::id=7981"

--- a/runtime-common/glib/spec
+++ b/runtime-common/glib/spec
@@ -1,4 +1,5 @@
 VER=2.88.2
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.gnome.org/GNOME/glib"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10024"


### PR DESCRIPTION
Topic Description
-----------------

- glib: rebuild for fixing ARM Erratum 843419 sequence in arm64 binary
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- binutils: enable loongson3 llsc workaround on all architectures
    As we now build binutils with \`--with-targets=all\`, all architectures'
    builds will be able to target mips64el, so it's better to propagate the
    workaround to all these builds.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>
- binutils: revert a commit that leads to broken glib on Cortex-A53
    The ARM erratum 843419 workaround code in ld.bfd is broken since
    Binutils 2.36, which leads to AOSC OS's glib 2.88.2 crashing on
    Cortex-A53.
    Revert the upstream patch, which will leads to more padding in binaries
    but erratum 843419 gets correctly worked around.
    Signed-off-by: Icenowy Zheng <uwu@icenowy.me>

Package(s) Affected
-------------------

- binutils: 2.47-3
- binutils+cross-amd64: 2.47-3
- binutils+cross-arm-none-eabi: 2.47-3
- binutils+cross-arm64: 2.47-3
- binutils+cross-i486: 2.47-3
- binutils+cross-loongarch64: 2.47-3
- binutils+cross-loongson3: 2.47-3
- binutils+cross-ppc64el: 2.47-3
- binutils+cross-riscv64: 2.47-3
- glib: 2.88.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils glib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
