### PR TITLE
kubernetes: update to 1.35.7

### DIFF
--- a/app-containers/kubernetes/spec
+++ b/app-containers/kubernetes/spec
@@ -1,5 +1,4 @@
-VER=1.34.1
-REL=5
+VER=1.35.7
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/kubernetes/kubernetes"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10954"


### PR DESCRIPTION
Topic Description
-----------------
kubectl: update to 1.35.7
kubeadm: update to 1.35.7
kubelet: update to 1.35.7

Package(s) Affected
-------------------
kubectl: 1.34.1 
kubeadm: 1.34.1
kubelet: 1.34.1

Security Update?
----------------
No

Build Order
-----------

```
#buildit kubernetes
```

Test Build(s) Done
------------------

<!-- The check boxes in this section should ONLY be set by the buildit
     infrastructure. Under no circumstances a person can set any of them
     by hand. Keep them unset for new pull requests, and unset them if
     you've made a change to the pull request after buildit set them. -->

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
