### PR TITLE
libpisp: update to 1.7.0

### DIFF
--- a/runtime-devices/libpisp/spec
+++ b/runtime-devices/libpisp/spec
@@ -1,5 +1,4 @@
-VER=1.6.0
-REL=1
+VER=1.7.0
 SRCS="git::commit=tags/v${VER}::https://github.com/raspberrypi/libpisp.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378526"


### PR DESCRIPTION
Topic Description
-----------------

- libpisp: update to 1.7.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- libpisp: 1.7.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libpisp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
