### PR TITLE
codex: build code-mode

### DIFF
--- a/app-utils/codex/autobuild/defines
+++ b/app-utils/codex/autobuild/defines
@@ -9,6 +9,7 @@ USECLANG=1
 CARGO_AFTER=(
     '--bin' 'codex'
     '--bin' 'codex-responses-api-proxy'
+    '--bin' 'codex-code-mode-host'
 )
 
 # FIXME: error: undefined symbol: aws_lc_0_39_0_SHA256
@@ -25,4 +26,4 @@ NOLTO=1
 # See //build/config/BUILDCONFIG.gn:369:3: which caused the file to be included.
 # "//build/config/sanitizers:default_sanitizer_flags",
 # ^-------------------------------------------------- 
-FAIL_ARCH="loongson3"
+FAIL_ARCH="@(loongson3|retro)"

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,5 @@
 VER=0.147.0
+REL=1
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=150.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: build code-mode

Package(s) Affected
-------------------

- codex: 0.147.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] 32-bit Intel 486 `i486`
