### PR TITLE
praat: update to 7.0.01

### DIFF
--- a/app-scientific/praat/autobuild/build
+++ b/app-scientific/praat/autobuild/build
@@ -1,5 +1,5 @@
 abinfo "Building praat ..."
-make
+make USE_SYS_ZLIB=yes
 
 abinfo "Installing praat ..."
 install -Dvm755 "$SRCDIR"/praat \

--- a/app-scientific/praat/autobuild/patches/0001-FROMGIT-Allow-the-user-to-link-praat-against-the-sys.patch
+++ b/app-scientific/praat/autobuild/patches/0001-FROMGIT-Allow-the-user-to-link-praat-against-the-sys.patch
@@ -1,0 +1,75 @@
+From b5d3788ecec2a9ced3f5374e9baff33850e1273d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafael=20Laboissi=C3=A8re?= <rafael@laboissiere.net>
+Date: Sat, 8 Aug 2026 15:41:25 +0200
+Subject: [PATCH] FROMGIT: Allow the user to link praat against the system's
+ Zlib.
+
+When building the Debian package for version 7.0 of Praat, Lintian (the
+Debian package checker) detects the following error: embedded-library [1].
+This is caused by linking the Praat executable against the version of Zlib
+shipped with the sources instead of using the shared version installed in
+the system.
+
+This patch introduces a new variable in the top-level Makefile
+(USE_SYS_ZLIB) for controlling which version of Zlib to use. The default
+value is "no", meaning the embedded version is used.
+
+[1] https://lintian.debian.org/tags/embedded-library.html
+
+(cherry picked from commit 44c7717d6b49e42a9c302d78cd3f965240c0482c)
+Signed-off-by: Kaiyang Wu <wukaiyang@loongfans.cn>
+---
+ Makefile | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 8d56b9dc5..efa181d0c 100644
+--- a/Makefile
++++ b/Makefile
+@@ -374,6 +374,14 @@ endif
+ 	$(INSTALL) -Dm0644 main/praat-512.png $(DATADIR)/icons/hicolor/512x512/apps/org.praat.Praat.png
+ endif
+ 
++# Use system's or embedded zlib library
++USE_SYS_ZLIB ?= no
++ifeq ($(USE_SYS_ZLIB),no)
++ZLIB = external/zlib/libzlib.a
++else
++ZLIB = -lz
++endif
++
+ # Export some variables to the makefiles in the subdirectories.
+ export CPPFLAGS   # listing of include files (plus any flags provided by any environment variables also called CPPFLAGS)
+ export CC
+@@ -406,7 +414,7 @@ all: all-external all-self
+ 		external/opusfile/libopusfile.a \
+ 		external/whispercpp/libwhisper.a \
+ 		external/blake3/libblake3.a \
+-		external/zlib/libzlib.a \
++		$(ZLIB) \
+                $(NON_PRAAT_LIBRARIES) $(LDFLAGS)
+ 
+ all-external:
+@@ -423,7 +431,9 @@ all-external:
+ 	$(MAKE) -C external/opusfile
+ 	$(MAKE) -C external/whispercpp
+ 	$(MAKE) -C external/blake3
++ifeq ($(USE_SYS_ZLIB),no)
+ 	$(MAKE) -C external/zlib
++endif
+ 
+ all-self:
+ 	$(MAKE) -C kar
+@@ -459,7 +469,9 @@ clean-external:
+ 	$(MAKE) -C external/opusfile clean
+ 	$(MAKE) -C external/whispercpp clean
+ 	$(MAKE) -C external/blake3 clean
++ifeq ($(USE_SYS_ZLIB),no)
+ 	$(MAKE) -C external/zlib clean
++endif
+ 
+ clean-self:
+ 	$(MAKE) -C kar clean
+-- 
+2.55.0
+

--- a/app-scientific/praat/spec
+++ b/app-scientific/praat/spec
@@ -1,4 +1,4 @@
-VER=6.6.30
+VER=7.0.01
 SRCS="git::commit=tags/v$VER::https://github.com/praat/praat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373832"


### PR DESCRIPTION
Topic Description
-----------------

- praat: update to 7.0.01
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- praat: 7.0.01

Security Update?
----------------

No

Build Order
-----------

```
#buildit praat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
