### PR TITLE
libmpdclient: update to 2.27

### DIFF
--- a/runtime-multimedia/libmpdclient/spec
+++ b/runtime-multimedia/libmpdclient/spec
@@ -1,4 +1,4 @@
-VER=2.26
+VER=2.27
 SRCS="tbl::https://www.musicpd.org/download/libmpdclient/${VER%.*}/libmpdclient-${VER}.tar.xz"
-CHKSUMS="sha256::35785c6d6318ade47e2c27b00fc6938f5e09d04714080fea3f5e5c522ba3e036"
+CHKSUMS="sha256::88945b5abc11d8f4cea2bb7028e545024a6e060650bd65527a29bc9400daead8"
 CHKUPDATE="anitya::id=21364"


### PR DESCRIPTION
Topic Description
-----------------

- libmpdclient: update to 2.27
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libmpdclient: 2.27

Security Update?
----------------

No

Build Order
-----------

```
#buildit libmpdclient
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
