### PR TITLE
ncmpc: update to 0.54

### DIFF
--- a/app-multimedia/ncmpc/spec
+++ b/app-multimedia/ncmpc/spec
@@ -1,4 +1,4 @@
-VER=0.53
+VER=0.54
 SRCS="https://www.musicpd.org/download/ncmpc/${VER%.*}/ncmpc-${VER}.tar.xz"
-CHKSUMS="sha256::92c68bb9bf294d48209587b19df9005db7247e9c38d7e4fb74f8586e6f23c56f"
+CHKSUMS="sha256::f678e6c600200af4c5d36174de4e1e82e423962c41b6f52844a25d6d1ec4cb11"
 CHKUPDATE="anitya::id=2055"


### PR DESCRIPTION
Topic Description
-----------------

- ncmpc: update to 0.54
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ncmpc: 0.54

Security Update?
----------------

No

Build Order
-----------

```
#buildit ncmpc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
