### PR TITLE
htop: update to 3.5.3

### DIFF
--- a/app-admin/htop/spec
+++ b/app-admin/htop/spec
@@ -1,4 +1,4 @@
-VER=3.5.2
+VER=3.5.3
 SRCS="tbl::https://github.com/htop-dev/htop/releases/download/$VER/htop-$VER.tar.xz"
-CHKSUMS="sha256::225128e697c4a8c8a878fd0078c965ff8bd5fb24913bfc8473b8edbd50f843f8"
+CHKSUMS="sha256::a8b164386494cb85bb255a415a3f5f80afe7a0c4491da5d113b3a0f951087e65"
 CHKUPDATE="anitya::id=1332"


### PR DESCRIPTION
Topic Description
-----------------

- htop: update to 3.5.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- htop: 1:3.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit htop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
