### PR TITLE
mpd: update to 0.24.14

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,5 +1,4 @@
-VER=0.24.13
-REL=1
+VER=0.24.14
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
-CHKSUMS="sha256::9f215a081cc1f7c98fcccc6620f4cb705b14ba2d87fd99e062dd0804e2e3d96e"
+CHKSUMS="sha256::367e85debb4427605cccb5415f2858ebb401d849a80615553f59520f4640811e"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.24.14
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- mpd: 0.24.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
