### PR TITLE
graphviz: update to 16.0.0

### DIFF
--- a/app-devel/kdsme/spec
+++ b/app-devel/kdsme/spec
@@ -1,5 +1,5 @@
 VER=1.2.8
-REL=8
+REL=9
 SRCS="tbl::https://github.com/KDAB/KDStateMachineEditor/releases/download/v${VER}/kdstatemachineeditor-${VER}.tar.gz"
 CHKSUMS="sha256::8676276debd1f8333794aba08d643660f36b698ca4c9711ce0a03c7a84f03e0c"
 CHKUPDATE="anitya::id=227020"

--- a/app-devel/vala/spec
+++ b/app-devel/vala/spec
@@ -1,5 +1,5 @@
 VER=0.56.19
-REL=1
+REL=2
 SRCS="https://download.gnome.org/sources/vala/${VER:0:4}/vala-$VER.tar.xz"
 CHKSUMS="sha256::5ad7cbbfcc0de61b403d6797c9ef60455bfbebd8e162aec33b5b0b097adfb9d5"
 CHKUPDATE="anitya::id=5065"

--- a/app-doc/graphviz/autobuild/defines
+++ b/app-doc/graphviz/autobuild/defines
@@ -13,7 +13,7 @@ BUILDDEP__RISCV64="${BUILDDEP__NOMONO}"
 
 PKGDEP__RETRO="libgd libtool librsvg x11-lib ghostscript pango gts libnsl2 poppler"
 BUILDDEP__RETRO="devil gtk-2 perl python-3 ruby tcl xterm swig tk"
-PKGBREAK="kdsme<=1.2.8-7 vala<=0.56.18"
+PKGBREAK="kdsme<=1.2.8-8 pygraphviz<=1.14-1 vala<=0.56.19-1"
 
 ABTYPE=autotools
 AUTOTOOLS_AFTER=(

--- a/app-doc/graphviz/spec
+++ b/app-doc/graphviz/spec
@@ -1,7 +1,6 @@
-VER=15.1.0
+VER=16.0.0
 # Requires copy-repo=true for version date
 # Submodules are for Windows build only
 SRCS="git::commit=tags/$VER;copy-repo=true;submodule=false::https://gitlab.com/graphviz/graphviz.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1249"
-REL=1

--- a/lang-python/pygraphviz/spec
+++ b/lang-python/pygraphviz/spec
@@ -2,4 +2,4 @@ VER=1.14
 SRCS="git::commit=pygraphviz-${VER}::https://github.com/pygraphviz/pygraphviz"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15839"
-REL="1"
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- graphviz: update to 16.0.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- graphviz: 16.0.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit graphviz kdsme pygraphviz vala
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
