### PR TITLE
uboot-tools: add loongarch64 support (again)

### DIFF
--- a/app-utils/uboot-tools/autobuild/patches/0001-grm-axiado-Add-AX3005-based-SCM3005-board-support.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0001-grm-axiado-Add-AX3005-based-SCM3005-board-support.patch
@@ -1,0 +1,432 @@
+From 28da13ec051410e30b3bda9bc3e01ba01f696c61 Mon Sep 17 00:00:00 2001
+From: Siu Ming Tong <smtong@axiado.com>
+Date: Wed, 27 May 2026 19:38:37 -0700
+Subject: [PATCH 01/22] grm: axiado: Add AX3005 based SCM3005 board support
+
+Introduce mach-axiado to support Axiado SoC-based boards. This adds
+the platform Kconfig and build infrastructure, along with initial
+SCM3005 board support using the AX3005 SoC.
+
+Introduces AXIADO_AX3005, which selects ARM64, driver
+model, GIC-v3, and Zynq UART. TARGET_SCM3005 selects ARCH_AXIADO,
+allowing future SoC variants to share the platform configuration.
+Secondary cores use spin-table boot. ft_board_setup() corrects
+the cpu-release-addr in the FDT, which arch_fixup_fdt() overwrites
+with the post-relocation address.
+Add U-Boot board support for the Axiado AX3005 based targets, a quad-core
+ARM Cortex-A53 (ARMv8) platform.
+
+Tested-by: Siu Ming Tong <smtong@axiado.com>
+Signed-off-by: Karthikeyan Mitran <kmitran@axiado.com>
+Signed-off-by: Siu Ming Tong <smtong@axiado.com>
+---
+ MAINTAINERS                          |  11 +++
+ arch/arm/Kconfig                     |   9 ++
+ arch/arm/mach-axiado/Kconfig         |  22 +++++
+ arch/arm/mach-axiado/Makefile        |   6 ++
+ arch/arm/mach-axiado/scm3005/Kconfig |  11 +++
+ board/axiado/scm3005/Kconfig         |  15 ++++
+ board/axiado/scm3005/Makefile        |   5 ++
+ board/axiado/scm3005/scm3005.c       | 128 +++++++++++++++++++++++++++
+ configs/ax3005_scm3005_defconfig     |  74 ++++++++++++++++
+ include/configs/ax3005-scm3005.h     |  29 ++++++
+ 10 files changed, 310 insertions(+)
+ create mode 100644 arch/arm/mach-axiado/Kconfig
+ create mode 100644 arch/arm/mach-axiado/Makefile
+ create mode 100644 arch/arm/mach-axiado/scm3005/Kconfig
+ create mode 100644 board/axiado/scm3005/Kconfig
+ create mode 100644 board/axiado/scm3005/Makefile
+ create mode 100644 board/axiado/scm3005/scm3005.c
+ create mode 100644 configs/ax3005_scm3005_defconfig
+ create mode 100644 include/configs/ax3005-scm3005.h
+
+diff --git a/MAINTAINERS b/MAINTAINERS
+index 45e9076de67..32c2a574e69 100644
+--- a/MAINTAINERS
++++ b/MAINTAINERS
+@@ -226,6 +226,17 @@ F:	drivers/reset/reset-ast2500.c
+ F:	drivers/watchdog/ast_wdt.c
+ N:	aspeed
+ 
++ARM AXIADO AX3005 SCM3005
++M:	Siu Ming Tong <smtong@axiado.com>
++M:	Karthikeyan Mitran <kmitran@axiado.com>
++M:	Prasad Bolisetty <pbolisetty@axiado.com>
++S:	Maintained
++F:	arch/arm/dts/ax3005*
++F:	arch/arm/mach-axiado/
++F:	board/axiado/scm3005/
++F:	configs/ax3005_scm3005_defconfig
++F:	include/configs/ax3005-scm3005.h
++
+ ARM BROADCOM BCM283X / BCM27XX
+ M:	Matthias Brugger <mbrugger@suse.com>
+ M:	Peter Robinson <pbrobinson@gmail.com>
+diff --git a/arch/arm/Kconfig b/arch/arm/Kconfig
+index 514bf2000b4..8047c5e1f87 100644
+--- a/arch/arm/Kconfig
++++ b/arch/arm/Kconfig
+@@ -2153,6 +2153,13 @@ config ARCH_ASPEED
+ 	select OF_CONTROL
+ 	imply CMD_DM
+ 
++config ARCH_AXIADO
++	bool "Support Axiado SoCs"
++	select AXIADO_AX3005
++	help
++	  Support for Axiado AX-series SoCs such as the AX3005.
++	  These ARM64 SoCs are used in BMC and security applications.
++
+ config TARGET_DURIAN
+ 	bool "Support Phytium Durian Platform"
+ 	select ARM64
+@@ -2294,6 +2301,8 @@ source "arch/arm/mach-aspeed/Kconfig"
+ 
+ source "arch/arm/mach-at91/Kconfig"
+ 
++source "arch/arm/mach-axiado/Kconfig"
++
+ source "arch/arm/mach-bcm283x/Kconfig"
+ 
+ source "arch/arm/mach-bcmbca/Kconfig"
+diff --git a/arch/arm/mach-axiado/Kconfig b/arch/arm/mach-axiado/Kconfig
+new file mode 100644
+index 00000000000..12ad44070eb
+--- /dev/null
++++ b/arch/arm/mach-axiado/Kconfig
+@@ -0,0 +1,22 @@
++if ARCH_AXIADO
++
++config SYS_ARCH
++	default "arm"
++
++config SYS_SOC
++	default "axiado"
++
++config AXIADO_AX3005
++	bool
++	select ARM64
++	select ARMV8_SWITCH_TO_EL1
++	select DM
++	select DM_SERIAL
++	select GICV3
++	select ZYNQ_SERIAL
++	select MMC_SDHCI_AXIADO
++	select PHY_AXIADO_EMMC
++
++source "arch/arm/mach-axiado/scm3005/Kconfig"
++
++endif
+diff --git a/arch/arm/mach-axiado/Makefile b/arch/arm/mach-axiado/Makefile
+new file mode 100644
+index 00000000000..2acd5466dd9
+--- /dev/null
++++ b/arch/arm/mach-axiado/Makefile
+@@ -0,0 +1,6 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (c) 2021-2026 Axiado Corporation (or its affiliates).
++#
++
++obj-$(CONFIG_AXIADO_AX3005) += scm3005/
+diff --git a/arch/arm/mach-axiado/scm3005/Kconfig b/arch/arm/mach-axiado/scm3005/Kconfig
+new file mode 100644
+index 00000000000..fc74aa0871b
+--- /dev/null
++++ b/arch/arm/mach-axiado/scm3005/Kconfig
+@@ -0,0 +1,11 @@
++if AXIADO_AX3005
++
++config TARGET_SCM3005
++	bool "Support Axiado AX3005 SCM3005"
++	help
++	  Support for the Axiado AX3005 SCM3005 board.
++	  Based on the Axiado AX3005 quad-core ARMv8 Cortex-A53 SoC.
++
++source "board/axiado/scm3005/Kconfig"
++
++endif
+diff --git a/board/axiado/scm3005/Kconfig b/board/axiado/scm3005/Kconfig
+new file mode 100644
+index 00000000000..d6f4f311f55
+--- /dev/null
++++ b/board/axiado/scm3005/Kconfig
+@@ -0,0 +1,15 @@
++if TARGET_SCM3005
++
++config SYS_BOARD
++	string
++	default "scm3005"
++
++config SYS_VENDOR
++	string
++	default "axiado"
++
++config SYS_CONFIG_NAME
++	string
++	default "ax3005-scm3005"
++
++endif
+diff --git a/board/axiado/scm3005/Makefile b/board/axiado/scm3005/Makefile
+new file mode 100644
+index 00000000000..3d35713bab9
+--- /dev/null
++++ b/board/axiado/scm3005/Makefile
+@@ -0,0 +1,5 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (c) 2021-2026 Axiado Corporation (or its affiliates).
++
++obj-y := scm3005.o
+diff --git a/board/axiado/scm3005/scm3005.c b/board/axiado/scm3005/scm3005.c
+new file mode 100644
+index 00000000000..4643ba4a55c
+--- /dev/null
++++ b/board/axiado/scm3005/scm3005.c
+@@ -0,0 +1,128 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2021-2026 Axiado Corporation (or its affiliates).
++ */
++
++#include <config.h>
++#include <dm.h>
++#include <init.h>
++#include <asm/global_data.h>
++#include <asm/armv8/mmu.h>
++#include <asm/io.h>
++#include <asm/spin_table.h>
++#include <asm/system.h>
++#include <fdt_support.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++static struct mm_region axiado_ax3005_mem_map[] = {
++	{ /* Peripherals including UART */
++	  .virt = 0x00000000UL,
++	  .phys = 0x00000000UL,
++	  .size = 0x4A000000UL, /* 0 to 0x4A000000: peripherals */
++	  .attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) | PTE_BLOCK_NON_SHARE |
++		   PTE_BLOCK_PXN | PTE_BLOCK_UXN },
++	{ .virt = 0x80000000UL,
++	  .phys = 0x80000000UL,
++	  .size = 0x80000000UL,
++	  .attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) | PTE_BLOCK_INNER_SHARE },
++	{
++		0,
++	}
++};
++
++struct mm_region *mem_map = axiado_ax3005_mem_map;
++
++/*
++ * Accept any FIT configuration name - the board loads a single FIT image
++ * and the first matching config is used.
++ */
++int board_fit_config_name_match(const char *name)
++{
++	return 0;
++}
++
++/*
++ * ft_board_setup - restore cpu-release-addr after relocation
++ *
++ * arch_fixup_fdt() / spin_table_update_dt() overwrites cpu-release-addr
++ * with U-Boot's relocated address.  Restore the pre-relocation physical
++ * address so secondary cores spin on the correct location.
++ */
++int ft_board_setup(void *blob, struct bd_info *bd)
++{
++	int cpus_offset, offset;
++	const char *prop;
++	int ret;
++	u64 cpu_release_addr = (u64)&spin_table_cpu_release_addr - gd->reloc_off;
++
++	cpus_offset = fdt_path_offset(blob, "/cpus");
++	if (cpus_offset < 0)
++		return 0;
++
++	for (offset = fdt_first_subnode(blob, cpus_offset); offset >= 0;
++	     offset = fdt_next_subnode(blob, offset)) {
++		prop = fdt_getprop(blob, offset, "device_type", NULL);
++		if (!prop || strcmp(prop, "cpu"))
++			continue;
++
++		prop = fdt_getprop(blob, offset, "enable-method", NULL);
++		if (!prop || strcmp(prop, "spin-table"))
++			continue;
++
++		ret = fdt_setprop_u64(blob, offset, "cpu-release-addr",
++				      cpu_release_addr);
++		if (ret) {
++			printf("WARNING: Failed to restore cpu-release-addr\n");
++			return ret;
++		}
++	}
++
++	return 0;
++}
++
++/*
++ * dram_init - DDR is initialized by firmware, just setting size
++ */
++int dram_init(void)
++{
++	gd->ram_size = get_ram_size((void *)CFG_SYS_SDRAM_BASE,
++				    CFG_SYS_SDRAM_SIZE);
++	return 0;
++}
++
++/*
++ * the SOC uses single bank, non-interleaving
++ */
++int dram_init_banksize(void)
++{
++	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->bd->bi_dram[0].size = CFG_SYS_SDRAM_SIZE;
++	return 0;
++}
++
++/*
++ * timer_init - enable the AX3005 platform system timer
++ *
++ * CNTFRQ_EL0 is already set by arch/arm/cpu/armv8/start.S using
++ * CONFIG_COUNTER_FREQUENCY from the defconfig.
++ *
++ * SYS_TIMER_CTRL (0x48016000) is the AX3005 system timer control
++ * register — writing SYS_TIMER_ENABLE starts the counter that feeds
++ * the ARM generic timer.
++ */
++int timer_init(void)
++{
++	writel(SYS_TIMER_ENABLE, SYS_TIMER_CTRL);
++	return 0;
++}
++
++int board_init(void)
++{
++	return 0;
++}
++
++void reset_cpu(void)
++{
++	/* For later ARM_PSCI_FW or watchdog reset */
++}
+diff --git a/configs/ax3005_scm3005_defconfig b/configs/ax3005_scm3005_defconfig
+new file mode 100644
+index 00000000000..5dd72d87220
+--- /dev/null
++++ b/configs/ax3005_scm3005_defconfig
+@@ -0,0 +1,74 @@
++CONFIG_ARM=y
++CONFIG_ARCH_AXIADO=y
++CONFIG_POSITION_INDEPENDENT=y
++CONFIG_TEXT_BASE=0x80000000
++CONFIG_SYS_MONITOR_BASE=0x80000000
++CONFIG_SYS_LOAD_ADDR=0x80100000
++CONFIG_SYS_MALLOC_F_LEN=0x8000
++CONFIG_SYS_MALLOC_LEN=0x20000
++CONFIG_SYS_BOOTM_LEN=0x20000000
++CONFIG_ENV_SIZE=0x10000
++CONFIG_ENV_OFFSET=0x5000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_COUNTER_FREQUENCY=1000000000
++CONFIG_ARMV8_MULTIENTRY=y
++CONFIG_ARMV8_SET_SMPEN=y
++CONFIG_ARMV8_SPIN_TABLE=y
++CONFIG_SYS_CUSTOM_LDSCRIPT=y
++CONFIG_SYS_LDSCRIPT="arch/arm/cpu/armv8/u-boot.lds"
++CONFIG_BOOTDELAY=5
++CONFIG_FIT=y
++CONFIG_OF_BOARD_SETUP=y
++CONFIG_USE_PREBOOT=y
++CONFIG_DEFAULT_FDT_FILE="ax3005-scm3005.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_HUSH_PARSER=y
++CONFIG_SYS_PROMPT="Axiado> "
++CONFIG_AUTOBOOT_KEYED=y
++CONFIG_AUTOBOOT_PROMPT="Press \"<Esc><Esc>\" to stop autobooting in %d seconds\n"
++CONFIG_AUTOBOOT_STOP_STR="\x1b\x1b"
++CONFIG_USE_BOOTARGS=y
++CONFIG_BOOTARGS="console=ttyPS3,115200 maxcpus=4 nr_cpus=4 earlycon hugepages=16 root=/dev/ram rw phram.phram=ramrofs,0x80B00000,0x6400000"
++CONFIG_USE_BOOTCOMMAND=y
++CONFIG_BOOTCOMMAND="bootm ${loadaddr}"
++CONFIG_SYS_VENDOR="axiado"
++CONFIG_SYS_BOARD="scm3005"
++CONFIG_SYS_CONFIG_NAME="ax3005-scm3005"
++# CONFIG_CMD_BOOTEFI is not set
++# CONFIG_CMD_ELF is not set
++# CONFIG_CMD_GO is not set
++CONFIG_CMD_NVEDIT_EFI=y
++CONFIG_CMD_MEMTEST=y
++CONFIG_SYS_ALT_MEMTEST=y
++CONFIG_CMD_CLK=y
++CONFIG_CMD_DFU=y
++CONFIG_CMD_DM=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_GPT_RENAME=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_PART=y
++CONFIG_CMD_TFTPPUT=y
++CONFIG_CMD_CACHE=y
++CONFIG_CMD_EXT2=y
++CONFIG_CMD_EXT4=y
++CONFIG_CMD_EXT4_WRITE=y
++CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
++CONFIG_OF_CONTROL=y
++CONFIG_OF_SEPARATE=y
++CONFIG_DEFAULT_DEVICE_TREE="ax3005-scm3005"
++CONFIG_MULTI_DTB_FIT=y
++# CONFIG_ENV_IS_IN_MMC is not set
++CONFIG_DM_MMC=y
++# CONFIG_SUPPORT_EMMC_BOOT is not set
++CONFIG_MMC_IO_VOLTAGE=y
++CONFIG_MMC_UHS_SUPPORT=y
++CONFIG_MMC_HS400_SUPPORT=y
++CONFIG_TARGET_SCM3005=y
++CONFIG_CLK=y
++CONFIG_LZMA=y
++CONFIG_XZ=y
++CONFIG_ZYNQ_SERIAL=y
++# CONFIG_AUTO_COMPLETE is not set
++# CONFIG_SYS_LONGHELP is not set
++# CONFIG_TOOLS_MKEFICAPSULE is not set
+diff --git a/include/configs/ax3005-scm3005.h b/include/configs/ax3005-scm3005.h
+new file mode 100644
+index 00000000000..4eead2910c8
+--- /dev/null
++++ b/include/configs/ax3005-scm3005.h
+@@ -0,0 +1,29 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (c) 2021-2026 Axiado Corporation (or its affiliates).
++ */
++
++#ifndef __AX3005_SCM3005_H
++#define __AX3005_SCM3005_H
++
++#include <linux/sizes.h>
++
++#define GICD_BASE		0x40400000
++#define GICR_BASE		0x40500000
++
++#define SYS_TIMER_CTRL		0x48016000
++#define SYS_TIMER_ENABLE	0x1
++#define SYS_TIMER_DISABLE	0x0
++
++/* DRAM: 2 GB at 0x80000000 */
++#define CFG_SYS_SDRAM_BASE	0x80000000
++#define CFG_SYS_SDRAM_SIZE	SZ_2G
++#define CFG_SYS_INIT_SP_ADDR	(CFG_SYS_SDRAM_BASE + SZ_1M)
++
++#define CFG_SYS_MAXARGS		64
++#define CFG_SYS_BARGSIZE	CFG_SYS_CBSIZE
++
++#define CFG_SYS_BAUDRATE_TABLE	\
++	{ 4800, 9600, 19200, 38400, 57600, 115200 }
++
++#endif /* __AX3005_SCM3005_H */
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0002-treewide-move-bi_dram-from-bd-to-gd.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0002-treewide-move-bi_dram-from-bd-to-gd.patch
@@ -1,0 +1,4381 @@
+From 3a6b8efa0cb98ae947ce8eba1f2d9cbf96c51fca Mon Sep 17 00:00:00 2001
+From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Date: Wed, 17 Jun 2026 10:48:19 +0300
+Subject: [PATCH 02/22] treewide: move bi_dram[] from bd to gd
+
+Currently, the bi_dram[] information is stored in the board info
+structure (bd). Because bd is only valid after reserve_board(),
+dram_init_banksize() must be called late in the initialization process.
+This limitation is problematic, as it forces us to rely on a variety of
+bespoke functions to determine board RAM, bank memory sizes, and other
+early setup requirements.
+
+By moving bi_dram[] into the global data (gd), we can run it earlier.
+This is particularly convenient since boards define their own
+dram_init_banksize() routines, which do not always rely on parsing
+Device Tree (DT) memory nodes.
+
+Additionally, U-Boot defaults to relocating to the top of the first memory
+bank. While boards currently use custom functions to override this
+behavior, having the DRAM bank information available earlier in gd makes
+relocating to a different bank trivial and standardizes the process.
+
+Reviewed-by: Anshul Dalal <anshuld@ti.com>
+Tested-by: Michal Simek <michal.simek@amd.com> # Versal Gen 2 Vek385
+Tested-by: Anshul Dalal <anshuld@ti.com>
+Reviewed-by: Simon Glass <sjg@chromium.org>
+Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Tested-by: Christophe Leroy (CS GROUP) <chleroy@kernel.org>
+---
+ api/api_platform.c                            |   4 +-
+ arch/arm/cpu/armv8/cache_v8.c                 |   6 +-
+ arch/arm/cpu/armv8/fsl-layerscape/cpu.c       | 118 +++++++++---------
+ arch/arm/lib/bootm-fdt.c                      |   5 +-
+ arch/arm/lib/bootm.c                          |   4 +-
+ arch/arm/lib/cache-cp15.c                     |   9 +-
+ arch/arm/lib/image.c                          |   2 +-
+ arch/arm/mach-airoha/an7581/init.c            |   8 +-
+ arch/arm/mach-apple/board.c                   |   4 +-
+ arch/arm/mach-davinci/misc.c                  |   4 +-
+ arch/arm/mach-imx/ele_ahab.c                  |   7 +-
+ arch/arm/mach-imx/imx8/ahab.c                 |   7 +-
+ arch/arm/mach-imx/imx8/cpu.c                  |  44 +++----
+ arch/arm/mach-imx/imx8m/soc.c                 |  24 ++--
+ arch/arm/mach-imx/imx8ulp/soc.c               |  20 +--
+ arch/arm/mach-imx/imx9/scmi/soc.c             |  24 ++--
+ arch/arm/mach-imx/imx9/soc.c                  |  24 ++--
+ arch/arm/mach-imx/mx5/mx53_dram.c             |   8 +-
+ arch/arm/mach-imx/spl.c                       |   4 +-
+ arch/arm/mach-k3/k3-ddr.c                     |   4 +-
+ arch/arm/mach-mvebu/alleycat5/cpu.c           |   4 +-
+ arch/arm/mach-mvebu/armada3700/cpu.c          |  10 +-
+ arch/arm/mach-mvebu/armada8k/dram.c           |  10 +-
+ arch/arm/mach-mvebu/dram.c                    |   6 +-
+ arch/arm/mach-omap2/am33xx/board.c            |   4 +-
+ arch/arm/mach-omap2/omap-cache.c              |   5 +-
+ arch/arm/mach-omap2/omap3/emif4.c             |   8 +-
+ arch/arm/mach-omap2/omap3/sdrc.c              |   8 +-
+ arch/arm/mach-owl/soc.c                       |   4 +-
+ arch/arm/mach-renesas/memmap-gen3.c           |   8 +-
+ arch/arm/mach-renesas/memmap-rzg2l.c          |   4 +-
+ arch/arm/mach-rockchip/rk3588/rk3588.c        |   8 +-
+ arch/arm/mach-rockchip/sdram.c                |  42 +++----
+ arch/arm/mach-snapdragon/board.c              |  16 +--
+ arch/arm/mach-socfpga/board.c                 |   5 +-
+ arch/arm/mach-socfpga/misc_arria10.c          |   7 +-
+ .../mach-stm32mp/cmd_stm32prog/stm32prog.c    |   4 +-
+ arch/arm/mach-stm32mp/stm32mp1/cpu.c          |   7 +-
+ arch/arm/mach-tegra/board2.c                  |  14 +--
+ arch/arm/mach-tegra/cboot.c                   |   4 +-
+ arch/arm/mach-uniphier/dram_init.c            |   6 +-
+ arch/arm/mach-uniphier/fdt-fixup.c            |   8 +-
+ arch/arm/mach-versal-net/cpu.c                |   8 +-
+ arch/arm/mach-versal/cpu.c                    |  16 +--
+ arch/arm/mach-versal2/cpu.c                   |   7 +-
+ arch/arm/mach-zynqmp/cpu.c                    |   8 +-
+ arch/mips/mach-octeon/dram.c                  |   4 +-
+ arch/riscv/cpu/k1/dram.c                      |  12 +-
+ arch/sandbox/cpu/spl.c                        |   4 +-
+ arch/x86/cpu/coreboot/sdram.c                 |   4 +-
+ arch/x86/cpu/efi/payload.c                    |   4 +-
+ arch/x86/cpu/efi/sdram.c                      |   4 +-
+ arch/x86/cpu/intel_common/mrc.c               |   4 +-
+ arch/x86/cpu/ivybridge/sdram_nop.c            |   4 +-
+ arch/x86/cpu/qemu/dram.c                      |   8 +-
+ arch/x86/cpu/quark/dram.c                     |   4 +-
+ arch/x86/cpu/slimbootloader/sdram.c           |   4 +-
+ arch/x86/cpu/tangier/sdram.c                  |   4 +-
+ arch/x86/lib/bootm.c                          |   5 +-
+ arch/x86/lib/fsp/fsp_dram.c                   |  18 +--
+ board/CZ.NIC/turris_1x/turris_1x.c            |  42 +++----
+ board/armltd/corstone1000/corstone1000.c      |   4 +-
+ board/armltd/integrator/integrator.c          |   4 +-
+ board/armltd/total_compute/total_compute.c    |   6 +-
+ board/armltd/vexpress/vexpress_common.c       |   8 +-
+ board/atmel/common/video_display.c            |   2 +-
+ .../sam9x60_curiosity/sam9x60_curiosity.c     |   2 +-
+ .../sam9x75_curiosity/sam9x75_curiosity.c     |   2 +-
+ .../atmel/sama5d27_som1_ek/sama5d27_som1_ek.c |   2 +-
+ .../sama5d27_wlsom1_ek/sama5d27_wlsom1_ek.c   |   2 +-
+ .../sama5d29_curiosity/sama5d29_curiosity.c   |   2 +-
+ .../atmel/sama5d2_xplained/sama5d2_xplained.c |   2 +-
+ .../sama7d65_curiosity/sama7d65_curiosity.c   |   2 +-
+ .../sama7g54_curiosity/sama7g54_curiosity.c   |   2 +-
+ board/axiado/scm3005/scm3005.c                |   4 +-
+ board/broadcom/bcmns3/ns3.c                   |   4 +-
+ board/compulab/cm_fx6/cm_fx6.c                |  28 ++---
+ board/elgin/elgin_rv1108/elgin_rv1108.c       |   4 +-
+ board/esd/meesc/meesc.c                       |   4 +-
+ board/friendlyarm/nanopi2/board.c             |  10 +-
+ board/ge/mx53ppd/mx53ppd.c                    |   8 +-
+ board/hisilicon/hikey/hikey.c                 |  24 ++--
+ board/hisilicon/hikey960/hikey960.c           |   4 +-
+ board/hisilicon/poplar/poplar.c               |   4 +-
+ board/k+p/kp_imx53/kp_imx53.c                 |   4 +-
+ board/keymile/pg-wcom-ls102xa/ddr.c           |   4 +-
+ board/kontron/sl28/sl28.c                     |   4 +-
+ board/kontron/sl28/spl_atf.c                  |   6 +-
+ board/liebherr/btt/btt.c                      |   2 +-
+ board/menlo/m53menlo/m53menlo.c               |   8 +-
+ board/nuvoton/arbel_evb/arbel_evb.c           |  26 ++--
+ board/nxp/imxrt1020-evk/imxrt1020-evk.c       |   2 +-
+ board/nxp/imxrt1050-evk/imxrt1050-evk.c       |   2 +-
+ board/nxp/imxrt1170-evk/imxrt1170-evk.c       |   2 +-
+ board/nxp/ls1021aqds/ddr.c                    |   4 +-
+ board/nxp/ls1028a/ls1028a.c                   |  10 +-
+ board/nxp/ls1043aqds/ls1043aqds.c             |   8 +-
+ board/nxp/ls1043ardb/ls1043ardb.c             |   8 +-
+ board/nxp/ls1046afrwy/ls1046afrwy.c           |   8 +-
+ board/nxp/ls1046aqds/ls1046aqds.c             |   8 +-
+ board/nxp/ls1046ardb/ls1046ardb.c             |   8 +-
+ board/nxp/ls1088a/ls1088a.c                   |   6 +-
+ board/nxp/ls2080aqds/ls2080aqds.c             |  14 +--
+ board/nxp/ls2080ardb/ls2080ardb.c             |  14 +--
+ board/nxp/lx2160a/lx2160a.c                   |   6 +-
+ board/phytec/phycore_am62x/phycore-am62x.c    |  26 ++--
+ board/phytec/phycore_am64x/phycore-am64x.c    |  18 +--
+ board/phytium/durian/durian.c                 |   4 +-
+ board/phytium/pe2201/pe2201.c                 |   4 +-
+ board/raspberrypi/rpi/rpi.c                   |   4 +-
+ board/renesas/common/rcar64-common.c          |   6 +-
+ board/renesas/genmai/genmai.c                 |   4 +-
+ board/renesas/sparrowhawk/sparrowhawk.c       |   8 +-
+ board/ronetix/pm9261/pm9261.c                 |   4 +-
+ board/ronetix/pm9263/pm9263.c                 |   4 +-
+ board/ronetix/pm9g45/pm9g45.c                 |   4 +-
+ board/samsung/arndale/arndale.c               |   4 +-
+ board/samsung/common/board.c                  |   6 +-
+ board/samsung/exynos-mobile/exynos-mobile.c   |   4 +-
+ board/samsung/goni/goni.c                     |  12 +-
+ board/samsung/smdkc100/smdkc100.c             |   4 +-
+ board/samsung/smdkv310/smdkv310.c             |  16 +--
+ board/siemens/iot2050/board.c                 |  16 +--
+ board/socionext/developerbox/developerbox.c   |   6 +-
+ board/st/stih410-b2260/board.c                |   4 +-
+ board/ste/stemmy/stemmy.c                     |   4 +-
+ board/ti/dra7xx/evm.c                         |   8 +-
+ board/ti/ks2_evm/board.c                      |   4 +-
+ board/toradex/colibri_imx7/colibri_imx7.c     |   8 +-
+ board/toradex/verdin-am62/verdin-am62.c       |   2 +-
+ board/toradex/verdin-am62p/verdin-am62p.c     |   2 +-
+ board/traverse/ten64/ten64.c                  |   6 +-
+ board/xilinx/zynq/cmds.c                      |   6 +-
+ board/xilinx/zynqmp/zynqmp.c                  |   4 +-
+ boot/image-board.c                            |   2 +-
+ boot/image-fdt.c                              |   4 +-
+ cmd/bdinfo.c                                  |  12 +-
+ cmd/ti/ddr4.c                                 |   8 +-
+ cmd/ufetch.c                                  |   4 +-
+ common/board_f.c                              |  10 +-
+ common/init/handoff.c                         |  10 +-
+ drivers/bootcount/bootcount_ram.c             |   4 +-
+ drivers/ddr/altera/sdram_agilex.c             |   4 +-
+ drivers/ddr/altera/sdram_agilex5.c            |  18 +--
+ drivers/ddr/altera/sdram_agilex7m.c           |   4 +-
+ drivers/ddr/altera/sdram_arria10.c            |  12 +-
+ drivers/ddr/altera/sdram_n5x.c                |   4 +-
+ drivers/ddr/altera/sdram_s10.c                |   4 +-
+ drivers/ddr/altera/sdram_soc64.c              |  28 ++---
+ drivers/mmc/mvebu_mmc.c                       |   4 +-
+ drivers/net/mvgbe.c                           |   4 +-
+ drivers/pci/pci-uclass.c                      |   8 +-
+ drivers/usb/host/ehci-marvell.c               |   4 +-
+ drivers/video/meson/meson_vpu.c               |   8 +-
+ drivers/video/sunxi/sunxi_de2.c               |   2 +-
+ drivers/video/sunxi/sunxi_display.c           |   2 +-
+ include/asm-generic/global_data.h             |   7 ++
+ include/asm-generic/u-boot.h                  |   4 -
+ include/configs/m53menlo.h                    |   4 +-
+ include/configs/mx53cx9020.h                  |   4 +-
+ include/configs/mx53loco.h                    |   4 +-
+ include/configs/mx53ppd.h                     |   4 +-
+ include/fdtdec.h                              |   7 +-
+ include/init.h                                |   2 +-
+ lib/fdtdec.c                                  |  23 ++--
+ lib/lmb.c                                     |  19 ++-
+ test/cmd/bdinfo.c                             |   7 +-
+ 167 files changed, 707 insertions(+), 714 deletions(-)
+
+diff --git a/api/api_platform.c b/api/api_platform.c
+index d5cbcd6e201..d4edf3a20fe 100644
+--- a/api/api_platform.c
++++ b/api/api_platform.c
+@@ -21,8 +21,8 @@ int platform_sys_info(struct sys_info *si)
+ 	si->clk_cpu = gd->cpu_clk;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++)
+-		platform_set_mr(si, gd->bd->bi_dram[i].start,
+-				gd->bd->bi_dram[i].size, MR_ATTR_DRAM);
++		platform_set_mr(si, gd->dram[i].start,
++				gd->dram[i].size, MR_ATTR_DRAM);
+ 
+ 	platform_set_mr(si, gd->ram_base, gd->ram_size, MR_ATTR_DRAM);
+ 	platform_set_mr(si, gd->bd->bi_flashstart, gd->bd->bi_flashsize, MR_ATTR_FLASH);
+diff --git a/arch/arm/cpu/armv8/cache_v8.c b/arch/arm/cpu/armv8/cache_v8.c
+index 7c0e3f6d055..ad06d7973fb 100644
+--- a/arch/arm/cpu/armv8/cache_v8.c
++++ b/arch/arm/cpu/armv8/cache_v8.c
+@@ -69,9 +69,9 @@ int mem_map_from_dram_banks(unsigned int index, unsigned int len, u64 attrs)
+ 	}
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		mem_map[index].virt = gd->bd->bi_dram[i].start;
+-		mem_map[index].phys = gd->bd->bi_dram[i].start;
+-		mem_map[index].size = gd->bd->bi_dram[i].size;
++		mem_map[index].virt = gd->dram[i].start;
++		mem_map[index].phys = gd->dram[i].start;
++		mem_map[index].size = gd->dram[i].size;
+ 		mem_map[index].attrs = attrs;
+ 		index++;
+ 	}
+diff --git a/arch/arm/cpu/armv8/fsl-layerscape/cpu.c b/arch/arm/cpu/armv8/fsl-layerscape/cpu.c
+index a047494b1fd..9bb3e748e68 100644
+--- a/arch/arm/cpu/armv8/fsl-layerscape/cpu.c
++++ b/arch/arm/cpu/armv8/fsl-layerscape/cpu.c
+@@ -538,16 +538,16 @@ static inline void final_mmu_setup(void)
+ 		 */
+ 		switch (final_map[index].virt) {
+ 		case CFG_SYS_FSL_DRAM_BASE1:
+-			final_map[index].virt = gd->bd->bi_dram[0].start;
+-			final_map[index].phys = gd->bd->bi_dram[0].start;
+-			final_map[index].size = gd->bd->bi_dram[0].size;
++			final_map[index].virt = gd->dram[0].start;
++			final_map[index].phys = gd->dram[0].start;
++			final_map[index].size = gd->dram[0].size;
+ 			break;
+ #ifdef CFG_SYS_FSL_DRAM_BASE2
+ 		case CFG_SYS_FSL_DRAM_BASE2:
+ #if (CONFIG_NR_DRAM_BANKS >= 2)
+-			final_map[index].virt = gd->bd->bi_dram[1].start;
+-			final_map[index].phys = gd->bd->bi_dram[1].start;
+-			final_map[index].size = gd->bd->bi_dram[1].size;
++			final_map[index].virt = gd->dram[1].start;
++			final_map[index].phys = gd->dram[1].start;
++			final_map[index].size = gd->dram[1].size;
+ #else
+ 			final_map[index].size = 0;
+ #endif
+@@ -556,9 +556,9 @@ static inline void final_mmu_setup(void)
+ #ifdef CFG_SYS_FSL_DRAM_BASE3
+ 		case CFG_SYS_FSL_DRAM_BASE3:
+ #if (CONFIG_NR_DRAM_BANKS >= 3)
+-			final_map[index].virt = gd->bd->bi_dram[2].start;
+-			final_map[index].phys = gd->bd->bi_dram[2].start;
+-			final_map[index].size = gd->bd->bi_dram[2].size;
++			final_map[index].virt = gd->dram[2].start;
++			final_map[index].phys = gd->dram[2].start;
++			final_map[index].size = gd->dram[2].size;
+ #else
+ 			final_map[index].size = 0;
+ #endif
+@@ -1375,10 +1375,10 @@ static int tfa_dram_init_banksize(void)
+ 		}
+ 
+ 		debug("bank[%d]: start %lx, size %lx\n", i, res.a1, res.a2);
+-		gd->bd->bi_dram[i].start = res.a1;
+-		gd->bd->bi_dram[i].size = res.a2;
++		gd->dram[i].start = res.a1;
++		gd->dram[i].size = res.a2;
+ 
+-		dram_size -= gd->bd->bi_dram[i].size;
++		dram_size -= gd->dram[i].size;
+ 
+ 		i++;
+ 	} while (dram_size);
+@@ -1389,24 +1389,24 @@ static int tfa_dram_init_banksize(void)
+ #if defined(CONFIG_RESV_RAM) && !defined(CONFIG_XPL_BUILD)
+ 	/* Assign memory for MC */
+ #ifdef CONFIG_SYS_DDR_BLOCK3_BASE
+-	if (gd->bd->bi_dram[2].size >=
+-	    board_reserve_ram_top(gd->bd->bi_dram[2].size)) {
+-		gd->arch.resv_ram = gd->bd->bi_dram[2].start +
+-			    gd->bd->bi_dram[2].size -
+-			    board_reserve_ram_top(gd->bd->bi_dram[2].size);
++	if (gd->dram[2].size >=
++	    board_reserve_ram_top(gd->dram[2].size)) {
++		gd->arch.resv_ram = gd->dram[2].start +
++			    gd->dram[2].size -
++			    board_reserve_ram_top(gd->dram[2].size);
+ 	} else
+ #endif
+ 	{
+-		if (gd->bd->bi_dram[1].size >=
+-		    board_reserve_ram_top(gd->bd->bi_dram[1].size)) {
+-			gd->arch.resv_ram = gd->bd->bi_dram[1].start +
+-				gd->bd->bi_dram[1].size -
+-				board_reserve_ram_top(gd->bd->bi_dram[1].size);
+-		} else if (gd->bd->bi_dram[0].size >
+-			   board_reserve_ram_top(gd->bd->bi_dram[0].size)) {
+-			gd->arch.resv_ram = gd->bd->bi_dram[0].start +
+-				gd->bd->bi_dram[0].size -
+-				board_reserve_ram_top(gd->bd->bi_dram[0].size);
++		if (gd->dram[1].size >=
++		    board_reserve_ram_top(gd->dram[1].size)) {
++			gd->arch.resv_ram = gd->dram[1].start +
++				gd->dram[1].size -
++				board_reserve_ram_top(gd->dram[1].size);
++		} else if (gd->dram[0].size >
++			   board_reserve_ram_top(gd->dram[0].size)) {
++			gd->arch.resv_ram = gd->dram[0].start +
++				gd->dram[0].size -
++				board_reserve_ram_top(gd->dram[0].size);
+ 		}
+ 	}
+ #endif	/* CONFIG_RESV_RAM */
+@@ -1443,30 +1443,30 @@ int dram_init_banksize(void)
+ 	}
+ #endif
+ 
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
+ 	if (gd->ram_size > CFG_SYS_DDR_BLOCK1_SIZE) {
+-		gd->bd->bi_dram[0].size = CFG_SYS_DDR_BLOCK1_SIZE;
+-		gd->bd->bi_dram[1].start = CFG_SYS_DDR_BLOCK2_BASE;
+-		gd->bd->bi_dram[1].size = gd->ram_size -
++		gd->dram[0].size = CFG_SYS_DDR_BLOCK1_SIZE;
++		gd->dram[1].start = CFG_SYS_DDR_BLOCK2_BASE;
++		gd->dram[1].size = gd->ram_size -
+ 					  CFG_SYS_DDR_BLOCK1_SIZE;
+ #ifdef CONFIG_SYS_DDR_BLOCK3_BASE
+-		if (gd->bi_dram[1].size > CONFIG_SYS_DDR_BLOCK2_SIZE) {
+-			gd->bd->bi_dram[2].start = CONFIG_SYS_DDR_BLOCK3_BASE;
+-			gd->bd->bi_dram[2].size = gd->bd->bi_dram[1].size -
++		if (gd->dram[1].size > CONFIG_SYS_DDR_BLOCK2_SIZE) {
++			gd->dram[2].start = CONFIG_SYS_DDR_BLOCK3_BASE;
++			gd->dram[2].size = gd->dram[1].size -
+ 						  CONFIG_SYS_DDR_BLOCK2_SIZE;
+-			gd->bd->bi_dram[1].size = CONFIG_SYS_DDR_BLOCK2_SIZE;
++			gd->dram[1].size = CONFIG_SYS_DDR_BLOCK2_SIZE;
+ 		}
+ #endif
+ 	} else {
+-		gd->bd->bi_dram[0].size = gd->ram_size;
++		gd->dram[0].size = gd->ram_size;
+ 	}
+ #ifdef CFG_SYS_MEM_RESERVE_SECURE
+-	if (gd->bd->bi_dram[0].size >
++	if (gd->dram[0].size >
+ 				CFG_SYS_MEM_RESERVE_SECURE) {
+-		gd->bd->bi_dram[0].size -=
++		gd->dram[0].size -=
+ 				CFG_SYS_MEM_RESERVE_SECURE;
+-		gd->arch.secure_ram = gd->bd->bi_dram[0].start +
+-				      gd->bd->bi_dram[0].size;
++		gd->arch.secure_ram = gd->dram[0].start +
++				      gd->dram[0].size;
+ 		gd->arch.secure_ram |= MEM_RESERVE_SECURE_MAINTAINED;
+ 		gd->ram_size -= CFG_SYS_MEM_RESERVE_SECURE;
+ 	}
+@@ -1475,24 +1475,24 @@ int dram_init_banksize(void)
+ #if defined(CONFIG_RESV_RAM) && !defined(CONFIG_XPL_BUILD)
+ 	/* Assign memory for MC */
+ #ifdef CONFIG_SYS_DDR_BLOCK3_BASE
+-	if (gd->bd->bi_dram[2].size >=
+-	    board_reserve_ram_top(gd->bd->bi_dram[2].size)) {
+-		gd->arch.resv_ram = gd->bd->bi_dram[2].start +
+-			    gd->bd->bi_dram[2].size -
+-			    board_reserve_ram_top(gd->bd->bi_dram[2].size);
++	if (gd->dram[2].size >=
++	    board_reserve_ram_top(gd->dram[2].size)) {
++		gd->arch.resv_ram = gd->dram[2].start +
++			    gd->dram[2].size -
++			    board_reserve_ram_top(gd->dram[2].size);
+ 	} else
+ #endif
+ 	{
+-		if (gd->bd->bi_dram[1].size >=
+-		    board_reserve_ram_top(gd->bd->bi_dram[1].size)) {
+-			gd->arch.resv_ram = gd->bd->bi_dram[1].start +
+-				gd->bd->bi_dram[1].size -
+-				board_reserve_ram_top(gd->bd->bi_dram[1].size);
+-		} else if (gd->bd->bi_dram[0].size >
+-			   board_reserve_ram_top(gd->bd->bi_dram[0].size)) {
+-			gd->arch.resv_ram = gd->bd->bi_dram[0].start +
+-				gd->bd->bi_dram[0].size -
+-				board_reserve_ram_top(gd->bd->bi_dram[0].size);
++		if (gd->dram[1].size >=
++		    board_reserve_ram_top(gd->dram[1].size)) {
++			gd->arch.resv_ram = gd->dram[1].start +
++				gd->dram[1].size -
++				board_reserve_ram_top(gd->dram[1].size);
++		} else if (gd->dram[0].size >
++			   board_reserve_ram_top(gd->dram[0].size)) {
++			gd->arch.resv_ram = gd->dram[0].start +
++				gd->dram[0].size -
++				board_reserve_ram_top(gd->dram[0].size);
+ 		}
+ 	}
+ #endif	/* CONFIG_RESV_RAM */
+@@ -1514,8 +1514,8 @@ int dram_init_banksize(void)
+ 					  CONFIG_DP_DDR_DIMM_SLOTS_PER_CTLR,
+ 					  NULL, NULL, NULL);
+ 		if (dp_ddr_size) {
+-			gd->bd->bi_dram[2].start = CONFIG_SYS_DP_DDR_BASE;
+-			gd->bd->bi_dram[2].size = dp_ddr_size;
++			gd->dram[2].start = CONFIG_SYS_DP_DDR_BASE;
++			gd->dram[2].size = dp_ddr_size;
+ 		} else {
+ 			puts("Not detected");
+ 		}
+@@ -1546,8 +1546,8 @@ void lmb_arch_add_memory(void)
+ 		if (i == 2)
+ 			continue;	/* skip DP-DDR */
+ #endif
+-		ram_start = gd->bd->bi_dram[i].start;
+-		ram_size = gd->bd->bi_dram[i].size;
++		ram_start = gd->dram[i].start;
++		ram_size = gd->dram[i].size;
+ #ifdef CONFIG_RESV_RAM
+ 		if (gd->arch.resv_ram >= ram_start &&
+ 		    gd->arch.resv_ram < ram_start + ram_size)
+diff --git a/arch/arm/lib/bootm-fdt.c b/arch/arm/lib/bootm-fdt.c
+index 2671f9a0ebf..a82ceeaf22f 100644
+--- a/arch/arm/lib/bootm-fdt.c
++++ b/arch/arm/lib/bootm-fdt.c
+@@ -35,14 +35,13 @@ int arch_fixup_fdt(void *blob)
+ {
+ 	__maybe_unused int ret = 0;
+ #if defined(CONFIG_ARMV7_NONSEC) || defined(CONFIG_OF_LIBFDT)
+-	struct bd_info *bd = gd->bd;
+ 	int bank;
+ 	u64 start[CONFIG_NR_DRAM_BANKS];
+ 	u64 size[CONFIG_NR_DRAM_BANKS];
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start[bank] = bd->bi_dram[bank].start;
+-		size[bank] = bd->bi_dram[bank].size;
++		start[bank] = gd->dram[bank].start;
++		size[bank] = gd->dram[bank].size;
+ #ifdef CONFIG_ARMV7_NONSEC
+ 		ret = armv7_apply_memory_carveout(&start[bank], &size[bank]);
+ 		if (ret)
+diff --git a/arch/arm/lib/bootm.c b/arch/arm/lib/bootm.c
+index 1cde655bc80..9a115cc6078 100644
+--- a/arch/arm/lib/bootm.c
++++ b/arch/arm/lib/bootm.c
+@@ -64,8 +64,8 @@ static void setup_memory_tags(struct bd_info *bd)
+ 		params->hdr.tag = ATAG_MEM;
+ 		params->hdr.size = tag_size (tag_mem32);
+ 
+-		params->u.mem.start = bd->bi_dram[i].start;
+-		params->u.mem.size = bd->bi_dram[i].size;
++		params->u.mem.start = gd->dram[i].start;
++		params->u.mem.size = gd->dram[i].size;
+ 
+ 		params = tag_next (params);
+ 	}
+diff --git a/arch/arm/lib/cache-cp15.c b/arch/arm/lib/cache-cp15.c
+index 947012f2996..28bb6fd36c8 100644
+--- a/arch/arm/lib/cache-cp15.c
++++ b/arch/arm/lib/cache-cp15.c
+@@ -94,17 +94,16 @@ void mmu_set_region_dcache_behaviour_phys(phys_addr_t start, phys_addr_t phys,
+ 
+ __weak void dram_bank_mmu_setup(int bank)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int	i;
+ 
+-	/* bd->bi_dram is available only after relocation */
++	/* gd->dram is available only after relocation */
+ 	if ((gd->flags & GD_FLG_RELOC) == 0)
+ 		return;
+ 
+ 	debug("%s: bank: %d\n", __func__, bank);
+-	for (i = bd->bi_dram[bank].start >> MMU_SECTION_SHIFT;
+-	     i < (bd->bi_dram[bank].start >> MMU_SECTION_SHIFT) +
+-		 (bd->bi_dram[bank].size >> MMU_SECTION_SHIFT);
++	for (i = gd->dram[bank].start >> MMU_SECTION_SHIFT;
++	     i < (gd->dram[bank].start >> MMU_SECTION_SHIFT) +
++		 (gd->dram[bank].size >> MMU_SECTION_SHIFT);
+ 	     i++)
+ 		set_section_dcache(i, DCACHE_DEFAULT_OPTION);
+ }
+diff --git a/arch/arm/lib/image.c b/arch/arm/lib/image.c
+index 1f672eee2c8..2268661de93 100644
+--- a/arch/arm/lib/image.c
++++ b/arch/arm/lib/image.c
+@@ -69,7 +69,7 @@ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+ 	if (!force_reloc && (le64_to_cpu(ih->flags) & BIT(3)))
+ 		dst = image - text_offset;
+ 	else
+-		dst = gd->bd->bi_dram[0].start;
++		dst = gd->dram[0].start;
+ 
+ 	*relocated_addr = ALIGN(dst, SZ_2M) + text_offset;
+ 
+diff --git a/arch/arm/mach-airoha/an7581/init.c b/arch/arm/mach-airoha/an7581/init.c
+index ab32706a79d..f33527ca129 100644
+--- a/arch/arm/mach-airoha/an7581/init.c
++++ b/arch/arm/mach-airoha/an7581/init.c
+@@ -23,12 +23,12 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = gd->ram_base;
+-	gd->bd->bi_dram[0].size = get_effective_memsize();
++	gd->dram[0].start = gd->ram_base;
++	gd->dram[0].size = get_effective_memsize();
+ 
+ 	if (gd->ram_size > SZ_2G) {
+-		gd->bd->bi_dram[1].start = gd->ram_base + SZ_2G;
+-		gd->bd->bi_dram[1].size = gd->ram_size - SZ_2G;
++		gd->dram[1].start = gd->ram_base + SZ_2G;
++		gd->dram[1].size = gd->ram_size - SZ_2G;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-apple/board.c b/arch/arm/mach-apple/board.c
+index 20054f54089..e74a5a76919 100644
+--- a/arch/arm/mach-apple/board.c
++++ b/arch/arm/mach-apple/board.c
+@@ -807,8 +807,8 @@ void build_mem_map(void)
+ 		;
+ 
+ 	/* Align RAM mapping to page boundaries */
+-	base = gd->bd->bi_dram[0].start;
+-	size = gd->bd->bi_dram[0].size;
++	base = gd->dram[0].start;
++	size = gd->dram[0].size;
+ 	size += (base - ALIGN_DOWN(base, SZ_4K));
+ 	base = ALIGN_DOWN(base, SZ_4K);
+ 	size = ALIGN(size, SZ_4K);
+diff --git a/arch/arm/mach-davinci/misc.c b/arch/arm/mach-davinci/misc.c
+index 07125eac7cd..2281686d633 100644
+--- a/arch/arm/mach-davinci/misc.c
++++ b/arch/arm/mach-davinci/misc.c
+@@ -33,8 +33,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-imx/ele_ahab.c b/arch/arm/mach-imx/ele_ahab.c
+index 9794391fb35..f49fabf3219 100644
+--- a/arch/arm/mach-imx/ele_ahab.c
++++ b/arch/arm/mach-imx/ele_ahab.c
+@@ -310,12 +310,11 @@ int ahab_verify_cntr_image(struct boot_img_t *img, int image_index)
+ static inline bool check_in_dram(ulong addr)
+ {
+ 	int i;
+-	struct bd_info *bd = gd->bd;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; ++i) {
+-		if (bd->bi_dram[i].size) {
+-			if (addr >= bd->bi_dram[i].start &&
+-			    addr < (bd->bi_dram[i].start + bd->bi_dram[i].size))
++		if (gd->dram[i].size) {
++			if (addr >= gd->dram[i].start &&
++			    addr < (gd->dram[i].start + gd->dram[i].size))
+ 				return true;
+ 		}
+ 	}
+diff --git a/arch/arm/mach-imx/imx8/ahab.c b/arch/arm/mach-imx/imx8/ahab.c
+index f13baa871cc..abefb9d5493 100644
+--- a/arch/arm/mach-imx/imx8/ahab.c
++++ b/arch/arm/mach-imx/imx8/ahab.c
+@@ -109,12 +109,11 @@ int ahab_verify_cntr_image(struct boot_img_t *img, int image_index)
+ static inline bool check_in_dram(ulong addr)
+ {
+ 	int i;
+-	struct bd_info *bd = gd->bd;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; ++i) {
+-		if (bd->bi_dram[i].size) {
+-			if (addr >= bd->bi_dram[i].start &&
+-			    addr < (bd->bi_dram[i].start + bd->bi_dram[i].size))
++		if (gd->dram[i].size) {
++			if (addr >= gd->dram[i].start &&
++			    addr < (gd->dram[i].start + gd->dram[i].size))
+ 				return true;
+ 		}
+ 	}
+diff --git a/arch/arm/mach-imx/imx8/cpu.c b/arch/arm/mach-imx/imx8/cpu.c
+index f4738e3fda8..b52675d8aba 100644
+--- a/arch/arm/mach-imx/imx8/cpu.c
++++ b/arch/arm/mach-imx/imx8/cpu.c
+@@ -604,18 +604,18 @@ static void dram_bank_sort(int current_bank)
+ 	phys_size_t size;
+ 
+ 	while (current_bank > 0) {
+-		if (gd->bd->bi_dram[current_bank - 1].start >
+-		    gd->bd->bi_dram[current_bank].start) {
+-			start = gd->bd->bi_dram[current_bank - 1].start;
+-			size = gd->bd->bi_dram[current_bank - 1].size;
+-
+-			gd->bd->bi_dram[current_bank - 1].start =
+-				gd->bd->bi_dram[current_bank].start;
+-			gd->bd->bi_dram[current_bank - 1].size =
+-				gd->bd->bi_dram[current_bank].size;
+-
+-			gd->bd->bi_dram[current_bank].start = start;
+-			gd->bd->bi_dram[current_bank].size = size;
++		if (gd->dram[current_bank - 1].start >
++		    gd->dram[current_bank].start) {
++			start = gd->dram[current_bank - 1].start;
++			size = gd->dram[current_bank - 1].size;
++
++			gd->dram[current_bank - 1].start =
++				gd->dram[current_bank].start;
++			gd->dram[current_bank - 1].size =
++				gd->dram[current_bank].size;
++
++			gd->dram[current_bank].start = start;
++			gd->dram[current_bank].size = size;
+ 		}
+ 		current_bank--;
+ 	}
+@@ -643,24 +643,24 @@ int dram_init_banksize(void)
+ 				continue;
+ 
+ 			if (start >= phys_sdram_1_start && start <= end1) {
+-				gd->bd->bi_dram[i].start = start;
++				gd->dram[i].start = start;
+ 
+ 				if ((end + 1) <= end1)
+-					gd->bd->bi_dram[i].size =
++					gd->dram[i].size =
+ 						end - start + 1;
+ 				else
+-					gd->bd->bi_dram[i].size = end1 - start;
++					gd->dram[i].size = end1 - start;
+ 
+ 				dram_bank_sort(i);
+ 				i++;
+ 			} else if (start >= phys_sdram_2_start && start <= end2) {
+-				gd->bd->bi_dram[i].start = start;
++				gd->dram[i].start = start;
+ 
+ 				if ((end + 1) <= end2)
+-					gd->bd->bi_dram[i].size =
++					gd->dram[i].size =
+ 						end - start + 1;
+ 				else
+-					gd->bd->bi_dram[i].size = end2 - start;
++					gd->dram[i].size = end2 - start;
+ 
+ 				dram_bank_sort(i);
+ 				i++;
+@@ -670,10 +670,10 @@ int dram_init_banksize(void)
+ 
+ 	/* If error, set to the default value */
+ 	if (!i) {
+-		gd->bd->bi_dram[0].start = phys_sdram_1_start;
+-		gd->bd->bi_dram[0].size = phys_sdram_1_size;
+-		gd->bd->bi_dram[1].start = phys_sdram_2_start;
+-		gd->bd->bi_dram[1].size = phys_sdram_2_size;
++		gd->dram[0].start = phys_sdram_1_start;
++		gd->dram[0].size = phys_sdram_1_size;
++		gd->dram[1].start = phys_sdram_2_start;
++		gd->dram[1].size = phys_sdram_2_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-imx/imx8m/soc.c b/arch/arm/mach-imx/imx8m/soc.c
+index 1fe083ae94f..84d4ebdb919 100644
+--- a/arch/arm/mach-imx/imx8m/soc.c
++++ b/arch/arm/mach-imx/imx8m/soc.c
+@@ -224,11 +224,11 @@ void enable_caches(void)
+ 
+ 	while (i < CONFIG_NR_DRAM_BANKS &&
+ 	       entry < ARRAY_SIZE(imx8m_mem_map)) {
+-		if (gd->bd->bi_dram[i].start == 0)
++		if (gd->dram[i].start == 0)
+ 			break;
+-		imx8m_mem_map[entry].phys = gd->bd->bi_dram[i].start;
+-		imx8m_mem_map[entry].virt = gd->bd->bi_dram[i].start;
+-		imx8m_mem_map[entry].size = gd->bd->bi_dram[i].size;
++		imx8m_mem_map[entry].phys = gd->dram[i].start;
++		imx8m_mem_map[entry].virt = gd->dram[i].start;
++		imx8m_mem_map[entry].size = gd->dram[i].size;
+ 		imx8m_mem_map[entry].attrs = attrs;
+ 		debug("Added memory mapping (%d): %llx %llx\n", entry,
+ 		      imx8m_mem_map[entry].phys, imx8m_mem_map[entry].size);
+@@ -290,24 +290,24 @@ int dram_init_banksize(void)
+ 		sdram_b2_size = 0;
+ 	}
+ 
+-	gd->bd->bi_dram[bank].start = PHYS_SDRAM;
++	gd->dram[bank].start = PHYS_SDRAM;
+ 	if (!IS_ENABLED(CONFIG_ARMV8_PSCI) && !IS_ENABLED(CONFIG_XPL_BUILD) && rom_pointer[1]) {
+ 		phys_addr_t optee_start = (phys_addr_t)rom_pointer[0];
+ 		phys_size_t optee_size = (size_t)rom_pointer[1];
+ 
+-		gd->bd->bi_dram[bank].size = optee_start - gd->bd->bi_dram[bank].start;
++		gd->dram[bank].size = optee_start - gd->dram[bank].start;
+ 		if ((optee_start + optee_size) < (PHYS_SDRAM + sdram_b1_size)) {
+ 			if (++bank >= CONFIG_NR_DRAM_BANKS) {
+ 				puts("CONFIG_NR_DRAM_BANKS is not enough\n");
+ 				return -1;
+ 			}
+ 
+-			gd->bd->bi_dram[bank].start = optee_start + optee_size;
+-			gd->bd->bi_dram[bank].size = PHYS_SDRAM +
+-				sdram_b1_size - gd->bd->bi_dram[bank].start;
++			gd->dram[bank].start = optee_start + optee_size;
++			gd->dram[bank].size = PHYS_SDRAM +
++				sdram_b1_size - gd->dram[bank].start;
+ 		}
+ 	} else {
+-		gd->bd->bi_dram[bank].size = sdram_b1_size;
++		gd->dram[bank].size = sdram_b1_size;
+ 	}
+ 
+ 	if (sdram_b2_size) {
+@@ -315,8 +315,8 @@ int dram_init_banksize(void)
+ 			puts("CONFIG_NR_DRAM_BANKS is not enough for SDRAM_2\n");
+ 			return -1;
+ 		}
+-		gd->bd->bi_dram[bank].start = 0x100000000UL;
+-		gd->bd->bi_dram[bank].size = sdram_b2_size;
++		gd->dram[bank].start = 0x100000000UL;
++		gd->dram[bank].size = sdram_b2_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-imx/imx8ulp/soc.c b/arch/arm/mach-imx/imx8ulp/soc.c
+index 1ee483065e8..22c79c8889b 100644
+--- a/arch/arm/mach-imx/imx8ulp/soc.c
++++ b/arch/arm/mach-imx/imx8ulp/soc.c
+@@ -502,11 +502,11 @@ void enable_caches(void)
+ 
+ 		while (i < CONFIG_NR_DRAM_BANKS &&
+ 		       entry < ARRAY_SIZE(imx8ulp_arm64_mem_map)) {
+-			if (gd->bd->bi_dram[i].start == 0)
++			if (gd->dram[i].start == 0)
+ 				break;
+-			imx8ulp_arm64_mem_map[entry].phys = gd->bd->bi_dram[i].start;
+-			imx8ulp_arm64_mem_map[entry].virt = gd->bd->bi_dram[i].start;
+-			imx8ulp_arm64_mem_map[entry].size = gd->bd->bi_dram[i].size;
++			imx8ulp_arm64_mem_map[entry].phys = gd->dram[i].start;
++			imx8ulp_arm64_mem_map[entry].virt = gd->dram[i].start;
++			imx8ulp_arm64_mem_map[entry].size = gd->dram[i].size;
+ 			imx8ulp_arm64_mem_map[entry].attrs = attrs;
+ 			debug("Added memory mapping (%d): %llx %llx\n", entry,
+ 			      imx8ulp_arm64_mem_map[entry].phys, imx8ulp_arm64_mem_map[entry].size);
+@@ -558,24 +558,24 @@ int dram_init_banksize(void)
+ 	if (ret)
+ 		return ret;
+ 
+-	gd->bd->bi_dram[bank].start = PHYS_SDRAM;
++	gd->dram[bank].start = PHYS_SDRAM;
+ 	if (rom_pointer[1]) {
+ 		phys_addr_t optee_start = (phys_addr_t)rom_pointer[0];
+ 		phys_size_t optee_size = (size_t)rom_pointer[1];
+ 
+-		gd->bd->bi_dram[bank].size = optee_start - gd->bd->bi_dram[bank].start;
++		gd->dram[bank].size = optee_start - gd->dram[bank].start;
+ 		if ((optee_start + optee_size) < (PHYS_SDRAM + sdram_size)) {
+ 			if (++bank >= CONFIG_NR_DRAM_BANKS) {
+ 				puts("CONFIG_NR_DRAM_BANKS is not enough\n");
+ 				return -1;
+ 			}
+ 
+-			gd->bd->bi_dram[bank].start = optee_start + optee_size;
+-			gd->bd->bi_dram[bank].size = PHYS_SDRAM +
+-				sdram_size - gd->bd->bi_dram[bank].start;
++			gd->dram[bank].start = optee_start + optee_size;
++			gd->dram[bank].size = PHYS_SDRAM +
++				sdram_size - gd->dram[bank].start;
+ 		}
+ 	} else {
+-		gd->bd->bi_dram[bank].size = sdram_size;
++		gd->dram[bank].size = sdram_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-imx/imx9/scmi/soc.c b/arch/arm/mach-imx/imx9/scmi/soc.c
+index e73f8c29d57..7390026a948 100644
+--- a/arch/arm/mach-imx/imx9/scmi/soc.c
++++ b/arch/arm/mach-imx/imx9/scmi/soc.c
+@@ -348,11 +348,11 @@ void enable_caches(void)
+ 
+ 	while (i < CONFIG_NR_DRAM_BANKS &&
+ 	       entry < ARRAY_SIZE(imx9_mem_map)) {
+-		if (gd->bd->bi_dram[i].start == 0)
++		if (gd->dram[i].start == 0)
+ 			break;
+-		imx9_mem_map[entry].phys = gd->bd->bi_dram[i].start;
+-		imx9_mem_map[entry].virt = gd->bd->bi_dram[i].start;
+-		imx9_mem_map[entry].size = gd->bd->bi_dram[i].size;
++		imx9_mem_map[entry].phys = gd->dram[i].start;
++		imx9_mem_map[entry].virt = gd->dram[i].start;
++		imx9_mem_map[entry].size = gd->dram[i].size;
+ 		imx9_mem_map[entry].attrs = attrs;
+ 		debug("Added memory mapping (%d): %llx %llx\n", entry,
+ 		      imx9_mem_map[entry].phys, imx9_mem_map[entry].size);
+@@ -445,24 +445,24 @@ int dram_init_banksize(void)
+ 		sdram_b2_size = 0;
+ 	}
+ 
+-	gd->bd->bi_dram[bank].start = PHYS_SDRAM;
++	gd->dram[bank].start = PHYS_SDRAM;
+ 	if (rom_pointer[1] && PHYS_SDRAM < (phys_addr_t)rom_pointer[0]) {
+ 		phys_addr_t optee_start = (phys_addr_t)rom_pointer[0];
+ 		phys_size_t optee_size = (size_t)rom_pointer[1];
+ 
+-		gd->bd->bi_dram[bank].size = optee_start - gd->bd->bi_dram[bank].start;
++		gd->dram[bank].size = optee_start - gd->dram[bank].start;
+ 		if ((optee_start + optee_size) < (PHYS_SDRAM + sdram_b1_size)) {
+ 			if (++bank >= CONFIG_NR_DRAM_BANKS) {
+ 				puts("CONFIG_NR_DRAM_BANKS is not enough\n");
+ 				return -1;
+ 			}
+ 
+-			gd->bd->bi_dram[bank].start = optee_start + optee_size;
+-			gd->bd->bi_dram[bank].size = PHYS_SDRAM +
+-				sdram_b1_size - gd->bd->bi_dram[bank].start;
++			gd->dram[bank].start = optee_start + optee_size;
++			gd->dram[bank].size = PHYS_SDRAM +
++				sdram_b1_size - gd->dram[bank].start;
+ 		}
+ 	} else {
+-		gd->bd->bi_dram[bank].size = sdram_b1_size;
++		gd->dram[bank].size = sdram_b1_size;
+ 	}
+ 
+ 	if (sdram_b2_size) {
+@@ -470,8 +470,8 @@ int dram_init_banksize(void)
+ 			puts("CONFIG_NR_DRAM_BANKS is not enough for SDRAM_2\n");
+ 			return -1;
+ 		}
+-		gd->bd->bi_dram[bank].start = 0x100000000UL;
+-		gd->bd->bi_dram[bank].size = sdram_b2_size;
++		gd->dram[bank].start = 0x100000000UL;
++		gd->dram[bank].size = sdram_b2_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-imx/imx9/soc.c b/arch/arm/mach-imx/imx9/soc.c
+index 44b3e0f5310..63806f1b484 100644
+--- a/arch/arm/mach-imx/imx9/soc.c
++++ b/arch/arm/mach-imx/imx9/soc.c
+@@ -370,11 +370,11 @@ void enable_caches(void)
+ 
+ 	while (i < CONFIG_NR_DRAM_BANKS &&
+ 	       entry < ARRAY_SIZE(imx93_mem_map)) {
+-		if (gd->bd->bi_dram[i].start == 0)
++		if (gd->dram[i].start == 0)
+ 			break;
+-		imx93_mem_map[entry].phys = gd->bd->bi_dram[i].start;
+-		imx93_mem_map[entry].virt = gd->bd->bi_dram[i].start;
+-		imx93_mem_map[entry].size = gd->bd->bi_dram[i].size;
++		imx93_mem_map[entry].phys = gd->dram[i].start;
++		imx93_mem_map[entry].virt = gd->dram[i].start;
++		imx93_mem_map[entry].size = gd->dram[i].size;
+ 		imx93_mem_map[entry].attrs = attrs;
+ 		debug("Added memory mapping (%d): %llx %llx\n", entry,
+ 		      imx93_mem_map[entry].phys, imx93_mem_map[entry].size);
+@@ -448,24 +448,24 @@ int dram_init_banksize(void)
+ 		sdram_b2_size = 0;
+ 	}
+ 
+-	gd->bd->bi_dram[bank].start = PHYS_SDRAM;
++	gd->dram[bank].start = PHYS_SDRAM;
+ 	if (!IS_ENABLED(CONFIG_XPL_BUILD) && rom_pointer[1]) {
+ 		phys_addr_t optee_start = (phys_addr_t)rom_pointer[0];
+ 		phys_size_t optee_size = (size_t)rom_pointer[1];
+ 
+-		gd->bd->bi_dram[bank].size = optee_start - gd->bd->bi_dram[bank].start;
++		gd->dram[bank].size = optee_start - gd->dram[bank].start;
+ 		if ((optee_start + optee_size) < (PHYS_SDRAM + sdram_b1_size)) {
+ 			if (++bank >= CONFIG_NR_DRAM_BANKS) {
+ 				puts("CONFIG_NR_DRAM_BANKS is not enough\n");
+ 				return -1;
+ 			}
+ 
+-			gd->bd->bi_dram[bank].start = optee_start + optee_size;
+-			gd->bd->bi_dram[bank].size = PHYS_SDRAM +
+-				sdram_b1_size - gd->bd->bi_dram[bank].start;
++			gd->dram[bank].start = optee_start + optee_size;
++			gd->dram[bank].size = PHYS_SDRAM +
++				sdram_b1_size - gd->dram[bank].start;
+ 		}
+ 	} else {
+-		gd->bd->bi_dram[bank].size = sdram_b1_size;
++		gd->dram[bank].size = sdram_b1_size;
+ 	}
+ 
+ 	if (sdram_b2_size) {
+@@ -473,8 +473,8 @@ int dram_init_banksize(void)
+ 			puts("CONFIG_NR_DRAM_BANKS is not enough for SDRAM_2\n");
+ 			return -1;
+ 		}
+-		gd->bd->bi_dram[bank].start = 0x100000000UL;
+-		gd->bd->bi_dram[bank].size = sdram_b2_size;
++		gd->dram[bank].start = 0x100000000UL;
++		gd->dram[bank].size = sdram_b2_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-imx/mx5/mx53_dram.c b/arch/arm/mach-imx/mx5/mx53_dram.c
+index 180a745d435..5f7709e00b0 100644
+--- a/arch/arm/mach-imx/mx5/mx53_dram.c
++++ b/arch/arm/mach-imx/mx5/mx53_dram.c
+@@ -35,11 +35,11 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = get_ram_size((void *)PHYS_SDRAM_1, 1 << 30);
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = get_ram_size((void *)PHYS_SDRAM_1, 1 << 30);
+ 
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
+-	gd->bd->bi_dram[1].size = get_ram_size((void *)PHYS_SDRAM_2, 1 << 30);
++	gd->dram[1].start = PHYS_SDRAM_2;
++	gd->dram[1].size = get_ram_size((void *)PHYS_SDRAM_2, 1 << 30);
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-imx/spl.c b/arch/arm/mach-imx/spl.c
+index 57ae81c7834..1029c1e4e85 100644
+--- a/arch/arm/mach-imx/spl.c
++++ b/arch/arm/mach-imx/spl.c
+@@ -375,8 +375,8 @@ void *spl_load_simple_fit_fix_load(const void *fit)
+ #if defined(CONFIG_MX6) && defined(CONFIG_SPL_OS_BOOT)
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = imx_ddr_size();
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = imx_ddr_size();
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-k3/k3-ddr.c b/arch/arm/mach-k3/k3-ddr.c
+index 6e3e60cdc86..35c30b1a16f 100644
+--- a/arch/arm/mach-k3/k3-ddr.c
++++ b/arch/arm/mach-k3/k3-ddr.c
+@@ -59,8 +59,8 @@ void fixup_memory_node(struct spl_image_info *spl_image)
+ 	dram_init_banksize();
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start[bank] = gd->bd->bi_dram[bank].start;
+-		size[bank] = gd->bd->bi_dram[bank].size;
++		start[bank] = gd->dram[bank].start;
++		size[bank] = gd->dram[bank].size;
+ 	}
+ 
+ 	ret = fdt_fixup_memory_banks(spl_image->fdt_addr, start, size,
+diff --git a/arch/arm/mach-mvebu/alleycat5/cpu.c b/arch/arm/mach-mvebu/alleycat5/cpu.c
+index be2d9a25bf9..3ebb4294bdd 100644
+--- a/arch/arm/mach-mvebu/alleycat5/cpu.c
++++ b/arch/arm/mach-mvebu/alleycat5/cpu.c
+@@ -138,8 +138,8 @@ int alleycat5_dram_init_banksize(void)
+ 	/*
+ 	 * Config single DRAM bank
+ 	 */
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-mvebu/armada3700/cpu.c b/arch/arm/mach-mvebu/armada3700/cpu.c
+index 17525691e68..38d9b40f482 100644
+--- a/arch/arm/mach-mvebu/armada3700/cpu.c
++++ b/arch/arm/mach-mvebu/armada3700/cpu.c
+@@ -256,7 +256,7 @@ int a3700_dram_init_banksize(void)
+ 		 * build_mem_map.
+ 		 */
+ 		if (last_end == dram_wins[win].base) {
+-			gd->bd->bi_dram[bank - 1].size += size;
++			gd->dram[bank - 1].size += size;
+ 			last_end += size;
+ 		} else {
+ 			if (bank == CONFIG_NR_DRAM_BANKS) {
+@@ -264,8 +264,8 @@ int a3700_dram_init_banksize(void)
+ 				return -ENOBUFS;
+ 			}
+ 
+-			gd->bd->bi_dram[bank].start = dram_wins[win].base;
+-			gd->bd->bi_dram[bank].size = size;
++			gd->dram[bank].start = dram_wins[win].base;
++			gd->dram[bank].size = size;
+ 			last_end = dram_wins[win].base + size;
+ 			++bank;
+ 		}
+@@ -276,8 +276,8 @@ int a3700_dram_init_banksize(void)
+ 	 * the rest with zeros.
+ 	 */
+ 	for (; bank < CONFIG_NR_DRAM_BANKS; ++bank) {
+-		gd->bd->bi_dram[bank].start = 0;
+-		gd->bd->bi_dram[bank].size = 0;
++		gd->dram[bank].start = 0;
++		gd->dram[bank].size = 0;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-mvebu/armada8k/dram.c b/arch/arm/mach-mvebu/armada8k/dram.c
+index fd58551d0e3..af37dfa2252 100644
+--- a/arch/arm/mach-mvebu/armada8k/dram.c
++++ b/arch/arm/mach-mvebu/armada8k/dram.c
+@@ -38,16 +38,16 @@ int a8k_dram_init_banksize(void)
+ 	 */
+ 	phys_size_t max_bank0_size = SZ_4G - SZ_1G;
+ 
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
+ 	if (gd->ram_size <= max_bank0_size) {
+-		gd->bd->bi_dram[0].size = gd->ram_size;
++		gd->dram[0].size = gd->ram_size;
+ 		return 0;
+ 	}
+ 
+-	gd->bd->bi_dram[0].size = max_bank0_size;
++	gd->dram[0].size = max_bank0_size;
+ 	if (CONFIG_NR_DRAM_BANKS > 1) {
+-		gd->bd->bi_dram[1].start = SZ_4G;
+-		gd->bd->bi_dram[1].size = gd->ram_size - max_bank0_size;
++		gd->dram[1].start = SZ_4G;
++		gd->dram[1].size = gd->ram_size - max_bank0_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-mvebu/dram.c b/arch/arm/mach-mvebu/dram.c
+index c00c6b9b3fc..41eaaa24bd0 100644
+--- a/arch/arm/mach-mvebu/dram.c
++++ b/arch/arm/mach-mvebu/dram.c
+@@ -294,11 +294,11 @@ int dram_init_banksize(void)
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		gd->bd->bi_dram[i].start = mvebu_sdram_bar(i);
+-		gd->bd->bi_dram[i].size = mvebu_sdram_bs(i);
++		gd->dram[i].start = mvebu_sdram_bar(i);
++		gd->dram[i].size = mvebu_sdram_bs(i);
+ 
+ 		/* Clip the banksize to 1GiB if it exceeds the max size */
+-		size += gd->bd->bi_dram[i].size;
++		size += gd->dram[i].size;
+ 		if (size > MVEBU_SDRAM_SIZE_MAX)
+ 			mvebu_sdram_bs_set(i, 0x40000000);
+ 	}
+diff --git a/arch/arm/mach-omap2/am33xx/board.c b/arch/arm/mach-omap2/am33xx/board.c
+index 4e9ad8935e3..38e4cfdb5b7 100644
+--- a/arch/arm/mach-omap2/am33xx/board.c
++++ b/arch/arm/mach-omap2/am33xx/board.c
+@@ -80,8 +80,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-omap2/omap-cache.c b/arch/arm/mach-omap2/omap-cache.c
+index 200a08fa5c8..f08a9b263f6 100644
+--- a/arch/arm/mach-omap2/omap-cache.c
++++ b/arch/arm/mach-omap2/omap-cache.c
+@@ -53,11 +53,10 @@ void enable_caches(void)
+ 
+ void dram_bank_mmu_setup(int bank)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int	i;
+ 
+-	u32 start = bd->bi_dram[bank].start >> MMU_SECTION_SHIFT;
+-	u32 size = bd->bi_dram[bank].size >> MMU_SECTION_SHIFT;
++	u32 start = gd->dram[bank].start >> MMU_SECTION_SHIFT;
++	u32 size = gd->dram[bank].size >> MMU_SECTION_SHIFT;
+ 	u32 end = start + size;
+ 
+ 	debug("%s: bank: %d\n", __func__, bank);
+diff --git a/arch/arm/mach-omap2/omap3/emif4.c b/arch/arm/mach-omap2/omap3/emif4.c
+index 049eedfeb65..67e14d70e92 100644
+--- a/arch/arm/mach-omap2/omap3/emif4.c
++++ b/arch/arm/mach-omap2/omap3/emif4.c
+@@ -150,10 +150,10 @@ int dram_init_banksize(void)
+ 	size0 = get_sdr_cs_size(CS0);
+ 	size1 = get_sdr_cs_size(CS1);
+ 
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = size0;
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_1 + get_sdr_cs_offset(CS1);
+-	gd->bd->bi_dram[1].size = size1;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = size0;
++	gd->dram[1].start = PHYS_SDRAM_1 + get_sdr_cs_offset(CS1);
++	gd->dram[1].size = size1;
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-omap2/omap3/sdrc.c b/arch/arm/mach-omap2/omap3/sdrc.c
+index 24fae484369..c4187369c29 100644
+--- a/arch/arm/mach-omap2/omap3/sdrc.c
++++ b/arch/arm/mach-omap2/omap3/sdrc.c
+@@ -222,10 +222,10 @@ int dram_init_banksize(void)
+ 	size0 = get_sdr_cs_size(CS0);
+ 	size1 = get_sdr_cs_size(CS1);
+ 
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = size0;
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_1 + get_sdr_cs_offset(CS1);
+-	gd->bd->bi_dram[1].size = size1;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = size0;
++	gd->dram[1].start = PHYS_SDRAM_1 + get_sdr_cs_offset(CS1);
++	gd->dram[1].size = size1;
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-owl/soc.c b/arch/arm/mach-owl/soc.c
+index 0130cad7678..e316c2cc40e 100644
+--- a/arch/arm/mach-owl/soc.c
++++ b/arch/arm/mach-owl/soc.c
+@@ -50,8 +50,8 @@ int dram_init(void)
+ /* This is called after dram_init() so use get_ram_size result */
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/arch/arm/mach-renesas/memmap-gen3.c b/arch/arm/mach-renesas/memmap-gen3.c
+index d24419f5daa..f7dc2be6cca 100644
+--- a/arch/arm/mach-renesas/memmap-gen3.c
++++ b/arch/arm/mach-renesas/memmap-gen3.c
+@@ -70,8 +70,8 @@ void enable_caches(void)
+ 
+ 	/* Generate entires for DRAM in 32bit address space */
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start = gd->bd->bi_dram[bank].start;
+-		size = gd->bd->bi_dram[bank].size;
++		start = gd->dram[bank].start;
++		size = gd->dram[bank].size;
+ 
+ 		/* Skip empty DRAM banks */
+ 		if (!size)
+@@ -114,8 +114,8 @@ void enable_caches(void)
+ 
+ 	/* Generate entires for DRAM in 64bit address space */
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start = gd->bd->bi_dram[bank].start;
+-		size = gd->bd->bi_dram[bank].size;
++		start = gd->dram[bank].start;
++		size = gd->dram[bank].size;
+ 
+ 		/* Skip empty DRAM banks */
+ 		if (!size)
+diff --git a/arch/arm/mach-renesas/memmap-rzg2l.c b/arch/arm/mach-renesas/memmap-rzg2l.c
+index 3b3c6f7cde9..5981b3c9c4d 100644
+--- a/arch/arm/mach-renesas/memmap-rzg2l.c
++++ b/arch/arm/mach-renesas/memmap-rzg2l.c
+@@ -67,8 +67,8 @@ void enable_caches(void)
+ 
+ 	/* Generate entries for DRAM in 32bit address space */
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start = gd->bd->bi_dram[bank].start;
+-		size = gd->bd->bi_dram[bank].size;
++		start = gd->dram[bank].start;
++		size = gd->dram[bank].size;
+ 
+ 		/* Skip empty DRAM banks */
+ 		if (!size)
+diff --git a/arch/arm/mach-rockchip/rk3588/rk3588.c b/arch/arm/mach-rockchip/rk3588/rk3588.c
+index eedce7b9b08..c8de1a21024 100644
+--- a/arch/arm/mach-rockchip/rk3588/rk3588.c
++++ b/arch/arm/mach-rockchip/rk3588/rk3588.c
+@@ -243,14 +243,14 @@ int arch_cpu_init(void)
+ 
+ int rockchip_dram_init_banksize_fixup(struct bd_info *bd)
+ {
+-	size_t ram_top = bd->bi_dram[1].start + bd->bi_dram[1].size;
++	size_t ram_top = gd->dram[1].start + gd->dram[1].size;
+ 
+ 	if (ram_top > DRAM_GAP_START) {
+-		bd->bi_dram[1].size = DRAM_GAP_START - bd->bi_dram[1].start;
++		gd->dram[1].size = DRAM_GAP_START - gd->dram[1].start;
+ 
+ 		if (ram_top > DRAM_GAP_END && CONFIG_NR_DRAM_BANKS > 2) {
+-			bd->bi_dram[2].start = DRAM_GAP_END;
+-			bd->bi_dram[2].size = ram_top - bd->bi_dram[2].start;
++			gd->dram[2].start = DRAM_GAP_END;
++			gd->dram[2].size = ram_top - gd->dram[2].start;
+ 		}
+ 	}
+ 
+diff --git a/arch/arm/mach-rockchip/sdram.c b/arch/arm/mach-rockchip/sdram.c
+index ea0e3621af7..f0923186fa6 100644
+--- a/arch/arm/mach-rockchip/sdram.c
++++ b/arch/arm/mach-rockchip/sdram.c
+@@ -171,7 +171,7 @@ static int rockchip_dram_init_banksize(void)
+ 
+ 	/*
+ 	 * Rockchip guaranteed DDR_MEM is ordered so no need to worry about
+-	 * bi_dram order.
++	 * dram order.
+ 	 */
+ 	for (i = 0, j = 0; i < ddr_info->count; i++, j++) {
+ 		phys_size_t size = ddr_info->bank[(i + ddr_info->count)];
+@@ -261,8 +261,8 @@ static int rockchip_dram_init_banksize(void)
+ 				 * split the region in two, one for before the
+ 				 * reserved memory area and one for after.
+ 				 */
+-				gd->bd->bi_dram[j].start = start_addr;
+-				gd->bd->bi_dram[j].size = rsrv_start - start_addr;
++				gd->dram[j].start = start_addr;
++				gd->dram[j].size = rsrv_start - start_addr;
+ 
+ 				j++;
+ 
+@@ -281,8 +281,8 @@ static int rockchip_dram_init_banksize(void)
+ 			return -ENOMEM;
+ 		}
+ 
+-		gd->bd->bi_dram[j].start = start_addr;
+-		gd->bd->bi_dram[j].size = size;
++		gd->dram[j].start = start_addr;
++		gd->dram[j].size = size;
+ 	}
+ 
+ 	return 0;
+@@ -309,15 +309,15 @@ int dram_init_banksize(void)
+ 	      ret);
+ 
+ 	/* Reserve 2M for ATF bl31 */
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE + SZ_2M;
+-	gd->bd->bi_dram[0].size = top - gd->bd->bi_dram[0].start;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE + SZ_2M;
++	gd->dram[0].size = top - gd->dram[0].start;
+ 
+ 	/* Add usable memory beyond the blob of space for peripheral near 4GB */
+ 	if (ram_top > SZ_4G && top < SZ_4G) {
+-		gd->bd->bi_dram[1].start = SZ_4G;
+-		gd->bd->bi_dram[1].size = ram_top - gd->bd->bi_dram[1].start;
++		gd->dram[1].start = SZ_4G;
++		gd->dram[1].size = ram_top - gd->dram[1].start;
+ 	} else if (ram_top > SZ_4G && top == SZ_4G) {
+-		gd->bd->bi_dram[0].size = ram_top - gd->bd->bi_dram[0].start;
++		gd->dram[0].size = ram_top - gd->dram[0].start;
+ 	}
+ #else
+ #ifdef CONFIG_SPL_OPTEE_IMAGE
+@@ -327,23 +327,23 @@ int dram_init_banksize(void)
+ 			TRUST_PARAMETER_OFFSET);
+ 
+ 	if (tos_parameter->tee_mem.flags == 1) {
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = tos_parameter->tee_mem.phy_addr
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = tos_parameter->tee_mem.phy_addr
+ 					- CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[1].start = tos_parameter->tee_mem.phy_addr +
++		gd->dram[1].start = tos_parameter->tee_mem.phy_addr +
+ 					tos_parameter->tee_mem.size;
+-		gd->bd->bi_dram[1].size = top - gd->bd->bi_dram[1].start;
++		gd->dram[1].size = top - gd->dram[1].start;
+ 	} else {
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x8400000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x8400000;
+ 		/* Reserve 32M for OPTEE with TA */
+-		gd->bd->bi_dram[1].start = CFG_SYS_SDRAM_BASE
+-					+ gd->bd->bi_dram[0].size + 0x2000000;
+-		gd->bd->bi_dram[1].size = top - gd->bd->bi_dram[1].start;
++		gd->dram[1].start = CFG_SYS_SDRAM_BASE
++					+ gd->dram[0].size + 0x2000000;
++		gd->dram[1].size = top - gd->dram[1].start;
+ 	}
+ #else
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = top - gd->bd->bi_dram[0].start;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = top - gd->dram[0].start;
+ #endif
+ #endif
+ 
+diff --git a/arch/arm/mach-snapdragon/board.c b/arch/arm/mach-snapdragon/board.c
+index 829a0109ac7..35735f1551c 100644
+--- a/arch/arm/mach-snapdragon/board.c
++++ b/arch/arm/mach-snapdragon/board.c
+@@ -73,19 +73,19 @@ static int ddr_bank_cmp(const void *v1, const void *v2)
+ }
+ 
+ /* This has to be done post-relocation since gd->bd isn't preserved */
+-static void qcom_configure_bi_dram(void)
++static void qcom_configure_dram(void)
+ {
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		gd->bd->bi_dram[i].start = prevbl_ddr_banks[i].start;
+-		gd->bd->bi_dram[i].size = prevbl_ddr_banks[i].size;
++		gd->dram[i].start = prevbl_ddr_banks[i].start;
++		gd->dram[i].size = prevbl_ddr_banks[i].size;
+ 	}
+ }
+ 
+ int dram_init_banksize(void)
+ {
+-	qcom_configure_bi_dram();
++	qcom_configure_dram();
+ 
+ 	return 0;
+ }
+@@ -594,15 +594,15 @@ static void build_mem_map(void)
+ 	 */
+ 	mem_map[0].phys = 0x1000;
+ 	mem_map[0].virt = mem_map[0].phys;
+-	mem_map[0].size = gd->bd->bi_dram[0].start - mem_map[0].phys;
++	mem_map[0].size = gd->dram[0].start - mem_map[0].phys;
+ 	mem_map[0].attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
+ 			 PTE_BLOCK_NON_SHARE |
+ 			 PTE_BLOCK_PXN | PTE_BLOCK_UXN;
+ 
+-	for (i = 1, j = 0; i < ARRAY_SIZE(rbx_mem_map) - 1 && gd->bd->bi_dram[j].size; i++, j++) {
+-		mem_map[i].phys = gd->bd->bi_dram[j].start;
++	for (i = 1, j = 0; i < ARRAY_SIZE(rbx_mem_map) - 1 && gd->dram[j].size; i++, j++) {
++		mem_map[i].phys = gd->dram[j].start;
+ 		mem_map[i].virt = mem_map[i].phys;
+-		mem_map[i].size = gd->bd->bi_dram[j].size;
++		mem_map[i].size = gd->dram[j].size;
+ 		mem_map[i].attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) | \
+ 				   PTE_BLOCK_INNER_SHARE;
+ 	}
+diff --git a/arch/arm/mach-socfpga/board.c b/arch/arm/mach-socfpga/board.c
+index 4d7f0b9a79c..b202ca258bc 100644
+--- a/arch/arm/mach-socfpga/board.c
++++ b/arch/arm/mach-socfpga/board.c
+@@ -202,11 +202,10 @@ void board_prep_linux(struct bootm_headers *images)
+ void lmb_arch_add_memory(void)
+ {
+ 	int i;
+-	struct bd_info *bd = gd->bd;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		if (bd->bi_dram[i].size)
+-			lmb_add(bd->bi_dram[i].start, bd->bi_dram[i].size);
++		if (gd->dram[i].size)
++			lmb_add(gd->dram[i].start, gd->dram[i].size);
+ 	}
+ }
+ #endif
+diff --git a/arch/arm/mach-socfpga/misc_arria10.c b/arch/arm/mach-socfpga/misc_arria10.c
+index 7e0f3875b7c..338f73d6e73 100644
+--- a/arch/arm/mach-socfpga/misc_arria10.c
++++ b/arch/arm/mach-socfpga/misc_arria10.c
+@@ -246,7 +246,6 @@ int qspi_flash_software_reset(void)
+ 
+ void dram_bank_mmu_setup(int bank)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	u32 start, size;
+ 	int i;
+ 
+@@ -261,11 +260,11 @@ void dram_bank_mmu_setup(int bank)
+ 	 * The default implementation of this function allows the DRAM dcache
+ 	 * to be enabled only after relocation. However, to speed up ECC
+ 	 * initialization, we want to be able to enable DRAM dcache before
+-	 * relocation, so we don't check GD_FLG_RELOC (this assumes bd->bi_dram
++	 * relocation, so we don't check GD_FLG_RELOC (this assumes gd->dram
+ 	 * is set first).
+ 	 */
+-	start = bd->bi_dram[bank].start >> MMU_SECTION_SHIFT;
+-	size = bd->bi_dram[bank].size >> MMU_SECTION_SHIFT;
++	start = gd->dram[bank].start >> MMU_SECTION_SHIFT;
++	size = gd->dram[bank].size >> MMU_SECTION_SHIFT;
+ 	for (i = start; i < start + size; i++)
+ 		set_section_dcache(i, DCACHE_DEFAULT_OPTION);
+ }
+diff --git a/arch/arm/mach-stm32mp/cmd_stm32prog/stm32prog.c b/arch/arm/mach-stm32mp/cmd_stm32prog/stm32prog.c
+index 835eaf48dfa..76c324b55ae 100644
+--- a/arch/arm/mach-stm32mp/cmd_stm32prog/stm32prog.c
++++ b/arch/arm/mach-stm32mp/cmd_stm32prog/stm32prog.c
+@@ -825,8 +825,8 @@ static int init_device(struct stm32prog_data *data,
+ 		dev->mtd = mtd;
+ 		break;
+ 	case STM32PROG_RAM:
+-		first_addr = gd->bd->bi_dram[0].start;
+-		last_addr = first_addr + gd->bd->bi_dram[0].size;
++		first_addr = gd->dram[0].start;
++		last_addr = first_addr + gd->dram[0].size;
+ 		dev->erase_size = 1;
+ 		break;
+ 	default:
+diff --git a/arch/arm/mach-stm32mp/stm32mp1/cpu.c b/arch/arm/mach-stm32mp/stm32mp1/cpu.c
+index 252aef1852e..4d81c70b230 100644
+--- a/arch/arm/mach-stm32mp/stm32mp1/cpu.c
++++ b/arch/arm/mach-stm32mp/stm32mp1/cpu.c
+@@ -52,7 +52,6 @@ u32 get_bootauth(void)
+  */
+ void dram_bank_mmu_setup(int bank)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int	i;
+ 	phys_addr_t start;
+ 	phys_addr_t addr;
+@@ -67,9 +66,9 @@ void dram_bank_mmu_setup(int bank)
+ 		size = ALIGN(STM32_SYSRAM_SIZE, MMU_SECTION_SIZE);
+ #endif
+ 	} else if (gd->flags & GD_FLG_RELOC) {
+-		/* bd->bi_dram is available only after relocation */
+-		start = bd->bi_dram[bank].start;
+-		size =  bd->bi_dram[bank].size;
++		/* gd->dram is available only after relocation */
++		start = gd->dram[bank].start;
++		size =  gd->dram[bank].size;
+ 		use_lmb = true;
+ 	} else {
+ 		/* mark cacheable and executable the beggining of the DDR */
+diff --git a/arch/arm/mach-tegra/board2.c b/arch/arm/mach-tegra/board2.c
+index 396851c5bd8..1763f95ace4 100644
+--- a/arch/arm/mach-tegra/board2.c
++++ b/arch/arm/mach-tegra/board2.c
+@@ -393,18 +393,18 @@ int dram_init_banksize(void)
+ 
+ 	/* fall back to default DRAM bank size computation */
+ 
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = usable_ram_size_below_4g();
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = usable_ram_size_below_4g();
+ 
+ #ifdef CONFIG_PHYS_64BIT
+ 	if (gd->ram_size > SZ_2G) {
+-		gd->bd->bi_dram[1].start = 0x100000000;
+-		gd->bd->bi_dram[1].size = gd->ram_size - SZ_2G;
++		gd->dram[1].start = 0x100000000;
++		gd->dram[1].size = gd->ram_size - SZ_2G;
+ 	} else
+ #endif
+ 	{
+-		gd->bd->bi_dram[1].start = 0;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[1].start = 0;
++		gd->dram[1].size = 0;
+ 	}
+ 
+ 	return 0;
+@@ -418,7 +418,7 @@ int dram_init_banksize(void)
+  * carve-out, as mentioned above.
+  *
+  * This function is called before dram_init_banksize(), so we can't simply
+- * return gd->bd->bi_dram[1].start + gd->bd->bi_dram[1].size.
++ * return gd->dram[1].start + gd->dram[1].size.
+  */
+ phys_addr_t board_get_usable_ram_top(phys_size_t total_size)
+ {
+diff --git a/arch/arm/mach-tegra/cboot.c b/arch/arm/mach-tegra/cboot.c
+index e2342b2aece..ff15fa28eb5 100644
+--- a/arch/arm/mach-tegra/cboot.c
++++ b/arch/arm/mach-tegra/cboot.c
+@@ -185,8 +185,8 @@ int cboot_dram_init_banksize(void)
+ 	}
+ 
+ 	for (i = 0; i < ram_bank_count; i++) {
+-		gd->bd->bi_dram[i].start = tegra_mem_map[1 + i].virt;
+-		gd->bd->bi_dram[i].size = tegra_mem_map[1 + i].size;
++		gd->dram[i].start = tegra_mem_map[1 + i].virt;
++		gd->dram[i].size = tegra_mem_map[1 + i].size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/arm/mach-uniphier/dram_init.c b/arch/arm/mach-uniphier/dram_init.c
+index 0e1164a2680..ae495808dec 100644
+--- a/arch/arm/mach-uniphier/dram_init.c
++++ b/arch/arm/mach-uniphier/dram_init.c
+@@ -280,9 +280,9 @@ int dram_init_banksize(void)
+ 		return ret;
+ 
+ 	for (i = 0; i < ARRAY_SIZE(dram_map); i++) {
+-		if (i < ARRAY_SIZE(gd->bd->bi_dram)) {
+-			gd->bd->bi_dram[i].start = dram_map[i].base;
+-			gd->bd->bi_dram[i].size = dram_map[i].size;
++		if (i < ARRAY_SIZE(gd->dram)) {
++			gd->dram[i].start = dram_map[i].base;
++			gd->dram[i].size = dram_map[i].size;
+ 		}
+ 
+ 		if (!dram_map[i].size)
+diff --git a/arch/arm/mach-uniphier/fdt-fixup.c b/arch/arm/mach-uniphier/fdt-fixup.c
+index dfa32fdd48b..4e1de15cd98 100644
+--- a/arch/arm/mach-uniphier/fdt-fixup.c
++++ b/arch/arm/mach-uniphier/fdt-fixup.c
+@@ -4,6 +4,7 @@
+  *   Author: Masahiro Yamada <yamada.masahiro@socionext.com>
+  */
+ 
++#include <asm/global_data.h>
+ #include <fdt_support.h>
+ #include <fdtdec.h>
+ #include <jffs2/load_kernel.h>
+@@ -20,6 +21,7 @@
+  */
+ static int uniphier_ld20_fdt_mem_rsv(void *fdt, struct bd_info *bd)
+ {
++	DECLARE_GLOBAL_DATA_PTR;
+ 	unsigned long rsv_addr;
+ 	const unsigned long rsv_size = 64;
+ 	int i, ret;
+@@ -28,11 +30,11 @@ static int uniphier_ld20_fdt_mem_rsv(void *fdt, struct bd_info *bd)
+ 	    uniphier_get_soc_id() != UNIPHIER_LD20_ID)
+ 		return 0;
+ 
+-	for (i = 0; i < ARRAY_SIZE(bd->bi_dram); i++) {
+-		if (!bd->bi_dram[i].size)
++	for (i = 0; i < ARRAY_SIZE(gd->dram); i++) {
++		if (!gd->dram[i].size)
+ 			continue;
+ 
+-		rsv_addr = bd->bi_dram[i].start + bd->bi_dram[i].size;
++		rsv_addr = gd->dram[i].start + gd->dram[i].size;
+ 		rsv_addr -= rsv_size;
+ 
+ 		ret = fdt_add_mem_rsv(fdt, rsv_addr, rsv_size);
+diff --git a/arch/arm/mach-versal-net/cpu.c b/arch/arm/mach-versal-net/cpu.c
+index d088e440f63..78ead1f45f6 100644
+--- a/arch/arm/mach-versal-net/cpu.c
++++ b/arch/arm/mach-versal-net/cpu.c
+@@ -69,12 +69,12 @@ void mem_map_fill(void)
+ 
+ 	for (int i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+ 		/* Zero size means no more DDR that's this is end */
+-		if (!gd->bd->bi_dram[i].size)
++		if (!gd->dram[i].size)
+ 			break;
+ 
+-		versal_mem_map[banks].virt = gd->bd->bi_dram[i].start;
+-		versal_mem_map[banks].phys = gd->bd->bi_dram[i].start;
+-		versal_mem_map[banks].size = gd->bd->bi_dram[i].size;
++		versal_mem_map[banks].virt = gd->dram[i].start;
++		versal_mem_map[banks].phys = gd->dram[i].start;
++		versal_mem_map[banks].size = gd->dram[i].size;
+ 		versal_mem_map[banks].attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+ 					      PTE_BLOCK_INNER_SHARE;
+ 		banks = banks + 1;
+diff --git a/arch/arm/mach-versal/cpu.c b/arch/arm/mach-versal/cpu.c
+index 363ce3007fd..0dd5cc153c4 100644
+--- a/arch/arm/mach-versal/cpu.c
++++ b/arch/arm/mach-versal/cpu.c
+@@ -82,21 +82,21 @@ void mem_map_fill(void)
+ 
+ 	for (int i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+ 		/* Zero size means no more DDR that's this is end */
+-		if (!gd->bd->bi_dram[i].size)
++		if (!gd->dram[i].size)
+ 			break;
+ 
+ #if defined(CONFIG_VERSAL_NO_DDR)
+-		if (gd->bd->bi_dram[i].start < 0x80000000UL ||
+-		    gd->bd->bi_dram[i].start > 0x100000000UL) {
++		if (gd->dram[i].start < 0x80000000UL ||
++		    gd->dram[i].start > 0x100000000UL) {
+ 			printf("Ignore caches over %llx/%llx\n",
+-			       gd->bd->bi_dram[i].start,
+-			       gd->bd->bi_dram[i].size);
++			       gd->dram[i].start,
++			       gd->dram[i].size);
+ 			continue;
+ 		}
+ #endif
+-		versal_mem_map[banks].virt = gd->bd->bi_dram[i].start;
+-		versal_mem_map[banks].phys = gd->bd->bi_dram[i].start;
+-		versal_mem_map[banks].size = gd->bd->bi_dram[i].size;
++		versal_mem_map[banks].virt = gd->dram[i].start;
++		versal_mem_map[banks].phys = gd->dram[i].start;
++		versal_mem_map[banks].size = gd->dram[i].size;
+ 		versal_mem_map[banks].attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+ 					      PTE_BLOCK_INNER_SHARE;
+ 		banks = banks + 1;
+diff --git a/arch/arm/mach-versal2/cpu.c b/arch/arm/mach-versal2/cpu.c
+index a81609cdec7..f65c231bdab 100644
+--- a/arch/arm/mach-versal2/cpu.c
++++ b/arch/arm/mach-versal2/cpu.c
+@@ -109,7 +109,7 @@ void mem_map_fill(struct mm_region *bank_info, u32 num_banks)
+  * fill_bd_mem_info() - Copy DRAM banks from mem_map to bd_info
+  *
+  * Transfers DRAM bank information from the global versal2_mem_map[]
+- * array to bd->bi_dram[] for passing memory configuration to the
++ * array to gd->dram[] for passing memory configuration to the
+  * Linux kernel via boot parameters (ATAGS/FDT). Each bank's physical
+  * address and size are copied.
+  *
+@@ -119,15 +119,14 @@ void mem_map_fill(struct mm_region *bank_info, u32 num_banks)
+  */
+ void fill_bd_mem_info(void)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int banks = VERSAL2_MEM_MAP_USED;
+ 
+ 	for (int i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+ 		if (!versal2_mem_map[banks].size)
+ 			break;
+ 
+-		bd->bi_dram[i].start = versal2_mem_map[banks].phys;
+-		bd->bi_dram[i].size = versal2_mem_map[banks].size;
++		gd->dram[i].start = versal2_mem_map[banks].phys;
++		gd->dram[i].size = versal2_mem_map[banks].size;
+ 		banks++;
+ 	}
+ }
+diff --git a/arch/arm/mach-zynqmp/cpu.c b/arch/arm/mach-zynqmp/cpu.c
+index 5f194aaff9a..3dc47e5d48e 100644
+--- a/arch/arm/mach-zynqmp/cpu.c
++++ b/arch/arm/mach-zynqmp/cpu.c
+@@ -92,12 +92,12 @@ void mem_map_fill(void)
+ #if !defined(CONFIG_ZYNQMP_NO_DDR)
+ 	for (int i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+ 		/* Zero size means no more DDR that's this is end */
+-		if (!gd->bd->bi_dram[i].size)
++		if (!gd->dram[i].size)
+ 			break;
+ 
+-		zynqmp_mem_map[banks].virt = gd->bd->bi_dram[i].start;
+-		zynqmp_mem_map[banks].phys = gd->bd->bi_dram[i].start;
+-		zynqmp_mem_map[banks].size = gd->bd->bi_dram[i].size;
++		zynqmp_mem_map[banks].virt = gd->dram[i].start;
++		zynqmp_mem_map[banks].phys = gd->dram[i].start;
++		zynqmp_mem_map[banks].size = gd->dram[i].size;
+ 		zynqmp_mem_map[banks].attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+ 					      PTE_BLOCK_INNER_SHARE;
+ 		banks = banks + 1;
+diff --git a/arch/mips/mach-octeon/dram.c b/arch/mips/mach-octeon/dram.c
+index 5b1311d8b5b..817728aa569 100644
+--- a/arch/mips/mach-octeon/dram.c
++++ b/arch/mips/mach-octeon/dram.c
+@@ -41,8 +41,8 @@ int dram_init(void)
+ 		 * No DDR init yet -> run in L2 cache
+ 		 */
+ 		gd->ram_size = (4 << 20);
+-		gd->bd->bi_dram[0].size = gd->ram_size;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[0].size = gd->ram_size;
++		gd->dram[1].size = 0;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/riscv/cpu/k1/dram.c b/arch/riscv/cpu/k1/dram.c
+index cc1e903c9dd..2893bc6b99a 100644
+--- a/arch/riscv/cpu/k1/dram.c
++++ b/arch/riscv/cpu/k1/dram.c
+@@ -56,12 +56,12 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = min_t(phys_size_t, gd->ram_size, SZ_2G);
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = min_t(phys_size_t, gd->ram_size, SZ_2G);
+ 
+ 	if (gd->ram_size > SZ_2G && CONFIG_NR_DRAM_BANKS > 1) {
+-		gd->bd->bi_dram[1].start = 0x100000000;
+-		gd->bd->bi_dram[1].size = gd->ram_size - SZ_2G;
++		gd->dram[1].start = 0x100000000;
++		gd->dram[1].size = gd->ram_size - SZ_2G;
+ 	}
+ 
+ 	return 0;
+@@ -82,8 +82,8 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		start[i] = gd->bd->bi_dram[i].start;
+-		size[i] = gd->bd->bi_dram[i].size;
++		start[i] = gd->dram[i].start;
++		size[i] = gd->dram[i].size;
+ 	}
+ 
+ 	return fdt_fixup_memory_banks(blob, start, size, CONFIG_NR_DRAM_BANKS);
+diff --git a/arch/sandbox/cpu/spl.c b/arch/sandbox/cpu/spl.c
+index 7ee4975523e..d00007a9440 100644
+--- a/arch/sandbox/cpu/spl.c
++++ b/arch/sandbox/cpu/spl.c
+@@ -131,8 +131,8 @@ SPL_LOAD_IMAGE_METHOD("sandbox_image", 7, BOOT_DEVICE_BOARD, load_from_image);
+ int dram_init_banksize(void)
+ {
+ 	/* These are necessary so TFTP can use LMBs to check its load address */
+-	gd->bd->bi_dram[0].start = gd->ram_base;
+-	gd->bd->bi_dram[0].size = get_effective_memsize();
++	gd->dram[0].start = gd->ram_base;
++	gd->dram[0].size = get_effective_memsize();
+ 
+ 	return 0;
+ }
+diff --git a/arch/x86/cpu/coreboot/sdram.c b/arch/x86/cpu/coreboot/sdram.c
+index cc1edd7badd..81604ee12fb 100644
+--- a/arch/x86/cpu/coreboot/sdram.c
++++ b/arch/x86/cpu/coreboot/sdram.c
+@@ -91,8 +91,8 @@ int dram_init_banksize(void)
+ 			struct memrange *memrange = &lib_sysinfo.memrange[i];
+ 
+ 			if (memrange->type == CB_MEM_RAM) {
+-				gd->bd->bi_dram[j].start = memrange->base;
+-				gd->bd->bi_dram[j].size = memrange->size;
++				gd->dram[j].start = memrange->base;
++				gd->dram[j].size = memrange->size;
+ 				j++;
+ 				if (j >= CONFIG_NR_DRAM_BANKS)
+ 					break;
+diff --git a/arch/x86/cpu/efi/payload.c b/arch/x86/cpu/efi/payload.c
+index 6845ce72ff9..b86d50b2cab 100644
+--- a/arch/x86/cpu/efi/payload.c
++++ b/arch/x86/cpu/efi/payload.c
+@@ -123,8 +123,8 @@ int dram_init_banksize(void)
+ 		if (desc->type != EFI_CONVENTIONAL_MEMORY ||
+ 		    (desc->num_pages << EFI_PAGE_SHIFT) < 1 << 20)
+ 			continue;
+-		gd->bd->bi_dram[num_banks].start = desc->physical_start;
+-		gd->bd->bi_dram[num_banks].size = desc->num_pages <<
++		gd->dram[num_banks].start = desc->physical_start;
++		gd->dram[num_banks].size = desc->num_pages <<
+ 			EFI_PAGE_SHIFT;
+ 		num_banks++;
+ 	}
+diff --git a/arch/x86/cpu/efi/sdram.c b/arch/x86/cpu/efi/sdram.c
+index 6fe40071140..e09fce8bb1b 100644
+--- a/arch/x86/cpu/efi/sdram.c
++++ b/arch/x86/cpu/efi/sdram.c
+@@ -24,8 +24,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = efi_get_ram_base();
+-	gd->bd->bi_dram[0].size = CONFIG_EFI_RAM_SIZE;
++	gd->dram[0].start = efi_get_ram_base();
++	gd->dram[0].size = CONFIG_EFI_RAM_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/arch/x86/cpu/intel_common/mrc.c b/arch/x86/cpu/intel_common/mrc.c
+index baa1f0e32d6..11ce97b5143 100644
+--- a/arch/x86/cpu/intel_common/mrc.c
++++ b/arch/x86/cpu/intel_common/mrc.c
+@@ -67,8 +67,8 @@ void mrc_common_dram_init_banksize(void)
+ 
+ 		if (area->start >= 1ULL << 32)
+ 			continue;
+-		gd->bd->bi_dram[num_banks].start = area->start;
+-		gd->bd->bi_dram[num_banks].size = area->size;
++		gd->dram[num_banks].start = area->start;
++		gd->dram[num_banks].size = area->size;
+ 		num_banks++;
+ 	}
+ }
+diff --git a/arch/x86/cpu/ivybridge/sdram_nop.c b/arch/x86/cpu/ivybridge/sdram_nop.c
+index d20c9a2a379..a5e81dfada5 100644
+--- a/arch/x86/cpu/ivybridge/sdram_nop.c
++++ b/arch/x86/cpu/ivybridge/sdram_nop.c
+@@ -11,8 +11,8 @@ DECLARE_GLOBAL_DATA_PTR;
+ int dram_init(void)
+ {
+ 	gd->ram_size = 1ULL << 31;
+-	gd->bd->bi_dram[0].start = 0;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = 0;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/arch/x86/cpu/qemu/dram.c b/arch/x86/cpu/qemu/dram.c
+index ba3638e6acc..3cba04f2c3e 100644
+--- a/arch/x86/cpu/qemu/dram.c
++++ b/arch/x86/cpu/qemu/dram.c
+@@ -69,13 +69,13 @@ int dram_init_banksize(void)
+ {
+ 	u64 high_mem_size;
+ 
+-	gd->bd->bi_dram[0].start = 0;
+-	gd->bd->bi_dram[0].size = qemu_get_low_memory_size();
++	gd->dram[0].start = 0;
++	gd->dram[0].size = qemu_get_low_memory_size();
+ 
+ 	high_mem_size = qemu_get_high_memory_size();
+ 	if (high_mem_size) {
+-		gd->bd->bi_dram[1].start = SZ_4G;
+-		gd->bd->bi_dram[1].size = high_mem_size;
++		gd->dram[1].start = SZ_4G;
++		gd->dram[1].size = high_mem_size;
+ 	}
+ 
+ 	return 0;
+diff --git a/arch/x86/cpu/quark/dram.c b/arch/x86/cpu/quark/dram.c
+index 34e576940d4..34fdb7e026a 100644
+--- a/arch/x86/cpu/quark/dram.c
++++ b/arch/x86/cpu/quark/dram.c
+@@ -169,8 +169,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = 0;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = 0;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/arch/x86/cpu/slimbootloader/sdram.c b/arch/x86/cpu/slimbootloader/sdram.c
+index 75ca5273625..5aa4f6d3e07 100644
+--- a/arch/x86/cpu/slimbootloader/sdram.c
++++ b/arch/x86/cpu/slimbootloader/sdram.c
+@@ -129,8 +129,8 @@ int dram_init_banksize(void)
+ 		return 0;
+ 
+ 	/* simply use a single bank to have whole size for now */
+-	gd->bd->bi_dram[0].start = 0;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = 0;
++	gd->dram[0].size = gd->ram_size;
+ 	return 0;
+ }
+ 
+diff --git a/arch/x86/cpu/tangier/sdram.c b/arch/x86/cpu/tangier/sdram.c
+index 6192f2296b8..6ce96b0569b 100644
+--- a/arch/x86/cpu/tangier/sdram.c
++++ b/arch/x86/cpu/tangier/sdram.c
+@@ -160,8 +160,8 @@ static int sfi_get_bank_size(void)
+ 		if (mentry->type != SFI_MEM_CONV)
+ 			continue;
+ 
+-		gd->bd->bi_dram[bank].start = mentry->phys_start;
+-		gd->bd->bi_dram[bank].size = mentry->pages << 12;
++		gd->dram[bank].start = mentry->phys_start;
++		gd->dram[bank].size = mentry->pages << 12;
+ 		bank++;
+ 	}
+ 
+diff --git a/arch/x86/lib/bootm.c b/arch/x86/lib/bootm.c
+index cde4fbf3557..e054f42fa86 100644
+--- a/arch/x86/lib/bootm.c
++++ b/arch/x86/lib/bootm.c
+@@ -43,14 +43,13 @@ void bootm_announce_and_cleanup(void)
+ #if defined(CONFIG_OF_LIBFDT) && !defined(CONFIG_OF_NO_KERNEL)
+ int arch_fixup_memory_node(void *blob)
+ {
+-	struct bd_info	*bd = gd->bd;
+ 	int bank;
+ 	u64 start[CONFIG_NR_DRAM_BANKS];
+ 	u64 size[CONFIG_NR_DRAM_BANKS];
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start[bank] = bd->bi_dram[bank].start;
+-		size[bank] = bd->bi_dram[bank].size;
++		start[bank] = gd->dram[bank].start;
++		size[bank] = gd->dram[bank].size;
+ 	}
+ 
+ 	return fdt_fixup_memory_banks(blob, start, size, CONFIG_NR_DRAM_BANKS);
+diff --git a/arch/x86/lib/fsp/fsp_dram.c b/arch/x86/lib/fsp/fsp_dram.c
+index 730721dc176..a45e4060ef2 100644
+--- a/arch/x86/lib/fsp/fsp_dram.c
++++ b/arch/x86/lib/fsp/fsp_dram.c
+@@ -64,8 +64,8 @@ int dram_init_banksize(void)
+ 	update_mtrr = CONFIG_IS_ENABLED(FSP_VERSION2);
+ 
+ 	if (!ll_boot_init()) {
+-		gd->bd->bi_dram[0].start = 0;
+-		gd->bd->bi_dram[0].size = gd->ram_size;
++		gd->dram[0].start = 0;
++		gd->dram[0].size = gd->ram_size;
+ 
+ 		if (update_mtrr)
+ 			mtrr_add_request(MTRR_TYPE_WRBACK, 0, gd->ram_size);
+@@ -89,21 +89,21 @@ int dram_init_banksize(void)
+ 			mtrr_top = max(mtrr_top,
+ 				       res_desc->phys_start + res_desc->len);
+ 		} else {
+-			gd->bd->bi_dram[bank].start = res_desc->phys_start;
+-			gd->bd->bi_dram[bank].size = res_desc->len;
++			gd->dram[bank].start = res_desc->phys_start;
++			gd->dram[bank].size = res_desc->len;
+ 			if (update_mtrr)
+ 				mtrr_add_request(MTRR_TYPE_WRBACK,
+ 						 res_desc->phys_start,
+ 						 res_desc->len);
+ 			log_debug("ram %llx %llx\n",
+-				  gd->bd->bi_dram[bank].start,
+-				  gd->bd->bi_dram[bank].size);
++				  gd->dram[bank].start,
++				  gd->dram[bank].size);
+ 		}
+ 	}
+ 
+ 	/* Add the memory below 4GB */
+-	gd->bd->bi_dram[0].start = 0;
+-	gd->bd->bi_dram[0].size = low_end;
++	gd->dram[0].start = 0;
++	gd->dram[0].size = low_end;
+ 
+ 	/*
+ 	 * Set up an MTRR to the top of low, reserved memory. This is necessary
+@@ -184,7 +184,7 @@ unsigned int install_e820_map(unsigned int max_entries,
+ #if CONFIG_IS_ENABLED(HANDOFF) && IS_ENABLED(CONFIG_USE_HOB)
+ int handoff_arch_save(struct spl_handoff *ho)
+ {
+-	ho->arch.usable_ram_top = gd->bd->bi_dram[0].size;
++	ho->arch.usable_ram_top = gd->dram[0].size;
+ 	ho->arch.hob_list = gd->arch.hob_list;
+ 
+ 	return 0;
+diff --git a/board/CZ.NIC/turris_1x/turris_1x.c b/board/CZ.NIC/turris_1x/turris_1x.c
+index 2f9557a4170..32535ed6ee0 100644
+--- a/board/CZ.NIC/turris_1x/turris_1x.c
++++ b/board/CZ.NIC/turris_1x/turris_1x.c
+@@ -42,9 +42,9 @@ int dram_init_banksize(void)
+ 
+ 	static_assert(CONFIG_NR_DRAM_BANKS >= 3);
+ 
+-	gd->bd->bi_dram[0].start = gd->ram_base;
+-	gd->bd->bi_dram[0].size = get_effective_memsize();
+-	size -= gd->bd->bi_dram[0].size;
++	gd->dram[0].start = gd->ram_base;
++	gd->dram[0].size = get_effective_memsize();
++	size -= gd->dram[0].size;
+ 
+ 	/* Note: This address space is not mapped via TLB entries in U-Boot */
+ 
+@@ -68,16 +68,16 @@ int dram_init_banksize(void)
+ 
+ 	if (size > 0) {
+ 		/* Free space between PCIe bus 3 MEM and NOR */
+-		gd->bd->bi_dram[1].start = 0xc0200000;
+-		gd->bd->bi_dram[1].size = min(size, 0xef000000 - gd->bd->bi_dram[1].start);
+-		size -= gd->bd->bi_dram[1].size;
++		gd->dram[1].start = 0xc0200000;
++		gd->dram[1].size = min(size, 0xef000000 - gd->dram[1].start);
++		size -= gd->dram[1].size;
+ 	}
+ 
+ 	if (size > 0) {
+ 		/* Free space between NOR and NAND */
+-		gd->bd->bi_dram[2].start = 0xf0000000;
+-		gd->bd->bi_dram[2].size = min(size, 0xff800000 - gd->bd->bi_dram[2].start);
+-		size -= gd->bd->bi_dram[2].size;
++		gd->dram[2].start = 0xf0000000;
++		gd->dram[2].size = min(size, 0xff800000 - gd->dram[2].start);
++		size -= gd->dram[2].size;
+ 	}
+ #else
+ 	puts("\n\n!!! TODO: fix sdcard >2GB RAM\n\n\n");
+@@ -231,8 +231,8 @@ void ft_memory_setup(void *blob, struct bd_info *bd)
+ 
+ 	if (!env_get("bootm_low") && !env_get("bootm_size")) {
+ 		for (count = 0; count < CONFIG_NR_DRAM_BANKS; count++) {
+-			start[count] = gd->bd->bi_dram[count].start;
+-			size[count] = gd->bd->bi_dram[count].size;
++			start[count] = gd->dram[count].start;
++			size[count] = gd->dram[count].size;
+ 			if (!size[count])
+ 				break;
+ 		}
+@@ -452,13 +452,13 @@ static void recalculate_used_pcie_mem(void)
+ 	size = gd->ram_size;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++)
+-		size -= gd->bd->bi_dram[i].size;
++		size -= gd->dram[i].size;
+ 
+ 	if (size == 0)
+ 		return;
+ 
+ 	e = find_law_by_addr_id(CFG_SYS_PCIE3_MEM_PHYS, LAW_TRGT_IF_PCIE_3);
+-	if (e.index < 0 && gd->bd->bi_dram[1].size > 0) {
++	if (e.index < 0 && gd->dram[1].size > 0) {
+ 		/*
+ 		 * If there is no LAW for PCIe 3 MEM then 3rd PCIe controller
+ 		 * is inactive, which is the case for Turris 1.0 boards. So
+@@ -471,8 +471,8 @@ static void recalculate_used_pcie_mem(void)
+ 		printf("Reserving unused ");
+ 		print_size(bank_size, "");
+ 		printf(" of PCIe 3 MEM for DDR RAM\n");
+-		gd->bd->bi_dram[1].start -= bank_size;
+-		gd->bd->bi_dram[1].size += bank_size;
++		gd->dram[1].start -= bank_size;
++		gd->dram[1].size += bank_size;
+ 		size -= bank_size;
+ 		if (size == 0)
+ 			return;
+@@ -534,9 +534,9 @@ static void recalculate_used_pcie_mem(void)
+ 		printf("Reserving unused ");
+ 		print_size(free_size2, "");
+ 		printf(" of PCIe 2 MEM for DDR RAM\n");
+-		gd->bd->bi_dram[i].start = free_start2;
+-		gd->bd->bi_dram[i].size = min(size, free_size2);
+-		size -= gd->bd->bi_dram[i].start;
++		gd->dram[i].start = free_start2;
++		gd->dram[i].size = min(size, free_size2);
++		size -= gd->dram[i].start;
+ 		i++;
+ 		if (size == 0)
+ 			return;
+@@ -548,9 +548,9 @@ static void recalculate_used_pcie_mem(void)
+ 		printf("Reserving unused ");
+ 		print_size(free_size1, "");
+ 		printf(" of PCIe 1 MEM for DDR RAM\n");
+-		gd->bd->bi_dram[i].start = free_start1;
+-		gd->bd->bi_dram[i].size = min(size, free_size1);
+-		size -= gd->bd->bi_dram[i].size;
++		gd->dram[i].start = free_start1;
++		gd->dram[i].size = min(size, free_size1);
++		size -= gd->dram[i].size;
+ 		i++;
+ 		if (size == 0)
+ 			return;
+diff --git a/board/armltd/corstone1000/corstone1000.c b/board/armltd/corstone1000/corstone1000.c
+index 16d0e679c3e..eb0f9c06849 100644
+--- a/board/armltd/corstone1000/corstone1000.c
++++ b/board/armltd/corstone1000/corstone1000.c
+@@ -86,8 +86,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_1_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = PHYS_SDRAM_1_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/armltd/integrator/integrator.c b/board/armltd/integrator/integrator.c
+index eaf87e3bfe3..6cd24bf25fb 100644
+--- a/board/armltd/integrator/integrator.c
++++ b/board/armltd/integrator/integrator.c
+@@ -137,7 +137,7 @@ int misc_init_r (void)
+ 
+ int dram_init (void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
+ #ifdef CONFIG_CM_SPD_DETECT
+ 	{
+ extern void dram_query(void);
+@@ -170,7 +170,7 @@ extern void dram_query(void);
+ 				    PHYS_SDRAM_1_SIZE);
+ #endif /* CM_SPD_DETECT */
+ 	/* We only have one bank of RAM, set it to whatever was detected */
+-	gd->bd->bi_dram[0].size	 = gd->ram_size;
++	gd->dram[0].size	 = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/board/armltd/total_compute/total_compute.c b/board/armltd/total_compute/total_compute.c
+index 12bb6defab2..057e916ab1b 100644
+--- a/board/armltd/total_compute/total_compute.c
++++ b/board/armltd/total_compute/total_compute.c
+@@ -89,9 +89,9 @@ void build_mem_map(void)
+ 		 * The first node is for I/O device, start from node 1 for
+ 		 * updating DRAM info.
+ 		 */
+-		mem_map[i + 1].virt = gd->bd->bi_dram[i].start;
+-		mem_map[i + 1].phys = gd->bd->bi_dram[i].start;
+-		mem_map[i + 1].size = gd->bd->bi_dram[i].size;
++		mem_map[i + 1].virt = gd->dram[i].start;
++		mem_map[i + 1].phys = gd->dram[i].start;
++		mem_map[i + 1].size = gd->dram[i].size;
+ 		mem_map[i + 1].attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) |
+ 				       PTE_BLOCK_INNER_SHARE;
+ 	}
+diff --git a/board/armltd/vexpress/vexpress_common.c b/board/armltd/vexpress/vexpress_common.c
+index 3833af59b09..87e53f64e06 100644
+--- a/board/armltd/vexpress/vexpress_common.c
++++ b/board/armltd/vexpress/vexpress_common.c
+@@ -79,11 +79,11 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size =
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size =
+ 			get_ram_size((long *)PHYS_SDRAM_1, PHYS_SDRAM_1_SIZE);
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
+-	gd->bd->bi_dram[1].size =
++	gd->dram[1].start = PHYS_SDRAM_2;
++	gd->dram[1].size =
+ 			get_ram_size((long *)PHYS_SDRAM_2, PHYS_SDRAM_2_SIZE);
+ 
+ 	return 0;
+diff --git a/board/atmel/common/video_display.c b/board/atmel/common/video_display.c
+index 77188820581..7cb492b2da6 100644
+--- a/board/atmel/common/video_display.c
++++ b/board/atmel/common/video_display.c
+@@ -40,7 +40,7 @@ int at91_video_show_board_info(void)
+ 
+ 	dram_size = 0;
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++)
+-		dram_size += gd->bd->bi_dram[i].size;
++		dram_size += gd->dram[i].size;
+ 
+ 	nand_size = 0;
+ #ifdef CONFIG_NAND_ATMEL
+diff --git a/board/atmel/sam9x60_curiosity/sam9x60_curiosity.c b/board/atmel/sam9x60_curiosity/sam9x60_curiosity.c
+index 43797d625e9..b19ae3b4b03 100644
+--- a/board/atmel/sam9x60_curiosity/sam9x60_curiosity.c
++++ b/board/atmel/sam9x60_curiosity/sam9x60_curiosity.c
+@@ -66,7 +66,7 @@ int misc_init_r(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	board_leds_init();
+ 
+diff --git a/board/atmel/sam9x75_curiosity/sam9x75_curiosity.c b/board/atmel/sam9x75_curiosity/sam9x75_curiosity.c
+index 364b6a3e24b..5c35239a90a 100644
+--- a/board/atmel/sam9x75_curiosity/sam9x75_curiosity.c
++++ b/board/atmel/sam9x75_curiosity/sam9x75_curiosity.c
+@@ -45,7 +45,7 @@ void board_debug_uart_init(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	return 0;
+ }
+diff --git a/board/atmel/sama5d27_som1_ek/sama5d27_som1_ek.c b/board/atmel/sama5d27_som1_ek/sama5d27_som1_ek.c
+index 858061bf9f9..33ae6a76bf7 100644
+--- a/board/atmel/sama5d27_som1_ek/sama5d27_som1_ek.c
++++ b/board/atmel/sama5d27_som1_ek/sama5d27_som1_ek.c
+@@ -64,7 +64,7 @@ void board_debug_uart_init(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	rgb_leds_init();
+ 
+diff --git a/board/atmel/sama5d27_wlsom1_ek/sama5d27_wlsom1_ek.c b/board/atmel/sama5d27_wlsom1_ek/sama5d27_wlsom1_ek.c
+index 19341d325bd..0e2d5592753 100644
+--- a/board/atmel/sama5d27_wlsom1_ek/sama5d27_wlsom1_ek.c
++++ b/board/atmel/sama5d27_wlsom1_ek/sama5d27_wlsom1_ek.c
+@@ -58,7 +58,7 @@ void board_debug_uart_init(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	rgb_leds_init();
+ 
+diff --git a/board/atmel/sama5d29_curiosity/sama5d29_curiosity.c b/board/atmel/sama5d29_curiosity/sama5d29_curiosity.c
+index 8759ff6f01a..1a17db1bd5b 100644
+--- a/board/atmel/sama5d29_curiosity/sama5d29_curiosity.c
++++ b/board/atmel/sama5d29_curiosity/sama5d29_curiosity.c
+@@ -65,7 +65,7 @@ int board_early_init_f(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	rgb_leds_init();
+ 
+diff --git a/board/atmel/sama5d2_xplained/sama5d2_xplained.c b/board/atmel/sama5d2_xplained/sama5d2_xplained.c
+index c0862f58606..b48e8fe7697 100644
+--- a/board/atmel/sama5d2_xplained/sama5d2_xplained.c
++++ b/board/atmel/sama5d2_xplained/sama5d2_xplained.c
+@@ -63,7 +63,7 @@ void board_debug_uart_init(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	rgb_leds_init();
+ 
+diff --git a/board/atmel/sama7d65_curiosity/sama7d65_curiosity.c b/board/atmel/sama7d65_curiosity/sama7d65_curiosity.c
+index 764c8f035c9..cdf2793b643 100644
+--- a/board/atmel/sama7d65_curiosity/sama7d65_curiosity.c
++++ b/board/atmel/sama7d65_curiosity/sama7d65_curiosity.c
+@@ -52,7 +52,7 @@ void board_debug_uart_init(void)
+ int board_init(void)
+ {
+ 	/* address of boot parameters */
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	board_leds_init();
+ 
+diff --git a/board/atmel/sama7g54_curiosity/sama7g54_curiosity.c b/board/atmel/sama7g54_curiosity/sama7g54_curiosity.c
+index b05c9754c96..02543d8e99f 100644
+--- a/board/atmel/sama7g54_curiosity/sama7g54_curiosity.c
++++ b/board/atmel/sama7g54_curiosity/sama7g54_curiosity.c
+@@ -19,7 +19,7 @@ DECLARE_GLOBAL_DATA_PTR;
+ int board_init(void)
+ {
+ 	// Address of boot parameters
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	return 0;
+ }
+diff --git a/board/axiado/scm3005/scm3005.c b/board/axiado/scm3005/scm3005.c
+index 4643ba4a55c..b2df6d89cd8 100644
+--- a/board/axiado/scm3005/scm3005.c
++++ b/board/axiado/scm3005/scm3005.c
+@@ -96,8 +96,8 @@ int dram_init(void)
+  */
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = CFG_SYS_SDRAM_SIZE;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = CFG_SYS_SDRAM_SIZE;
+ 	return 0;
+ }
+ 
+diff --git a/board/broadcom/bcmns3/ns3.c b/board/broadcom/bcmns3/ns3.c
+index bb2f1e4f62a..2683f46f41c 100644
+--- a/board/broadcom/bcmns3/ns3.c
++++ b/board/broadcom/bcmns3/ns3.c
+@@ -176,8 +176,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = (BCM_NS3_MEM_END - SZ_16M);
+-	gd->bd->bi_dram[0].size = SZ_16M;
++	gd->dram[0].start = (BCM_NS3_MEM_END - SZ_16M);
++	gd->dram[0].size = SZ_16M;
+ 
+ 	return 0;
+ }
+diff --git a/board/compulab/cm_fx6/cm_fx6.c b/board/compulab/cm_fx6/cm_fx6.c
+index 40047cf6783..01ebb0a57cc 100644
+--- a/board/compulab/cm_fx6/cm_fx6.c
++++ b/board/compulab/cm_fx6/cm_fx6.c
+@@ -666,34 +666,34 @@ int misc_init_r(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[1].start = PHYS_SDRAM_2;
+ 
+ 	switch (gd->ram_size) {
+ 	case 0x10000000: /* DDR_16BIT_256MB */
+-		gd->bd->bi_dram[0].size = 0x10000000;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[0].size = 0x10000000;
++		gd->dram[1].size = 0;
+ 		break;
+ 	case 0x20000000: /* DDR_32BIT_512MB */
+-		gd->bd->bi_dram[0].size = 0x20000000;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[0].size = 0x20000000;
++		gd->dram[1].size = 0;
+ 		break;
+ 	case 0x40000000:
+ 		if (is_cpu_type(MXC_CPU_MX6SOLO)) { /* DDR_32BIT_1GB */
+-			gd->bd->bi_dram[0].size = 0x20000000;
+-			gd->bd->bi_dram[1].size = 0x20000000;
++			gd->dram[0].size = 0x20000000;
++			gd->dram[1].size = 0x20000000;
+ 		} else { /* DDR_64BIT_1GB */
+-			gd->bd->bi_dram[0].size = 0x40000000;
+-			gd->bd->bi_dram[1].size = 0;
++			gd->dram[0].size = 0x40000000;
++			gd->dram[1].size = 0;
+ 		}
+ 		break;
+ 	case 0x80000000: /* DDR_64BIT_2GB */
+-		gd->bd->bi_dram[0].size = 0x40000000;
+-		gd->bd->bi_dram[1].size = 0x40000000;
++		gd->dram[0].size = 0x40000000;
++		gd->dram[1].size = 0x40000000;
+ 		break;
+ 	case 0xEFF00000: /* DDR_64BIT_4GB */
+-		gd->bd->bi_dram[0].size = 0x70000000;
+-		gd->bd->bi_dram[1].size = 0x7FF00000;
++		gd->dram[0].size = 0x70000000;
++		gd->dram[1].size = 0x7FF00000;
+ 		break;
+ 	}
+ 
+diff --git a/board/elgin/elgin_rv1108/elgin_rv1108.c b/board/elgin/elgin_rv1108/elgin_rv1108.c
+index 9fea4f86d5a..33f7ec6d048 100644
+--- a/board/elgin/elgin_rv1108/elgin_rv1108.c
++++ b/board/elgin/elgin_rv1108/elgin_rv1108.c
+@@ -66,8 +66,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = 0x60000000;
+-	gd->bd->bi_dram[0].size = 0x8000000;
++	gd->dram[0].start = 0x60000000;
++	gd->dram[0].size = 0x8000000;
+ 
+ 	return 0;
+ }
+diff --git a/board/esd/meesc/meesc.c b/board/esd/meesc/meesc.c
+index dce69abdfd1..3d76c936073 100644
+--- a/board/esd/meesc/meesc.c
++++ b/board/esd/meesc/meesc.c
+@@ -141,8 +141,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_SIZE;
++	gd->dram[0].start = PHYS_SDRAM;
++	gd->dram[0].size = PHYS_SDRAM_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/friendlyarm/nanopi2/board.c b/board/friendlyarm/nanopi2/board.c
+index eb10cd5143d..5e560a7f927 100644
+--- a/board/friendlyarm/nanopi2/board.c
++++ b/board/friendlyarm/nanopi2/board.c
+@@ -532,17 +532,17 @@ int dram_init_banksize(void)
+ 	/* set global data memory */
+ 	gd->bd->bi_boot_params = CFG_SYS_SDRAM_BASE + 0x00000100;
+ 
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size  = CFG_SYS_SDRAM_SIZE;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size  = CFG_SYS_SDRAM_SIZE;
+ 
+ 	/* Number of Row: 14 bits */
+ 	if ((reg_val >> 28) == 14)
+-		gd->bd->bi_dram[0].size -= 0x20000000;
++		gd->dram[0].size -= 0x20000000;
+ 
+ 	/* Number of Memory Chips */
+ 	if ((reg_val & 0x3) > 1) {
+-		gd->bd->bi_dram[1].start = 0x80000000;
+-		gd->bd->bi_dram[1].size  = 0x40000000;
++		gd->dram[1].start = 0x80000000;
++		gd->dram[1].size  = 0x40000000;
+ 	}
+ 	return 0;
+ }
+diff --git a/board/ge/mx53ppd/mx53ppd.c b/board/ge/mx53ppd/mx53ppd.c
+index cb9b88a1a58..d3a385bf6b7 100644
+--- a/board/ge/mx53ppd/mx53ppd.c
++++ b/board/ge/mx53ppd/mx53ppd.c
+@@ -71,11 +71,11 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = mx53_dram_size[0];
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = mx53_dram_size[0];
+ 
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
+-	gd->bd->bi_dram[1].size = mx53_dram_size[1];
++	gd->dram[1].start = PHYS_SDRAM_2;
++	gd->dram[1].size = mx53_dram_size[1];
+ 
+ 	return 0;
+ }
+diff --git a/board/hisilicon/hikey/hikey.c b/board/hisilicon/hikey/hikey.c
+index 5e60ab9d7b7..ba0465cf96f 100644
+--- a/board/hisilicon/hikey/hikey.c
++++ b/board/hisilicon/hikey/hikey.c
+@@ -456,23 +456,23 @@ int dram_init_banksize(void)
+ 	 *  0x3e00,0000 - 0x3fff,ffff: OP-TEE
+ 	*/
+ 
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = 0x05e00000;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = 0x05e00000;
+ 
+-	gd->bd->bi_dram[1].start = 0x05f00000;
+-	gd->bd->bi_dram[1].size = 0x00001000;
++	gd->dram[1].start = 0x05f00000;
++	gd->dram[1].size = 0x00001000;
+ 
+-	gd->bd->bi_dram[2].start = 0x05f02000;
+-	gd->bd->bi_dram[2].size = 0x00efd000;
++	gd->dram[2].start = 0x05f02000;
++	gd->dram[2].size = 0x00efd000;
+ 
+-	gd->bd->bi_dram[3].start = 0x06e00000;
+-	gd->bd->bi_dram[3].size = 0x0060f000;
++	gd->dram[3].start = 0x06e00000;
++	gd->dram[3].size = 0x0060f000;
+ 
+-	gd->bd->bi_dram[4].start = 0x07410000;
+-	gd->bd->bi_dram[4].size = 0x1aaf0000;
++	gd->dram[4].start = 0x07410000;
++	gd->dram[4].size = 0x1aaf0000;
+ 
+-	gd->bd->bi_dram[5].start = 0x22000000;
+-	gd->bd->bi_dram[5].size = 0x1c000000;
++	gd->dram[5].start = 0x22000000;
++	gd->dram[5].size = 0x1c000000;
+ 
+ 	return 0;
+ }
+diff --git a/board/hisilicon/hikey960/hikey960.c b/board/hisilicon/hikey960/hikey960.c
+index fb56762fff6..e7908d4c048 100644
+--- a/board/hisilicon/hikey960/hikey960.c
++++ b/board/hisilicon/hikey960/hikey960.c
+@@ -74,8 +74,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/board/hisilicon/poplar/poplar.c b/board/hisilicon/poplar/poplar.c
+index c3ea080ff75..dbab67d6f65 100644
+--- a/board/hisilicon/poplar/poplar.c
++++ b/board/hisilicon/poplar/poplar.c
+@@ -87,8 +87,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = KERNEL_TEXT_OFFSET;
+-	gd->bd->bi_dram[0].size = gd->ram_size - gd->bd->bi_dram[0].start;
++	gd->dram[0].start = KERNEL_TEXT_OFFSET;
++	gd->dram[0].size = gd->ram_size - gd->dram[0].start;
+ 
+ 	return 0;
+ }
+diff --git a/board/k+p/kp_imx53/kp_imx53.c b/board/k+p/kp_imx53/kp_imx53.c
+index efb7b49cbe0..07668bae7a9 100644
+--- a/board/k+p/kp_imx53/kp_imx53.c
++++ b/board/k+p/kp_imx53/kp_imx53.c
+@@ -39,8 +39,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_1_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = PHYS_SDRAM_1_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/keymile/pg-wcom-ls102xa/ddr.c b/board/keymile/pg-wcom-ls102xa/ddr.c
+index 51938a1b4d8..e37d4e767db 100644
+--- a/board/keymile/pg-wcom-ls102xa/ddr.c
++++ b/board/keymile/pg-wcom-ls102xa/ddr.c
+@@ -84,8 +84,8 @@ int fsl_initdram(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/board/kontron/sl28/sl28.c b/board/kontron/sl28/sl28.c
+index 8a9502037fb..ce778bc0849 100644
+--- a/board/kontron/sl28/sl28.c
++++ b/board/kontron/sl28/sl28.c
+@@ -175,8 +175,8 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 
+ 	/* fixup DT for the two GPP DDR banks */
+ 	for (i = 0; i < nbanks; i++) {
+-		base[i] = gd->bd->bi_dram[i].start;
+-		size[i] = gd->bd->bi_dram[i].size;
++		base[i] = gd->dram[i].start;
++		size[i] = gd->dram[i].size;
+ 	}
+ 
+ 	fdt_fixup_memory_banks(blob, base, size, nbanks);
+diff --git a/board/kontron/sl28/spl_atf.c b/board/kontron/sl28/spl_atf.c
+index 0710316a48b..cc741dea504 100644
+--- a/board/kontron/sl28/spl_atf.c
++++ b/board/kontron/sl28/spl_atf.c
+@@ -36,9 +36,9 @@ struct bl_params *bl2_plat_get_bl31_params_v2(uintptr_t bl32_entry,
+ 
+ 	dram_regions_info.num_dram_regions = CONFIG_NR_DRAM_BANKS;
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		dram_regions_info.region[i].addr = gd->bd->bi_dram[i].start;
+-		dram_regions_info.region[i].size = gd->bd->bi_dram[i].size;
+-		dram_regions_info.total_dram_size += gd->bd->bi_dram[i].size;
++		dram_regions_info.region[i].addr = gd->dram[i].start;
++		dram_regions_info.region[i].size = gd->dram[i].size;
++		dram_regions_info.total_dram_size += gd->dram[i].size;
+ 	}
+ 
+ 	bl_params = bl2_plat_get_bl31_params_v2_default(bl32_entry, bl33_entry,
+diff --git a/board/liebherr/btt/btt.c b/board/liebherr/btt/btt.c
+index e1ff041c54f..ba922b43064 100644
+--- a/board/liebherr/btt/btt.c
++++ b/board/liebherr/btt/btt.c
+@@ -239,7 +239,7 @@ int spl_start_uboot(void)
+ 
+ static const char *get_board_name(void)
+ {
+-	if (gd->bd->bi_dram[0].size == SZ_128M)
++	if (gd->dram[0].size == SZ_128M)
+ 		return STR_BTTC;
+ 
+ 	return STR_BTT3;
+diff --git a/board/menlo/m53menlo/m53menlo.c b/board/menlo/m53menlo/m53menlo.c
+index fc76d5765fa..5e76942783f 100644
+--- a/board/menlo/m53menlo/m53menlo.c
++++ b/board/menlo/m53menlo/m53menlo.c
+@@ -69,11 +69,11 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = mx53_dram_size[0];
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = mx53_dram_size[0];
+ 
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
+-	gd->bd->bi_dram[1].size = mx53_dram_size[1];
++	gd->dram[1].start = PHYS_SDRAM_2;
++	gd->dram[1].size = mx53_dram_size[1];
+ 
+ 	return 0;
+ }
+diff --git a/board/nuvoton/arbel_evb/arbel_evb.c b/board/nuvoton/arbel_evb/arbel_evb.c
+index 05c4dd187fe..68d516c7db8 100644
+--- a/board/nuvoton/arbel_evb/arbel_evb.c
++++ b/board/nuvoton/arbel_evb/arbel_evb.c
+@@ -57,7 +57,7 @@ int dram_init_banksize(void)
+ {
+ 	phys_size_t ram_size = gd->ram_size;
+ 
+-	gd->bd->bi_dram[0].start = 0;
++	gd->dram[0].start = 0;
+ 
+ 	#if defined(CONFIG_SYS_MEM_TOP_HIDE)
+ 		ram_size += CONFIG_SYS_MEM_TOP_HIDE;
+@@ -69,25 +69,25 @@ int dram_init_banksize(void)
+ 	case DRAM_1GB_SIZE:
+ 	case DRAM_2GB_ECC_SIZE:
+ 	case DRAM_2GB_SIZE:
+-		gd->bd->bi_dram[0].size = ram_size;
+-		gd->bd->bi_dram[1].start = 0;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[0].size = ram_size;
++		gd->dram[1].start = 0;
++		gd->dram[1].size = 0;
+ 		break;
+ 	case DRAM_4GB_ECC_SIZE:
+-		gd->bd->bi_dram[0].size = DRAM_2GB_SIZE;
+-		gd->bd->bi_dram[1].start = DRAM_4GB_SIZE;
+-		gd->bd->bi_dram[1].size = DRAM_2GB_SIZE -
++		gd->dram[0].size = DRAM_2GB_SIZE;
++		gd->dram[1].start = DRAM_4GB_SIZE;
++		gd->dram[1].size = DRAM_2GB_SIZE -
+ 			(DRAM_4GB_SIZE - DRAM_4GB_ECC_SIZE);
+ 		break;
+ 	case DRAM_4GB_SIZE:
+-		gd->bd->bi_dram[0].size = DRAM_2GB_SIZE;
+-		gd->bd->bi_dram[1].start = DRAM_4GB_SIZE;
+-		gd->bd->bi_dram[1].size = DRAM_2GB_SIZE;
++		gd->dram[0].size = DRAM_2GB_SIZE;
++		gd->dram[1].start = DRAM_4GB_SIZE;
++		gd->dram[1].size = DRAM_2GB_SIZE;
+ 		break;
+ 	default:
+-		gd->bd->bi_dram[0].size = DRAM_1GB_SIZE;
+-		gd->bd->bi_dram[1].start = 0;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[0].size = DRAM_1GB_SIZE;
++		gd->dram[1].start = 0;
++		gd->dram[1].size = 0;
+ 		break;
+ 	}
+ 
+diff --git a/board/nxp/imxrt1020-evk/imxrt1020-evk.c b/board/nxp/imxrt1020-evk/imxrt1020-evk.c
+index 11dbef84688..6843b33679d 100644
+--- a/board/nxp/imxrt1020-evk/imxrt1020-evk.c
++++ b/board/nxp/imxrt1020-evk/imxrt1020-evk.c
+@@ -73,7 +73,7 @@ u32 spl_boot_device(void)
+ 
+ int board_init(void)
+ {
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	return 0;
+ }
+diff --git a/board/nxp/imxrt1050-evk/imxrt1050-evk.c b/board/nxp/imxrt1050-evk/imxrt1050-evk.c
+index 056489932ac..19d068fc626 100644
+--- a/board/nxp/imxrt1050-evk/imxrt1050-evk.c
++++ b/board/nxp/imxrt1050-evk/imxrt1050-evk.c
+@@ -78,7 +78,7 @@ u32 spl_boot_device(void)
+ 
+ int board_init(void)
+ {
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	return 0;
+ }
+diff --git a/board/nxp/imxrt1170-evk/imxrt1170-evk.c b/board/nxp/imxrt1170-evk/imxrt1170-evk.c
+index 047aea8181a..3afd5ae2136 100644
+--- a/board/nxp/imxrt1170-evk/imxrt1170-evk.c
++++ b/board/nxp/imxrt1170-evk/imxrt1170-evk.c
+@@ -73,7 +73,7 @@ u32 spl_boot_device(void)
+ 
+ int board_init(void)
+ {
+-	gd->bd->bi_boot_params = gd->bd->bi_dram[0].start + 0x100;
++	gd->bd->bi_boot_params = gd->dram[0].start + 0x100;
+ 
+ 	return 0;
+ }
+diff --git a/board/nxp/ls1021aqds/ddr.c b/board/nxp/ls1021aqds/ddr.c
+index fd897e832c8..8d07f6110ce 100644
+--- a/board/nxp/ls1021aqds/ddr.c
++++ b/board/nxp/ls1021aqds/ddr.c
+@@ -192,8 +192,8 @@ int fsl_initdram(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return 0;
+ }
+diff --git a/board/nxp/ls1028a/ls1028a.c b/board/nxp/ls1028a/ls1028a.c
+index 007125358bd..8fc5db7c759 100644
+--- a/board/nxp/ls1028a/ls1028a.c
++++ b/board/nxp/ls1028a/ls1028a.c
+@@ -147,7 +147,7 @@ int board_early_init_f(void)
+ void detail_board_ddr_info(void)
+ {
+ 	puts("\nDDR    ");
+-	print_size(gd->bd->bi_dram[0].size + gd->bd->bi_dram[1].size, "");
++	print_size(gd->dram[0].size + gd->dram[1].size, "");
+ 	print_ddr_info(0);
+ }
+ 
+@@ -200,10 +200,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	ft_cpu_setup(blob, bd);
+ 
+ 	/* fixup DT for the two GPP DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ #ifdef CONFIG_RESV_RAM
+ 	/* reduce size if reserved memory is within this bank */
+diff --git a/board/nxp/ls1043aqds/ls1043aqds.c b/board/nxp/ls1043aqds/ls1043aqds.c
+index 0f115c16232..dba93add698 100644
+--- a/board/nxp/ls1043aqds/ls1043aqds.c
++++ b/board/nxp/ls1043aqds/ls1043aqds.c
+@@ -542,10 +542,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	u8 reg;
+ 
+ 	/* fixup DT for the two DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ 	fdt_fixup_memory_banks(blob, base, size, 2);
+ 	ft_cpu_setup(blob, bd);
+diff --git a/board/nxp/ls1043ardb/ls1043ardb.c b/board/nxp/ls1043ardb/ls1043ardb.c
+index bba041065b5..678c529cf55 100644
+--- a/board/nxp/ls1043ardb/ls1043ardb.c
++++ b/board/nxp/ls1043ardb/ls1043ardb.c
+@@ -305,10 +305,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	u64 size[CONFIG_NR_DRAM_BANKS];
+ 
+ 	/* fixup DT for the two DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ 	fdt_fixup_memory_banks(blob, base, size, 2);
+ 	ft_cpu_setup(blob, bd);
+diff --git a/board/nxp/ls1046afrwy/ls1046afrwy.c b/board/nxp/ls1046afrwy/ls1046afrwy.c
+index 8889c24f1f0..6c35c0a4347 100644
+--- a/board/nxp/ls1046afrwy/ls1046afrwy.c
++++ b/board/nxp/ls1046afrwy/ls1046afrwy.c
+@@ -198,10 +198,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	u64 size[CONFIG_NR_DRAM_BANKS];
+ 
+ 	/* fixup DT for the two DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ 	fdt_fixup_memory_banks(blob, base, size, 2);
+ 	ft_cpu_setup(blob, bd);
+diff --git a/board/nxp/ls1046aqds/ls1046aqds.c b/board/nxp/ls1046aqds/ls1046aqds.c
+index 679b0b2235f..ddd9993986f 100644
+--- a/board/nxp/ls1046aqds/ls1046aqds.c
++++ b/board/nxp/ls1046aqds/ls1046aqds.c
+@@ -426,10 +426,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	u8 reg;
+ 
+ 	/* fixup DT for the two DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ 	fdt_fixup_memory_banks(blob, base, size, 2);
+ 	ft_cpu_setup(blob, bd);
+diff --git a/board/nxp/ls1046ardb/ls1046ardb.c b/board/nxp/ls1046ardb/ls1046ardb.c
+index 83b280f7646..6677e271029 100644
+--- a/board/nxp/ls1046ardb/ls1046ardb.c
++++ b/board/nxp/ls1046ardb/ls1046ardb.c
+@@ -171,10 +171,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	u64 size[CONFIG_NR_DRAM_BANKS];
+ 
+ 	/* fixup DT for the two DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ 	fdt_fixup_memory_banks(blob, base, size, 2);
+ 	ft_cpu_setup(blob, bd);
+diff --git a/board/nxp/ls1088a/ls1088a.c b/board/nxp/ls1088a/ls1088a.c
+index 5783dd8a403..1b477e83676 100644
+--- a/board/nxp/ls1088a/ls1088a.c
++++ b/board/nxp/ls1088a/ls1088a.c
+@@ -830,7 +830,7 @@ int board_init(void)
+ void detail_board_ddr_info(void)
+ {
+ 	puts("\nDDR    ");
+-	print_size(gd->bd->bi_dram[0].size + gd->bd->bi_dram[1].size, "");
++	print_size(gd->dram[0].size + gd->dram[1].size, "");
+ 	print_ddr_info(0);
+ }
+ 
+@@ -959,8 +959,8 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 
+ 	/* fixup DT for the two GPP DDR banks */
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		base[i] = gd->bd->bi_dram[i].start;
+-		size[i] = gd->bd->bi_dram[i].size;
++		base[i] = gd->dram[i].start;
++		size[i] = gd->dram[i].size;
+ 	}
+ 
+ #ifdef CONFIG_RESV_RAM
+diff --git a/board/nxp/ls2080aqds/ls2080aqds.c b/board/nxp/ls2080aqds/ls2080aqds.c
+index aba0560181a..325dc817aaf 100644
+--- a/board/nxp/ls2080aqds/ls2080aqds.c
++++ b/board/nxp/ls2080aqds/ls2080aqds.c
+@@ -253,12 +253,12 @@ int misc_init_r(void)
+ void detail_board_ddr_info(void)
+ {
+ 	puts("\nDDR    ");
+-	print_size(gd->bd->bi_dram[0].size + gd->bd->bi_dram[1].size, "");
++	print_size(gd->dram[0].size + gd->dram[1].size, "");
+ 	print_ddr_info(0);
+ #ifdef CONFIG_SYS_FSL_HAS_DP_DDR
+-	if (soc_has_dp_ddr() && gd->bd->bi_dram[2].size) {
++	if (soc_has_dp_ddr() && gd->dram[2].size) {
+ 		puts("\nDP-DDR ");
+-		print_size(gd->bd->bi_dram[2].size, "");
++		print_size(gd->dram[2].size, "");
+ 		print_ddr_info(CONFIG_DP_DDR_CTRL);
+ 	}
+ #endif
+@@ -302,10 +302,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	ft_cpu_setup(blob, bd);
+ 
+ 	/* fixup DT for the two GPP DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ #ifdef CONFIG_RESV_RAM
+ 	/* reduce size if reserved memory is within this bank */
+diff --git a/board/nxp/ls2080ardb/ls2080ardb.c b/board/nxp/ls2080ardb/ls2080ardb.c
+index d08598d1c62..9dec818280b 100644
+--- a/board/nxp/ls2080ardb/ls2080ardb.c
++++ b/board/nxp/ls2080ardb/ls2080ardb.c
+@@ -359,12 +359,12 @@ int misc_init_r(void)
+ void detail_board_ddr_info(void)
+ {
+ 	puts("\nDDR    ");
+-	print_size(gd->bd->bi_dram[0].size + gd->bd->bi_dram[1].size, "");
++	print_size(gd->dram[0].size + gd->dram[1].size, "");
+ 	print_ddr_info(0);
+ #ifdef CONFIG_SYS_FSL_HAS_DP_DDR
+-	if (soc_has_dp_ddr() && gd->bd->bi_dram[2].size) {
++	if (soc_has_dp_ddr() && gd->dram[2].size) {
+ 		puts("\nDP-DDR ");
+-		print_size(gd->bd->bi_dram[2].size, "");
++		print_size(gd->dram[2].size, "");
+ 		print_ddr_info(CONFIG_DP_DDR_CTRL);
+ 	}
+ #endif
+@@ -487,10 +487,10 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	size = calloc(total_memory_banks, sizeof(u64));
+ 
+ 	/* fixup DT for the two GPP DDR banks */
+-	base[0] = gd->bd->bi_dram[0].start;
+-	size[0] = gd->bd->bi_dram[0].size;
+-	base[1] = gd->bd->bi_dram[1].start;
+-	size[1] = gd->bd->bi_dram[1].size;
++	base[0] = gd->dram[0].start;
++	size[0] = gd->dram[0].size;
++	base[1] = gd->dram[1].start;
++	size[1] = gd->dram[1].size;
+ 
+ #ifdef CONFIG_RESV_RAM
+ 	/* reduce size if reserved memory is within this bank */
+diff --git a/board/nxp/lx2160a/lx2160a.c b/board/nxp/lx2160a/lx2160a.c
+index b7a6ccf46aa..10729dfaf24 100644
+--- a/board/nxp/lx2160a/lx2160a.c
++++ b/board/nxp/lx2160a/lx2160a.c
+@@ -573,7 +573,7 @@ void detail_board_ddr_info(void)
+ 
+ 	puts("\nDDR    ");
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++)
+-		ddr_size += gd->bd->bi_dram[i].size;
++		ddr_size += gd->dram[i].size;
+ 	print_size(ddr_size, "");
+ 	print_ddr_info(0);
+ }
+@@ -808,8 +808,8 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 
+ 	/* fixup DT for the three GPP DDR banks */
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		base[i] = gd->bd->bi_dram[i].start;
+-		size[i] = gd->bd->bi_dram[i].size;
++		base[i] = gd->dram[i].start;
++		size[i] = gd->dram[i].size;
+ 	}
+ 
+ #ifdef CONFIG_RESV_RAM
+diff --git a/board/phytec/phycore_am62x/phycore-am62x.c b/board/phytec/phycore_am62x/phycore-am62x.c
+index 3cdcbf2ecc9..6df521d789f 100644
+--- a/board/phytec/phycore_am62x/phycore-am62x.c
++++ b/board/phytec/phycore_am62x/phycore-am62x.c
+@@ -93,7 +93,7 @@ int dram_init_banksize(void)
+ {
+ 	u8 ram_size;
+ 
+-	memset(gd->bd->bi_dram, 0, sizeof(gd->bd->bi_dram[0]) * CONFIG_NR_DRAM_BANKS);
++	memset(gd->dram, 0, sizeof(gd->dram[0]) * CONFIG_NR_DRAM_BANKS);
+ 
+ 	if (!IS_ENABLED(CONFIG_CPU_V7R))
+ 		return fdtdec_setup_memory_banksize();
+@@ -101,34 +101,34 @@ int dram_init_banksize(void)
+ 	ram_size = phytec_get_am62_ddr_size_default();
+ 	switch (ram_size) {
+ 	case EEPROM_RAM_SIZE_1GB:
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x40000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x40000000;
+ 		gd->ram_size = 0x40000000;
+ 		break;
+ 
+ 	case EEPROM_RAM_SIZE_2GB:
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x80000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x80000000;
+ 		gd->ram_size = 0x80000000;
+ 		break;
+ 
+ 	case EEPROM_RAM_SIZE_4GB:
+ 		/* Bank 0 declares the memory available in the DDR low region */
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x80000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x80000000;
+ 		gd->ram_size = 0x80000000;
+ 
+ #ifdef CONFIG_PHYS_64BIT
+ 		/* Bank 1 declares the memory available in the DDR upper region */
+-		gd->bd->bi_dram[1].start = 0x880000000;
+-		gd->bd->bi_dram[1].size = 0x80000000;
++		gd->dram[1].start = 0x880000000;
++		gd->dram[1].size = 0x80000000;
+ 		gd->ram_size = 0x100000000;
+ #endif
+ 		break;
+ 	default:
+ 		/* Continue with default 2GB setup */
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x80000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x80000000;
+ 		gd->ram_size = 0x80000000;
+ 		printf("DDR size %d is not supported\n", ram_size);
+ 	}
+@@ -186,8 +186,8 @@ int do_board_detect(void)
+ 	dram_init_banksize();
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start[bank] = gd->bd->bi_dram[bank].start;
+-		size[bank] = gd->bd->bi_dram[bank].size;
++		start[bank] = gd->dram[bank].start;
++		size[bank] = gd->dram[bank].size;
+ 	}
+ 
+ 	ret = fdt_fixup_memory_banks(fdt, start, size, CONFIG_NR_DRAM_BANKS);
+diff --git a/board/phytec/phycore_am64x/phycore-am64x.c b/board/phytec/phycore_am64x/phycore-am64x.c
+index 114aa217023..5e077872152 100644
+--- a/board/phytec/phycore_am64x/phycore-am64x.c
++++ b/board/phytec/phycore_am64x/phycore-am64x.c
+@@ -66,7 +66,7 @@ int dram_init_banksize(void)
+ {
+ 	u8 ram_size;
+ 
+-	memset(gd->bd->bi_dram, 0, sizeof(gd->bd->bi_dram[0]) * CONFIG_NR_DRAM_BANKS);
++	memset(gd->dram, 0, sizeof(gd->dram[0]) * CONFIG_NR_DRAM_BANKS);
+ 
+ 	if (!IS_ENABLED(CONFIG_CPU_V7R))
+ 		return fdtdec_setup_memory_banksize();
+@@ -74,21 +74,21 @@ int dram_init_banksize(void)
+ 	ram_size = phytec_get_am64_ddr_size_default();
+ 	switch (ram_size) {
+ 	case EEPROM_RAM_SIZE_1GB:
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x40000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x40000000;
+ 		gd->ram_size = 0x40000000;
+ 		break;
+ 
+ 	case EEPROM_RAM_SIZE_2GB:
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x80000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x80000000;
+ 		gd->ram_size = 0x80000000;
+ 		break;
+ 
+ 	default:
+ 		/* Continue with default 2GB setup */
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = 0x80000000;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = 0x80000000;
+ 		gd->ram_size = 0x80000000;
+ 		printf("DDR size %d is not supported\n", ram_size);
+ 	}
+@@ -109,8 +109,8 @@ int do_board_detect(void)
+ 	dram_init_banksize();
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		start[bank] = gd->bd->bi_dram[bank].start;
+-		size[bank] = gd->bd->bi_dram[bank].size;
++		start[bank] = gd->dram[bank].start;
++		size[bank] = gd->dram[bank].size;
+ 	}
+ 
+ 	return fdt_fixup_memory_banks(fdt, start, size, CONFIG_NR_DRAM_BANKS);
+diff --git a/board/phytium/durian/durian.c b/board/phytium/durian/durian.c
+index 9fc63febdac..a738e3542e2 100644
+--- a/board/phytium/durian/durian.c
++++ b/board/phytium/durian/durian.c
+@@ -31,8 +31,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size =  PHYS_SDRAM_1_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size =  PHYS_SDRAM_1_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/phytium/pe2201/pe2201.c b/board/phytium/pe2201/pe2201.c
+index 6824454cdf4..421e193e730 100644
+--- a/board/phytium/pe2201/pe2201.c
++++ b/board/phytium/pe2201/pe2201.c
+@@ -44,8 +44,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_1_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = PHYS_SDRAM_1_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/raspberrypi/rpi/rpi.c b/board/raspberrypi/rpi/rpi.c
+index b0a1484c0fa..885c660a289 100644
+--- a/board/raspberrypi/rpi/rpi.c
++++ b/board/raspberrypi/rpi/rpi.c
+@@ -356,9 +356,9 @@ int dram_init_banksize(void)
+ 
+ 	/* Update gd->ram_size to reflect total RAM across all banks */
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		if (gd->bd->bi_dram[i].size == 0)
++		if (gd->dram[i].size == 0)
+ 			break;
+-		total_size += gd->bd->bi_dram[i].size;
++		total_size += gd->dram[i].size;
+ 	}
+ 	gd->ram_size = total_size;
+ 
+diff --git a/board/renesas/common/rcar64-common.c b/board/renesas/common/rcar64-common.c
+index 3d537be4d02..09667d46d99 100644
+--- a/board/renesas/common/rcar64-common.c
++++ b/board/renesas/common/rcar64-common.c
+@@ -49,15 +49,15 @@ int dram_init_banksize(void)
+ 		return 0;
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		if (gd->bd->bi_dram[bank].start != 0x48000000)
++		if (gd->dram[bank].start != 0x48000000)
+ 			continue;
+ 
+ 		/*
+ 		 * If this U-Boot runs in EL3, make the bottom 128 MiB
+ 		 * available for loading of follow up firmware blobs.
+ 		 */
+-		gd->bd->bi_dram[bank].start -= 0x8000000;
+-		gd->bd->bi_dram[bank].size += 0x8000000;
++		gd->dram[bank].start -= 0x8000000;
++		gd->dram[bank].size += 0x8000000;
+ 		break;
+ 	}
+ 
+diff --git a/board/renesas/genmai/genmai.c b/board/renesas/genmai/genmai.c
+index 8153aed15e3..9245bf348f8 100644
+--- a/board/renesas/genmai/genmai.c
++++ b/board/renesas/genmai/genmai.c
+@@ -43,7 +43,7 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = gd->ram_base;
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].start = gd->ram_base;
++	gd->dram[0].size = gd->ram_size;
+ 	return 0;
+ }
+diff --git a/board/renesas/sparrowhawk/sparrowhawk.c b/board/renesas/sparrowhawk/sparrowhawk.c
+index a229542ba7e..1503de675d5 100644
+--- a/board/renesas/sparrowhawk/sparrowhawk.c
++++ b/board/renesas/sparrowhawk/sparrowhawk.c
+@@ -261,10 +261,10 @@ void renesas_dram_init_banksize(void)
+ 
+ 	/* 16 GiB device, adjust memory map. */
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		if (gd->bd->bi_dram[bank].start == 0x480000000ULL)
+-			gd->bd->bi_dram[bank].size = 0x180000000ULL;
+-		else if (gd->bd->bi_dram[bank].start == 0x600000000ULL)
+-			gd->bd->bi_dram[bank].size = 0x200000000ULL;
++		if (gd->dram[bank].start == 0x480000000ULL)
++			gd->dram[bank].size = 0x180000000ULL;
++		else if (gd->dram[bank].start == 0x600000000ULL)
++			gd->dram[bank].size = 0x200000000ULL;
+ 	}
+ }
+ 
+diff --git a/board/ronetix/pm9261/pm9261.c b/board/ronetix/pm9261/pm9261.c
+index 1f78654b685..7a0a93c1afe 100644
+--- a/board/ronetix/pm9261/pm9261.c
++++ b/board/ronetix/pm9261/pm9261.c
+@@ -103,8 +103,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_SIZE;
++	gd->dram[0].start = PHYS_SDRAM;
++	gd->dram[0].size = PHYS_SDRAM_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/ronetix/pm9263/pm9263.c b/board/ronetix/pm9263/pm9263.c
+index cc58e0f3a38..0ff49dceb9e 100644
+--- a/board/ronetix/pm9263/pm9263.c
++++ b/board/ronetix/pm9263/pm9263.c
+@@ -97,8 +97,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_SIZE;
++	gd->dram[0].start = PHYS_SDRAM;
++	gd->dram[0].size = PHYS_SDRAM_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/ronetix/pm9g45/pm9g45.c b/board/ronetix/pm9g45/pm9g45.c
+index 5d5edd9f253..b5664296a81 100644
+--- a/board/ronetix/pm9g45/pm9g45.c
++++ b/board/ronetix/pm9g45/pm9g45.c
+@@ -150,8 +150,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = CFG_SYS_SDRAM_SIZE;
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = CFG_SYS_SDRAM_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/samsung/arndale/arndale.c b/board/samsung/arndale/arndale.c
+index e70b4a82687..130136e8596 100644
+--- a/board/samsung/arndale/arndale.c
++++ b/board/samsung/arndale/arndale.c
+@@ -67,8 +67,8 @@ int dram_init_banksize(void)
+ 		addr = CFG_SYS_SDRAM_BASE + (i * SDRAM_BANK_SIZE);
+ 		size = get_ram_size((long *)addr, SDRAM_BANK_SIZE);
+ 
+-		gd->bd->bi_dram[i].start = addr;
+-		gd->bd->bi_dram[i].size = size;
++		gd->dram[i].start = addr;
++		gd->dram[i].size = size;
+ 	}
+ 
+ 	return 0;
+diff --git a/board/samsung/common/board.c b/board/samsung/common/board.c
+index eed1c2450fa..da3510023c4 100644
+--- a/board/samsung/common/board.c
++++ b/board/samsung/common/board.c
+@@ -115,7 +115,7 @@ int board_init(void)
+ 	ulong size = CONFIG_SYS_MEM_TOP_HIDE;
+ 
+ 	gd->ram_size -= size;
+-	gd->bd->bi_dram[CONFIG_NR_DRAM_BANKS - 1].size -= size;
++	gd->dram[CONFIG_NR_DRAM_BANKS - 1].size -= size;
+ #endif
+ 	exynos_init();
+ 
+@@ -143,8 +143,8 @@ int dram_init_banksize(void)
+ 		addr = CFG_SYS_SDRAM_BASE + (i * SDRAM_BANK_SIZE);
+ 		size = get_ram_size((long *)addr, SDRAM_BANK_SIZE);
+ 
+-		gd->bd->bi_dram[i].start = addr;
+-		gd->bd->bi_dram[i].size = size;
++		gd->dram[i].start = addr;
++		gd->dram[i].size = size;
+ 	}
+ 
+ 	return 0;
+diff --git a/board/samsung/exynos-mobile/exynos-mobile.c b/board/samsung/exynos-mobile/exynos-mobile.c
+index 6b2b1523663..d91e2e7d3f2 100644
+--- a/board/samsung/exynos-mobile/exynos-mobile.c
++++ b/board/samsung/exynos-mobile/exynos-mobile.c
+@@ -346,8 +346,8 @@ int dram_init_banksize(void)
+ 	unsigned int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		gd->bd->bi_dram[i].start = mem_map[i + 1].phys;
+-		gd->bd->bi_dram[i].size = mem_map[i + 1].size;
++		gd->dram[i].start = mem_map[i + 1].phys;
++		gd->dram[i].size = mem_map[i + 1].size;
+ 	}
+ 
+ 	return 0;
+diff --git a/board/samsung/goni/goni.c b/board/samsung/goni/goni.c
+index a1047f3fd2a..96a411233d1 100644
+--- a/board/samsung/goni/goni.c
++++ b/board/samsung/goni/goni.c
+@@ -43,12 +43,12 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_1_SIZE;
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
+-	gd->bd->bi_dram[1].size = PHYS_SDRAM_2_SIZE;
+-	gd->bd->bi_dram[2].start = PHYS_SDRAM_3;
+-	gd->bd->bi_dram[2].size = PHYS_SDRAM_3_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = PHYS_SDRAM_1_SIZE;
++	gd->dram[1].start = PHYS_SDRAM_2;
++	gd->dram[1].size = PHYS_SDRAM_2_SIZE;
++	gd->dram[2].start = PHYS_SDRAM_3;
++	gd->dram[2].size = PHYS_SDRAM_3_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/samsung/smdkc100/smdkc100.c b/board/samsung/smdkc100/smdkc100.c
+index 7d0b0fcb0ae..7e992c23a1b 100644
+--- a/board/samsung/smdkc100/smdkc100.c
++++ b/board/samsung/smdkc100/smdkc100.c
+@@ -56,8 +56,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_1_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = PHYS_SDRAM_1_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/samsung/smdkv310/smdkv310.c b/board/samsung/smdkv310/smdkv310.c
+index 5a4874b29cd..f013893b465 100644
+--- a/board/samsung/smdkv310/smdkv310.c
++++ b/board/samsung/smdkv310/smdkv310.c
+@@ -57,17 +57,17 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = get_ram_size((long *)PHYS_SDRAM_1,
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = get_ram_size((long *)PHYS_SDRAM_1,
+ 							PHYS_SDRAM_1_SIZE);
+-	gd->bd->bi_dram[1].start = PHYS_SDRAM_2;
+-	gd->bd->bi_dram[1].size = get_ram_size((long *)PHYS_SDRAM_2,
++	gd->dram[1].start = PHYS_SDRAM_2;
++	gd->dram[1].size = get_ram_size((long *)PHYS_SDRAM_2,
+ 							PHYS_SDRAM_2_SIZE);
+-	gd->bd->bi_dram[2].start = PHYS_SDRAM_3;
+-	gd->bd->bi_dram[2].size = get_ram_size((long *)PHYS_SDRAM_3,
++	gd->dram[2].start = PHYS_SDRAM_3;
++	gd->dram[2].size = get_ram_size((long *)PHYS_SDRAM_3,
+ 							PHYS_SDRAM_3_SIZE);
+-	gd->bd->bi_dram[3].start = PHYS_SDRAM_4;
+-	gd->bd->bi_dram[3].size = get_ram_size((long *)PHYS_SDRAM_4,
++	gd->dram[3].start = PHYS_SDRAM_4;
++	gd->dram[3].size = get_ram_size((long *)PHYS_SDRAM_4,
+ 							PHYS_SDRAM_4_SIZE);
+ 
+ 	return 0;
+diff --git a/board/siemens/iot2050/board.c b/board/siemens/iot2050/board.c
+index 79cf34b40eb..69d3b9d61d3 100644
+--- a/board/siemens/iot2050/board.c
++++ b/board/siemens/iot2050/board.c
+@@ -397,20 +397,20 @@ int dram_init_banksize(void)
+ 
+ 	if (gd->ram_size > SZ_2G) {
+ 		/* Bank 0 declares the memory available in the DDR low region */
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = SZ_2G;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = SZ_2G;
+ 
+ 		/* Bank 1 declares the memory available in the DDR high region */
+-		gd->bd->bi_dram[1].start = CFG_SYS_SDRAM_BASE1;
+-		gd->bd->bi_dram[1].size = gd->ram_size - SZ_2G;
++		gd->dram[1].start = CFG_SYS_SDRAM_BASE1;
++		gd->dram[1].size = gd->ram_size - SZ_2G;
+ 	} else {
+ 		/* Bank 0 declares the memory available in the DDR low region */
+-		gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-		gd->bd->bi_dram[0].size = gd->ram_size;
++		gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++		gd->dram[0].size = gd->ram_size;
+ 
+ 		/* Bank 1 declares the memory available in the DDR high region */
+-		gd->bd->bi_dram[1].start = 0;
+-		gd->bd->bi_dram[1].size = 0;
++		gd->dram[1].start = 0;
++		gd->dram[1].size = 0;
+ 	}
+ 
+ 	return 0;
+diff --git a/board/socionext/developerbox/developerbox.c b/board/socionext/developerbox/developerbox.c
+index 556a9ed527e..a7bd08f69ad 100644
+--- a/board/socionext/developerbox/developerbox.c
++++ b/board/socionext/developerbox/developerbox.c
+@@ -170,11 +170,11 @@ int dram_init_banksize(void)
+ 	struct draminfo_entry *ent = synquacer_draminfo->entry;
+ 	int i;
+ 
+-	for (i = 0; i < ARRAY_SIZE(gd->bd->bi_dram); i++) {
++	for (i = 0; i < ARRAY_SIZE(gd->dram); i++) {
+ 		if (i < synquacer_draminfo->nr_regions) {
+ 			debug("%s: dram[%d] = %llx@%llx\n", __func__, i, ent[i].size, ent[i].base);
+-			gd->bd->bi_dram[i].start = ent[i].base;
+-			gd->bd->bi_dram[i].size = ent[i].size;
++			gd->dram[i].start = ent[i].base;
++			gd->dram[i].size = ent[i].size;
+ 		}
+ 	}
+ 
+diff --git a/board/st/stih410-b2260/board.c b/board/st/stih410-b2260/board.c
+index f5174720434..a1b0265d5ac 100644
+--- a/board/st/stih410-b2260/board.c
++++ b/board/st/stih410-b2260/board.c
+@@ -18,8 +18,8 @@ int dram_init(void)
+ 
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = PHYS_SDRAM_1;
+-	gd->bd->bi_dram[0].size = PHYS_SDRAM_1_SIZE;
++	gd->dram[0].start = PHYS_SDRAM_1;
++	gd->dram[0].size = PHYS_SDRAM_1_SIZE;
+ 
+ 	return 0;
+ }
+diff --git a/board/ste/stemmy/stemmy.c b/board/ste/stemmy/stemmy.c
+index 826c002907d..66330184af8 100644
+--- a/board/ste/stemmy/stemmy.c
++++ b/board/ste/stemmy/stemmy.c
+@@ -70,8 +70,8 @@ int dram_init_banksize(void)
+ 		if (t->hdr.tag != ATAG_MEM)
+ 			continue;
+ 
+-		gd->bd->bi_dram[bank].start = t->u.mem.start;
+-		gd->bd->bi_dram[bank].size = t->u.mem.size;
++		gd->dram[bank].start = t->u.mem.start;
++		gd->dram[bank].size = t->u.mem.size;
+ 		if (++bank == CONFIG_NR_DRAM_BANKS)
+ 			break;
+ 	}
+diff --git a/board/ti/dra7xx/evm.c b/board/ti/dra7xx/evm.c
+index 0966db2bb62..6f1fed43e36 100644
+--- a/board/ti/dra7xx/evm.c
++++ b/board/ti/dra7xx/evm.c
+@@ -643,11 +643,11 @@ int dram_init_banksize(void)
+ 
+ 	ram_size = board_ti_get_emif_size();
+ 
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = get_effective_memsize();
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = get_effective_memsize();
+ 	if (ram_size > CFG_MAX_MEM_MAPPED) {
+-		gd->bd->bi_dram[1].start = 0x200000000;
+-		gd->bd->bi_dram[1].size = ram_size - CFG_MAX_MEM_MAPPED;
++		gd->dram[1].start = 0x200000000;
++		gd->dram[1].size = ram_size - CFG_MAX_MEM_MAPPED;
+ 	}
+ 
+ 	return 0;
+diff --git a/board/ti/ks2_evm/board.c b/board/ti/ks2_evm/board.c
+index a92aa5cfc67..43330993955 100644
+--- a/board/ti/ks2_evm/board.c
++++ b/board/ti/ks2_evm/board.c
+@@ -117,8 +117,8 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 	}
+ 
+ 	nbanks = 1;
+-	start[0] = bd->bi_dram[0].start;
+-	size[0]  = bd->bi_dram[0].size;
++	start[0] = gd->dram[0].start;
++	size[0]  = gd->dram[0].size;
+ 
+ 	/* adjust memory start address for LPAE */
+ 	if (lpae) {
+diff --git a/board/toradex/colibri_imx7/colibri_imx7.c b/board/toradex/colibri_imx7/colibri_imx7.c
+index 69a8a18d3a7..c63812bd966 100644
+--- a/board/toradex/colibri_imx7/colibri_imx7.c
++++ b/board/toradex/colibri_imx7/colibri_imx7.c
+@@ -288,13 +288,13 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 		 * Reserve 1MB of memory for M4 (1MiB is also the minimum
+ 		 * alignment for Linux due to MMU section size restrictions).
+ 		 */
+-		start[0] = gd->bd->bi_dram[0].start;
++		start[0] = gd->dram[0].start;
+ 		size[0] = SZ_256M - SZ_1M;
+ 
+ 		/* If needed, create a second entry for memory beyond 256M */
+-		if (gd->bd->bi_dram[0].size > SZ_256M) {
+-			start[1] = gd->bd->bi_dram[0].start + SZ_256M;
+-			size[1] = gd->bd->bi_dram[0].size - SZ_256M;
++		if (gd->dram[0].size > SZ_256M) {
++			start[1] = gd->dram[0].start + SZ_256M;
++			size[1] = gd->dram[0].size - SZ_256M;
+ 			areas = 2;
+ 		}
+ 
+diff --git a/board/toradex/verdin-am62/verdin-am62.c b/board/toradex/verdin-am62/verdin-am62.c
+index 19ac2ae9313..26af1af2069 100644
+--- a/board/toradex/verdin-am62/verdin-am62.c
++++ b/board/toradex/verdin-am62/verdin-am62.c
+@@ -44,7 +44,7 @@ int dram_init_banksize(void)
+ 		printf("Error setting up memory banksize. %d\n", ret);
+ 
+ 	/* Use the detected RAM size, we only support 1 bank right now. */
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return ret;
+ }
+diff --git a/board/toradex/verdin-am62p/verdin-am62p.c b/board/toradex/verdin-am62p/verdin-am62p.c
+index 1234b3887c6..ec7775e06a7 100644
+--- a/board/toradex/verdin-am62p/verdin-am62p.c
++++ b/board/toradex/verdin-am62p/verdin-am62p.c
+@@ -78,7 +78,7 @@ int dram_init_banksize(void)
+ 		printf("Error setting up memory banksize. %d\n", ret);
+ 
+ 	/* Use the detected RAM size, we only support 1 bank right now. */
+-	gd->bd->bi_dram[0].size = gd->ram_size;
++	gd->dram[0].size = gd->ram_size;
+ 
+ 	return ret;
+ }
+diff --git a/board/traverse/ten64/ten64.c b/board/traverse/ten64/ten64.c
+index ac8c9a9a81a..5c45f9932c5 100644
+--- a/board/traverse/ten64/ten64.c
++++ b/board/traverse/ten64/ten64.c
+@@ -148,7 +148,7 @@ int fsl_initdram(void)
+ void detail_board_ddr_info(void)
+ {
+ 	puts("\nDDR    ");
+-	print_size(gd->bd->bi_dram[0].size + gd->bd->bi_dram[1].size, "");
++	print_size(gd->dram[0].size + gd->dram[1].size, "");
+ 	print_ddr_info(0);
+ }
+ 
+@@ -277,8 +277,8 @@ int ft_board_setup(void *blob, struct bd_info *bd)
+ 
+ 	/* fixup DT for the two GPP DDR banks */
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		base[i] = gd->bd->bi_dram[i].start;
+-		size[i] = gd->bd->bi_dram[i].size;
++		base[i] = gd->dram[i].start;
++		size[i] = gd->dram[i].size;
+ 		/* reduce size if reserved memory is within this bank */
+ 		if (IS_ENABLED(CONFIG_RESV_RAM) && RESV_MEM_IN_BANK(i))
+ 			size[i] = gd->arch.resv_ram - base[i];
+diff --git a/board/xilinx/zynq/cmds.c b/board/xilinx/zynq/cmds.c
+index 05ecb75406b..d8eff203a56 100644
+--- a/board/xilinx/zynq/cmds.c
++++ b/board/xilinx/zynq/cmds.c
+@@ -347,10 +347,10 @@ static int zynq_verify_image(u32 src_ptr)
+ 		 * This validation is just for PS DDR.
+ 		 * TODO: Update this for PL DDR check as well.
+ 		 */
+-		if (part_load_addr < gd->bd->bi_dram[0].start &&
++		if (part_load_addr < gd->dram[0].start &&
+ 		    ((part_load_addr + part_data_len) >
+-		    (gd->bd->bi_dram[0].start +
+-		     gd->bd->bi_dram[0].size))) {
++		    (gd->dram[0].start +
++		     gd->dram[0].size))) {
+ 			printf("INVALID_LOAD_ADDRESS_FAIL\n");
+ 			return -1;
+ 		}
+diff --git a/board/xilinx/zynqmp/zynqmp.c b/board/xilinx/zynqmp/zynqmp.c
+index a1d8ae26673..60947038827 100644
+--- a/board/xilinx/zynqmp/zynqmp.c
++++ b/board/xilinx/zynqmp/zynqmp.c
+@@ -279,8 +279,8 @@ int dram_init(void)
+ #else
+ int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = CFG_SYS_SDRAM_BASE;
+-	gd->bd->bi_dram[0].size = get_effective_memsize();
++	gd->dram[0].start = CFG_SYS_SDRAM_BASE;
++	gd->dram[0].size = get_effective_memsize();
+ 
+ 	mem_map_fill();
+ 
+diff --git a/boot/image-board.c b/boot/image-board.c
+index 005d60caf5c..57bee7e3773 100644
+--- a/boot/image-board.c
++++ b/boot/image-board.c
+@@ -118,7 +118,7 @@ phys_addr_t env_get_bootm_low(void)
+ #if defined(CFG_SYS_SDRAM_BASE)
+ 	return CFG_SYS_SDRAM_BASE;
+ #elif defined(CONFIG_ARM) || defined(CONFIG_MICROBLAZE) || defined(CONFIG_RISCV)
+-	return gd->bd->bi_dram[0].start;
++	return gd->dram[0].start;
+ #else
+ 	return 0;
+ #endif
+diff --git a/boot/image-fdt.c b/boot/image-fdt.c
+index a3a4fb8b558..91612dcf91b 100644
+--- a/boot/image-fdt.c
++++ b/boot/image-fdt.c
+@@ -223,8 +223,8 @@ int boot_relocate_fdt(char **of_flat_tree, ulong *of_size)
+ 		of_start = NULL;
+ 
+ 		for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-			start = gd->bd->bi_dram[bank].start;
+-			size = gd->bd->bi_dram[bank].size;
++			start = gd->dram[bank].start;
++			size = gd->dram[bank].size;
+ 
+ 			/* DRAM bank addresses are too low, skip it. */
+ 			if (start + size < low)
+diff --git a/cmd/bdinfo.c b/cmd/bdinfo.c
+index ddf77303735..bf1eca75904 100644
+--- a/cmd/bdinfo.c
++++ b/cmd/bdinfo.c
+@@ -77,15 +77,15 @@ void bdinfo_print_mhz(const char *name, unsigned long hz)
+ 	printf("%-12s= %6s MHz\n", name, strmhz(buf, hz));
+ }
+ 
+-static void print_bi_dram(const struct bd_info *bd)
++static void print_dram(const struct bd_info *bd)
+ {
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; ++i) {
+-		if (bd->bi_dram[i].size) {
++		if (gd->dram[i].size) {
+ 			bdinfo_print_num_l("DRAM bank",	i);
+-			bdinfo_print_num_ll("-> start",	bd->bi_dram[i].start);
+-			bdinfo_print_num_ll("-> size",	bd->bi_dram[i].size);
++			bdinfo_print_num_ll("-> start",	gd->dram[i].start);
++			bdinfo_print_num_ll("-> size",	gd->dram[i].size);
+ 		}
+ 	}
+ }
+@@ -144,7 +144,7 @@ static int bdinfo_print_all(struct bd_info *bd)
+ 	bdinfo_print_num_l("bd address", (ulong)bd);
+ #endif
+ 	bdinfo_print_num_l("boot_params", (ulong)bd->bi_boot_params);
+-	print_bi_dram(bd);
++	print_dram(bd);
+ 	bdinfo_print_num_l("flashstart", (ulong)bd->bi_flashstart);
+ 	bdinfo_print_num_l("flashsize", (ulong)bd->bi_flashsize);
+ 	bdinfo_print_num_l("flashoffset", (ulong)bd->bi_flashoffset);
+@@ -199,7 +199,7 @@ int do_bdinfo(struct cmd_tbl *cmdtp, int flag, int argc, char *const argv[])
+ 			print_eth();
+ 			return CMD_RET_SUCCESS;
+ 		case 'm':
+-			print_bi_dram(bd);
++			print_dram(bd);
+ 			return CMD_RET_SUCCESS;
+ 		default:
+ 			return CMD_RET_USAGE;
+diff --git a/cmd/ti/ddr4.c b/cmd/ti/ddr4.c
+index a8d71d11a91..36277cc154c 100644
+--- a/cmd/ti/ddr4.c
++++ b/cmd/ti/ddr4.c
+@@ -227,10 +227,10 @@ static int do_ddr4_ecc_inject(struct cmd_tbl *cmdtp, int flag, int argc,
+ 		return CMD_RET_FAILURE;
+ 	}
+ 
+-	if (!((start_addr >= gd->bd->bi_dram[0].start &&
+-	       (start_addr <= (gd->bd->bi_dram[0].start + gd->bd->bi_dram[0].size - 1))) ||
+-	      (start_addr >= gd->bd->bi_dram[1].start &&
+-	       (start_addr <= (gd->bd->bi_dram[1].start + gd->bd->bi_dram[1].size - 1))))) {
++	if (!((start_addr >= gd->dram[0].start &&
++	       (start_addr <= (gd->dram[0].start + gd->dram[0].size - 1))) ||
++	      (start_addr >= gd->dram[1].start &&
++	       (start_addr <= (gd->dram[1].start + gd->dram[1].size - 1))))) {
+ 		puts("Address is not in the DDR range\n");
+ 		return CMD_RET_FAILURE;
+ 	}
+diff --git a/cmd/ufetch.c b/cmd/ufetch.c
+index f8dc904bdd0..3b44f5324e2 100644
+--- a/cmd/ufetch.c
++++ b/cmd/ufetch.c
+@@ -191,8 +191,8 @@ static int do_ufetch(struct cmd_tbl *cmdtp, int flag, int argc,
+ 			printf("CPU: " RESET CONFIG_SYS_ARCH " (%d cores, 1 in use)\n", n_cpus);
+ 			break;
+ 		case MEMORY:
+-			for (int j = 0; j < CONFIG_NR_DRAM_BANKS && gd->bd->bi_dram[j].size; j++)
+-				size += gd->bd->bi_dram[j].size;
++			for (int j = 0; j < CONFIG_NR_DRAM_BANKS && gd->dram[j].size; j++)
++				size += gd->dram[j].size;
+ 			printf("Memory:" RESET " ");
+ 			print_size(size, "\n");
+ 			break;
+diff --git a/common/board_f.c b/common/board_f.c
+index ce87c619e68..f0d07cb6f59 100644
+--- a/common/board_f.c
++++ b/common/board_f.c
+@@ -222,11 +222,11 @@ static int show_dram_config(void)
+ 
+ 	debug("\nRAM Configuration:\n");
+ 	for (i = size = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		size += gd->bd->bi_dram[i].size;
++		size += gd->dram[i].size;
+ 		debug("Bank #%d: %llx ", i,
+-		      (unsigned long long)(gd->bd->bi_dram[i].start));
++		      (unsigned long long)(gd->dram[i].start));
+ #ifdef DEBUG
+-		print_size(gd->bd->bi_dram[i].size, "\n");
++		print_size(gd->dram[i].size, "\n");
+ #endif
+ 	}
+ 	debug("\nDRAM:  ");
+@@ -244,8 +244,8 @@ static int show_dram_config(void)
+ 
+ __weak int dram_init_banksize(void)
+ {
+-	gd->bd->bi_dram[0].start = gd->ram_base;
+-	gd->bd->bi_dram[0].size = get_effective_memsize();
++	gd->dram[0].start = gd->ram_base;
++	gd->dram[0].size = get_effective_memsize();
+ 
+ 	return 0;
+ }
+diff --git a/common/init/handoff.c b/common/init/handoff.c
+index a7cd065fb38..a4d9d14393b 100644
+--- a/common/init/handoff.c
++++ b/common/init/handoff.c
+@@ -12,14 +12,13 @@ DECLARE_GLOBAL_DATA_PTR;
+ 
+ void handoff_save_dram(struct spl_handoff *ho)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int i;
+ 
+ 	ho->ram_size = gd->ram_size;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		ho->ram_bank[i].start = bd->bi_dram[i].start;
+-		ho->ram_bank[i].size = bd->bi_dram[i].size;
++		ho->ram_bank[i].start = gd->dram[i].start;
++		ho->ram_bank[i].size = gd->dram[i].size;
+ 	}
+ }
+ 
+@@ -30,11 +29,10 @@ void handoff_load_dram_size(struct spl_handoff *ho)
+ 
+ void handoff_load_dram_banks(struct spl_handoff *ho)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		bd->bi_dram[i].start = ho->ram_bank[i].start;
+-		bd->bi_dram[i].size = ho->ram_bank[i].size;
++		gd->dram[i].start = ho->ram_bank[i].start;
++		gd->dram[i].size = ho->ram_bank[i].size;
+ 	}
+ }
+diff --git a/drivers/bootcount/bootcount_ram.c b/drivers/bootcount/bootcount_ram.c
+index 33e157b865a..f726d9ab016 100644
+--- a/drivers/bootcount/bootcount_ram.c
++++ b/drivers/bootcount/bootcount_ram.c
+@@ -27,7 +27,7 @@ void bootcount_store(ulong a)
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++)
+-		size += gd->bd->bi_dram[i].size;
++		size += gd->dram[i].size;
+ 	save_addr = (ulong *)(size - BOOTCOUNT_ADDR);
+ 	writel(a, save_addr);
+ 	writel(CONFIG_SYS_BOOTCOUNT_MAGIC, &save_addr[1]);
+@@ -50,7 +50,7 @@ ulong bootcount_load(void)
+ 	int i, tmp;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++)
+-		size += gd->bd->bi_dram[i].size;
++		size += gd->dram[i].size;
+ 	save_addr = (ulong *)(size - BOOTCOUNT_ADDR);
+ 
+ 	counter = readl(&save_addr[0]);
+diff --git a/drivers/ddr/altera/sdram_agilex.c b/drivers/ddr/altera/sdram_agilex.c
+index b36a765a5de..2d2b72cf766 100644
+--- a/drivers/ddr/altera/sdram_agilex.c
++++ b/drivers/ddr/altera/sdram_agilex.c
+@@ -104,7 +104,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	/* Get bank configuration from devicetree */
+ 	ret = fdtdec_decode_ram_size(gd->fdt_blob, NULL, 0, NULL,
+-				     (phys_size_t *)&gd->ram_size, &bd);
++				     (phys_size_t *)&gd->ram_size, gd);
+ 	if (ret) {
+ 		puts("DDR: Failed to decode memory node\n");
+ 		return -ENXIO;
+@@ -158,7 +158,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	sdram_set_firewall(&bd);
+ 
+-	priv->info.base = bd.bi_dram[0].start;
++	priv->info.base = gd->dram[0].start;
+ 	priv->info.size = gd->ram_size;
+ 
+ 	debug("DDR: HMC init success\n");
+diff --git a/drivers/ddr/altera/sdram_agilex5.c b/drivers/ddr/altera/sdram_agilex5.c
+index ee66c72157a..d14e4bc5dcc 100644
+--- a/drivers/ddr/altera/sdram_agilex5.c
++++ b/drivers/ddr/altera/sdram_agilex5.c
+@@ -302,7 +302,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	/* Get bank configuration from devicetree */
+ 	ret = fdtdec_decode_ram_size(gd->fdt_blob, NULL, 0, NULL,
+-				     (phys_size_t *)&gd->ram_size, gd->bd);
++				     (phys_size_t *)&gd->ram_size, gd);
+ 	if (ret) {
+ 		puts("DDR: Failed to decode memory node\n");
+ 		ret = -ENXIO;
+@@ -345,19 +345,19 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 		for (i = 0; i < config_dram_banks; i++) {
+ 			remaining_size = hw_size - size_counter;
+ 			if (remaining_size <= dram_bank_info[i].max_size) {
+-				gd->bd->bi_dram[i].start = dram_bank_info[i].start;
+-				gd->bd->bi_dram[i].size = remaining_size;
++				gd->dram[i].start = dram_bank_info[i].start;
++				gd->dram[i].size = remaining_size;
+ 				debug("Memory bank[%d]  Starting address: 0x%llx  size: 0x%llx\n",
+-				      i, gd->bd->bi_dram[i].start, gd->bd->bi_dram[i].size);
++				      i, gd->dram[i].start, gd->dram[i].size);
+ 				break;
+ 			}
+ 
+-			gd->bd->bi_dram[i].start = dram_bank_info[i].start;
+-			gd->bd->bi_dram[i].size = dram_bank_info[i].max_size;
++			gd->dram[i].start = dram_bank_info[i].start;
++			gd->dram[i].size = dram_bank_info[i].max_size;
+ 
+ 			debug("Memory bank[%d]  Starting address: 0x%llx  size: 0x%llx\n",
+-			      i, gd->bd->bi_dram[i].start, gd->bd->bi_dram[i].size);
+-			size_counter += gd->bd->bi_dram[i].size;
++			      i, gd->dram[i].start, gd->dram[i].size);
++			size_counter += gd->dram[i].size;
+ 		}
+ 
+ 		gd->ram_size = hw_size;
+@@ -408,7 +408,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	printf("DDR: firewall init success\n");
+ 
+-	priv->info.base = gd->bd->bi_dram[0].start;
++	priv->info.base = gd->dram[0].start;
+ 	priv->info.size = gd->ram_size;
+ 
+ 	/* Ending DDR driver initialization success tracking */
+diff --git a/drivers/ddr/altera/sdram_agilex7m.c b/drivers/ddr/altera/sdram_agilex7m.c
+index 9b3cc5c7b86..e4d522202d8 100644
+--- a/drivers/ddr/altera/sdram_agilex7m.c
++++ b/drivers/ddr/altera/sdram_agilex7m.c
+@@ -375,7 +375,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	/* Get bank configuration from devicetree */
+ 	ret = fdtdec_decode_ram_size(gd->fdt_blob, NULL, 0, NULL,
+-				     (phys_size_t *)&gd->ram_size, &bd);
++				     (phys_size_t *)&gd->ram_size, gd);
+ 	if (ret) {
+ 		printf("%s: Failed to decode memory node\n", memory_type_in_use(dev));
+ 
+@@ -484,7 +484,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	printf("%s: firewall init success\n", (is_ddr_in_use(dev) ? io96b_ctrl->ddr_type : "HBM"));
+ 
+-	priv->info.base = bd.bi_dram[0].start;
++	priv->info.base = gd->dram[0].start;
+ 	priv->info.size = gd->ram_size;
+ 
+ 	/* Ending DDR driver initialization success tracking */
+diff --git a/drivers/ddr/altera/sdram_arria10.c b/drivers/ddr/altera/sdram_arria10.c
+index c281f711fdf..9cc809b8001 100644
+--- a/drivers/ddr/altera/sdram_arria10.c
++++ b/drivers/ddr/altera/sdram_arria10.c
+@@ -674,9 +674,9 @@ static void sdram_size_check(void)
+ 
+ 	debug("DDR: Running SDRAM size sanity check\n");
+ 
+-	ram_check = get_ram_size((long *)gd->bd->bi_dram[0].start,
+-				 gd->bd->bi_dram[0].size);
+-	if (ram_check != gd->bd->bi_dram[0].size) {
++	ram_check = get_ram_size((long *)gd->dram[0].start,
++				 gd->dram[0].size);
++	if (ram_check != gd->dram[0].size) {
+ 		puts("DDR: SDRAM size check failed!\n");
+ 		hang();
+ 	}
+@@ -719,14 +719,14 @@ int ddr_calibration_sequence(void)
+ 	/* setup the dram info within bd */
+ 	dram_init_banksize();
+ 
+-	if (gd->ram_size != gd->bd->bi_dram[0].size) {
++	if (gd->ram_size != gd->dram[0].size) {
+ 		printf("DDR: Warning: DRAM size from device tree (%ld MiB)\n",
+-		       gd->bd->bi_dram[0].size >> 20);
++		       gd->dram[0].size >> 20);
+ 		printf(" mismatch with hardware (%ld MiB).\n",
+ 		       gd->ram_size >> 20);
+ 	}
+ 
+-	if (gd->bd->bi_dram[0].size > gd->ram_size) {
++	if (gd->dram[0].size > gd->ram_size) {
+ 		printf("DDR: Error: DRAM size from device tree is greater\n");
+ 		printf(" than hardware size.\n");
+ 		hang();
+diff --git a/drivers/ddr/altera/sdram_n5x.c b/drivers/ddr/altera/sdram_n5x.c
+index 17ec6afa82b..900d4f59989 100644
+--- a/drivers/ddr/altera/sdram_n5x.c
++++ b/drivers/ddr/altera/sdram_n5x.c
+@@ -2279,7 +2279,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	/* Get bank configuration from devicetree */
+ 	ret = fdtdec_decode_ram_size(gd->fdt_blob, NULL, 0, NULL,
+-				     (phys_size_t *)&gd->ram_size, &bd);
++				     (phys_size_t *)&gd->ram_size, gd);
+ 	if (ret) {
+ 		debug("%s: Failed to decode memory node\n",  __func__);
+ 		return -1;
+@@ -2287,7 +2287,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	printf("DDR: %lld MiB\n", gd->ram_size >> 20);
+ 
+-	priv->info.base = bd.bi_dram[0].start;
++	priv->info.base = gd->dram[0].start;
+ 	priv->info.size = gd->ram_size;
+ 
+ 	sdram_size_check(&bd);
+diff --git a/drivers/ddr/altera/sdram_s10.c b/drivers/ddr/altera/sdram_s10.c
+index 4ac4c79e0ac..6664090f86a 100644
+--- a/drivers/ddr/altera/sdram_s10.c
++++ b/drivers/ddr/altera/sdram_s10.c
+@@ -285,7 +285,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	/* Get bank configuration from devicetree */
+ 	ret = fdtdec_decode_ram_size(gd->fdt_blob, NULL, 0, NULL,
+-				     (phys_size_t *)&gd->ram_size, &bd);
++				     (phys_size_t *)&gd->ram_size, gd);
+ 	if (ret) {
+ 		puts("DDR: Failed to decode memory node\n");
+ 		return -1;
+@@ -328,7 +328,7 @@ int sdram_mmr_init_full(struct udevice *dev)
+ 
+ 	sdram_size_check(&bd);
+ 
+-	priv->info.base = bd.bi_dram[0].start;
++	priv->info.base = gd->dram[0].start;
+ 	priv->info.size = gd->ram_size;
+ 
+ 	debug("DDR: HMC init success\n");
+diff --git a/drivers/ddr/altera/sdram_soc64.c b/drivers/ddr/altera/sdram_soc64.c
+index 8ee7049b164..93df3d1812a 100644
+--- a/drivers/ddr/altera/sdram_soc64.c
++++ b/drivers/ddr/altera/sdram_soc64.c
+@@ -150,8 +150,8 @@ void sdram_init_ecc_bits(struct bd_info *bd)
+ 
+ 	icache_enable();
+ 
+-	start_addr = bd->bi_dram[0].start;
+-	size = bd->bi_dram[0].size;
++	start_addr = gd->dram[0].start;
++	size = gd->dram[0].size;
+ 
+ 	/* Initialize small block for page table */
+ 	memset((void *)start_addr, 0, PGTABLE_SIZE + PGTABLE_OFF);
+@@ -174,8 +174,8 @@ void sdram_init_ecc_bits(struct bd_info *bd)
+ 		if (bank >= CONFIG_NR_DRAM_BANKS)
+ 			break;
+ 
+-		start_addr = bd->bi_dram[bank].start;
+-		size = bd->bi_dram[bank].size;
++		start_addr = gd->dram[bank].start;
++		size = gd->dram[bank].size;
+ 	}
+ 
+ 	dcache_disable();
+@@ -198,12 +198,12 @@ void sdram_size_check(struct bd_info *bd)
+ 		phys_addr_t start = 0;
+ 		phys_size_t remaining_size;
+ 
+-		start = bd->bi_dram[bank].start;
+-		remaining_size = bd->bi_dram[bank].size;
++		start = gd->dram[bank].start;
++		remaining_size = gd->dram[bank].size;
+ 		debug("Checking bank %d: start=0x%llx, size=0x%llx\n",
+ 		      bank, start, remaining_size);
+ 
+-		while (ram_check < bd->bi_dram[bank].size) {
++		while (ram_check < gd->dram[bank].size) {
+ 			phys_size_t size, test_size, detected_size;
+ 
+ 			size = min((phys_addr_t)SZ_1G, (phys_addr_t)remaining_size);
+@@ -232,7 +232,7 @@ void sdram_size_check(struct bd_info *bd)
+ 			}
+ 
+ 			ram_check += detected_size;
+-			remaining_size = bd->bi_dram[bank].size - ram_check;
++			remaining_size = gd->dram[bank].size - ram_check;
+ 		}
+ 
+ 		total_ram_check += ram_check;
+@@ -292,10 +292,10 @@ static void sdram_set_firewall_non_f2sdram(struct bd_info *bd)
+ 	u32 lower, upper;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		if (!bd->bi_dram[i].size)
++		if (!gd->dram[i].size)
+ 			continue;
+ 
+-		value = bd->bi_dram[i].start;
++		value = gd->dram[i].start;
+ 
+ 		/* Keep first 1MB of SDRAM memory region as secure region when
+ 		 * using ATF flow, where the ATF code is located.
+@@ -322,7 +322,7 @@ static void sdram_set_firewall_non_f2sdram(struct bd_info *bd)
+ 				      (i * 4 * sizeof(u32)));
+ 
+ 		/* Setting non-secure MPU limit and limit extended */
+-		value = bd->bi_dram[i].start + bd->bi_dram[i].size - 1;
++		value = gd->dram[i].start + gd->dram[i].size - 1;
+ 
+ 		lower = lower_32_bits(value);
+ 		upper = upper_32_bits(value);
+@@ -354,10 +354,10 @@ static void sdram_set_firewall_f2sdram(struct bd_info *bd)
+ 	phys_size_t value;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		if (!bd->bi_dram[i].size)
++		if (!gd->dram[i].size)
+ 			continue;
+ 
+-		value = bd->bi_dram[i].start;
++		value = gd->dram[i].start;
+ 
+ 		/* Keep first 1MB of SDRAM memory region as secure region when
+ 		 * using ATF flow, where the ATF code is located.
+@@ -376,7 +376,7 @@ static void sdram_set_firewall_f2sdram(struct bd_info *bd)
+ 					  (i * 4 * sizeof(u32)));
+ 
+ 		/* Setting limit and limit extended */
+-		value = bd->bi_dram[i].start + bd->bi_dram[i].size - 1;
++		value = gd->dram[i].start + gd->dram[i].size - 1;
+ 
+ 		lower = lower_32_bits(value);
+ 		upper = upper_32_bits(value);
+diff --git a/drivers/mmc/mvebu_mmc.c b/drivers/mmc/mvebu_mmc.c
+index 5af1953cd14..89d511c1a6f 100644
+--- a/drivers/mmc/mvebu_mmc.c
++++ b/drivers/mmc/mvebu_mmc.c
+@@ -375,8 +375,8 @@ static void mvebu_window_setup(const struct mmc *mmc)
+ 			break;
+ 		}
+ 
+-		size = gd->bd->bi_dram[i].size;
+-		base = gd->bd->bi_dram[i].start;
++		size = gd->dram[i].size;
++		base = gd->dram[i].start;
+ 		if (size && attrib) {
+ 			mvebu_mmc_write(mmc, WINDOW_CTRL(i),
+ 					MVCPU_WIN_CTRL_DATA(size,
+diff --git a/drivers/net/mvgbe.c b/drivers/net/mvgbe.c
+index 107a33aa9f5..4dc738980cb 100644
+--- a/drivers/net/mvgbe.c
++++ b/drivers/net/mvgbe.c
+@@ -256,8 +256,8 @@ static void set_dram_access(struct mvgbe_registers *regs)
+ 		win_param.access_ctrl = EWIN_ACCESS_FULL;
+ 		win_param.high_addr = 0;
+ 		/* Get bank base and size */
+-		win_param.base_addr = gd->bd->bi_dram[i].start;
+-		win_param.size = gd->bd->bi_dram[i].size;
++		win_param.base_addr = gd->dram[i].start;
++		win_param.size = gd->dram[i].size;
+ 		if (win_param.size == 0)
+ 			win_param.enable = 0;
+ 		else
+diff --git a/drivers/pci/pci-uclass.c b/drivers/pci/pci-uclass.c
+index f58d542ef75..4bdd1f7477f 100644
+--- a/drivers/pci/pci-uclass.c
++++ b/drivers/pci/pci-uclass.c
+@@ -1126,14 +1126,14 @@ static int decode_regions(struct pci_controller *hose, ofnode parent_node,
+ 		return 0;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; ++i) {
+-		if (bd->bi_dram[i].size) {
+-			phys_addr_t start = bd->bi_dram[i].start;
++		if (gd->dram[i].size) {
++			phys_addr_t start = gd->dram[i].start;
+ 
+ 			if (IS_ENABLED(CONFIG_PCI_MAP_SYSTEM_MEMORY))
+-				start = virt_to_phys((void *)(uintptr_t)bd->bi_dram[i].start);
++				start = virt_to_phys((void *)(uintptr_t)gd->dram[i].start);
+ 
+ 			pci_set_region(hose->regions + hose->region_count++,
+-				       start, start, bd->bi_dram[i].size,
++				       start, start, gd->dram[i].size,
+ 				       PCI_REGION_MEM | PCI_REGION_SYS_MEMORY);
+ 		}
+ 	}
+diff --git a/drivers/usb/host/ehci-marvell.c b/drivers/usb/host/ehci-marvell.c
+index 794a4168913..38ee17f063d 100644
+--- a/drivers/usb/host/ehci-marvell.c
++++ b/drivers/usb/host/ehci-marvell.c
+@@ -222,8 +222,8 @@ static void usb_brg_adrdec_setup(int index)
+ 			break;
+ 		}
+ 
+-		size = gd->bd->bi_dram[i].size;
+-		base = gd->bd->bi_dram[i].start;
++		size = gd->dram[i].size;
++		base = gd->dram[i].start;
+ 		if ((size) && (attrib))
+ 			writel(MVCPU_WIN_CTRL_DATA(size, USB_TARGET_DRAM,
+ 						   attrib, MVCPU_WIN_ENABLE),
+diff --git a/drivers/video/meson/meson_vpu.c b/drivers/video/meson/meson_vpu.c
+index ca627728743..a686faf9f58 100644
+--- a/drivers/video/meson/meson_vpu.c
++++ b/drivers/video/meson/meson_vpu.c
+@@ -81,8 +81,8 @@ cvbs:
+ 	meson_fb.fb_size = ALIGN(meson_fb.xsize * meson_fb.ysize *
+ 				 ((1 << VPU_MAX_LOG2_BPP) / 8) +
+ 				 MESON_VPU_OVERSCAN, EFI_PAGE_SIZE);
+-	meson_fb.base = gd->bd->bi_dram[0].start +
+-			gd->bd->bi_dram[0].size - meson_fb.fb_size;
++	meson_fb.base = gd->dram[0].start +
++			gd->dram[0].size - meson_fb.fb_size;
+ 
+ 	/* Override the framebuffer address */
+ 	uc_plat->base = meson_fb.base;
+@@ -175,8 +175,8 @@ static void meson_vpu_setup_simplefb(void *fdt)
+ 	 * at the end of the RAM and we strip this portion from the kernel
+ 	 * allowed region
+ 	 */
+-	mem_start = gd->bd->bi_dram[0].start;
+-	mem_size = gd->bd->bi_dram[0].size - meson_fb.fb_size;
++	mem_start = gd->dram[0].start;
++	mem_size = gd->dram[0].size - meson_fb.fb_size;
+ 	ret = fdt_fixup_memory_banks(fdt, &mem_start, &mem_size, 1);
+ 	if (ret) {
+ 		eprintf("Cannot setup simplefb: Error reserving memory\n");
+diff --git a/drivers/video/sunxi/sunxi_de2.c b/drivers/video/sunxi/sunxi_de2.c
+index 154641b9a69..ab36ee1595b 100644
+--- a/drivers/video/sunxi/sunxi_de2.c
++++ b/drivers/video/sunxi/sunxi_de2.c
+@@ -368,7 +368,7 @@ int sunxi_simplefb_setup(void *blob)
+ 		return 0; /* Keep older kernels working */
+ 	}
+ 
+-	start = gd->bd->bi_dram[0].start;
++	start = gd->dram[0].start;
+ 	size = de2_plat->base - start;
+ 	ret = fdt_fixup_memory_banks(blob, &start, &size, 1);
+ 	if (ret) {
+diff --git a/drivers/video/sunxi/sunxi_display.c b/drivers/video/sunxi/sunxi_display.c
+index 4a6a89ef9d2..fa492c661db 100644
+--- a/drivers/video/sunxi/sunxi_display.c
++++ b/drivers/video/sunxi/sunxi_display.c
+@@ -1336,7 +1336,7 @@ int sunxi_simplefb_setup(void *blob)
+ 	 * and e.g. Linux refuses to iomap RAM on ARM, see:
+ 	 * linux/arch/arm/mm/ioremap.c around line 301.
+ 	 */
+-	start = gd->bd->bi_dram[0].start;
++	start = gd->dram[0].start;
+ 	size = sunxi_display->fb_addr - start;
+ 	ret = fdt_fixup_memory_banks(blob, &start, &size, 1);
+ 	if (ret) {
+diff --git a/include/asm-generic/global_data.h b/include/asm-generic/global_data.h
+index 745d2c3a966..72acd26a3d0 100644
+--- a/include/asm-generic/global_data.h
++++ b/include/asm-generic/global_data.h
+@@ -448,6 +448,13 @@ struct global_data {
+ 	 */
+ 	struct upl *upl;
+ #endif
++	/**
++	 * @dram: array describing DRAM banks (start address and size for each bank)
++	 */
++	struct {			/* RAM configuration */
++		phys_addr_t start;
++		phys_size_t size;
++	} dram[CONFIG_NR_DRAM_BANKS];
+ };
+ #ifndef DO_DEPS_ONLY
+ static_assert(sizeof(struct global_data) == GD_SIZE);
+diff --git a/include/asm-generic/u-boot.h b/include/asm-generic/u-boot.h
+index 8c619c1b74a..931fe2f3274 100644
+--- a/include/asm-generic/u-boot.h
++++ b/include/asm-generic/u-boot.h
+@@ -59,10 +59,6 @@ struct bd_info {
+ #endif
+ 	ulong	        bi_arch_number;	/* unique id for this board */
+ 	ulong	        bi_boot_params;	/* where this board expects params */
+-	struct {			/* RAM configuration */
+-		phys_addr_t start;
+-		phys_size_t size;
+-	} bi_dram[CONFIG_NR_DRAM_BANKS];
+ };
+ 
+ #endif /* __ASSEMBLY__ */
+diff --git a/include/configs/m53menlo.h b/include/configs/m53menlo.h
+index a6aafb51854..36e330887cd 100644
+--- a/include/configs/m53menlo.h
++++ b/include/configs/m53menlo.h
+@@ -15,9 +15,9 @@
+  * Memory configurations
+  */
+ #define PHYS_SDRAM_1			CSD0_BASE_ADDR
+-#define PHYS_SDRAM_1_SIZE		(gd->bd->bi_dram[0].size)
++#define PHYS_SDRAM_1_SIZE		(gd->dram[0].size)
+ #define PHYS_SDRAM_2			CSD1_BASE_ADDR
+-#define PHYS_SDRAM_2_SIZE		(gd->bd->bi_dram[1].size)
++#define PHYS_SDRAM_2_SIZE		(gd->dram[1].size)
+ #define PHYS_SDRAM_SIZE			(gd->ram_size)
+ 
+ #define CFG_SYS_SDRAM_BASE		(PHYS_SDRAM_1)
+diff --git a/include/configs/mx53cx9020.h b/include/configs/mx53cx9020.h
+index 2bd1426c7d9..e823611d2e4 100644
+--- a/include/configs/mx53cx9020.h
++++ b/include/configs/mx53cx9020.h
+@@ -51,9 +51,9 @@
+ 
+ /* Physical Memory Map */
+ #define PHYS_SDRAM_1			CSD0_BASE_ADDR
+-#define PHYS_SDRAM_1_SIZE		(gd->bd->bi_dram[0].size)
++#define PHYS_SDRAM_1_SIZE		(gd->dram[0].size)
+ #define PHYS_SDRAM_2			CSD1_BASE_ADDR
+-#define PHYS_SDRAM_2_SIZE		(gd->bd->bi_dram[1].size)
++#define PHYS_SDRAM_2_SIZE		(gd->dram[1].size)
+ #define PHYS_SDRAM_SIZE			(gd->ram_size)
+ 
+ #define CFG_SYS_SDRAM_BASE		(PHYS_SDRAM_1)
+diff --git a/include/configs/mx53loco.h b/include/configs/mx53loco.h
+index 14095b99f03..acd6eb6f8ac 100644
+--- a/include/configs/mx53loco.h
++++ b/include/configs/mx53loco.h
+@@ -86,9 +86,9 @@
+ 
+ /* Physical Memory Map */
+ #define PHYS_SDRAM_1			CSD0_BASE_ADDR
+-#define PHYS_SDRAM_1_SIZE		(gd->bd->bi_dram[0].size)
++#define PHYS_SDRAM_1_SIZE		(gd->dram[0].size)
+ #define PHYS_SDRAM_2			CSD1_BASE_ADDR
+-#define PHYS_SDRAM_2_SIZE		(gd->bd->bi_dram[1].size)
++#define PHYS_SDRAM_2_SIZE		(gd->dram[1].size)
+ #define PHYS_SDRAM_SIZE			(gd->ram_size)
+ 
+ #define CFG_SYS_SDRAM_BASE		(PHYS_SDRAM_1)
+diff --git a/include/configs/mx53ppd.h b/include/configs/mx53ppd.h
+index 3707de254e1..65babf50546 100644
+--- a/include/configs/mx53ppd.h
++++ b/include/configs/mx53ppd.h
+@@ -81,9 +81,9 @@
+ 
+ /* Physical Memory Map */
+ #define PHYS_SDRAM_1			CSD0_BASE_ADDR
+-#define PHYS_SDRAM_1_SIZE		(gd->bd->bi_dram[0].size)
++#define PHYS_SDRAM_1_SIZE		(gd->dram[0].size)
+ #define PHYS_SDRAM_2			CSD1_BASE_ADDR
+-#define PHYS_SDRAM_2_SIZE		(gd->bd->bi_dram[1].size)
++#define PHYS_SDRAM_2_SIZE		(gd->dram[1].size)
+ #define PHYS_SDRAM_SIZE			(gd->ram_size)
+ 
+ #define CFG_SYS_SDRAM_BASE		(PHYS_SDRAM_1)
+diff --git a/include/fdtdec.h b/include/fdtdec.h
+index 46eaa0da63c..51d9f14a9f2 100644
+--- a/include/fdtdec.h
++++ b/include/fdtdec.h
+@@ -57,6 +57,7 @@ struct fdt_memory {
+ };
+ 
+ struct bd_info;
++struct global_data;
+ 
+ /**
+  * enum fdt_source_t - indicates where the devicetree came from
+@@ -974,7 +975,7 @@ int fdtdec_setup_mem_size_base(void);
+ int fdtdec_setup_mem_size_base_lowest(void);
+ 
+ /**
+- * fdtdec_setup_memory_banksize() - decode and populate gd->bd->bi_dram
++ * fdtdec_setup_memory_banksize() - decode and populate gd->dram
+  *
+  * Decode the /memory 'reg' property to determine the address and size of the
+  * memory banks. Use this data to populate the global data board info with the
+@@ -1256,12 +1257,12 @@ int board_fdt_blob_setup(void **fdtp);
+  * @param basep		Returns base address of first memory bank (NULL to
+  *			ignore)
+  * @param sizep		Returns total memory size (NULL to ignore)
+- * @param bd		Updated with the memory bank information (NULL to skip)
++ * @param gd_ptr	Updated with the memory bank information (NULL to skip)
+  * Return: 0 if OK, -ve on error
+  */
+ int fdtdec_decode_ram_size(const void *blob, const char *area, int board_id,
+ 			   phys_addr_t *basep, phys_size_t *sizep,
+-			   struct bd_info *bd);
++			   struct global_data *gd_ptr);
+ 
+ /**
+  * fdtdec_get_srcname() - Get the name of where the devicetree comes from
+diff --git a/include/init.h b/include/init.h
+index c31ebd83b85..23466d3f153 100644
+--- a/include/init.h
++++ b/include/init.h
+@@ -80,7 +80,7 @@ int dram_init(void);
+  * dram_init_banksize() - Set up DRAM bank sizes
+  *
+  * This can be implemented by boards to set up the DRAM bank information in
+- * gd->bd->bi_dram(). It is called just before relocation, after dram_init()
++ * gd->dram[] It is called just before relocation, after dram_init()
+  * is called.
+  *
+  * If this is not provided, a default implementation will try to set up a
+diff --git a/lib/fdtdec.c b/lib/fdtdec.c
+index c67b6e8c133..4de8a6bc22d 100644
+--- a/lib/fdtdec.c
++++ b/lib/fdtdec.c
+@@ -35,6 +35,7 @@
+ #include <linux/ctype.h>
+ #include <linux/lzo.h>
+ #include <linux/ioport.h>
++#include <asm/global_data.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -1142,14 +1143,14 @@ int fdtdec_setup_memory_banksize(void)
+ 		if (ret != 0)
+ 			return -EINVAL;
+ 
+-		gd->bd->bi_dram[bank].start = (phys_addr_t)res.start;
+-		gd->bd->bi_dram[bank].size =
++		gd->dram[bank].start = (phys_addr_t)res.start;
++		gd->dram[bank].size =
+ 			(phys_size_t)(res.end - res.start + 1);
+ 
+ 		debug("%s: DRAM Bank #%d: start = %pap, size = %pap\n",
+ 		      __func__, bank,
+-		      &gd->bd->bi_dram[bank].start,
+-		      &gd->bd->bi_dram[bank].size);
++		      &gd->dram[bank].start,
++		      &gd->dram[bank].size);
+ 	}
+ 
+ 	return 0;
+@@ -1935,7 +1936,7 @@ int fdtdec_resetup(int *rescan)
+ 
+ int fdtdec_decode_ram_size(const void *blob, const char *area, int board_id,
+ 			   phys_addr_t *basep, phys_size_t *sizep,
+-			   struct bd_info *bd)
++			   gd_t *gd_ptr)
+ {
+ 	int addr_cells, size_cells;
+ 	const u32 *cell, *end;
+@@ -1987,8 +1988,8 @@ int fdtdec_decode_ram_size(const void *blob, const char *area, int board_id,
+ 	}
+ 	/* Note: if no matching subnode was found we use the parent node */
+ 
+-	if (bd) {
+-		memset(bd->bi_dram, '\0', sizeof(bd->bi_dram[0]) *
++	if (gd_ptr) {
++		memset(gd_ptr->dram, '\0', sizeof(gd_ptr->dram[0]) *
+ 						CONFIG_NR_DRAM_BANKS);
+ 	}
+ 
+@@ -2004,8 +2005,8 @@ int fdtdec_decode_ram_size(const void *blob, const char *area, int board_id,
+ 		if (addr_cells == 2)
+ 			addr += (u64)fdt32_to_cpu(*cell++) << 32UL;
+ 		addr += fdt32_to_cpu(*cell++);
+-		if (bd)
+-			bd->bi_dram[bank].start = addr;
++		if (gd_ptr)
++			gd_ptr->dram[bank].start = addr;
+ 		if (basep && !bank)
+ 			*basep = (phys_addr_t)addr;
+ 
+@@ -2027,8 +2028,8 @@ int fdtdec_decode_ram_size(const void *blob, const char *area, int board_id,
+ 			}
+ 		}
+ 
+-		if (bd)
+-			bd->bi_dram[bank].size = size;
++		if (gd_ptr)
++			gd_ptr->dram[bank].size = size;
+ 		total_size += size;
+ 	}
+ 
+diff --git a/lib/lmb.c b/lib/lmb.c
+index 275d105c5aa..0707f52800e 100644
+--- a/lib/lmb.c
++++ b/lib/lmb.c
+@@ -554,12 +554,12 @@ static void lmb_reserve_uboot_region(void)
+ #endif
+ 
+ 	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		if (!gd->bd->bi_dram[bank].size ||
+-		    rsv_start < gd->bd->bi_dram[bank].start)
++		if (!gd->dram[bank].size ||
++		    rsv_start < gd->dram[bank].start)
+ 			continue;
+ 		/* Watch out for RAM at end of address space! */
+-		bank_end = gd->bd->bi_dram[bank].start +
+-			gd->bd->bi_dram[bank].size - 1;
++		bank_end = gd->dram[bank].start +
++			gd->dram[bank].size - 1;
+ 		if (rsv_start > bank_end)
+ 			continue;
+ 		if (bank_end > end)
+@@ -614,7 +614,6 @@ static void lmb_add_memory(void)
+ 	phys_addr_t bank_end;
+ 	phys_size_t size;
+ 	u64 ram_top = gd->ram_top;
+-	struct bd_info *bd = gd->bd;
+ 
+ 	if (CONFIG_IS_ENABLED(LMB_ARCH_MEM_MAP))
+ 		return lmb_arch_add_memory();
+@@ -624,22 +623,22 @@ static void lmb_add_memory(void)
+ 		ram_top = 0x100000000ULL;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; i++) {
+-		size = bd->bi_dram[i].size;
++		size = gd->dram[i].size;
+ 
+ 		if (size) {
+-			lmb_add(bd->bi_dram[i].start, size);
++			lmb_add(gd->dram[i].start, size);
+ 			if (!IS_ENABLED(CONFIG_LMB_LIMIT_DMA_BELOW_RAM_TOP))
+ 				continue;
+ 
+-			bank_end = bd->bi_dram[i].start + size;
++			bank_end = gd->dram[i].start + size;
+ 
+ 			/*
+ 			 * Reserve memory above ram_top as
+ 			 * no-overwrite so that it cannot be
+ 			 * allocated
+ 			 */
+-			if (bd->bi_dram[i].start >= ram_top)
+-				lmb_reserve(bd->bi_dram[i].start, size,
++			if (gd->dram[i].start >= ram_top)
++				lmb_reserve(gd->dram[i].start, size,
+ 					    LMB_NOOVERWRITE);
+ 			else if (bank_end > ram_top)
+ 				lmb_reserve(ram_top, bank_end - ram_top,
+diff --git a/test/cmd/bdinfo.c b/test/cmd/bdinfo.c
+index 7f4f1868c6a..7b7fb0894dd 100644
+--- a/test/cmd/bdinfo.c
++++ b/test/cmd/bdinfo.c
+@@ -138,16 +138,15 @@ static int lmb_test_dump_all(struct unit_test_state *uts)
+ 
+ static int bdinfo_check_mem(struct unit_test_state *uts)
+ {
+-	struct bd_info *bd = gd->bd;
+ 	int i;
+ 
+ 	for (i = 0; i < CONFIG_NR_DRAM_BANKS; ++i) {
+-		if (bd->bi_dram[i].size) {
++		if (gd->dram[i].size) {
+ 			ut_assertok(test_num_l(uts, "DRAM bank", i));
+ 			ut_assertok(test_num_ll(uts, "-> start",
+-						bd->bi_dram[i].start));
++						gd->dram[i].start));
+ 			ut_assertok(test_num_ll(uts, "-> size",
+-						bd->bi_dram[i].size));
++						gd->dram[i].size));
+ 		}
+ 	}
+ 
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0003-lib-fdtdec-Handle-multiple-memory-nodes.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0003-lib-fdtdec-Handle-multiple-memory-nodes.patch
@@ -1,0 +1,212 @@
+From 238f9fe1763b68cfd92e1b2b1dbfdc30f5d9d728 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:44 +0100
+Subject: [PATCH 03/22] lib: fdtdec: Handle multiple memory nodes
+
+Current code only tries to fetch the first memory node found in
+fdt tree and determine memory banks from multiple reg properties.
+
+Specification allows multiple memory nodes in devicetree, rework
+fdtdec_setup_mem_size_base_lowest and fdtdec_setup_memory_banksize
+to iterate over all memory nodes.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ include/asm-generic/global_data.h |   2 +-
+ lib/fdtdec.c                      | 129 +++++++++++++++++-------------
+ 2 files changed, 76 insertions(+), 55 deletions(-)
+
+diff --git a/include/asm-generic/global_data.h b/include/asm-generic/global_data.h
+index 72acd26a3d0..061d7c5c3b2 100644
+--- a/include/asm-generic/global_data.h
++++ b/include/asm-generic/global_data.h
+@@ -451,7 +451,7 @@ struct global_data {
+ 	/**
+ 	 * @dram: array describing DRAM banks (start address and size for each bank)
+ 	 */
+-	struct {			/* RAM configuration */
++	struct dram_bank {		/* RAM configuration */
+ 		phys_addr_t start;
+ 		phys_size_t size;
+ 	} dram[CONFIG_NR_DRAM_BANKS];
+diff --git a/lib/fdtdec.c b/lib/fdtdec.c
+index 4de8a6bc22d..225b49fc52c 100644
+--- a/lib/fdtdec.c
++++ b/lib/fdtdec.c
+@@ -36,6 +36,7 @@
+ #include <linux/lzo.h>
+ #include <linux/ioport.h>
+ #include <asm/global_data.h>
++#include <sort.h>
+ 
+ DECLARE_GLOBAL_DATA_PTR;
+ 
+@@ -1115,90 +1116,110 @@ ofnode fdtdec_get_next_memory_node(ofnode mem)
+ 	return get_next_memory_node(mem);
+ }
+ 
++static int cmp_memory_bank(const void *a, const void *b)
++{
++	const struct dram_bank *a1 = a, *b1 = b;
++
++	return a1->start > b1->start ? 1 :
++	       a1->start < b1->start ? -1 : 0;
++}
++
+ int fdtdec_setup_memory_banksize(void)
+ {
+-	int bank, ret, reg = 0;
+-	struct resource res;
++	int bank = 0;
+ 	ofnode mem = ofnode_null();
+ 
+-	mem = get_next_memory_node(mem);
+-	if (!ofnode_valid(mem)) {
+-		debug("%s: Missing /memory node\n", __func__);
+-		return -EINVAL;
+-	}
++	while (true) {
++		struct resource res;
++		int reg = 0;
+ 
+-	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		ret = ofnode_read_resource(mem, reg++, &res);
+-		if (ret < 0) {
+-			reg = 0;
+-			mem = get_next_memory_node(mem);
+-			if (!ofnode_valid(mem))
+-				break;
++		mem = get_next_memory_node(mem);
++		if (!ofnode_valid(mem))
++			break;
++
++		while (true) {
++			int ret = ofnode_read_resource(mem, reg, &res);
+ 
+-			ret = ofnode_read_resource(mem, reg++, &res);
+ 			if (ret < 0)
+ 				break;
+-		}
+ 
+-		if (ret != 0)
+-			return -EINVAL;
++			if (bank >= CONFIG_NR_DRAM_BANKS)
++				goto too_may_memory_banks;
+ 
+-		gd->dram[bank].start = (phys_addr_t)res.start;
+-		gd->dram[bank].size =
+-			(phys_size_t)(res.end - res.start + 1);
++			gd->dram[bank].start = res.start;
++			gd->dram[bank].size =
++					(phys_size_t)(res.end - res.start + 1);
+ 
+-		debug("%s: DRAM Bank #%d: start = %pap, size = %pap\n",
+-		      __func__, bank,
+-		      &gd->dram[bank].start,
+-		      &gd->dram[bank].size);
++			log_debug("%s: DRAM Bank #%d %s.%d: start = 0x%llx, size = 0x%llx\n",
++				  __func__, bank, ofnode_get_name(mem), reg,
++				 (unsigned long long)gd->dram[bank].start,
++				 (unsigned long long)gd->dram[bank].size);
++			reg++;
++			bank++;
++		}
++	}
++
++	if (!bank) {
++		log_warning("%s: Missing /memory node\n", __func__);
++		return -EINVAL;
+ 	}
+ 
++	qsort(gd->dram, bank, sizeof(gd->dram[0]), cmp_memory_bank);
++
+ 	return 0;
++
++too_may_memory_banks:
++	log_warning("%s: Too many memory banks\n", __func__);
++	return -EINVAL;
+ }
+ 
+ int fdtdec_setup_mem_size_base_lowest(void)
+ {
+-	int bank, ret, reg = 0;
+-	struct resource res;
+-	unsigned long base;
+-	phys_size_t size;
++	int bank = 0;
+ 	ofnode mem = ofnode_null();
++	__maybe_unused const char *final_name;
++	__maybe_unused int final_reg;
+ 
+-	gd->ram_base = (unsigned long)~0;
++	gd->ram_base = ULONG_MAX;
+ 
+-	mem = get_next_memory_node(mem);
+-	if (!ofnode_valid(mem)) {
+-		debug("%s: Missing /memory node\n", __func__);
+-		return -EINVAL;
+-	}
++	while (true) {
++		struct resource res;
++		phys_size_t base, size;
++		int reg = 0;
+ 
+-	for (bank = 0; bank < CONFIG_NR_DRAM_BANKS; bank++) {
+-		ret = ofnode_read_resource(mem, reg++, &res);
+-		if (ret < 0) {
+-			reg = 0;
+-			mem = get_next_memory_node(mem);
+-			if (!ofnode_valid(mem))
+-				break;
++		mem = get_next_memory_node(mem);
++		if (!ofnode_valid(mem))
++			break;
++
++		while (true) {
++			int ret = ofnode_read_resource(mem, reg, &res);
+ 
+-			ret = ofnode_read_resource(mem, reg++, &res);
+ 			if (ret < 0)
+ 				break;
+-		}
+ 
+-		if (ret != 0)
+-			return -EINVAL;
+-
+-		base = (unsigned long)res.start;
+-		size = (phys_size_t)(res.end - res.start + 1);
++			base = res.start;
++			size = res.end - res.start + 1;
++			if (gd->ram_base > base && size) {
++				gd->ram_base = base;
++				gd->ram_size = size;
++				final_name = ofnode_get_name(mem);
++				final_reg = reg;
++			}
+ 
+-		if (gd->ram_base > base && size) {
+-			gd->ram_base = base;
+-			gd->ram_size = size;
+-			debug("%s: Initial DRAM base %lx size %lx\n",
+-			      __func__, base, (unsigned long)size);
++			reg++;
++			bank++;
+ 		}
+ 	}
+ 
++	if (!bank) {
++		log_warning("%s: Missing /memory node\n", __func__);
++		return -EINVAL;
++	}
++
++	log_debug("%s: Initial DRAM %s.%d: base %lx size %pap\n",
++		  __func__, final_name, final_reg,
++		  gd->ram_base, &gd->ram_size);
++
+ 	return 0;
+ }
+ 
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0004-linux-io.h-Use-map_physmem-to-implement-ioremap.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0004-linux-io.h-Use-map_physmem-to-implement-ioremap.patch
@@ -1,0 +1,42 @@
+From 6b6b1e3ea1df675b44bae835f1b7750ad57dc7c8 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:45 +0100
+Subject: [PATCH 04/22] linux/io.h: Use map_physmem to implement ioremap
+
+ioremap API is here to be compatible with Linux drivers,
+to maintain compatibility we need to ensure we are using
+the same way to determine virtual address for IO devices
+from physical address.
+
+map_physmem is U-Boot's standard way for doing the trick,
+we should follow that. For architectures VA == PA it has
+no impact, for MIPS it has it's own ioremap implementation
+in asm/io.h anyway.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ include/linux/io.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/include/linux/io.h b/include/linux/io.h
+index 79847886be9..ada6525a1c6 100644
+--- a/include/linux/io.h
++++ b/include/linux/io.h
+@@ -59,11 +59,12 @@ static inline void iowrite64(u64 value, volatile void __iomem *addr)
+ static inline void __iomem *ioremap(resource_size_t offset,
+ 				    resource_size_t size)
+ {
+-	return (void __iomem *)(unsigned long)offset;
++	return (void __iomem *)map_physmem(offset, size, MAP_NOCACHE);
+ }
+ 
+ static inline void iounmap(void __iomem *addr)
+ {
++	return unmap_physmem(addr, MAP_NOCACHE);
+ }
+ #endif
+ 
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0005-image-Take-entry-point-as-an-output-of-setup_booti.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0005-image-Take-entry-point-as-an-output-of-setup_booti.patch
@@ -1,0 +1,186 @@
+From 210c3ea065103785f0d0d53a21a1fc490dc6cbfa Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:46 +0100
+Subject: [PATCH 05/22] image: Take entry point as an output of setup_booti
+
+For LoongArch the start of the image is not the entry
+point to the image.
+
+We refactor the code base to allow entry point to be
+supplied by setup_booti.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/arm/lib/image.c     | 3 ++-
+ arch/riscv/lib/image.c   | 4 +++-
+ arch/sandbox/lib/bootm.c | 2 +-
+ boot/bootm.c             | 5 +++--
+ cmd/booti.c              | 5 +++--
+ common/spl/spl.c         | 9 +++++----
+ include/image.h          | 3 ++-
+ 7 files changed, 19 insertions(+), 12 deletions(-)
+
+diff --git a/arch/arm/lib/image.c b/arch/arm/lib/image.c
+index 2268661de93..62c28b8310a 100644
+--- a/arch/arm/lib/image.c
++++ b/arch/arm/lib/image.c
+@@ -29,7 +29,7 @@ struct Image_header {
+ };
+ 
+ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+-		bool force_reloc)
++		ulong *entry, bool force_reloc)
+ {
+ 	struct Image_header *ih;
+ 	uint64_t dst;
+@@ -72,6 +72,7 @@ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+ 		dst = gd->dram[0].start;
+ 
+ 	*relocated_addr = ALIGN(dst, SZ_2M) + text_offset;
++	*entry = *relocated_addr;
+ 
+ 	unmap_sysmem(ih);
+ 
+diff --git a/arch/riscv/lib/image.c b/arch/riscv/lib/image.c
+index a82f48e9a50..300be365ddf 100644
+--- a/arch/riscv/lib/image.c
++++ b/arch/riscv/lib/image.c
+@@ -33,7 +33,7 @@ struct linux_image_h {
+ };
+ 
+ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+-		bool force_reloc)
++		ulong *entry, bool force_reloc)
+ {
+ 	struct linux_image_h *lhdr;
+ 
+@@ -56,6 +56,8 @@ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+ 		*relocated_addr = image;
+ 	}
+ 
++	*entry = *relocated_addr;
++
+ 	unmap_sysmem(lhdr);
+ 
+ 	return 0;
+diff --git a/arch/sandbox/lib/bootm.c b/arch/sandbox/lib/bootm.c
+index 7a5f6f7d36e..1a41c7c2735 100644
+--- a/arch/sandbox/lib/bootm.c
++++ b/arch/sandbox/lib/bootm.c
+@@ -84,7 +84,7 @@ int do_bootm_linux(int flag, struct bootm_info *bmi)
+ 
+ /* used for testing 'booti' command */
+ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+-		bool force_reloc)
++		ulong *entry, bool force_reloc)
+ {
+ 	log_err("Booting is not supported on the sandbox.\n");
+ 
+diff --git a/boot/bootm.c b/boot/bootm.c
+index 4836d6b2d41..ee8fabd563b 100644
+--- a/boot/bootm.c
++++ b/boot/bootm.c
+@@ -682,9 +682,10 @@ static int bootm_load_os(struct bootm_headers *images, int boot_progress)
+ 	    images->os.os == IH_OS_LINUX) {
+ 		ulong relocated_addr;
+ 		ulong image_size;
++		ulong entry;
+ 		int ret;
+ 
+-		ret = booti_setup(load, &relocated_addr, &image_size, false);
++		ret = booti_setup(load, &relocated_addr, &image_size, &entry, false);
+ 		if (ret) {
+ 			printf("Failed to prep arm64 kernel (err=%d)\n", ret);
+ 			return BOOTM_ERR_RESET;
+@@ -698,7 +699,7 @@ static int bootm_load_os(struct bootm_headers *images, int boot_progress)
+ 			memmove((void *)relocated_addr, load_buf, image_size);
+ 		}
+ 
+-		images->ep = relocated_addr;
++		images->ep = entry;
+ 		images->os.start = relocated_addr;
+ 		images->os.end = relocated_addr + image_size;
+ 	}
+diff --git a/cmd/booti.c b/cmd/booti.c
+index e6f67d6e136..24c55ff92a2 100644
+--- a/cmd/booti.c
++++ b/cmd/booti.c
+@@ -27,6 +27,7 @@ static int booti_start(struct bootm_info *bmi)
+ 	ulong ld;
+ 	ulong relocated_addr;
+ 	ulong image_size;
++	ulong entry;
+ 	uint8_t *temp;
+ 	ulong dest;
+ 	ulong dest_end;
+@@ -74,7 +75,7 @@ static int booti_start(struct bootm_info *bmi)
+ 	}
+ 	unmap_sysmem((void *)ld);
+ 
+-	ret = booti_setup(ld, &relocated_addr, &image_size, false);
++	ret = booti_setup(ld, &relocated_addr, &image_size, &entry, false);
+ 	if (ret)
+ 		return 1;
+ 
+@@ -85,7 +86,7 @@ static int booti_start(struct bootm_info *bmi)
+ 		memmove((void *)relocated_addr, (void *)ld, image_size);
+ 	}
+ 
+-	images->ep = relocated_addr;
++	images->ep = entry;
+ 	images->os.start = relocated_addr;
+ 	images->os.end = relocated_addr + image_size;
+ 
+diff --git a/common/spl/spl.c b/common/spl/spl.c
+index 722b18c98ed..1d32b0a5b7f 100644
+--- a/common/spl/spl.c
++++ b/common/spl/spl.c
+@@ -114,7 +114,8 @@ int __weak bootz_setup(ulong image, ulong *start, ulong *end)
+ 	 return 1;
+ }
+ 
+-int __weak booti_setup(ulong image, ulong *relocated_addr, ulong *size, bool force_reloc)
++int __weak booti_setup(ulong image, ulong *relocated_addr, ulong *size,
++		       ulong *entry, bool force_reloc)
+ {
+ 	 return 1;
+ }
+@@ -341,13 +342,13 @@ int spl_parse_image_header(struct spl_image_info *spl_image,
+ 	}
+ 
+ 	if (IS_ENABLED(CONFIG_SPL_OS_BOOT) && IS_ENABLED(CONFIG_SPL_BOOTI)) {
+-		ulong start, size;
++		ulong start, size, entry;
+ 
+-		if (!booti_setup((ulong)header, &start, &size, 0)) {
++		if (!booti_setup((ulong)header, &start, &size, &entry, 0)) {
+ 			spl_image->name = "Linux";
+ 			spl_image->os = IH_OS_LINUX;
+ 			spl_image->load_addr = start;
+-			spl_image->entry_point = start;
++			spl_image->entry_point = entry;
+ 			spl_image->size = size;
+ 			debug(PHASE_PROMPT
+ 			      "payload Image, load addr: 0x%lx size: %d\n",
+diff --git a/include/image.h b/include/image.h
+index 34efac6056d..91d22afcac7 100644
+--- a/include/image.h
++++ b/include/image.h
+@@ -1053,11 +1053,12 @@ int bootz_setup(ulong image, ulong *start, ulong *end);
+  * @image: Address of image
+  * @start: Returns start address of image
+  * @size : Returns size image
++ * @entry: Returns entry point of image
+  * @force_reloc: Ignore image->ep field, always place image to RAM start
+  * Return: 0 if OK, 1 if the image was not recognised
+  */
+ int booti_setup(ulong image, ulong *relocated_addr, ulong *size,
+-		bool force_reloc);
++		ulong *entry, bool force_reloc);
+ 
+ /*******************************************************************/
+ /* New uImage format specific code (prefixed with fit_) */
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0006-elf-Define-LoongArch-bits.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0006-elf-Define-LoongArch-bits.patch
@@ -1,0 +1,44 @@
+From 104afa62c48a11924da53929389ec7c025ab188d Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:47 +0100
+Subject: [PATCH 06/22] elf: Define LoongArch bits
+
+They all come from glibc's elf.h
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ include/elf.h | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/include/elf.h b/include/elf.h
+index b88e6cf4032..b69b1adc404 100644
+--- a/include/elf.h
++++ b/include/elf.h
+@@ -225,7 +225,8 @@ typedef struct {
+ #define EM_MN10300	89		/* Matsushita MN10200 */
+ #define EM_MN10200	90		/* Matsushita MN10200 */
+ #define EM_PJ		91		/* picoJava */
+-#define EM_NUM		92		/* number of machine types */
++#define EM_LOONGARCH	258	/* LoongArch */
++
+ 
+ /* Version */
+ #define EV_NONE		0		/* Invalid */
+@@ -705,6 +706,12 @@ unsigned long elf_hash(const unsigned char *name);
+ #define R_RISCV_64		2
+ #define R_RISCV_RELATIVE	3
+ 
++/* LoongArch Relocations */
++#define R_LARCH_NONE				0
++#define R_LARCH_32				1
++#define R_LARCH_64				2
++#define R_LARCH_RELATIVE			3
++
+ #ifndef __ASSEMBLY__
+ unsigned long bootelf_exec(ulong (*entry)(int, char * const[]),
+ 			   int argc, char *const argv[]);
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0007-image-Define-IH_ARCH_LOONGARCH.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0007-image-Define-IH_ARCH_LOONGARCH.patch
@@ -1,0 +1,42 @@
+From 6fe715ef5024ff5482d22f3553c8bb516cf6efec Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:48 +0100
+Subject: [PATCH 07/22] image: Define IH_ARCH_LOONGARCH
+
+Allocate the next value to IH_ARCH_LOONGARCH.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Reviewed-by: Heinrich Schuchardt <xypron.glpk@gmx.de>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ boot/image.c    | 1 +
+ include/image.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/boot/image.c b/boot/image.c
+index 185d52ba492..fddbf01e04f 100644
+--- a/boot/image.c
++++ b/boot/image.c
+@@ -86,6 +86,7 @@ static const table_entry_t uimage_arch[] = {
+ 	{	IH_ARCH_X86_64,		"x86_64",	"AMD x86_64",	},
+ 	{	IH_ARCH_XTENSA,		"xtensa",	"Xtensa",	},
+ 	{	IH_ARCH_RISCV,		"riscv",	"RISC-V",	},
++	{	IH_ARCH_LOONGARCH,	"loongarch",	"LoongArch",	},
+ 	{	-1,			"",		"",		},
+ };
+ 
+diff --git a/include/image.h b/include/image.h
+index 91d22afcac7..64a1b4ec8be 100644
+--- a/include/image.h
++++ b/include/image.h
+@@ -139,6 +139,7 @@ enum {
+ 	IH_ARCH_X86_64,			/* AMD x86_64, Intel and Via */
+ 	IH_ARCH_XTENSA,			/* Xtensa	*/
+ 	IH_ARCH_RISCV,			/* RISC-V */
++	IH_ARCH_LOONGARCH,		/* Loongson LoongArch */
+ 
+ 	IH_ARCH_COUNT,
+ };
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0008-LoongArch-skeleton-and-headers.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0008-LoongArch-skeleton-and-headers.patch
@@ -1,0 +1,3708 @@
+From 3aa5df17c4b39529c04a56f08f02f99e7726b01f Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:49 +0100
+Subject: [PATCH 08/22] LoongArch: skeleton and headers
+
+Commit for directories, Kconfig, Makefile and headers
+
+Some of them are copied from linux, some of them are derived
+from other architectures, the rest are wriiten on my own.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ Makefile                                      |    2 +
+ arch/Kconfig                                  |   15 +
+ arch/loongarch/Kconfig                        |   40 +
+ arch/loongarch/Makefile                       |   19 +
+ arch/loongarch/config.mk                      |   23 +
+ arch/loongarch/cpu/Makefile                   |    5 +
+ arch/loongarch/cpu/u-boot.lds                 |   85 +
+ arch/loongarch/dts/Makefile                   |    6 +
+ arch/loongarch/include/asm/acpi_table.h       |    8 +
+ arch/loongarch/include/asm/addrspace.h        |   86 +
+ .../include/asm/arch-generic/entry-init.h     |   15 +
+ arch/loongarch/include/asm/asm.h              |  186 +++
+ arch/loongarch/include/asm/atomic.h           |   12 +
+ arch/loongarch/include/asm/barrier.h          |  138 ++
+ arch/loongarch/include/asm/bitops.h           |  156 ++
+ arch/loongarch/include/asm/byteorder.h        |   22 +
+ arch/loongarch/include/asm/cache.h            |   24 +
+ arch/loongarch/include/asm/config.h           |   11 +
+ arch/loongarch/include/asm/cpu.h              |  123 ++
+ arch/loongarch/include/asm/dma-mapping.h      |   27 +
+ arch/loongarch/include/asm/global_data.h      |   43 +
+ arch/loongarch/include/asm/gpio.h             |   11 +
+ arch/loongarch/include/asm/io.h               |  399 +++++
+ arch/loongarch/include/asm/linkage.h          |   11 +
+ arch/loongarch/include/asm/loongarch.h        | 1467 +++++++++++++++++
+ arch/loongarch/include/asm/posix_types.h      |   87 +
+ arch/loongarch/include/asm/processor.h        |   11 +
+ arch/loongarch/include/asm/ptrace.h           |   33 +
+ arch/loongarch/include/asm/regdef.h           |   42 +
+ arch/loongarch/include/asm/sections.h         |    8 +
+ arch/loongarch/include/asm/setjmp.h           |   25 +
+ arch/loongarch/include/asm/spl.h              |   11 +
+ arch/loongarch/include/asm/string.h           |   11 +
+ arch/loongarch/include/asm/system.h           |   74 +
+ arch/loongarch/include/asm/types.h            |   37 +
+ arch/loongarch/include/asm/u-boot-loongarch.h |   23 +
+ arch/loongarch/include/asm/u-boot.h           |   30 +
+ arch/loongarch/include/asm/unaligned.h        |   11 +
+ arch/loongarch/lib/Makefile                   |    5 +
+ include/host_arch.h                           |    2 +
+ 40 files changed, 3344 insertions(+)
+ create mode 100644 arch/loongarch/Kconfig
+ create mode 100644 arch/loongarch/Makefile
+ create mode 100644 arch/loongarch/config.mk
+ create mode 100644 arch/loongarch/cpu/Makefile
+ create mode 100644 arch/loongarch/cpu/u-boot.lds
+ create mode 100644 arch/loongarch/dts/Makefile
+ create mode 100644 arch/loongarch/include/asm/acpi_table.h
+ create mode 100644 arch/loongarch/include/asm/addrspace.h
+ create mode 100644 arch/loongarch/include/asm/arch-generic/entry-init.h
+ create mode 100644 arch/loongarch/include/asm/asm.h
+ create mode 100644 arch/loongarch/include/asm/atomic.h
+ create mode 100644 arch/loongarch/include/asm/barrier.h
+ create mode 100644 arch/loongarch/include/asm/bitops.h
+ create mode 100644 arch/loongarch/include/asm/byteorder.h
+ create mode 100644 arch/loongarch/include/asm/cache.h
+ create mode 100644 arch/loongarch/include/asm/config.h
+ create mode 100644 arch/loongarch/include/asm/cpu.h
+ create mode 100644 arch/loongarch/include/asm/dma-mapping.h
+ create mode 100644 arch/loongarch/include/asm/global_data.h
+ create mode 100644 arch/loongarch/include/asm/gpio.h
+ create mode 100644 arch/loongarch/include/asm/io.h
+ create mode 100644 arch/loongarch/include/asm/linkage.h
+ create mode 100644 arch/loongarch/include/asm/loongarch.h
+ create mode 100644 arch/loongarch/include/asm/posix_types.h
+ create mode 100644 arch/loongarch/include/asm/processor.h
+ create mode 100644 arch/loongarch/include/asm/ptrace.h
+ create mode 100644 arch/loongarch/include/asm/regdef.h
+ create mode 100644 arch/loongarch/include/asm/sections.h
+ create mode 100644 arch/loongarch/include/asm/setjmp.h
+ create mode 100644 arch/loongarch/include/asm/spl.h
+ create mode 100644 arch/loongarch/include/asm/string.h
+ create mode 100644 arch/loongarch/include/asm/system.h
+ create mode 100644 arch/loongarch/include/asm/types.h
+ create mode 100644 arch/loongarch/include/asm/u-boot-loongarch.h
+ create mode 100644 arch/loongarch/include/asm/u-boot.h
+ create mode 100644 arch/loongarch/include/asm/unaligned.h
+ create mode 100644 arch/loongarch/lib/Makefile
+
+diff --git a/Makefile b/Makefile
+index 7f5d83658d7..2e18774af90 100644
+--- a/Makefile
++++ b/Makefile
+@@ -243,6 +243,8 @@ else ifeq ("riscv32", $(MK_ARCH))
+   export HOST_ARCH=$(HOST_ARCH_RISCV32)
+ else ifeq ("riscv64", $(MK_ARCH))
+   export HOST_ARCH=$(HOST_ARCH_RISCV64)
++else ifeq ("loongarch64", $(MK_ARCH))
++  export HOST_ARCH=$(HOST_ARCH_LOONGARCH64)
+ endif
+ undefine MK_ARCH
+ 
+diff --git a/arch/Kconfig b/arch/Kconfig
+index e28e4c4bce7..98e1e58c619 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -110,6 +110,20 @@ config ARM
+ 	select SUPPORT_LITTLE_ENDIAN
+ 	select SUPPORT_OF_CONTROL
+ 
++config LOONGARCH
++	bool "LoongArch architecture"
++	select CREATE_ARCH_SYMLINK
++	select SUPPORT_OF_CONTROL
++	select OF_CONTROL
++	select DM
++	select DM_EVENT
++	imply DM_SERIAL
++	imply BLK
++	imply CLK
++	imply MTD
++	imply TIMER
++	imply CMD_DM
++
+ config M68K
+ 	bool "M68000 architecture"
+ 	select HAVE_PRIVATE_LIBGCC
+@@ -569,6 +583,7 @@ config SYS_NONCACHED_MEMORY
+ 
+ source "arch/arc/Kconfig"
+ source "arch/arm/Kconfig"
++source "arch/loongarch/Kconfig"
+ source "arch/m68k/Kconfig"
+ source "arch/microblaze/Kconfig"
+ source "arch/mips/Kconfig"
+diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
+new file mode 100644
+index 00000000000..4e8e9d4ee88
+--- /dev/null
++++ b/arch/loongarch/Kconfig
+@@ -0,0 +1,40 @@
++menu "LoongArch architecture"
++	depends on LOONGARCH
++
++config SYS_ARCH
++	default "loongarch"
++
++choice
++	prompt "Target select"
++
++endchoice
++
++# board-specific options below
++
++# platform-specific options below
++
++# architecture-specific options below
++choice
++	prompt "Base ISA"
++
++config ARCH_LA64
++	bool "LoongArch64"
++	select 64BIT
++	select PHYS_64BIT
++	help
++	  Choose this option to target the LoongArch64 base ISA.
++
++endchoice
++
++config DMA_ADDR_T_64BIT
++	bool
++	default y if 64BIT
++
++config STACK_SIZE_SHIFT
++	int
++	default 14
++
++config OF_BOARD_FIXUP
++	default y if OF_SEPARATE
++
++endmenu
+diff --git a/arch/loongarch/Makefile b/arch/loongarch/Makefile
+new file mode 100644
+index 00000000000..288c695a634
+--- /dev/null
++++ b/arch/loongarch/Makefile
+@@ -0,0 +1,19 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
++ARCH_FLAGS = -march=loongarch64 -mabi=lp64s -msoft-float
++
++ifeq ($(CONFIG_$(SPL_)FRAMEPOINTER),y)
++	ARCH_FLAGS += -fno-omit-frame-pointer
++endif
++
++PLATFORM_CPPFLAGS += $(ARCH_FLAGS)
++
++head-y := arch/loongarch/cpu/start.o
++
++libs-y += arch/loongarch/cpu/
++libs-y += arch/loongarch/cpu/$(CPU)/
++libs-y += arch/loongarch/lib/
++
+diff --git a/arch/loongarch/config.mk b/arch/loongarch/config.mk
+new file mode 100644
+index 00000000000..7c247400e36
+--- /dev/null
++++ b/arch/loongarch/config.mk
+@@ -0,0 +1,23 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
++32bit-bfd		= elf32-loongarch
++64bit-bfd		= elf64-loongarch
++32bit-emul		= elf32loongarch
++64bit-emul		= elf64loongarch
++
++ifdef CONFIG_32BIT
++KBUILD_LDFLAGS		+= -m $(32bit-emul)
++PLATFORM_ELFFLAGS	+= -B loongarch -O $(32bit-bfd)
++endif
++
++ifdef CONFIG_64BIT
++KBUILD_LDFLAGS		+= -m $(64bit-emul)
++PLATFORM_ELFFLAGS	+= -B loongarch -O $(64bit-bfd)
++endif
++
++PLATFORM_CPPFLAGS	+= -fpic
++PLATFORM_RELFLAGS	+= -fno-common -ffunction-sections -fdata-sections
++LDFLAGS_u-boot		+= --gc-sections -static -pie
+diff --git a/arch/loongarch/cpu/Makefile b/arch/loongarch/cpu/Makefile
+new file mode 100644
+index 00000000000..3dbed94cc62
+--- /dev/null
++++ b/arch/loongarch/cpu/Makefile
+@@ -0,0 +1,5 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
+diff --git a/arch/loongarch/cpu/u-boot.lds b/arch/loongarch/cpu/u-boot.lds
+new file mode 100644
+index 00000000000..2f0201c0c81
+--- /dev/null
++++ b/arch/loongarch/cpu/u-boot.lds
+@@ -0,0 +1,85 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++OUTPUT_ARCH(loongarch)
++ENTRY(_start)
++
++SECTIONS
++{
++	. = ALIGN(4);
++	.text : {
++		arch/loongarch/cpu/start.o	(.text)
++	}
++
++	/* This needs to come before *(.text*) */
++	.efi_runtime : {
++		__efi_runtime_start = .;
++		*(.text.efi_runtime*)
++		*(.rodata.efi_runtime*)
++		*(.data.efi_runtime*)
++		__efi_runtime_stop = .;
++	}
++
++	.text_rest : {
++		*(.text*)
++	}
++
++	. = ALIGN(4);
++	.rodata : { *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.rodata*))) }
++
++	. = ALIGN(4);
++	.data : {
++		*(.data*)
++	}
++	. = ALIGN(4);
++
++	.got : {
++		__got_start = .;
++		*(.got.plt) *(.got)
++		__got_end = .;
++	}
++
++	. = ALIGN(4);
++
++	__u_boot_list : {
++		KEEP(*(SORT(__u_boot_list*)));
++	}
++
++	. = ALIGN(8);
++
++	.efi_runtime_rel : {
++		__efi_runtime_rel_start = .;
++		*(.rel*.efi_runtime)
++		*(.rel*.efi_runtime.*)
++		__efi_runtime_rel_stop = .;
++	}
++
++	/DISCARD/ : { *(.rela.plt*) }
++	.rela.dyn : {
++		__rel_dyn_start = .;
++		*(.rela*)
++		__rel_dyn_end = .;
++	}
++
++	. = ALIGN(8);
++
++	.dynsym : {
++		__dyn_sym_start = .;
++		*(.dynsym)
++		__dyn_sym_end = .;
++	}
++
++	. = ALIGN(8);
++
++	_end = .;
++	__init_end = .;
++
++	.bss : {
++		__bss_start = .;
++		*(.bss*)
++		. = ALIGN(8);
++		__bss_end = .;
++	}
++}
+diff --git a/arch/loongarch/dts/Makefile b/arch/loongarch/dts/Makefile
+new file mode 100644
+index 00000000000..5cc395b6ea5
+--- /dev/null
++++ b/arch/loongarch/dts/Makefile
+@@ -0,0 +1,6 @@
++# SPDX-License-Identifier: GPL-2.0+
++
++include $(srctree)/scripts/Makefile.dts
++
++# Add any required device tree compiler flags here
++DTC_FLAGS += -R 4 -p 0x1000
+diff --git a/arch/loongarch/include/asm/acpi_table.h b/arch/loongarch/include/asm/acpi_table.h
+new file mode 100644
+index 00000000000..db2f644f07a
+--- /dev/null
++++ b/arch/loongarch/include/asm/acpi_table.h
+@@ -0,0 +1,8 @@
++/* SPDX-License-Identifier: GPL-2.0-or-later */
++
++#ifndef __ASM_ACPI_TABLE_H__
++#define __ASM_ACPI_TABLE_H__
++
++/* Dummy header */
++
++#endif /* __ASM_ACPI_TABLE_H__ */
+diff --git a/arch/loongarch/include/asm/addrspace.h b/arch/loongarch/include/asm/addrspace.h
+new file mode 100644
+index 00000000000..e2f534ee22c
+--- /dev/null
++++ b/arch/loongarch/include/asm/addrspace.h
+@@ -0,0 +1,86 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ *
++ * Derived from MIPS:
++ * Copyright (C) 1996, 99 Ralf Baechle
++ * Copyright (C) 2000, 2002  Maciej W. Rozycki
++ * Copyright (C) 1990, 1999 by Silicon Graphics, Inc.
++ */
++#ifndef _ASM_ADDRSPACE_H
++#define _ASM_ADDRSPACE_H
++
++#include <linux/const.h>
++#include <linux/sizes.h>
++
++#include <asm/loongarch.h>
++
++#ifndef IO_BASE
++#define IO_BASE			CSR_DMW0_BASE
++#endif
++
++#ifndef CACHE_BASE
++#define CACHE_BASE		CSR_DMW1_BASE
++#endif
++
++#ifndef UNCACHE_BASE
++#define UNCACHE_BASE		CSR_DMW0_BASE
++#endif
++
++#define DMW_PABITS	48
++#define TO_PHYS_MASK	((1ULL << DMW_PABITS) - 1)
++
++#define TO_PHYS(x)		(		((x) & TO_PHYS_MASK))
++#define TO_CACHE(x)		(CACHE_BASE   |	((x) & TO_PHYS_MASK))
++#define TO_UNCACHE(x)		(UNCACHE_BASE |	((x) & TO_PHYS_MASK))
++
++#ifdef __ASSEMBLY__
++#define _ATYPE_
++#define _ATYPE32_
++#define _ATYPE64_
++#else
++#define _ATYPE_		__PTRDIFF_TYPE__
++#define _ATYPE32_	int
++#define _ATYPE64_	__s64
++#endif
++
++#ifdef CONFIG_64BIT
++#define _CONST64_(x)	_UL(x)
++#else
++#define _CONST64_(x)	_ULL(x)
++#endif
++
++/*
++ *  32/64-bit LoongArch address spaces
++ */
++#ifdef __ASSEMBLY__
++#define _ACAST32_
++#define _ACAST64_
++#else
++#define _ACAST32_		(_ATYPE_)(_ATYPE32_)	/* widen if necessary */
++#define _ACAST64_		(_ATYPE64_)		/* do _not_ narrow */
++#endif
++
++#ifdef CONFIG_32BIT
++
++#define UVRANGE			0x00000000
++#define KPRANGE0		0x80000000
++#define KPRANGE1		0xa0000000
++#define KVRANGE			0xc0000000
++
++#else
++
++#define XUVRANGE		_CONST64_(0x0000000000000000)
++#define XSPRANGE		_CONST64_(0x4000000000000000)
++#define XKPRANGE		_CONST64_(0x8000000000000000)
++#define XKVRANGE		_CONST64_(0xc000000000000000)
++
++#endif
++
++/*
++ * Returns the physical address of a KPRANGEx / XKPRANGE address
++ */
++#define PHYSADDR(a)		((_ACAST64_(a)) & TO_PHYS_MASK)
++
++#endif /* _ASM_ADDRSPACE_H */
+diff --git a/arch/loongarch/include/asm/arch-generic/entry-init.h b/arch/loongarch/include/asm/arch-generic/entry-init.h
+new file mode 100644
+index 00000000000..a618f66d0d7
+--- /dev/null
++++ b/arch/loongarch/include/asm/arch-generic/entry-init.h
+@@ -0,0 +1,15 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_ENTRY_INIT_H
++#define __ASM_ENTRY_INIT_H
++
++	.macro	entry_setup
++	.endm
++
++	.macro	smp_secondary_setup
++	.endm
++
++#endif
+diff --git a/arch/loongarch/include/asm/asm.h b/arch/loongarch/include/asm/asm.h
+new file mode 100644
+index 00000000000..176bf42cdcc
+--- /dev/null
++++ b/arch/loongarch/include/asm/asm.h
+@@ -0,0 +1,186 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Some useful macros for LoongArch assembler code
++ *
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ *
++ * Derived from MIPS:
++ * Copyright (C) 1995, 1996, 1997, 1999, 2001 by Ralf Baechle
++ * Copyright (C) 1999 by Silicon Graphics, Inc.
++ * Copyright (C) 2001 MIPS Technologies, Inc.
++ * Copyright (C) 2002  Maciej W. Rozycki
++ */
++#ifndef __ASM_ASM_H
++#define __ASM_ASM_H
++
++#include <asm/regdef.h>
++
++/*
++ * Stack alignment
++ */
++#define STACK_ALIGN	~(0xf)
++
++/*
++ * Macros to handle different pointer/register sizes for 32/64-bit code
++ */
++
++/*
++ * Size of a register
++ */
++#if defined(__loongarch__) && __loongarch_grlen == 64
++#define SZREG	4
++#else
++#define SZREG	8
++#endif
++
++/*
++ * Use the following macros in assemblercode to load/store registers,
++ * pointers etc.
++ */
++#if (SZREG == 4)
++#define REG_L		ld.w
++#define REG_S		st.w
++#define REG_ADD		add.w
++#define REG_SUB		sub.w
++#else /* SZREG == 8 */
++#define REG_L		ld.d
++#define REG_S		st.d
++#define REG_ADD		add.d
++#define REG_SUB		sub.d
++#endif
++
++/*
++ * How to add/sub/load/store/shift C int variables.
++ */
++#if (__SIZEOF_INT__ == 4)
++#define INT_ADD		add.w
++#define INT_ADDI	addi.w
++#define INT_SUB		sub.w
++#define INT_L		ld.w
++#define INT_S		st.w
++#define INT_SLL		slli.w
++#define INT_SLLV	sll.w
++#define INT_SRL		srli.w
++#define INT_SRLV	srl.w
++#define INT_SRA		srai.w
++#define INT_SRAV	sra.w
++#endif
++
++#if (__SIZEOF_INT__ == 8)
++#define INT_ADD		add.d
++#define INT_ADDI	addi.d
++#define INT_SUB		sub.d
++#define INT_L		ld.d
++#define INT_S		st.d
++#define INT_SLL		slli.d
++#define INT_SLLV	sll.d
++#define INT_SRL		srli.d
++#define INT_SRLV	srl.d
++#define INT_SRA		srai.d
++#define INT_SRAV	sra.d
++#endif
++
++/*
++ * How to add/sub/load/store/shift C long variables.
++ */
++#if (__SIZEOF_LONG__ == 4)
++#define LONG_ADD	add.w
++#define LONG_ADDI	addi.w
++#define LONG_SUB	sub.w
++#define LONG_L		ld.w
++#define LONG_LI		li.w
++#define LONG_S		st.w
++#define LONG_SLL	slli.w
++#define LONG_SLLV	sll.w
++#define LONG_SRL	srli.w
++#define LONG_SRLV	srl.w
++#define LONG_SRA	srai.w
++#define LONG_SRAV	sra.w
++#define LONG_IOCSRRD	iocsrrd.w
++#define LONG_IOCSRWR	iocsrwr.w
++
++#ifdef __ASSEMBLY__
++#define LONG		.word
++#endif
++#define LONGSIZE	4
++#define LONGMASK	3
++#define LONGLOG		2
++#endif
++
++#if (__SIZEOF_LONG__ == 8)
++#define LONG_ADD	add.d
++#define LONG_ADDI	addi.d
++#define LONG_SUB	sub.d
++#define LONG_L		ld.d
++#define LONG_LI		li.d
++#define LONG_S		st.d
++#define LONG_SLL	slli.d
++#define LONG_SLLV	sll.d
++#define LONG_SRL	srli.d
++#define LONG_SRLV	srl.d
++#define LONG_SRA	srai.d
++#define LONG_SRAV	sra.d
++#define LONG_IOCSRRD	iocsrrd.w
++#define LONG_IOCSRWR	iocsrwr.w
++
++#ifdef __ASSEMBLY__
++#define LONG		.dword
++#endif
++#define LONGSIZE	8
++#define LONGMASK	7
++#define LONGLOG		3
++#endif
++
++/*
++ * How to add/sub/load/store/shift pointers.
++ */
++#if (__SIZEOF_POINTER__ == 4)
++#define PTR_ADD		add.w
++#define PTR_ADDI	addi.w
++#define PTR_SUB		sub.w
++#define PTR_L		ld.w
++#define PTR_S		st.w
++#define PTR_LI		li.w
++#define PTR_SLL		slli.w
++#define PTR_SLLV	sll.w
++#define PTR_SRL		srli.w
++#define PTR_SRLV	srl.w
++#define PTR_SRA		srai.w
++#define PTR_SRAV	sra.w
++#define PTR_MUL		mul.w
++
++#define PTR_SCALESHIFT	2
++
++#ifdef __ASSEMBLY__
++#define PTR		.word
++#endif
++#define PTRSIZE		4
++#define PTRLOG		2
++#endif
++
++#if (__SIZEOF_POINTER__ == 8)
++#define PTR_ADD		add.d
++#define PTR_ADDI	addi.d
++#define PTR_SUB		sub.d
++#define PTR_L		ld.d
++#define PTR_S		st.d
++#define PTR_LI		li.d
++#define PTR_SLL		slli.d
++#define PTR_SLLV	sll.d
++#define PTR_SRL		srli.d
++#define PTR_SRLV	srl.d
++#define PTR_SRA		srai.d
++#define PTR_SRAV	sra.d
++#define PTR_MUL		mul.d
++
++#define PTR_SCALESHIFT	3
++
++#ifdef __ASSEMBLY__
++#define PTR		.dword
++#endif
++#define PTRSIZE		8
++#define PTRLOG		3
++#endif
++
++#endif /* __ASM_ASM_H */
+diff --git a/arch/loongarch/include/asm/atomic.h b/arch/loongarch/include/asm/atomic.h
+new file mode 100644
+index 00000000000..abd0b6f5f34
+--- /dev/null
++++ b/arch/loongarch/include/asm/atomic.h
+@@ -0,0 +1,12 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __LOONGARCH_ATOMIC_H
++#define __LOONGARCH_ATOMIC_H
++
++#include <asm/system.h>
++#include <asm-generic/atomic.h>
++
++#endif
+diff --git a/arch/loongarch/include/asm/barrier.h b/arch/loongarch/include/asm/barrier.h
+new file mode 100644
+index 00000000000..952222116f5
+--- /dev/null
++++ b/arch/loongarch/include/asm/barrier.h
+@@ -0,0 +1,138 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++#ifndef __ASM_BARRIER_H
++#define __ASM_BARRIER_H
++
++/*
++ * Hint encoding:
++ *
++ * Bit4: ordering or completion (0: completion, 1: ordering)
++ * Bit3: barrier for previous read (0: true, 1: false)
++ * Bit2: barrier for previous write (0: true, 1: false)
++ * Bit1: barrier for succeeding read (0: true, 1: false)
++ * Bit0: barrier for succeeding write (0: true, 1: false)
++ *
++ * Hint 0x700: barrier for "read after read" from the same address
++ */
++
++#define DBAR(hint) __asm__ __volatile__("dbar %0 " : : "I"(hint) : "memory")
++
++#define crwrw		0b00000
++#define cr_r_		0b00101
++#define c_w_w		0b01010
++
++#define orwrw		0b10000
++#define or_r_		0b10101
++#define o_w_w		0b11010
++
++#define orw_w		0b10010
++#define or_rw		0b10100
++
++#define c_sync()	DBAR(crwrw)
++#define c_rsync()	DBAR(cr_r_)
++#define c_wsync()	DBAR(c_w_w)
++
++#define o_sync()	DBAR(orwrw)
++#define o_rsync()	DBAR(or_r_)
++#define o_wsync()	DBAR(o_w_w)
++
++#define ldacq_mb()	DBAR(or_rw)
++#define strel_mb()	DBAR(orw_w)
++
++#define mb()		c_sync()
++#define rmb()		c_rsync()
++#define wmb()		c_wsync()
++#define iob()		c_sync()
++#define wbflush()	c_sync()
++
++#define __smp_mb()	o_sync()
++#define __smp_rmb()	o_rsync()
++#define __smp_wmb()	o_wsync()
++
++#ifdef CONFIG_SMP
++#define __WEAK_LLSC_MB		"	dbar 0x700	\n"
++#else
++#define __WEAK_LLSC_MB		"			\n"
++#endif
++
++#define __smp_mb__before_atomic()	barrier()
++#define __smp_mb__after_atomic()	barrier()
++
++/**
++ * array_index_mask_nospec() - generate a ~0 mask when index < size, 0 otherwise
++ * @index: array element index
++ * @size: number of elements in array
++ *
++ * Returns:
++ *     0 - (@index < @size)
++ */
++#define array_index_mask_nospec array_index_mask_nospec
++static inline unsigned long array_index_mask_nospec(unsigned long index,
++						    unsigned long size)
++{
++	unsigned long mask;
++
++	__asm__ __volatile__(
++		"sltu	%0, %1, %2\n\t"
++#if (__SIZEOF_LONG__ == 4)
++		"sub.w	%0, $zero, %0\n\t"
++#elif (__SIZEOF_LONG__ == 8)
++		"sub.d	%0, $zero, %0\n\t"
++#endif
++		: "=r" (mask)
++		: "r" (index), "r" (size)
++		:);
++
++	return mask;
++}
++
++#define __smp_load_acquire(p)				\
++({							\
++	typeof(*p) ___p1 = READ_ONCE(*p);		\
++	compiletime_assert_atomic_type(*p);		\
++	ldacq_mb();					\
++	___p1;						\
++})
++
++#define __smp_store_release(p, v)			\
++do {							\
++	compiletime_assert_atomic_type(*p);		\
++	strel_mb();					\
++	WRITE_ONCE(*p, v);				\
++} while (0)
++
++#define __smp_store_mb(p, v)							\
++do {										\
++	union { typeof(p) __val; char __c[1]; } __u =				\
++		{ .__val = (__force typeof(p)) (v) };				\
++	unsigned long __tmp;							\
++	switch (sizeof(p)) {							\
++	case 1:									\
++		*(volatile __u8 *)&p = *(__u8 *)__u.__c;			\
++		__smp_mb();							\
++		break;								\
++	case 2:									\
++		*(volatile __u16 *)&p = *(__u16 *)__u.__c;			\
++		__smp_mb();							\
++		break;								\
++	case 4:									\
++		__asm__ __volatile__(						\
++		"amswap_db.w %[tmp], %[val], %[mem]	\n"			\
++		: [mem] "+ZB" (*(u32 *)&p), [tmp] "=&r" (__tmp)			\
++		: [val] "r" (*(__u32 *)__u.__c)					\
++		: );								\
++		break;								\
++	case 8:									\
++		__asm__ __volatile__(						\
++		"amswap_db.d %[tmp], %[val], %[mem]	\n"			\
++		: [mem] "+ZB" (*(u64 *)&p), [tmp] "=&r" (__tmp)			\
++		: [val] "r" (*(__u64 *)__u.__c)					\
++		: );								\
++		break;								\
++	}									\
++} while (0)
++
++#endif /* __ASM_BARRIER_H */
+diff --git a/arch/loongarch/include/asm/bitops.h b/arch/loongarch/include/asm/bitops.h
+new file mode 100644
+index 00000000000..32a60d218b7
+--- /dev/null
++++ b/arch/loongarch/include/asm/bitops.h
+@@ -0,0 +1,156 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright 1995, Russell King.
++ * Various bits and pieces copyrights include:
++ * Linus Torvalds (test_bit).
++ *
++ * Copyright (C) 2017 Andes Technology Corporation
++ * Rick Chen, Andes Technology Corporation <rick@andestech.com>
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ *
++ * bit 0 is the LSB of addr; bit 32 is the LSB of (addr+1).
++ *
++ * Please note that the code in this file should never be included
++ * from user space.  Many of these are not implemented in assembler
++ * since they would be too costly.  Also, they require privileged
++ * instructions (which are not available from user mode) to ensure
++ * that they are atomic.
++ */
++
++#ifndef __ASM_LOONGARCH_BITOPS_H
++#define __ASM_LOONGARCH_BITOPS_H
++
++#ifdef __KERNEL__
++
++#include <asm/barrier.h>
++
++#include <asm-generic/bitops/builtin-ffs.h>
++#include <asm-generic/bitops/builtin-fls.h>
++#include <asm-generic/bitops/builtin-__ffs.h>
++#include <asm-generic/bitops/builtin-__fls.h>
++#include <asm-generic/bitops/fls64.h>
++
++#define PLATFORM_FFS
++
++static inline void __change_bit(int nr, void *addr)
++{
++	int mask;
++	unsigned long *ADDR = (unsigned long *)addr;
++
++	ADDR += nr >> 5;
++	mask = 1 << (nr & 31);
++	*ADDR ^= mask;
++}
++
++static inline int __test_and_set_bit(int nr, void *addr)
++{
++	int mask, retval;
++	unsigned int *a = (unsigned int *)addr;
++
++	a += nr >> 5;
++	mask = 1 << (nr & 0x1f);
++	retval = (mask & *a) != 0;
++	*a |= mask;
++	return retval;
++}
++
++static inline int __test_and_clear_bit(int nr, void *addr)
++{
++	int mask, retval;
++	unsigned int *a = (unsigned int *)addr;
++
++	a += nr >> 5;
++	mask = 1 << (nr & 0x1f);
++	retval = (mask & *a) != 0;
++	*a &= ~mask;
++	return retval;
++}
++
++static inline int __test_and_change_bit(int nr, void *addr)
++{
++	int mask, retval;
++	unsigned int *a = (unsigned int *)addr;
++
++	a += nr >> 5;
++	mask = 1 << (nr & 0x1f);
++	retval = (mask & *a) != 0;
++	*a ^= mask;
++	return retval;
++}
++
++/*
++ * This routine doesn't need to be atomic.
++ */
++static inline int test_bit(int nr, const void *addr)
++{
++	return ((unsigned char *)addr)[nr >> 3] & (1U << (nr & 7));
++}
++
++/*
++ * ffz = Find First Zero in word. Undefined if no zero exists,
++ * so code should check against ~0UL first..
++ */
++static inline unsigned long ffz(unsigned long word)
++{
++	int k;
++
++	word = ~word;
++	k = 31;
++	if (word & 0x0000ffff) {
++		k -= 16; word <<= 16;
++	}
++	if (word & 0x00ff0000) {
++		k -= 8;  word <<= 8;
++	}
++	if (word & 0x0f000000) {
++		k -= 4;  word <<= 4;
++	}
++	if (word & 0x30000000) {
++		k -= 2;  word <<= 2;
++	}
++	if (word & 0x40000000)
++		k -= 1;
++
++	return k;
++}
++
++/*
++ * ffs: find first bit set. This is defined the same way as
++ * the libc and compiler builtin ffs routines, therefore
++ * differs in spirit from the above ffz (man ffs).
++ */
++
++/*
++ * redefined in include/linux/bitops.h
++ * #define ffs(x) generic_ffs(x)
++ */
++
++/*
++ * hweightN: returns the hamming weight (i.e. the number
++ * of bits set) of a N-bit word
++ */
++
++#define hweight32(x) generic_hweight32(x)
++#define hweight16(x) generic_hweight16(x)
++#define hweight8(x) generic_hweight8(x)
++
++#define test_and_set_bit		__test_and_set_bit
++#define test_and_clear_bit		__test_and_clear_bit
++
++#define ext2_set_bit			test_and_set_bit
++#define ext2_clear_bit			test_and_clear_bit
++#define ext2_test_bit			test_bit
++#define ext2_find_first_zero_bit	find_first_zero_bit
++#define ext2_find_next_zero_bit		find_next_zero_bit
++
++/* Bitmap functions for the minix filesystem. */
++#define minix_test_and_set_bit(nr, addr)	test_and_set_bit(nr, addr)
++#define minix_set_bit(nr, addr)			set_bit(nr, addr)
++#define minix_test_and_clear_bit(nr, addr)	test_and_clear_bit(nr, addr)
++#define minix_test_bit(nr, addr)		test_bit(nr, addr)
++#define minix_find_first_zero_bit(addr, size)	find_first_zero_bit(addr, size)
++
++#endif /* __KERNEL__ */
++
++#endif /* __ASM_LOONGARCH_BITOPS_H */
+diff --git a/arch/loongarch/include/asm/byteorder.h b/arch/loongarch/include/asm/byteorder.h
+new file mode 100644
+index 00000000000..ba25f25729a
+--- /dev/null
++++ b/arch/loongarch/include/asm/byteorder.h
+@@ -0,0 +1,22 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_BYTEORDER_H
++#define __ASM_LOONGARCH_BYTEORDER_H
++
++#include <asm/types.h>
++
++#if !defined(__STRICT_ANSI__) || defined(__KERNEL__)
++#  define __BYTEORDER_HAS_U64__
++#  define __SWAB_64_THRU_32__
++#endif
++
++#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
++#include <linux/byteorder/little_endian.h>
++#else
++#include <linux/byteorder/big_endian.h>
++#endif
++
++#endif
+diff --git a/arch/loongarch/include/asm/cache.h b/arch/loongarch/include/asm/cache.h
+new file mode 100644
+index 00000000000..854dd0c0a02
+--- /dev/null
++++ b/arch/loongarch/include/asm/cache.h
+@@ -0,0 +1,24 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef _ASM_LOONGARCH_CACHE_H
++#define _ASM_LOONGARCH_CACHE_H
++
++/* cache */
++void cache_flush(void);
++
++#define cache_op(op, addr)						\
++	__asm__ __volatile__(						\
++	"	cacop	%0, %1					\n"	\
++	:								\
++	: "i" (op), "ZC" (*(unsigned char *)(addr)))
++
++#ifdef CONFIG_SYS_CACHELINE_SIZE
++#define ARCH_DMA_MINALIGN	CONFIG_SYS_CACHELINE_SIZE
++#else
++#define ARCH_DMA_MINALIGN	32
++#endif
++
++#endif /* _ASM_LOONGARCH_CACHE_H */
+diff --git a/arch/loongarch/include/asm/config.h b/arch/loongarch/include/asm/config.h
+new file mode 100644
+index 00000000000..23eb49847e7
+--- /dev/null
++++ b/arch/loongarch/include/asm/config.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef _ASM_CONFIG_H_
++#define _ASM_CONFIG_H_
++
++/* Dummy header */
++
++#endif
+diff --git a/arch/loongarch/include/asm/cpu.h b/arch/loongarch/include/asm/cpu.h
+new file mode 100644
+index 00000000000..e65ef273ed4
+--- /dev/null
++++ b/arch/loongarch/include/asm/cpu.h
+@@ -0,0 +1,123 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * cpu.h: Values of the PRID register used to match up
++ *	  various LoongArch CPU types.
++ *
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ */
++#ifndef _ASM_CPU_H
++#define _ASM_CPU_H
++
++#include <linux/bitops.h>
++
++/*
++ * As described in LoongArch specs from Loongson Technology, the PRID register
++ * (CPUCFG.00) has the following layout:
++ *
++ * +---------------+----------------+------------+--------------------+
++ * | Reserved      | Company ID     | Series ID  |  Product ID        |
++ * +---------------+----------------+------------+--------------------+
++ *  31		 24 23		  16 15	       12 11		     0
++ */
++
++/*
++ * Assigned Company values for bits 23:16 of the PRID register.
++ */
++
++#define PRID_COMP_MASK		0xff0000
++
++#define PRID_COMP_LOONGSON	0x140000
++
++/*
++ * Assigned Series ID values for bits 15:12 of the PRID register. In order
++ * to detect a certain CPU type exactly eventually additional registers may
++ * need to be examined.
++ */
++
++#define PRID_SERIES_MASK	0xf000
++
++#define PRID_SERIES_LA132	0x8000  /* Loongson 32bit */
++#define PRID_SERIES_LA264	0xa000  /* Loongson 64bit, 2-issue */
++#define PRID_SERIES_LA364	0xb000  /* Loongson 64bit, 3-issue */
++#define PRID_SERIES_LA464	0xc000  /* Loongson 64bit, 4-issue */
++#define PRID_SERIES_LA664	0xd000  /* Loongson 64bit, 6-issue */
++
++/*
++ * Particular Product ID values for bits 11:0 of the PRID register.
++ */
++
++#define PRID_PRODUCT_MASK	0x0fff
++
++
++/*
++ * ISA Level encodings
++ *
++ */
++
++#define LOONGARCH_CPU_ISA_LA32R 0x00000001
++#define LOONGARCH_CPU_ISA_LA32S 0x00000002
++#define LOONGARCH_CPU_ISA_LA64  0x00000004
++
++#define LOONGARCH_CPU_ISA_32BIT (LOONGARCH_CPU_ISA_LA32R | LOONGARCH_CPU_ISA_LA32S)
++#define LOONGARCH_CPU_ISA_64BIT LOONGARCH_CPU_ISA_LA64
++
++/*
++ * CPU Option encodings
++ */
++#define CPU_FEATURE_CPUCFG		0	/* CPU has CPUCFG */
++#define CPU_FEATURE_LAM			1	/* CPU has Atomic instructions */
++#define CPU_FEATURE_UAL			2	/* CPU supports unaligned access */
++#define CPU_FEATURE_FPU			3	/* CPU has FPU */
++#define CPU_FEATURE_LSX			4	/* CPU has LSX (128-bit SIMD) */
++#define CPU_FEATURE_LASX		5	/* CPU has LASX (256-bit SIMD) */
++#define CPU_FEATURE_CRC32		6	/* CPU has CRC32 instructions */
++#define CPU_FEATURE_COMPLEX		7	/* CPU has Complex instructions */
++#define CPU_FEATURE_CRYPTO		8	/* CPU has Crypto instructions */
++#define CPU_FEATURE_LVZ			9	/* CPU has Virtualization extension */
++#define CPU_FEATURE_LBT_X86		10	/* CPU has X86 Binary Translation */
++#define CPU_FEATURE_LBT_ARM		11	/* CPU has ARM Binary Translation */
++#define CPU_FEATURE_LBT_MIPS		12	/* CPU has MIPS Binary Translation */
++#define CPU_FEATURE_TLB			13	/* CPU has TLB */
++#define CPU_FEATURE_CSR			14	/* CPU has CSR */
++#define CPU_FEATURE_WATCH		15	/* CPU has watchpoint registers */
++#define CPU_FEATURE_VINT		16	/* CPU has vectored interrupts */
++#define CPU_FEATURE_CSRIPI		17	/* CPU has CSR-IPI */
++#define CPU_FEATURE_EXTIOI		18	/* CPU has EXT-IOI */
++#define CPU_FEATURE_PREFETCH		19	/* CPU has prefetch instructions */
++#define CPU_FEATURE_PMP			20	/* CPU has perfermance counter */
++#define CPU_FEATURE_SCALEFREQ		21	/* CPU supports cpufreq scaling */
++#define CPU_FEATURE_FLATMODE		22	/* CPU has flat mode */
++#define CPU_FEATURE_EIODECODE		23	/* CPU has EXTIOI interrupt pin decode mode */
++#define CPU_FEATURE_GUESTID		24	/* CPU has GuestID feature */
++#define CPU_FEATURE_HYPERVISOR		25	/* CPU has hypervisor (running in VM) */
++#define CPU_FEATURE_PTW			26	/* CPU has hardware page table walker */
++
++#define LOONGARCH_CPU_CPUCFG		BIT_ULL(CPU_FEATURE_CPUCFG)
++#define LOONGARCH_CPU_LAM		BIT_ULL(CPU_FEATURE_LAM)
++#define LOONGARCH_CPU_UAL		BIT_ULL(CPU_FEATURE_UAL)
++#define LOONGARCH_CPU_FPU		BIT_ULL(CPU_FEATURE_FPU)
++#define LOONGARCH_CPU_LSX		BIT_ULL(CPU_FEATURE_LSX)
++#define LOONGARCH_CPU_LASX		BIT_ULL(CPU_FEATURE_LASX)
++#define LOONGARCH_CPU_CRC32		BIT_ULL(CPU_FEATURE_CRC32)
++#define LOONGARCH_CPU_COMPLEX		BIT_ULL(CPU_FEATURE_COMPLEX)
++#define LOONGARCH_CPU_CRYPTO		BIT_ULL(CPU_FEATURE_CRYPTO)
++#define LOONGARCH_CPU_LVZ		BIT_ULL(CPU_FEATURE_LVZ)
++#define LOONGARCH_CPU_LBT_X86		BIT_ULL(CPU_FEATURE_LBT_X86)
++#define LOONGARCH_CPU_LBT_ARM		BIT_ULL(CPU_FEATURE_LBT_ARM)
++#define LOONGARCH_CPU_LBT_MIPS		BIT_ULL(CPU_FEATURE_LBT_MIPS)
++#define LOONGARCH_CPU_TLB		BIT_ULL(CPU_FEATURE_TLB)
++#define LOONGARCH_CPU_CSR		BIT_ULL(CPU_FEATURE_CSR)
++#define LOONGARCH_CPU_WATCH		BIT_ULL(CPU_FEATURE_WATCH)
++#define LOONGARCH_CPU_VINT		BIT_ULL(CPU_FEATURE_VINT)
++#define LOONGARCH_CPU_CSRIPI		BIT_ULL(CPU_FEATURE_CSRIPI)
++#define LOONGARCH_CPU_EXTIOI		BIT_ULL(CPU_FEATURE_EXTIOI)
++#define LOONGARCH_CPU_PREFETCH		BIT_ULL(CPU_FEATURE_PREFETCH)
++#define LOONGARCH_CPU_PMP		BIT_ULL(CPU_FEATURE_PMP)
++#define LOONGARCH_CPU_SCALEFREQ		BIT_ULL(CPU_FEATURE_SCALEFREQ)
++#define LOONGARCH_CPU_FLATMODE		BIT_ULL(CPU_FEATURE_FLATMODE)
++#define LOONGARCH_CPU_EIODECODE		BIT_ULL(CPU_FEATURE_EIODECODE)
++#define LOONGARCH_CPU_GUESTID		BIT_ULL(CPU_FEATURE_GUESTID)
++#define LOONGARCH_CPU_HYPERVISOR	BIT_ULL(CPU_FEATURE_HYPERVISOR)
++#define LOONGARCH_CPU_PTW		BIT_ULL(CPU_FEATURE_PTW)
++
++#endif /* _ASM_CPU_H */
+diff --git a/arch/loongarch/include/asm/dma-mapping.h b/arch/loongarch/include/asm/dma-mapping.h
+new file mode 100644
+index 00000000000..87088815b95
+--- /dev/null
++++ b/arch/loongarch/include/asm/dma-mapping.h
+@@ -0,0 +1,27 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_DMA_MAPPING_H
++#define __ASM_LOONGARCH_DMA_MAPPING_H
++
++#include <linux/types.h>
++#include <asm/cache.h>
++#include <cpu_func.h>
++#include <linux/dma-direction.h>
++#include <malloc.h>
++
++static inline void *dma_alloc_coherent(size_t len, unsigned long *handle)
++{
++	/* TODO:For non-coherent system allocate from DMW1 */
++	*handle = (unsigned long)memalign(ARCH_DMA_MINALIGN, len);
++	return (void *)*handle;
++}
++
++static inline void dma_free_coherent(void *addr)
++{
++	free(addr);
++}
++
++#endif
+diff --git a/arch/loongarch/include/asm/global_data.h b/arch/loongarch/include/asm/global_data.h
+new file mode 100644
+index 00000000000..2a9a525e2f3
+--- /dev/null
++++ b/arch/loongarch/include/asm/global_data.h
+@@ -0,0 +1,43 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * (C) Copyright 2002
++ * Wolfgang Denk, DENX Software Engineering, wd@denx.de.
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_GBL_DATA_H
++#define __ASM_GBL_DATA_H
++
++#include <linux/types.h>
++#include <asm/u-boot.h>
++#include <compiler.h>
++
++/* Architecture-specific global data */
++struct arch_global_data {
++#if CONFIG_IS_ENABLED(ACPI)
++	ulong table_start;		/* Start address of ACPI tables */
++	ulong table_end;		/* End address of ACPI tables */
++	ulong table_start_high;		/* Start address of high ACPI tables */
++	ulong table_end_high;		/* End address of high ACPI tables */
++#endif
++#ifdef CONFIG_SMBIOS
++	ulong smbios_start;		/* Start address of SMBIOS table */
++#endif
++};
++
++#include <asm-generic/global_data.h>
++
++/* GD is stored in u0 (per CPU pointer) */
++#define DECLARE_GLOBAL_DATA_PTR register gd_t *gd asm ("$r21")
++
++static inline void set_gd(volatile gd_t *gd_ptr)
++{
++#ifdef CONFIG_64BIT
++	asm volatile("ld.d $r21, %0\n" : : "m"(gd_ptr));
++#else
++	asm volatile("ld.w $r21, %0\n" : : "m"(gd_ptr));
++#endif
++}
++
++#endif /* __ASM_GBL_DATA_H */
+diff --git a/arch/loongarch/include/asm/gpio.h b/arch/loongarch/include/asm/gpio.h
+new file mode 100644
+index 00000000000..b2508fc2e9f
+--- /dev/null
++++ b/arch/loongarch/include/asm/gpio.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_GPIO_H
++#define __ASM_GPIO_H
++
++#include <asm-generic/gpio.h>
++
++#endif
+diff --git a/arch/loongarch/include/asm/io.h b/arch/loongarch/include/asm/io.h
+new file mode 100644
+index 00000000000..1fd6ccd9f9a
+--- /dev/null
++++ b/arch/loongarch/include/asm/io.h
+@@ -0,0 +1,399 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2017 Andes Technology Corporation
++ * Rick Chen, Andes Technology Corporation <rick@andestech.com>
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_IO_H
++#define __ASM_LOONGARCH_IO_H
++
++#include <linux/types.h>
++#include <asm/addrspace.h>
++#include <asm/barrier.h>
++#include <asm/byteorder.h>
++
++static inline void sync(void)
++{
++}
++
++#define __arch_getb(a)			(*(volatile unsigned char *)(a))
++#define __arch_getw(a)			(*(volatile unsigned short *)(a))
++#define __arch_getl(a)			(*(volatile unsigned int *)(a))
++#define __arch_getq(a)			(*(volatile unsigned long long *)(a))
++
++#define __arch_putb(v, a)		(*(volatile unsigned char *)(a) = (v))
++#define __arch_putw(v, a)		(*(volatile unsigned short *)(a) = (v))
++#define __arch_putl(v, a)		(*(volatile unsigned int *)(a) = (v))
++#define __arch_putq(v, a)		(*(volatile unsigned long long *)(a) = (v))
++
++#define __raw_writeb(v, a)		__arch_putb(v, a)
++#define __raw_writew(v, a)		__arch_putw(v, a)
++#define __raw_writel(v, a)		__arch_putl(v, a)
++#define __raw_writeq(v, a)		__arch_putq(v, a)
++
++#define __raw_readb(a)			__arch_getb(a)
++#define __raw_readw(a)			__arch_getw(a)
++#define __raw_readl(a)			__arch_getl(a)
++#define __raw_readq(a)			__arch_getq(a)
++
++/* adding for cadence_qspi_apb.c */
++#define memcpy_fromio(a, c, l)		memcpy((a), (c), (l))
++#define memcpy_toio(c, a, l)		memcpy((c), (a), (l))
++
++#define dmb()		mb()
++#define __iormb()	rmb()
++#define __iowmb()	wmb()
++
++static inline void writeb(u8 val, volatile void __iomem *addr)
++{
++	__iowmb();
++	__arch_putb(val, addr);
++}
++
++static inline void writew(u16 val, volatile void __iomem *addr)
++{
++	__iowmb();
++	__arch_putw(val, addr);
++}
++
++static inline void writel(u32 val, volatile void __iomem *addr)
++{
++	__iowmb();
++	__arch_putl(val, addr);
++}
++
++static inline void writeq(u64 val, volatile void __iomem *addr)
++{
++	__iowmb();
++	__arch_putq(val, addr);
++}
++
++static inline u8 readb(const volatile void __iomem *addr)
++{
++	u8	val;
++
++	val = __arch_getb(addr);
++	__iormb();
++	return val;
++}
++
++static inline u16 readw(const volatile void __iomem *addr)
++{
++	u16	val;
++
++	val = __arch_getw(addr);
++	__iormb();
++	return val;
++}
++
++static inline u32 readl(const volatile void __iomem *addr)
++{
++	u32	val;
++
++	val = __arch_getl(addr);
++	__iormb();
++	return val;
++}
++
++static inline u64 readq(const volatile void __iomem *addr)
++{
++	u64	val;
++
++	val = __arch_getq(addr);
++	__iormb();
++	return val;
++}
++
++/*
++ * The compiler seems to be incapable of optimising constants
++ * properly.  Spell it out to the compiler in some cases.
++ * These are only valid for small values of "off" (< 1<<12)
++ */
++#define __raw_base_writeb(val, base, off)	__arch_base_putb(val, base, off)
++#define __raw_base_writew(val, base, off)	__arch_base_putw(val, base, off)
++#define __raw_base_writel(val, base, off)	__arch_base_putl(val, base, off)
++
++#define __raw_base_readb(base, off)	__arch_base_getb(base, off)
++#define __raw_base_readw(base, off)	__arch_base_getw(base, off)
++#define __raw_base_readl(base, off)	__arch_base_getl(base, off)
++
++#define out_arch(type, endian, a, v)	__raw_write##type(cpu_to_##endian(v), a)
++#define in_arch(type, endian, a)	endian##_to_cpu(__raw_read##type(a))
++
++#define out_le32(a, v)			out_arch(l, le32, a, v)
++#define out_le16(a, v)			out_arch(w, le16, a, v)
++
++#define in_le32(a)			in_arch(l, le32, a)
++#define in_le16(a)			in_arch(w, le16, a)
++
++#define out_be32(a, v)			out_arch(l, be32, a, v)
++#define out_be16(a, v)			out_arch(w, be16, a, v)
++
++#define in_be32(a)			in_arch(l, be32, a)
++#define in_be16(a)			in_arch(w, be16, a)
++
++#define out_8(a, v)			__raw_writeb(v, a)
++#define in_8(a)				__raw_readb(a)
++
++/*
++ * Clear and set bits in one shot. These macros can be used to clear and
++ * set multiple bits in a register using a single call. These macros can
++ * also be used to set a multiple-bit bit pattern using a mask, by
++ * specifying the mask in the 'clear' parameter and the new bit pattern
++ * in the 'set' parameter.
++ */
++
++#define clrbits(type, addr, clear) \
++	out_##type((addr), in_##type(addr) & ~(clear))
++
++#define setbits(type, addr, set) \
++	out_##type((addr), in_##type(addr) | (set))
++
++#define clrsetbits(type, addr, clear, set) \
++	out_##type((addr), (in_##type(addr) & ~(clear)) | (set))
++
++#define clrbits_be32(addr, clear) clrbits(be32, addr, clear)
++#define setbits_be32(addr, set) setbits(be32, addr, set)
++#define clrsetbits_be32(addr, clear, set) clrsetbits(be32, addr, clear, set)
++
++#define clrbits_le32(addr, clear) clrbits(le32, addr, clear)
++#define setbits_le32(addr, set) setbits(le32, addr, set)
++#define clrsetbits_le32(addr, clear, set) clrsetbits(le32, addr, clear, set)
++
++#define clrbits_be16(addr, clear) clrbits(be16, addr, clear)
++#define setbits_be16(addr, set) setbits(be16, addr, set)
++#define clrsetbits_be16(addr, clear, set) clrsetbits(be16, addr, clear, set)
++
++#define clrbits_le16(addr, clear) clrbits(le16, addr, clear)
++#define setbits_le16(addr, set) setbits(le16, addr, set)
++#define clrsetbits_le16(addr, clear, set) clrsetbits(le16, addr, clear, set)
++
++#define clrbits_8(addr, clear) clrbits(8, addr, clear)
++#define setbits_8(addr, set) setbits(8, addr, set)
++#define clrsetbits_8(addr, clear, set) clrsetbits(8, addr, clear, set)
++
++
++/*
++ *  IO port access primitives
++ *  -------------------------
++ *
++ * LoongArch doesn't have special IO access instructions just like
++ * ARM and RISC-V all IO is either memory mapped or IOCSR mapped.
++ *
++ * Note that these are defined to perform little endian accesses
++ * only.  Their primary purpose is to access PCI and ISA peripherals.
++ */
++#ifdef __io
++#define outb(v, p)			__raw_writeb(v, __io(p))
++#define outw(v, p)			__raw_writew(cpu_to_le16(v), __io(p))
++#define outl(v, p)			__raw_writel(cpu_to_le32(v), __io(p))
++
++#define inb(p)	({ unsigned int __v = __raw_readb(__io(p)); __v; })
++#define inw(p)	({ unsigned int __v = le16_to_cpu(__raw_readw(__io(p))); __v; })
++#define inl(p)	({ unsigned int __v = le32_to_cpu(__raw_readl(__io(p))); __v; })
++
++#define outsb(p, d, l)			writesb(__io(p), d, l)
++#define outsw(p, d, l)			writesw(__io(p), d, l)
++#define outsl(p, d, l)			writesl(__io(p), d, l)
++
++#define insb(p, d, l)			readsb(__io(p), d, l)
++#define insw(p, d, l)			readsw(__io(p), d, l)
++#define insl(p, d, l)			readsl(__io(p), d, l)
++
++static inline void readsb(const volatile void __iomem *addr, void *data,
++			  unsigned int bytelen)
++{
++	unsigned char *ptr;
++	unsigned char *ptr2;
++
++	ptr = (unsigned char *)addr;
++	ptr2 = (unsigned char *)data;
++
++	while (bytelen) {
++		*ptr2 = *ptr;
++		ptr2++;
++		bytelen--;
++	}
++}
++
++static inline void readsw(const volatile void __iomem *addr, void *data,
++			  unsigned int wordlen)
++{
++	unsigned short *ptr;
++	unsigned short *ptr2;
++
++	ptr = (unsigned short *)addr;
++	ptr2 = (unsigned short *)data;
++
++	while (wordlen) {
++		*ptr2 = *ptr;
++		ptr2++;
++		wordlen--;
++	}
++}
++
++static inline void readsl(const volatile void __iomem *addr, void *data,
++			  unsigned int longlen)
++{
++	unsigned int *ptr;
++	unsigned int *ptr2;
++
++	ptr = (unsigned int *)addr;
++	ptr2 = (unsigned int *)data;
++
++	while (longlen) {
++		*ptr2 = *ptr;
++		ptr2++;
++		longlen--;
++	}
++}
++
++static inline void writesb(volatile void __iomem *addr, const void *data,
++			   unsigned int bytelen)
++{
++	unsigned char *ptr;
++	unsigned char *ptr2;
++
++	ptr = (unsigned char *)addr;
++	ptr2 = (unsigned char *)data;
++
++	while (bytelen) {
++		*ptr = *ptr2;
++		ptr2++;
++		bytelen--;
++	}
++}
++
++static inline void writesw(volatile void __iomem *addr, const void *data,
++			   unsigned int wordlen)
++{
++	unsigned short *ptr;
++	unsigned short *ptr2;
++
++	ptr = (unsigned short *)addr;
++	ptr2 = (unsigned short *)data;
++
++	while (wordlen) {
++		*ptr = *ptr2;
++		ptr2++;
++		wordlen--;
++	}
++}
++
++static inline void writesl(volatile void __iomem *addr, const void *data,
++			   unsigned int longlen)
++{
++	unsigned int *ptr;
++	unsigned int *ptr2;
++
++	ptr = (unsigned int *)addr;
++	ptr2 = (unsigned int *)data;
++
++	while (longlen) {
++		*ptr = *ptr2;
++		ptr2++;
++		longlen--;
++	}
++}
++
++#define readsb readsb
++#define readsw readsw
++#define readsl readsl
++#define writesb writesb
++#define writesw writesw
++#define writesl writesl
++
++#endif
++
++#define outb_p(val, port)		outb((val), (port))
++#define outw_p(val, port)		outw((val), (port))
++#define outl_p(val, port)		outl((val), (port))
++#define inb_p(port)			inb((port))
++#define inw_p(port)			inw((port))
++#define inl_p(port)			inl((port))
++
++#define outsb_p(port, from, len)	outsb(port, from, len)
++#define outsw_p(port, from, len)	outsw(port, from, len)
++#define outsl_p(port, from, len)	outsl(port, from, len)
++#define insb_p(port, to, len)		insb(port, to, len)
++#define insw_p(port, to, len)		insw(port, to, len)
++#define insl_p(port, to, len)		insl(port, to, len)
++
++/*
++ * Unordered I/O memory access primitives.  These are even more relaxed than
++ * the relaxed versions, as they don't even order accesses between successive
++ * operations to the I/O regions.
++ */
++#define readb_cpu(c)		({ u8  __r = __raw_readb(c); __r; })
++#define readw_cpu(c)		({ u16 __r = le16_to_cpu((__force __le16)__raw_readw(c)); __r; })
++#define readl_cpu(c)		({ u32 __r = le32_to_cpu((__force __le32)__raw_readl(c)); __r; })
++
++#define writeb_cpu(v, c)	((void)__raw_writeb((v), (c)))
++#define writew_cpu(v, c)	((void)__raw_writew((__force u16)cpu_to_le16(v), (c)))
++#define writel_cpu(v, c)	((void)__raw_writel((__force u32)cpu_to_le32(v), (c)))
++
++#ifdef CONFIG_64BIT
++#define readq_cpu(c)		({ u64 __r = le64_to_cpu((__force __le64)__raw_readq(c)); __r; })
++#define writeq_cpu(v, c)	((void)__raw_writeq((__force u64)cpu_to_le64(v), (c)))
++#endif
++
++/*
++ * Relaxed I/O memory access primitives. These follow the Device memory
++ * ordering rules but do not guarantee any ordering relative to Normal memory
++ * accesses.  These are defined to order the indicated access (either a read or
++ * write) with all other I/O memory accesses to the same peripheral. Since the
++ * platform specification defines that all I/O regions are strongly ordered on
++ * channel 0, no explicit fences are required to enforce this ordering.
++ */
++/* FIXME: These are now the same as asm-generic */
++#define __io_rbr()		do {} while (0)
++#define __io_rar()		do {} while (0)
++#define __io_rbw()		do {} while (0)
++#define __io_raw()		do {} while (0)
++
++#define readb_relaxed(c)	({ u8  __v; __io_rbr(); __v = readb_cpu(c); __io_rar(); __v; })
++#define readw_relaxed(c)	({ u16 __v; __io_rbr(); __v = readw_cpu(c); __io_rar(); __v; })
++#define readl_relaxed(c)	({ u32 __v; __io_rbr(); __v = readl_cpu(c); __io_rar(); __v; })
++
++#define writeb_relaxed(v, c)	({ __io_rbw(); writeb_cpu((v), (c)); __io_raw(); })
++#define writew_relaxed(v, c)	({ __io_rbw(); writew_cpu((v), (c)); __io_raw(); })
++#define writel_relaxed(v, c)	({ __io_rbw(); writel_cpu((v), (c)); __io_raw(); })
++
++#ifdef CONFIG_64BIT
++#define readq_relaxed(c)	({ u64 __v; __io_rbr(); __v = readq_cpu(c); __io_rar(); __v; })
++#define writeq_relaxed(v, c)	({ __io_rbw(); writeq_cpu((v), (c)); __io_raw(); })
++#endif
++
++static inline phys_addr_t virt_to_phys(volatile const void *address)
++{
++	return TO_PHYS((unsigned long)address);
++}
++#define virt_to_phys virt_to_phys
++
++static inline void *phys_to_virt(phys_addr_t address)
++{
++	/* Assume it is always for U-Boot memory access */
++	return (void *)(address);
++}
++#define phys_to_virt phys_to_virt
++
++/* These two needs to be uncaced */
++#define MAP_NOCACHE		1
++#define MAP_WRCOMBINE	MAP_NOCACHE
++
++static inline void *map_physmem(phys_addr_t paddr, unsigned long len,
++				unsigned long flags)
++{
++	if (flags == MAP_NOCACHE)
++		return (void *)TO_UNCACHE(paddr);
++
++	/* Assume cached mapping is always for U-Boot memory access */
++	return (void *)(paddr);
++}
++#define map_physmem map_physmem
++
++#include <asm-generic/io.h>
++
++#endif	/* __ASM_LOONGARCH_IO_H */
+diff --git a/arch/loongarch/include/asm/linkage.h b/arch/loongarch/include/asm/linkage.h
+new file mode 100644
+index 00000000000..f004bdd8efe
+--- /dev/null
++++ b/arch/loongarch/include/asm/linkage.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LINKAGE_H
++#define __ASM_LINKAGE_H
++
++/* Dummy header */
++
++#endif
+diff --git a/arch/loongarch/include/asm/loongarch.h b/arch/loongarch/include/asm/loongarch.h
+new file mode 100644
+index 00000000000..72625b38c9a
+--- /dev/null
++++ b/arch/loongarch/include/asm/loongarch.h
+@@ -0,0 +1,1467 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++#ifndef _ASM_LOONGARCH_H
++#define _ASM_LOONGARCH_H
++
++#include <linux/bitops.h>
++#include <linux/const.h>
++#ifndef __ASSEMBLY__
++#include <linux/types.h>
++#include <larchintrin.h>
++
++/* CPUCFG */
++#define read_cpucfg(reg) __cpucfg(reg)
++
++#endif /* !__ASSEMBLY__ */
++
++/*
++ *  Configure language
++ */
++#ifdef __ASSEMBLY__
++#define _ULCAST_
++#define _U64CAST_
++#else
++#define _ULCAST_ (unsigned long)
++#define _U64CAST_ (u64)
++#endif
++
++#ifdef __ASSEMBLY__
++
++/* LoongArch Registers */
++#define REG_ZERO	0x0
++#define REG_RA		0x1
++#define REG_TP		0x2
++#define REG_SP		0x3
++#define REG_A0		0x4 /* Reused as V0 for return value */
++#define REG_A1		0x5 /* Reused as V1 for return value */
++#define REG_A2		0x6
++#define REG_A3		0x7
++#define REG_A4		0x8
++#define REG_A5		0x9
++#define REG_A6		0xa
++#define REG_A7		0xb
++#define REG_T0		0xc
++#define REG_T1		0xd
++#define REG_T2		0xe
++#define REG_T3		0xf
++#define REG_T4		0x10
++#define REG_T5		0x11
++#define REG_T6		0x12
++#define REG_T7		0x13
++#define REG_T8		0x14
++#define REG_U0		0x15 /* Kernel uses it as percpu base */
++#define REG_FP		0x16
++#define REG_S0		0x17
++#define REG_S1		0x18
++#define REG_S2		0x19
++#define REG_S3		0x1a
++#define REG_S4		0x1b
++#define REG_S5		0x1c
++#define REG_S6		0x1d
++#define REG_S7		0x1e
++#define REG_S8		0x1f
++
++#endif /* __ASSEMBLY__ */
++
++/* Bit fields for CPUCFG registers */
++#define LOONGARCH_CPUCFG0		0x0
++#define  CPUCFG0_PRID			GENMASK(31, 0)
++
++#define LOONGARCH_CPUCFG1		0x1
++#define  CPUCFG1_ISGR32			BIT(0)
++#define  CPUCFG1_ISGR64			BIT(1)
++#define  CPUCFG1_PAGING			BIT(2)
++#define  CPUCFG1_IOCSR			BIT(3)
++#define  CPUCFG1_PABITS			GENMASK(11, 4)
++#define  CPUCFG1_VABITS			GENMASK(19, 12)
++#define  CPUCFG1_UAL			BIT(20)
++#define  CPUCFG1_RI			BIT(21)
++#define  CPUCFG1_EP			BIT(22)
++#define  CPUCFG1_RPLV			BIT(23)
++#define  CPUCFG1_HUGEPG			BIT(24)
++#define  CPUCFG1_CRC32			BIT(25)
++#define  CPUCFG1_MSGINT			BIT(26)
++
++#define LOONGARCH_CPUCFG2		0x2
++#define  CPUCFG2_FP			BIT(0)
++#define  CPUCFG2_FPSP			BIT(1)
++#define  CPUCFG2_FPDP			BIT(2)
++#define  CPUCFG2_FPVERS			GENMASK(5, 3)
++#define  CPUCFG2_LSX			BIT(6)
++#define  CPUCFG2_LASX			BIT(7)
++#define  CPUCFG2_COMPLEX		BIT(8)
++#define  CPUCFG2_CRYPTO			BIT(9)
++#define  CPUCFG2_LVZP			BIT(10)
++#define  CPUCFG2_LVZVER			GENMASK(13, 11)
++#define  CPUCFG2_LLFTP			BIT(14)
++#define  CPUCFG2_LLFTPREV		GENMASK(17, 15)
++#define  CPUCFG2_X86BT			BIT(18)
++#define  CPUCFG2_ARMBT			BIT(19)
++#define  CPUCFG2_MIPSBT			BIT(20)
++#define  CPUCFG2_LSPW			BIT(21)
++#define  CPUCFG2_LAM			BIT(22)
++#define  CPUCFG2_PTW			BIT(24)
++
++#define LOONGARCH_CPUCFG3		0x3
++#define  CPUCFG3_CCDMA			BIT(0)
++#define  CPUCFG3_SFB			BIT(1)
++#define  CPUCFG3_UCACC			BIT(2)
++#define  CPUCFG3_LLEXC			BIT(3)
++#define  CPUCFG3_SCDLY			BIT(4)
++#define  CPUCFG3_LLDBAR			BIT(5)
++#define  CPUCFG3_ITLBT			BIT(6)
++#define  CPUCFG3_ICACHET		BIT(7)
++#define  CPUCFG3_SPW_LVL		GENMASK(10, 8)
++#define  CPUCFG3_SPW_HG_HF		BIT(11)
++#define  CPUCFG3_RVA			BIT(12)
++#define  CPUCFG3_RVAMAX			GENMASK(16, 13)
++
++#define LOONGARCH_CPUCFG4		0x4
++#define  CPUCFG4_CCFREQ			GENMASK(31, 0)
++
++#define LOONGARCH_CPUCFG5		0x5
++#define  CPUCFG5_CCMUL			GENMASK(15, 0)
++#define  CPUCFG5_CCDIV			GENMASK(31, 16)
++
++#define LOONGARCH_CPUCFG6		0x6
++#define  CPUCFG6_PMP			BIT(0)
++#define  CPUCFG6_PAMVER			GENMASK(3, 1)
++#define  CPUCFG6_PMNUM			GENMASK(7, 4)
++#define  CPUCFG6_PMBITS			GENMASK(13, 8)
++#define  CPUCFG6_UPM			BIT(14)
++
++#define LOONGARCH_CPUCFG16		0x10
++#define  CPUCFG16_L1_IUPRE		BIT(0)
++#define  CPUCFG16_L1_IUUNIFY		BIT(1)
++#define  CPUCFG16_L1_DPRE		BIT(2)
++#define  CPUCFG16_L2_IUPRE		BIT(3)
++#define  CPUCFG16_L2_IUUNIFY		BIT(4)
++#define  CPUCFG16_L2_IUPRIV		BIT(5)
++#define  CPUCFG16_L2_IUINCL		BIT(6)
++#define  CPUCFG16_L2_DPRE		BIT(7)
++#define  CPUCFG16_L2_DPRIV		BIT(8)
++#define  CPUCFG16_L2_DINCL		BIT(9)
++#define  CPUCFG16_L3_IUPRE		BIT(10)
++#define  CPUCFG16_L3_IUUNIFY		BIT(11)
++#define  CPUCFG16_L3_IUPRIV		BIT(12)
++#define  CPUCFG16_L3_IUINCL		BIT(13)
++#define  CPUCFG16_L3_DPRE		BIT(14)
++#define  CPUCFG16_L3_DPRIV		BIT(15)
++#define  CPUCFG16_L3_DINCL		BIT(16)
++
++#define LOONGARCH_CPUCFG17		0x11
++#define LOONGARCH_CPUCFG18		0x12
++#define LOONGARCH_CPUCFG19		0x13
++#define LOONGARCH_CPUCFG20		0x14
++#define  CPUCFG_CACHE_WAYS_M		GENMASK(15, 0)
++#define  CPUCFG_CACHE_SETS_M		GENMASK(23, 16)
++#define  CPUCFG_CACHE_LSIZE_M		GENMASK(30, 24)
++#define  CPUCFG_CACHE_WAYS		0
++#define  CPUCFG_CACHE_SETS		16
++#define  CPUCFG_CACHE_LSIZE		24
++
++#define LOONGARCH_CPUCFG48		0x30
++#define  CPUCFG48_MCSR_LCK		BIT(0)
++#define  CPUCFG48_NAP_EN		BIT(1)
++#define  CPUCFG48_VFPU_CG		BIT(2)
++#define  CPUCFG48_RAM_CG		BIT(3)
++
++/*
++ * CPUCFG index area: 0x40000000 -- 0x400000ff
++ * SW emulation for KVM hypervirsor
++ */
++#define CPUCFG_KVM_BASE			0x40000000
++#define CPUCFG_KVM_SIZE			0x100
++
++#define CPUCFG_KVM_SIG			(CPUCFG_KVM_BASE + 0)
++#define  KVM_SIGNATURE			"KVM\0"
++#define CPUCFG_KVM_FEATURE		(CPUCFG_KVM_BASE + 4)
++#define  KVM_FEATURE_IPI		BIT(1)
++
++#ifndef __ASSEMBLY__
++
++/* CSR */
++#define csr_read32(reg) __csrrd_w(reg)
++#define csr_read64(reg) __csrrd_d(reg)
++#define csr_write32(val, reg) __csrwr_w(val, reg)
++#define csr_write64(val, reg) __csrwr_d(val, reg)
++#define csr_xchg32(val, mask, reg) __csrxchg_w(val, mask, reg)
++#define csr_xchg64(val, mask, reg) __csrxchg_d(val, mask, reg)
++
++/* IOCSR */
++#define iocsr_read32(reg) __iocsrrd_w(reg)
++#define iocsr_read64(reg) __iocsrrd_d(reg)
++#define iocsr_write32(val, reg) __iocsrwr_w(val, reg)
++#define iocsr_write64(val, reg) __iocsrwr_d(val, reg)
++
++#endif /* !__ASSEMBLY__ */
++
++/* CSR register number */
++
++/* Basic CSR registers */
++#define LOONGARCH_CSR_CRMD		0x0	/* Current mode info */
++#define  CSR_CRMD_WE_SHIFT		9
++#define  CSR_CRMD_WE			(_ULCAST_(0x1) << CSR_CRMD_WE_SHIFT)
++#define  CSR_CRMD_DACM_SHIFT		7
++#define  CSR_CRMD_DACM_WIDTH		2
++#define  CSR_CRMD_DACM			(_ULCAST_(0x3) << CSR_CRMD_DACM_SHIFT)
++#define  CSR_CRMD_DACF_SHIFT		5
++#define  CSR_CRMD_DACF_WIDTH		2
++#define  CSR_CRMD_DACF			(_ULCAST_(0x3) << CSR_CRMD_DACF_SHIFT)
++#define  CSR_CRMD_PG_SHIFT		4
++#define  CSR_CRMD_PG			(_ULCAST_(0x1) << CSR_CRMD_PG_SHIFT)
++#define  CSR_CRMD_DA_SHIFT		3
++#define  CSR_CRMD_DA			(_ULCAST_(0x1) << CSR_CRMD_DA_SHIFT)
++#define  CSR_CRMD_IE_SHIFT		2
++#define  CSR_CRMD_IE			(_ULCAST_(0x1) << CSR_CRMD_IE_SHIFT)
++#define  CSR_CRMD_PLV_SHIFT		0
++#define  CSR_CRMD_PLV_WIDTH		2
++#define  CSR_CRMD_PLV			(_ULCAST_(0x3) << CSR_CRMD_PLV_SHIFT)
++
++#define PLV_KERN			0
++#define PLV_USER			3
++#define PLV_MASK			0x3
++
++#define LOONGARCH_CSR_PRMD		0x1	/* Prev-exception mode info */
++#define  CSR_PRMD_PWE_SHIFT		3
++#define  CSR_PRMD_PWE			(_ULCAST_(0x1) << CSR_PRMD_PWE_SHIFT)
++#define  CSR_PRMD_PIE_SHIFT		2
++#define  CSR_PRMD_PIE			(_ULCAST_(0x1) << CSR_PRMD_PIE_SHIFT)
++#define  CSR_PRMD_PPLV_SHIFT		0
++#define  CSR_PRMD_PPLV_WIDTH		2
++#define  CSR_PRMD_PPLV			(_ULCAST_(0x3) << CSR_PRMD_PPLV_SHIFT)
++
++#define LOONGARCH_CSR_EUEN		0x2	/* Extended unit enable */
++#define  CSR_EUEN_LBTEN_SHIFT		3
++#define  CSR_EUEN_LBTEN			(_ULCAST_(0x1) << CSR_EUEN_LBTEN_SHIFT)
++#define  CSR_EUEN_LASXEN_SHIFT		2
++#define  CSR_EUEN_LASXEN		(_ULCAST_(0x1) << CSR_EUEN_LASXEN_SHIFT)
++#define  CSR_EUEN_LSXEN_SHIFT		1
++#define  CSR_EUEN_LSXEN			(_ULCAST_(0x1) << CSR_EUEN_LSXEN_SHIFT)
++#define  CSR_EUEN_FPEN_SHIFT		0
++#define  CSR_EUEN_FPEN			(_ULCAST_(0x1) << CSR_EUEN_FPEN_SHIFT)
++
++#define LOONGARCH_CSR_MISC		0x3	/* Misc config */
++
++#define LOONGARCH_CSR_ECFG		0x4	/* Exception config */
++#define  CSR_ECFG_VS_SHIFT		16
++#define  CSR_ECFG_VS_WIDTH		3
++#define  CSR_ECFG_VS_SHIFT_END		(CSR_ECFG_VS_SHIFT + CSR_ECFG_VS_WIDTH - 1)
++#define  CSR_ECFG_VS			(_ULCAST_(0x7) << CSR_ECFG_VS_SHIFT)
++#define  CSR_ECFG_IM_SHIFT		0
++#define  CSR_ECFG_IM_WIDTH		14
++#define  CSR_ECFG_IM			(_ULCAST_(0x3fff) << CSR_ECFG_IM_SHIFT)
++
++#define LOONGARCH_CSR_ESTAT		0x5	/* Exception status */
++#define  CSR_ESTAT_ESUBCODE_SHIFT	22
++#define  CSR_ESTAT_ESUBCODE_WIDTH	9
++#define  CSR_ESTAT_ESUBCODE		(_ULCAST_(0x1ff) << CSR_ESTAT_ESUBCODE_SHIFT)
++#define  CSR_ESTAT_EXC_SHIFT		16
++#define  CSR_ESTAT_EXC_WIDTH		6
++#define  CSR_ESTAT_EXC			(_ULCAST_(0x3f) << CSR_ESTAT_EXC_SHIFT)
++#define  CSR_ESTAT_IS_SHIFT		0
++#define  CSR_ESTAT_IS_WIDTH		14
++#define  CSR_ESTAT_IS			(_ULCAST_(0x3fff) << CSR_ESTAT_IS_SHIFT)
++
++#define LOONGARCH_CSR_ERA		0x6	/* ERA */
++
++#define LOONGARCH_CSR_BADV		0x7	/* Bad virtual address */
++
++#define LOONGARCH_CSR_BADI		0x8	/* Bad instruction */
++
++#define LOONGARCH_CSR_EENTRY		0xc	/* Exception entry */
++
++/* TLB related CSR registers */
++#define LOONGARCH_CSR_TLBIDX		0x10	/* TLB Index, EHINV, PageSize, NP */
++#define  CSR_TLBIDX_EHINV_SHIFT		31
++#define  CSR_TLBIDX_EHINV		(_ULCAST_(1) << CSR_TLBIDX_EHINV_SHIFT)
++#define  CSR_TLBIDX_PS_SHIFT		24
++#define  CSR_TLBIDX_PS_WIDTH		6
++#define  CSR_TLBIDX_PS			(_ULCAST_(0x3f) << CSR_TLBIDX_PS_SHIFT)
++#define  CSR_TLBIDX_IDX_SHIFT		0
++#define  CSR_TLBIDX_IDX_WIDTH		12
++#define  CSR_TLBIDX_IDX			(_ULCAST_(0xfff) << CSR_TLBIDX_IDX_SHIFT)
++#define  CSR_TLBIDX_SIZEM		0x3f000000
++#define  CSR_TLBIDX_SIZE		CSR_TLBIDX_PS_SHIFT
++#define  CSR_TLBIDX_IDXM		0xfff
++#define  CSR_INVALID_ENTRY(e)		(CSR_TLBIDX_EHINV | e)
++
++#define LOONGARCH_CSR_TLBEHI		0x11	/* TLB EntryHi */
++
++#define LOONGARCH_CSR_TLBELO0		0x12	/* TLB EntryLo0 */
++#define  CSR_TLBLO0_RPLV_SHIFT		63
++#define  CSR_TLBLO0_RPLV		(_ULCAST_(0x1) << CSR_TLBLO0_RPLV_SHIFT)
++#define  CSR_TLBLO0_NX_SHIFT		62
++#define  CSR_TLBLO0_NX			(_ULCAST_(0x1) << CSR_TLBLO0_NX_SHIFT)
++#define  CSR_TLBLO0_NR_SHIFT		61
++#define  CSR_TLBLO0_NR			(_ULCAST_(0x1) << CSR_TLBLO0_NR_SHIFT)
++#define  CSR_TLBLO0_PFN_SHIFT		12
++#define  CSR_TLBLO0_PFN_WIDTH		36
++#define  CSR_TLBLO0_PFN			(_ULCAST_(0xfffffffff) << CSR_TLBLO0_PFN_SHIFT)
++#define  CSR_TLBLO0_GLOBAL_SHIFT	6
++#define  CSR_TLBLO0_GLOBAL		(_ULCAST_(0x1) << CSR_TLBLO0_GLOBAL_SHIFT)
++#define  CSR_TLBLO0_CCA_SHIFT		4
++#define  CSR_TLBLO0_CCA_WIDTH		2
++#define  CSR_TLBLO0_CCA			(_ULCAST_(0x3) << CSR_TLBLO0_CCA_SHIFT)
++#define  CSR_TLBLO0_PLV_SHIFT		2
++#define  CSR_TLBLO0_PLV_WIDTH		2
++#define  CSR_TLBLO0_PLV			(_ULCAST_(0x3) << CSR_TLBLO0_PLV_SHIFT)
++#define  CSR_TLBLO0_WE_SHIFT		1
++#define  CSR_TLBLO0_WE			(_ULCAST_(0x1) << CSR_TLBLO0_WE_SHIFT)
++#define  CSR_TLBLO0_V_SHIFT		0
++#define  CSR_TLBLO0_V			(_ULCAST_(0x1) << CSR_TLBLO0_V_SHIFT)
++
++#define LOONGARCH_CSR_TLBELO1		0x13	/* TLB EntryLo1 */
++#define  CSR_TLBLO1_RPLV_SHIFT		63
++#define  CSR_TLBLO1_RPLV		(_ULCAST_(0x1) << CSR_TLBLO1_RPLV_SHIFT)
++#define  CSR_TLBLO1_NX_SHIFT		62
++#define  CSR_TLBLO1_NX			(_ULCAST_(0x1) << CSR_TLBLO1_NX_SHIFT)
++#define  CSR_TLBLO1_NR_SHIFT		61
++#define  CSR_TLBLO1_NR			(_ULCAST_(0x1) << CSR_TLBLO1_NR_SHIFT)
++#define  CSR_TLBLO1_PFN_SHIFT		12
++#define  CSR_TLBLO1_PFN_WIDTH		36
++#define  CSR_TLBLO1_PFN			(_ULCAST_(0xfffffffff) << CSR_TLBLO1_PFN_SHIFT)
++#define  CSR_TLBLO1_GLOBAL_SHIFT	6
++#define  CSR_TLBLO1_GLOBAL		(_ULCAST_(0x1) << CSR_TLBLO1_GLOBAL_SHIFT)
++#define  CSR_TLBLO1_CCA_SHIFT		4
++#define  CSR_TLBLO1_CCA_WIDTH		2
++#define  CSR_TLBLO1_CCA			(_ULCAST_(0x3) << CSR_TLBLO1_CCA_SHIFT)
++#define  CSR_TLBLO1_PLV_SHIFT		2
++#define  CSR_TLBLO1_PLV_WIDTH		2
++#define  CSR_TLBLO1_PLV			(_ULCAST_(0x3) << CSR_TLBLO1_PLV_SHIFT)
++#define  CSR_TLBLO1_WE_SHIFT		1
++#define  CSR_TLBLO1_WE			(_ULCAST_(0x1) << CSR_TLBLO1_WE_SHIFT)
++#define  CSR_TLBLO1_V_SHIFT		0
++#define  CSR_TLBLO1_V			(_ULCAST_(0x1) << CSR_TLBLO1_V_SHIFT)
++
++#define LOONGARCH_CSR_GTLBC		0x15	/* Guest TLB control */
++#define  CSR_GTLBC_TGID_SHIFT		16
++#define  CSR_GTLBC_TGID_WIDTH		8
++#define  CSR_GTLBC_TGID_SHIFT_END	(CSR_GTLBC_TGID_SHIFT + CSR_GTLBC_TGID_WIDTH - 1)
++#define  CSR_GTLBC_TGID			(_ULCAST_(0xff) << CSR_GTLBC_TGID_SHIFT)
++#define  CSR_GTLBC_TOTI_SHIFT		13
++#define  CSR_GTLBC_TOTI			(_ULCAST_(0x1) << CSR_GTLBC_TOTI_SHIFT)
++#define  CSR_GTLBC_USETGID_SHIFT	12
++#define  CSR_GTLBC_USETGID		(_ULCAST_(0x1) << CSR_GTLBC_USETGID_SHIFT)
++#define  CSR_GTLBC_GMTLBSZ_SHIFT	0
++#define  CSR_GTLBC_GMTLBSZ_WIDTH	6
++#define  CSR_GTLBC_GMTLBSZ		(_ULCAST_(0x3f) << CSR_GTLBC_GMTLBSZ_SHIFT)
++
++#define LOONGARCH_CSR_TRGP		0x16	/* TLBR read guest info */
++#define  CSR_TRGP_RID_SHIFT		16
++#define  CSR_TRGP_RID_WIDTH		8
++#define  CSR_TRGP_RID			(_ULCAST_(0xff) << CSR_TRGP_RID_SHIFT)
++#define  CSR_TRGP_GTLB_SHIFT		0
++#define  CSR_TRGP_GTLB			(1 << CSR_TRGP_GTLB_SHIFT)
++
++#define LOONGARCH_CSR_ASID		0x18	/* ASID */
++#define  CSR_ASID_BIT_SHIFT		16	/* ASIDBits */
++#define  CSR_ASID_BIT_WIDTH		8
++#define  CSR_ASID_BIT			(_ULCAST_(0xff) << CSR_ASID_BIT_SHIFT)
++#define  CSR_ASID_ASID_SHIFT		0
++#define  CSR_ASID_ASID_WIDTH		10
++#define  CSR_ASID_ASID			(_ULCAST_(0x3ff) << CSR_ASID_ASID_SHIFT)
++
++#define LOONGARCH_CSR_PGDL		0x19	/* Page table base address when VA[VALEN-1] = 0 */
++
++#define LOONGARCH_CSR_PGDH		0x1a	/* Page table base address when VA[VALEN-1] = 1 */
++
++#define LOONGARCH_CSR_PGD		0x1b	/* Page table base */
++
++#define LOONGARCH_CSR_PWCTL0		0x1c	/* PWCtl0 */
++#define  CSR_PWCTL0_PTEW_SHIFT		30
++#define  CSR_PWCTL0_PTEW_WIDTH		2
++#define  CSR_PWCTL0_PTEW		(_ULCAST_(0x3) << CSR_PWCTL0_PTEW_SHIFT)
++#define  CSR_PWCTL0_DIR1WIDTH_SHIFT	25
++#define  CSR_PWCTL0_DIR1WIDTH_WIDTH	5
++#define  CSR_PWCTL0_DIR1WIDTH		(_ULCAST_(0x1f) << CSR_PWCTL0_DIR1WIDTH_SHIFT)
++#define  CSR_PWCTL0_DIR1BASE_SHIFT	20
++#define  CSR_PWCTL0_DIR1BASE_WIDTH	5
++#define  CSR_PWCTL0_DIR1BASE		(_ULCAST_(0x1f) << CSR_PWCTL0_DIR1BASE_SHIFT)
++#define  CSR_PWCTL0_DIR0WIDTH_SHIFT	15
++#define  CSR_PWCTL0_DIR0WIDTH_WIDTH	5
++#define  CSR_PWCTL0_DIR0WIDTH		(_ULCAST_(0x1f) << CSR_PWCTL0_DIR0WIDTH_SHIFT)
++#define  CSR_PWCTL0_DIR0BASE_SHIFT	10
++#define  CSR_PWCTL0_DIR0BASE_WIDTH	5
++#define  CSR_PWCTL0_DIR0BASE		(_ULCAST_(0x1f) << CSR_PWCTL0_DIR0BASE_SHIFT)
++#define  CSR_PWCTL0_PTWIDTH_SHIFT	5
++#define  CSR_PWCTL0_PTWIDTH_WIDTH	5
++#define  CSR_PWCTL0_PTWIDTH		(_ULCAST_(0x1f) << CSR_PWCTL0_PTWIDTH_SHIFT)
++#define  CSR_PWCTL0_PTBASE_SHIFT	0
++#define  CSR_PWCTL0_PTBASE_WIDTH	5
++#define  CSR_PWCTL0_PTBASE		(_ULCAST_(0x1f) << CSR_PWCTL0_PTBASE_SHIFT)
++
++#define LOONGARCH_CSR_PWCTL1		0x1d	/* PWCtl1 */
++#define  CSR_PWCTL1_PTW_SHIFT		24
++#define  CSR_PWCTL1_PTW_WIDTH		1
++#define  CSR_PWCTL1_PTW			(_ULCAST_(0x1) << CSR_PWCTL1_PTW_SHIFT)
++#define  CSR_PWCTL1_DIR3WIDTH_SHIFT	18
++#define  CSR_PWCTL1_DIR3WIDTH_WIDTH	5
++#define  CSR_PWCTL1_DIR3WIDTH		(_ULCAST_(0x1f) << CSR_PWCTL1_DIR3WIDTH_SHIFT)
++#define  CSR_PWCTL1_DIR3BASE_SHIFT	12
++#define  CSR_PWCTL1_DIR3BASE_WIDTH	5
++#define  CSR_PWCTL1_DIR3BASE		(_ULCAST_(0x1f) << CSR_PWCTL0_DIR3BASE_SHIFT)
++#define  CSR_PWCTL1_DIR2WIDTH_SHIFT	6
++#define  CSR_PWCTL1_DIR2WIDTH_WIDTH	5
++#define  CSR_PWCTL1_DIR2WIDTH		(_ULCAST_(0x1f) << CSR_PWCTL1_DIR2WIDTH_SHIFT)
++#define  CSR_PWCTL1_DIR2BASE_SHIFT	0
++#define  CSR_PWCTL1_DIR2BASE_WIDTH	5
++#define  CSR_PWCTL1_DIR2BASE		(_ULCAST_(0x1f) << CSR_PWCTL0_DIR2BASE_SHIFT)
++
++#define LOONGARCH_CSR_STLBPGSIZE	0x1e
++#define  CSR_STLBPGSIZE_PS_WIDTH	6
++#define  CSR_STLBPGSIZE_PS		(_ULCAST_(0x3f))
++
++#define LOONGARCH_CSR_RVACFG		0x1f
++#define  CSR_RVACFG_RDVA_WIDTH		4
++#define  CSR_RVACFG_RDVA		(_ULCAST_(0xf))
++
++/* Config CSR registers */
++#define LOONGARCH_CSR_CPUID		0x20	/* CPU core id */
++#define  CSR_CPUID_COREID_WIDTH		9
++#define  CSR_CPUID_COREID		_ULCAST_(0x1ff)
++
++#define LOONGARCH_CSR_PRCFG1		0x21	/* Config1 */
++#define  CSR_CONF1_VSMAX_SHIFT		12
++#define  CSR_CONF1_VSMAX_WIDTH		3
++#define  CSR_CONF1_VSMAX		(_ULCAST_(7) << CSR_CONF1_VSMAX_SHIFT)
++#define  CSR_CONF1_TMRBITS_SHIFT	4
++#define  CSR_CONF1_TMRBITS_WIDTH	8
++#define  CSR_CONF1_TMRBITS		(_ULCAST_(0xff) << CSR_CONF1_TMRBITS_SHIFT)
++#define  CSR_CONF1_KSNUM_WIDTH		4
++#define  CSR_CONF1_KSNUM		_ULCAST_(0xf)
++
++#define LOONGARCH_CSR_PRCFG2		0x22	/* Config2 */
++#define  CSR_CONF2_PGMASK_SUPP		0x3ffff000
++
++#define LOONGARCH_CSR_PRCFG3		0x23	/* Config3 */
++#define  CSR_CONF3_STLBIDX_SHIFT	20
++#define  CSR_CONF3_STLBIDX_WIDTH	6
++#define  CSR_CONF3_STLBIDX		(_ULCAST_(0x3f) << CSR_CONF3_STLBIDX_SHIFT)
++#define  CSR_CONF3_STLBWAYS_SHIFT	12
++#define  CSR_CONF3_STLBWAYS_WIDTH	8
++#define  CSR_CONF3_STLBWAYS		(_ULCAST_(0xff) << CSR_CONF3_STLBWAYS_SHIFT)
++#define  CSR_CONF3_MTLBSIZE_SHIFT	4
++#define  CSR_CONF3_MTLBSIZE_WIDTH	8
++#define  CSR_CONF3_MTLBSIZE		(_ULCAST_(0xff) << CSR_CONF3_MTLBSIZE_SHIFT)
++#define  CSR_CONF3_TLBTYPE_SHIFT	0
++#define  CSR_CONF3_TLBTYPE_WIDTH	4
++#define  CSR_CONF3_TLBTYPE		(_ULCAST_(0xf) << CSR_CONF3_TLBTYPE_SHIFT)
++
++/* KSave registers */
++#define LOONGARCH_CSR_KS0		0x30
++#define LOONGARCH_CSR_KS1		0x31
++#define LOONGARCH_CSR_KS2		0x32
++#define LOONGARCH_CSR_KS3		0x33
++#define LOONGARCH_CSR_KS4		0x34
++#define LOONGARCH_CSR_KS5		0x35
++#define LOONGARCH_CSR_KS6		0x36
++#define LOONGARCH_CSR_KS7		0x37
++#define LOONGARCH_CSR_KS8		0x38
++
++/* Exception allocated KS0, KS1 and KS2 statically */
++#define EXCEPTION_KS0			LOONGARCH_CSR_KS0
++#define EXCEPTION_KS1			LOONGARCH_CSR_KS1
++#define EXCEPTION_KS2			LOONGARCH_CSR_KS2
++#define EXC_KSAVE_MASK			(1 << 0 | 1 << 1 | 1 << 2)
++
++/* Percpu-data base allocated KS3 statically */
++#define PERCPU_BASE_KS			LOONGARCH_CSR_KS3
++#define PERCPU_KSAVE_MASK		(1 << 3)
++
++/* KVM allocated KS4 and KS5 statically */
++#define KVM_VCPU_KS			LOONGARCH_CSR_KS4
++#define KVM_TEMP_KS			LOONGARCH_CSR_KS5
++#define KVM_KSAVE_MASK			(1 << 4 | 1 << 5)
++
++/* Timer registers */
++#define LOONGARCH_CSR_TMID		0x40	/* Timer ID */
++
++#define LOONGARCH_CSR_TCFG		0x41	/* Timer config */
++#define  CSR_TCFG_VAL_SHIFT		2
++#define	 CSR_TCFG_VAL_WIDTH		48
++#define  CSR_TCFG_VAL			(_ULCAST_(0x3fffffffffff) << CSR_TCFG_VAL_SHIFT)
++#define  CSR_TCFG_PERIOD_SHIFT		1
++#define  CSR_TCFG_PERIOD		(_ULCAST_(0x1) << CSR_TCFG_PERIOD_SHIFT)
++#define  CSR_TCFG_EN			(_ULCAST_(0x1))
++
++#define LOONGARCH_CSR_TVAL		0x42	/* Timer value */
++
++#define LOONGARCH_CSR_CNTC		0x43	/* Timer offset */
++
++#define LOONGARCH_CSR_TINTCLR		0x44	/* Timer interrupt clear */
++#define  CSR_TINTCLR_TI_SHIFT		0
++#define  CSR_TINTCLR_TI			(1 << CSR_TINTCLR_TI_SHIFT)
++
++/* Guest registers */
++#define LOONGARCH_CSR_GSTAT		0x50	/* Guest status */
++#define  CSR_GSTAT_GID_SHIFT		16
++#define  CSR_GSTAT_GID_WIDTH		8
++#define  CSR_GSTAT_GID_SHIFT_END	(CSR_GSTAT_GID_SHIFT + CSR_GSTAT_GID_WIDTH - 1)
++#define  CSR_GSTAT_GID			(_ULCAST_(0xff) << CSR_GSTAT_GID_SHIFT)
++#define  CSR_GSTAT_GIDBIT_SHIFT		4
++#define  CSR_GSTAT_GIDBIT_WIDTH		6
++#define  CSR_GSTAT_GIDBIT		(_ULCAST_(0x3f) << CSR_GSTAT_GIDBIT_SHIFT)
++#define  CSR_GSTAT_PVM_SHIFT		1
++#define  CSR_GSTAT_PVM			(_ULCAST_(0x1) << CSR_GSTAT_PVM_SHIFT)
++#define  CSR_GSTAT_VM_SHIFT		0
++#define  CSR_GSTAT_VM			(_ULCAST_(0x1) << CSR_GSTAT_VM_SHIFT)
++
++#define LOONGARCH_CSR_GCFG		0x51	/* Guest config */
++#define  CSR_GCFG_GPERF_SHIFT		24
++#define  CSR_GCFG_GPERF_WIDTH		3
++#define  CSR_GCFG_GPERF			(_ULCAST_(0x7) << CSR_GCFG_GPERF_SHIFT)
++#define  CSR_GCFG_GCI_SHIFT		20
++#define  CSR_GCFG_GCI_WIDTH		2
++#define  CSR_GCFG_GCI			(_ULCAST_(0x3) << CSR_GCFG_GCI_SHIFT)
++#define  CSR_GCFG_GCI_ALL		(_ULCAST_(0x0) << CSR_GCFG_GCI_SHIFT)
++#define  CSR_GCFG_GCI_HIT		(_ULCAST_(0x1) << CSR_GCFG_GCI_SHIFT)
++#define  CSR_GCFG_GCI_SECURE		(_ULCAST_(0x2) << CSR_GCFG_GCI_SHIFT)
++#define  CSR_GCFG_GCIP_SHIFT		16
++#define  CSR_GCFG_GCIP			(_ULCAST_(0xf) << CSR_GCFG_GCIP_SHIFT)
++#define  CSR_GCFG_GCIP_ALL		(_ULCAST_(0x1) << CSR_GCFG_GCIP_SHIFT)
++#define  CSR_GCFG_GCIP_HIT		(_ULCAST_(0x1) << (CSR_GCFG_GCIP_SHIFT + 1))
++#define  CSR_GCFG_GCIP_SECURE		(_ULCAST_(0x1) << (CSR_GCFG_GCIP_SHIFT + 2))
++#define  CSR_GCFG_TORU_SHIFT		15
++#define  CSR_GCFG_TORU			(_ULCAST_(0x1) << CSR_GCFG_TORU_SHIFT)
++#define  CSR_GCFG_TORUP_SHIFT		14
++#define  CSR_GCFG_TORUP			(_ULCAST_(0x1) << CSR_GCFG_TORUP_SHIFT)
++#define  CSR_GCFG_TOP_SHIFT		13
++#define  CSR_GCFG_TOP			(_ULCAST_(0x1) << CSR_GCFG_TOP_SHIFT)
++#define  CSR_GCFG_TOPP_SHIFT		12
++#define  CSR_GCFG_TOPP			(_ULCAST_(0x1) << CSR_GCFG_TOPP_SHIFT)
++#define  CSR_GCFG_TOE_SHIFT		11
++#define  CSR_GCFG_TOE			(_ULCAST_(0x1) << CSR_GCFG_TOE_SHIFT)
++#define  CSR_GCFG_TOEP_SHIFT		10
++#define  CSR_GCFG_TOEP			(_ULCAST_(0x1) << CSR_GCFG_TOEP_SHIFT)
++#define  CSR_GCFG_TIT_SHIFT		9
++#define  CSR_GCFG_TIT			(_ULCAST_(0x1) << CSR_GCFG_TIT_SHIFT)
++#define  CSR_GCFG_TITP_SHIFT		8
++#define  CSR_GCFG_TITP			(_ULCAST_(0x1) << CSR_GCFG_TITP_SHIFT)
++#define  CSR_GCFG_SIT_SHIFT		7
++#define  CSR_GCFG_SIT			(_ULCAST_(0x1) << CSR_GCFG_SIT_SHIFT)
++#define  CSR_GCFG_SITP_SHIFT		6
++#define  CSR_GCFG_SITP			(_ULCAST_(0x1) << CSR_GCFG_SITP_SHIFT)
++#define  CSR_GCFG_MATC_SHITF		4
++#define  CSR_GCFG_MATC_WIDTH		2
++#define  CSR_GCFG_MATC_MASK		(_ULCAST_(0x3) << CSR_GCFG_MATC_SHITF)
++#define  CSR_GCFG_MATC_GUEST		(_ULCAST_(0x0) << CSR_GCFG_MATC_SHITF)
++#define  CSR_GCFG_MATC_ROOT		(_ULCAST_(0x1) << CSR_GCFG_MATC_SHITF)
++#define  CSR_GCFG_MATC_NEST		(_ULCAST_(0x2) << CSR_GCFG_MATC_SHITF)
++#define  CSR_GCFG_MATP_NEST_SHIFT	2
++#define  CSR_GCFG_MATP_NEST		(_ULCAST_(0x1) << CSR_GCFG_MATP_NEST_SHIFT)
++#define  CSR_GCFG_MATP_ROOT_SHIFT	1
++#define  CSR_GCFG_MATP_ROOT		(_ULCAST_(0x1) << CSR_GCFG_MATP_ROOT_SHIFT)
++#define  CSR_GCFG_MATP_GUEST_SHIFT	0
++#define  CSR_GCFG_MATP_GUEST		(_ULCAST_(0x1) << CSR_GCFG_MATP_GUEST_SHIFT)
++
++#define LOONGARCH_CSR_GINTC		0x52	/* Guest interrupt control */
++#define  CSR_GINTC_HC_SHIFT		16
++#define  CSR_GINTC_HC_WIDTH		8
++#define  CSR_GINTC_HC			(_ULCAST_(0xff) << CSR_GINTC_HC_SHIFT)
++#define  CSR_GINTC_PIP_SHIFT		8
++#define  CSR_GINTC_PIP_WIDTH		8
++#define  CSR_GINTC_PIP			(_ULCAST_(0xff) << CSR_GINTC_PIP_SHIFT)
++#define  CSR_GINTC_VIP_SHIFT		0
++#define  CSR_GINTC_VIP_WIDTH		8
++#define  CSR_GINTC_VIP			(_ULCAST_(0xff))
++
++#define LOONGARCH_CSR_GCNTC		0x53	/* Guest timer offset */
++
++/* LLBCTL register */
++#define LOONGARCH_CSR_LLBCTL		0x60	/* LLBit control */
++#define  CSR_LLBCTL_ROLLB_SHIFT		0
++#define  CSR_LLBCTL_ROLLB		(_ULCAST_(1) << CSR_LLBCTL_ROLLB_SHIFT)
++#define  CSR_LLBCTL_WCLLB_SHIFT		1
++#define  CSR_LLBCTL_WCLLB		(_ULCAST_(1) << CSR_LLBCTL_WCLLB_SHIFT)
++#define  CSR_LLBCTL_KLO_SHIFT		2
++#define  CSR_LLBCTL_KLO			(_ULCAST_(1) << CSR_LLBCTL_KLO_SHIFT)
++
++/* Implement dependent */
++#define LOONGARCH_CSR_IMPCTL1		0x80	/* Loongson config1 */
++#define  CSR_MISPEC_SHIFT		20
++#define  CSR_MISPEC_WIDTH		8
++#define  CSR_MISPEC			(_ULCAST_(0xff) << CSR_MISPEC_SHIFT)
++#define  CSR_SSEN_SHIFT			18
++#define  CSR_SSEN			(_ULCAST_(1) << CSR_SSEN_SHIFT)
++#define  CSR_SCRAND_SHIFT		17
++#define  CSR_SCRAND			(_ULCAST_(1) << CSR_SCRAND_SHIFT)
++#define  CSR_LLEXCL_SHIFT		16
++#define  CSR_LLEXCL			(_ULCAST_(1) << CSR_LLEXCL_SHIFT)
++#define  CSR_DISVC_SHIFT		15
++#define  CSR_DISVC			(_ULCAST_(1) << CSR_DISVC_SHIFT)
++#define  CSR_VCLRU_SHIFT		14
++#define  CSR_VCLRU			(_ULCAST_(1) << CSR_VCLRU_SHIFT)
++#define  CSR_DCLRU_SHIFT		13
++#define  CSR_DCLRU			(_ULCAST_(1) << CSR_DCLRU_SHIFT)
++#define  CSR_FASTLDQ_SHIFT		12
++#define  CSR_FASTLDQ			(_ULCAST_(1) << CSR_FASTLDQ_SHIFT)
++#define  CSR_USERCAC_SHIFT		11
++#define  CSR_USERCAC			(_ULCAST_(1) << CSR_USERCAC_SHIFT)
++#define  CSR_ANTI_MISPEC_SHIFT		10
++#define  CSR_ANTI_MISPEC		(_ULCAST_(1) << CSR_ANTI_MISPEC_SHIFT)
++#define  CSR_AUTO_FLUSHSFB_SHIFT	9
++#define  CSR_AUTO_FLUSHSFB		(_ULCAST_(1) << CSR_AUTO_FLUSHSFB_SHIFT)
++#define  CSR_STFILL_SHIFT		8
++#define  CSR_STFILL			(_ULCAST_(1) << CSR_STFILL_SHIFT)
++#define  CSR_LIFEP_SHIFT		7
++#define  CSR_LIFEP			(_ULCAST_(1) << CSR_LIFEP_SHIFT)
++#define  CSR_LLSYNC_SHIFT		6
++#define  CSR_LLSYNC			(_ULCAST_(1) << CSR_LLSYNC_SHIFT)
++#define  CSR_BRBTDIS_SHIFT		5
++#define  CSR_BRBTDIS			(_ULCAST_(1) << CSR_BRBTDIS_SHIFT)
++#define  CSR_RASDIS_SHIFT		4
++#define  CSR_RASDIS			(_ULCAST_(1) << CSR_RASDIS_SHIFT)
++#define  CSR_STPRE_SHIFT		2
++#define  CSR_STPRE_WIDTH		2
++#define  CSR_STPRE			(_ULCAST_(3) << CSR_STPRE_SHIFT)
++#define  CSR_INSTPRE_SHIFT		1
++#define  CSR_INSTPRE			(_ULCAST_(1) << CSR_INSTPRE_SHIFT)
++#define  CSR_DATAPRE_SHIFT		0
++#define  CSR_DATAPRE			(_ULCAST_(1) << CSR_DATAPRE_SHIFT)
++
++#define LOONGARCH_CSR_IMPCTL2		0x81	/* Loongson config2 */
++#define  CSR_FLUSH_MTLB_SHIFT		0
++#define  CSR_FLUSH_MTLB			(_ULCAST_(1) << CSR_FLUSH_MTLB_SHIFT)
++#define  CSR_FLUSH_STLB_SHIFT		1
++#define  CSR_FLUSH_STLB			(_ULCAST_(1) << CSR_FLUSH_STLB_SHIFT)
++#define  CSR_FLUSH_DTLB_SHIFT		2
++#define  CSR_FLUSH_DTLB			(_ULCAST_(1) << CSR_FLUSH_DTLB_SHIFT)
++#define  CSR_FLUSH_ITLB_SHIFT		3
++#define  CSR_FLUSH_ITLB			(_ULCAST_(1) << CSR_FLUSH_ITLB_SHIFT)
++#define  CSR_FLUSH_BTAC_SHIFT		4
++#define  CSR_FLUSH_BTAC			(_ULCAST_(1) << CSR_FLUSH_BTAC_SHIFT)
++
++#define LOONGARCH_CSR_GNMI		0x82
++
++/* TLB Refill registers */
++#define LOONGARCH_CSR_TLBRENTRY		0x88	/* TLB refill exception entry */
++#define LOONGARCH_CSR_TLBRBADV		0x89	/* TLB refill badvaddr */
++#define LOONGARCH_CSR_TLBRERA		0x8a	/* TLB refill ERA */
++#define LOONGARCH_CSR_TLBRSAVE		0x8b	/* KSave for TLB refill exception */
++#define LOONGARCH_CSR_TLBRELO0		0x8c	/* TLB refill entrylo0 */
++#define LOONGARCH_CSR_TLBRELO1		0x8d	/* TLB refill entrylo1 */
++#define LOONGARCH_CSR_TLBREHI		0x8e	/* TLB refill entryhi */
++#define  CSR_TLBREHI_PS_SHIFT		0
++#define  CSR_TLBREHI_PS			(_ULCAST_(0x3f) << CSR_TLBREHI_PS_SHIFT)
++#define LOONGARCH_CSR_TLBRPRMD		0x8f	/* TLB refill mode info */
++
++/* Machine Error registers */
++#define LOONGARCH_CSR_MERRCTL		0x90	/* MERRCTL */
++#define LOONGARCH_CSR_MERRINFO1		0x91	/* MError info1 */
++#define LOONGARCH_CSR_MERRINFO2		0x92	/* MError info2 */
++#define LOONGARCH_CSR_MERRENTRY		0x93	/* MError exception entry */
++#define LOONGARCH_CSR_MERRERA		0x94	/* MError exception ERA */
++#define LOONGARCH_CSR_MERRSAVE		0x95	/* KSave for machine error exception */
++
++#define LOONGARCH_CSR_CTAG		0x98	/* TagLo + TagHi */
++
++#define LOONGARCH_CSR_PRID		0xc0
++
++/* Shadow MCSR : 0xc0 ~ 0xff */
++#define LOONGARCH_CSR_MCSR0		0xc0	/* CPUCFG0 and CPUCFG1 */
++#define  MCSR0_INT_IMPL_SHIFT		58
++#define  MCSR0_INT_IMPL			0
++#define  MCSR0_IOCSR_BRD_SHIFT		57
++#define  MCSR0_IOCSR_BRD		(_ULCAST_(1) << MCSR0_IOCSR_BRD_SHIFT)
++#define  MCSR0_HUGEPG_SHIFT		56
++#define  MCSR0_HUGEPG			(_ULCAST_(1) << MCSR0_HUGEPG_SHIFT)
++#define  MCSR0_RPLMTLB_SHIFT		55
++#define  MCSR0_RPLMTLB			(_ULCAST_(1) << MCSR0_RPLMTLB_SHIFT)
++#define  MCSR0_EP_SHIFT			54
++#define  MCSR0_EP			(_ULCAST_(1) << MCSR0_EP_SHIFT)
++#define  MCSR0_RI_SHIFT			53
++#define  MCSR0_RI			(_ULCAST_(1) << MCSR0_RI_SHIFT)
++#define  MCSR0_UAL_SHIFT		52
++#define  MCSR0_UAL			(_ULCAST_(1) << MCSR0_UAL_SHIFT)
++#define  MCSR0_VABIT_SHIFT		44
++#define  MCSR0_VABIT_WIDTH		8
++#define  MCSR0_VABIT			(_ULCAST_(0xff) << MCSR0_VABIT_SHIFT)
++#define  VABIT_DEFAULT			0x2f
++#define  MCSR0_PABIT_SHIFT		36
++#define  MCSR0_PABIT_WIDTH		8
++#define  MCSR0_PABIT			(_ULCAST_(0xff) << MCSR0_PABIT_SHIFT)
++#define  PABIT_DEFAULT			0x2f
++#define  MCSR0_IOCSR_SHIFT		35
++#define  MCSR0_IOCSR			(_ULCAST_(1) << MCSR0_IOCSR_SHIFT)
++#define  MCSR0_PAGING_SHIFT		34
++#define  MCSR0_PAGING			(_ULCAST_(1) << MCSR0_PAGING_SHIFT)
++#define  MCSR0_GR64_SHIFT		33
++#define  MCSR0_GR64			(_ULCAST_(1) << MCSR0_GR64_SHIFT)
++#define  GR64_DEFAULT			1
++#define  MCSR0_GR32_SHIFT		32
++#define  MCSR0_GR32			(_ULCAST_(1) << MCSR0_GR32_SHIFT)
++#define  GR32_DEFAULT			0
++#define  MCSR0_PRID_WIDTH		32
++#define  MCSR0_PRID			0x14C010
++
++#define LOONGARCH_CSR_MCSR1		0xc1	/* CPUCFG2 and CPUCFG3 */
++#define  MCSR1_HPFOLD_SHIFT		43
++#define  MCSR1_HPFOLD			(_ULCAST_(1) << MCSR1_HPFOLD_SHIFT)
++#define  MCSR1_SPW_LVL_SHIFT		40
++#define  MCSR1_SPW_LVL_WIDTH		3
++#define  MCSR1_SPW_LVL			(_ULCAST_(7) << MCSR1_SPW_LVL_SHIFT)
++#define  MCSR1_ICACHET_SHIFT		39
++#define  MCSR1_ICACHET			(_ULCAST_(1) << MCSR1_ICACHET_SHIFT)
++#define  MCSR1_ITLBT_SHIFT		38
++#define  MCSR1_ITLBT			(_ULCAST_(1) << MCSR1_ITLBT_SHIFT)
++#define  MCSR1_LLDBAR_SHIFT		37
++#define  MCSR1_LLDBAR			(_ULCAST_(1) << MCSR1_LLDBAR_SHIFT)
++#define  MCSR1_SCDLY_SHIFT		36
++#define  MCSR1_SCDLY			(_ULCAST_(1) << MCSR1_SCDLY_SHIFT)
++#define  MCSR1_LLEXC_SHIFT		35
++#define  MCSR1_LLEXC			(_ULCAST_(1) << MCSR1_LLEXC_SHIFT)
++#define  MCSR1_UCACC_SHIFT		34
++#define  MCSR1_UCACC			(_ULCAST_(1) << MCSR1_UCACC_SHIFT)
++#define  MCSR1_SFB_SHIFT		33
++#define  MCSR1_SFB			(_ULCAST_(1) << MCSR1_SFB_SHIFT)
++#define  MCSR1_CCDMA_SHIFT		32
++#define  MCSR1_CCDMA			(_ULCAST_(1) << MCSR1_CCDMA_SHIFT)
++#define  MCSR1_LAMO_SHIFT		22
++#define  MCSR1_LAMO			(_ULCAST_(1) << MCSR1_LAMO_SHIFT)
++#define  MCSR1_LSPW_SHIFT		21
++#define  MCSR1_LSPW			(_ULCAST_(1) << MCSR1_LSPW_SHIFT)
++#define  MCSR1_MIPSBT_SHIFT		20
++#define  MCSR1_MIPSBT			(_ULCAST_(1) << MCSR1_MIPSBT_SHIFT)
++#define  MCSR1_ARMBT_SHIFT		19
++#define  MCSR1_ARMBT			(_ULCAST_(1) << MCSR1_ARMBT_SHIFT)
++#define  MCSR1_X86BT_SHIFT		18
++#define  MCSR1_X86BT			(_ULCAST_(1) << MCSR1_X86BT_SHIFT)
++#define  MCSR1_LLFTPVERS_SHIFT		15
++#define  MCSR1_LLFTPVERS_WIDTH		3
++#define  MCSR1_LLFTPVERS		(_ULCAST_(7) << MCSR1_LLFTPVERS_SHIFT)
++#define  MCSR1_LLFTP_SHIFT		14
++#define  MCSR1_LLFTP			(_ULCAST_(1) << MCSR1_LLFTP_SHIFT)
++#define  MCSR1_VZVERS_SHIFT		11
++#define  MCSR1_VZVERS_WIDTH		3
++#define  MCSR1_VZVERS			(_ULCAST_(7) << MCSR1_VZVERS_SHIFT)
++#define  MCSR1_VZ_SHIFT			10
++#define  MCSR1_VZ			(_ULCAST_(1) << MCSR1_VZ_SHIFT)
++#define  MCSR1_CRYPTO_SHIFT		9
++#define  MCSR1_CRYPTO			(_ULCAST_(1) << MCSR1_CRYPTO_SHIFT)
++#define  MCSR1_COMPLEX_SHIFT		8
++#define  MCSR1_COMPLEX			(_ULCAST_(1) << MCSR1_COMPLEX_SHIFT)
++#define  MCSR1_LASX_SHIFT		7
++#define  MCSR1_LASX			(_ULCAST_(1) << MCSR1_LASX_SHIFT)
++#define  MCSR1_LSX_SHIFT		6
++#define  MCSR1_LSX			(_ULCAST_(1) << MCSR1_LSX_SHIFT)
++#define  MCSR1_FPVERS_SHIFT		3
++#define  MCSR1_FPVERS_WIDTH		3
++#define  MCSR1_FPVERS			(_ULCAST_(7) << MCSR1_FPVERS_SHIFT)
++#define  MCSR1_FPDP_SHIFT		2
++#define  MCSR1_FPDP			(_ULCAST_(1) << MCSR1_FPDP_SHIFT)
++#define  MCSR1_FPSP_SHIFT		1
++#define  MCSR1_FPSP			(_ULCAST_(1) << MCSR1_FPSP_SHIFT)
++#define  MCSR1_FP_SHIFT			0
++#define  MCSR1_FP			(_ULCAST_(1) << MCSR1_FP_SHIFT)
++
++#define LOONGARCH_CSR_MCSR2		0xc2	/* CPUCFG4 and CPUCFG5 */
++#define  MCSR2_CCDIV_SHIFT		48
++#define  MCSR2_CCDIV_WIDTH		16
++#define  MCSR2_CCDIV			(_ULCAST_(0xffff) << MCSR2_CCDIV_SHIFT)
++#define  MCSR2_CCMUL_SHIFT		32
++#define  MCSR2_CCMUL_WIDTH		16
++#define  MCSR2_CCMUL			(_ULCAST_(0xffff) << MCSR2_CCMUL_SHIFT)
++#define  MCSR2_CCFREQ_WIDTH		32
++#define  MCSR2_CCFREQ			(_ULCAST_(0xffffffff))
++#define  CCFREQ_DEFAULT			0x5f5e100	/* 100MHz */
++
++#define LOONGARCH_CSR_MCSR3		0xc3	/* CPUCFG6 */
++#define  MCSR3_UPM_SHIFT		14
++#define  MCSR3_UPM			(_ULCAST_(1) << MCSR3_UPM_SHIFT)
++#define  MCSR3_PMBITS_SHIFT		8
++#define  MCSR3_PMBITS_WIDTH		6
++#define  MCSR3_PMBITS			(_ULCAST_(0x3f) << MCSR3_PMBITS_SHIFT)
++#define  PMBITS_DEFAULT			0x40
++#define  MCSR3_PMNUM_SHIFT		4
++#define  MCSR3_PMNUM_WIDTH		4
++#define  MCSR3_PMNUM			(_ULCAST_(0xf) << MCSR3_PMNUM_SHIFT)
++#define  MCSR3_PAMVER_SHIFT		1
++#define  MCSR3_PAMVER_WIDTH		3
++#define  MCSR3_PAMVER			(_ULCAST_(0x7) << MCSR3_PAMVER_SHIFT)
++#define  MCSR3_PMP_SHIFT		0
++#define  MCSR3_PMP			(_ULCAST_(1) << MCSR3_PMP_SHIFT)
++
++#define LOONGARCH_CSR_MCSR8		0xc8	/* CPUCFG16 and CPUCFG17 */
++#define  MCSR8_L1I_SIZE_SHIFT		56
++#define  MCSR8_L1I_SIZE_WIDTH		7
++#define  MCSR8_L1I_SIZE			(_ULCAST_(0x7f) << MCSR8_L1I_SIZE_SHIFT)
++#define  MCSR8_L1I_IDX_SHIFT		48
++#define  MCSR8_L1I_IDX_WIDTH		8
++#define  MCSR8_L1I_IDX			(_ULCAST_(0xff) << MCSR8_L1I_IDX_SHIFT)
++#define  MCSR8_L1I_WAY_SHIFT		32
++#define  MCSR8_L1I_WAY_WIDTH		16
++#define  MCSR8_L1I_WAY			(_ULCAST_(0xffff) << MCSR8_L1I_WAY_SHIFT)
++#define  MCSR8_L3DINCL_SHIFT		16
++#define  MCSR8_L3DINCL			(_ULCAST_(1) << MCSR8_L3DINCL_SHIFT)
++#define  MCSR8_L3DPRIV_SHIFT		15
++#define  MCSR8_L3DPRIV			(_ULCAST_(1) << MCSR8_L3DPRIV_SHIFT)
++#define  MCSR8_L3DPRE_SHIFT		14
++#define  MCSR8_L3DPRE			(_ULCAST_(1) << MCSR8_L3DPRE_SHIFT)
++#define  MCSR8_L3IUINCL_SHIFT		13
++#define  MCSR8_L3IUINCL			(_ULCAST_(1) << MCSR8_L3IUINCL_SHIFT)
++#define  MCSR8_L3IUPRIV_SHIFT		12
++#define  MCSR8_L3IUPRIV			(_ULCAST_(1) << MCSR8_L3IUPRIV_SHIFT)
++#define  MCSR8_L3IUUNIFY_SHIFT		11
++#define  MCSR8_L3IUUNIFY		(_ULCAST_(1) << MCSR8_L3IUUNIFY_SHIFT)
++#define  MCSR8_L3IUPRE_SHIFT		10
++#define  MCSR8_L3IUPRE			(_ULCAST_(1) << MCSR8_L3IUPRE_SHIFT)
++#define  MCSR8_L2DINCL_SHIFT		9
++#define  MCSR8_L2DINCL			(_ULCAST_(1) << MCSR8_L2DINCL_SHIFT)
++#define  MCSR8_L2DPRIV_SHIFT		8
++#define  MCSR8_L2DPRIV			(_ULCAST_(1) << MCSR8_L2DPRIV_SHIFT)
++#define  MCSR8_L2DPRE_SHIFT		7
++#define  MCSR8_L2DPRE			(_ULCAST_(1) << MCSR8_L2DPRE_SHIFT)
++#define  MCSR8_L2IUINCL_SHIFT		6
++#define  MCSR8_L2IUINCL			(_ULCAST_(1) << MCSR8_L2IUINCL_SHIFT)
++#define  MCSR8_L2IUPRIV_SHIFT		5
++#define  MCSR8_L2IUPRIV			(_ULCAST_(1) << MCSR8_L2IUPRIV_SHIFT)
++#define  MCSR8_L2IUUNIFY_SHIFT		4
++#define  MCSR8_L2IUUNIFY		(_ULCAST_(1) << MCSR8_L2IUUNIFY_SHIFT)
++#define  MCSR8_L2IUPRE_SHIFT		3
++#define  MCSR8_L2IUPRE			(_ULCAST_(1) << MCSR8_L2IUPRE_SHIFT)
++#define  MCSR8_L1DPRE_SHIFT		2
++#define  MCSR8_L1DPRE			(_ULCAST_(1) << MCSR8_L1DPRE_SHIFT)
++#define  MCSR8_L1IUUNIFY_SHIFT		1
++#define  MCSR8_L1IUUNIFY		(_ULCAST_(1) << MCSR8_L1IUUNIFY_SHIFT)
++#define  MCSR8_L1IUPRE_SHIFT		0
++#define  MCSR8_L1IUPRE			(_ULCAST_(1) << MCSR8_L1IUPRE_SHIFT)
++
++#define LOONGARCH_CSR_MCSR9		0xc9	/* CPUCFG18 and CPUCFG19 */
++#define  MCSR9_L2U_SIZE_SHIFT		56
++#define  MCSR9_L2U_SIZE_WIDTH		7
++#define  MCSR9_L2U_SIZE			(_ULCAST_(0x7f) << MCSR9_L2U_SIZE_SHIFT)
++#define  MCSR9_L2U_IDX_SHIFT		48
++#define  MCSR9_L2U_IDX_WIDTH		8
++#define  MCSR9_L2U_IDX			(_ULCAST_(0xff) << MCSR9_IDX_LOG_SHIFT)
++#define  MCSR9_L2U_WAY_SHIFT		32
++#define  MCSR9_L2U_WAY_WIDTH		16
++#define  MCSR9_L2U_WAY			(_ULCAST_(0xffff) << MCSR9_L2U_WAY_SHIFT)
++#define  MCSR9_L1D_SIZE_SHIFT		24
++#define  MCSR9_L1D_SIZE_WIDTH		7
++#define  MCSR9_L1D_SIZE			(_ULCAST_(0x7f) << MCSR9_L1D_SIZE_SHIFT)
++#define  MCSR9_L1D_IDX_SHIFT		16
++#define  MCSR9_L1D_IDX_WIDTH		8
++#define  MCSR9_L1D_IDX			(_ULCAST_(0xff) << MCSR9_L1D_IDX_SHIFT)
++#define  MCSR9_L1D_WAY_SHIFT		0
++#define  MCSR9_L1D_WAY_WIDTH		16
++#define  MCSR9_L1D_WAY			(_ULCAST_(0xffff) << MCSR9_L1D_WAY_SHIFT)
++
++#define LOONGARCH_CSR_MCSR10		0xca	/* CPUCFG20 */
++#define  MCSR10_L3U_SIZE_SHIFT		24
++#define  MCSR10_L3U_SIZE_WIDTH		7
++#define  MCSR10_L3U_SIZE		(_ULCAST_(0x7f) << MCSR10_L3U_SIZE_SHIFT)
++#define  MCSR10_L3U_IDX_SHIFT		16
++#define  MCSR10_L3U_IDX_WIDTH		8
++#define  MCSR10_L3U_IDX			(_ULCAST_(0xff) << MCSR10_L3U_IDX_SHIFT)
++#define  MCSR10_L3U_WAY_SHIFT		0
++#define  MCSR10_L3U_WAY_WIDTH		16
++#define  MCSR10_L3U_WAY			(_ULCAST_(0xffff) << MCSR10_L3U_WAY_SHIFT)
++
++#define LOONGARCH_CSR_MCSR24		0xf0	/* cpucfg48 */
++#define  MCSR24_RAMCG_SHIFT		3
++#define  MCSR24_RAMCG			(_ULCAST_(1) << MCSR24_RAMCG_SHIFT)
++#define  MCSR24_VFPUCG_SHIFT		2
++#define  MCSR24_VFPUCG			(_ULCAST_(1) << MCSR24_VFPUCG_SHIFT)
++#define  MCSR24_NAPEN_SHIFT		1
++#define  MCSR24_NAPEN			(_ULCAST_(1) << MCSR24_NAPEN_SHIFT)
++#define  MCSR24_MCSRLOCK_SHIFT		0
++#define  MCSR24_MCSRLOCK		(_ULCAST_(1) << MCSR24_MCSRLOCK_SHIFT)
++
++/* Uncached accelerate windows registers */
++#define LOONGARCH_CSR_UCAWIN		0x100
++#define LOONGARCH_CSR_UCAWIN0_LO	0x102
++#define LOONGARCH_CSR_UCAWIN0_HI	0x103
++#define LOONGARCH_CSR_UCAWIN1_LO	0x104
++#define LOONGARCH_CSR_UCAWIN1_HI	0x105
++#define LOONGARCH_CSR_UCAWIN2_LO	0x106
++#define LOONGARCH_CSR_UCAWIN2_HI	0x107
++#define LOONGARCH_CSR_UCAWIN3_LO	0x108
++#define LOONGARCH_CSR_UCAWIN3_HI	0x109
++
++/* Direct Map windows registers */
++#define LOONGARCH_CSR_DMWIN0		0x180	/* 64 direct map win0: MEM & IF */
++#define LOONGARCH_CSR_DMWIN1		0x181	/* 64 direct map win1: MEM & IF */
++#define LOONGARCH_CSR_DMWIN2		0x182	/* 64 direct map win2: MEM */
++#define LOONGARCH_CSR_DMWIN3		0x183	/* 64 direct map win3: MEM */
++
++/* Direct Map window 0/1 */
++#define CSR_DMW0_PLV0		_CONST64_(1 << 0)
++#define CSR_DMW0_VSEG		_CONST64_(0x8000)
++#define CSR_DMW0_BASE		(CSR_DMW0_VSEG << DMW_PABITS)
++#define CSR_DMW0_INIT		(CSR_DMW0_BASE | CSR_DMW0_PLV0)
++
++#define CSR_DMW1_PLV0		_CONST64_(1 << 0)
++#define CSR_DMW1_MAT		_CONST64_(1 << 4)
++#define CSR_DMW1_VSEG		_CONST64_(0x9000)
++#define CSR_DMW1_BASE		(CSR_DMW1_VSEG << DMW_PABITS)
++#define CSR_DMW1_INIT		(CSR_DMW1_BASE | CSR_DMW1_MAT | CSR_DMW1_PLV0)
++
++/* Performance Counter registers */
++#define LOONGARCH_CSR_PERFCTRL0		0x200	/* 32 perf event 0 config */
++#define LOONGARCH_CSR_PERFCNTR0		0x201	/* 64 perf event 0 count value */
++#define LOONGARCH_CSR_PERFCTRL1		0x202	/* 32 perf event 1 config */
++#define LOONGARCH_CSR_PERFCNTR1		0x203	/* 64 perf event 1 count value */
++#define LOONGARCH_CSR_PERFCTRL2		0x204	/* 32 perf event 2 config */
++#define LOONGARCH_CSR_PERFCNTR2		0x205	/* 64 perf event 2 count value */
++#define LOONGARCH_CSR_PERFCTRL3		0x206	/* 32 perf event 3 config */
++#define LOONGARCH_CSR_PERFCNTR3		0x207	/* 64 perf event 3 count value */
++#define  CSR_PERFCTRL_PLV0		(_ULCAST_(1) << 16)
++#define  CSR_PERFCTRL_PLV1		(_ULCAST_(1) << 17)
++#define  CSR_PERFCTRL_PLV2		(_ULCAST_(1) << 18)
++#define  CSR_PERFCTRL_PLV3		(_ULCAST_(1) << 19)
++#define  CSR_PERFCTRL_IE		(_ULCAST_(1) << 20)
++#define  CSR_PERFCTRL_EVENT		0x3ff
++
++/* Debug registers */
++#define LOONGARCH_CSR_MWPC		0x300	/* data breakpoint config */
++#define LOONGARCH_CSR_MWPS		0x301	/* data breakpoint status */
++
++#define LOONGARCH_CSR_DB0ADDR		0x310	/* data breakpoint 0 address */
++#define LOONGARCH_CSR_DB0MASK		0x311	/* data breakpoint 0 mask */
++#define LOONGARCH_CSR_DB0CTRL		0x312	/* data breakpoint 0 control */
++#define LOONGARCH_CSR_DB0ASID		0x313	/* data breakpoint 0 asid */
++
++#define LOONGARCH_CSR_DB1ADDR		0x318	/* data breakpoint 1 address */
++#define LOONGARCH_CSR_DB1MASK		0x319	/* data breakpoint 1 mask */
++#define LOONGARCH_CSR_DB1CTRL		0x31a	/* data breakpoint 1 control */
++#define LOONGARCH_CSR_DB1ASID		0x31b	/* data breakpoint 1 asid */
++
++#define LOONGARCH_CSR_DB2ADDR		0x320	/* data breakpoint 2 address */
++#define LOONGARCH_CSR_DB2MASK		0x321	/* data breakpoint 2 mask */
++#define LOONGARCH_CSR_DB2CTRL		0x322	/* data breakpoint 2 control */
++#define LOONGARCH_CSR_DB2ASID		0x323	/* data breakpoint 2 asid */
++
++#define LOONGARCH_CSR_DB3ADDR		0x328	/* data breakpoint 3 address */
++#define LOONGARCH_CSR_DB3MASK		0x329	/* data breakpoint 3 mask */
++#define LOONGARCH_CSR_DB3CTRL		0x32a	/* data breakpoint 3 control */
++#define LOONGARCH_CSR_DB3ASID		0x32b	/* data breakpoint 3 asid */
++
++#define LOONGARCH_CSR_DB4ADDR		0x330	/* data breakpoint 4 address */
++#define LOONGARCH_CSR_DB4MASK		0x331	/* data breakpoint 4 maks */
++#define LOONGARCH_CSR_DB4CTRL		0x332	/* data breakpoint 4 control */
++#define LOONGARCH_CSR_DB4ASID		0x333	/* data breakpoint 4 asid */
++
++#define LOONGARCH_CSR_DB5ADDR		0x338	/* data breakpoint 5 address */
++#define LOONGARCH_CSR_DB5MASK		0x339	/* data breakpoint 5 mask */
++#define LOONGARCH_CSR_DB5CTRL		0x33a	/* data breakpoint 5 control */
++#define LOONGARCH_CSR_DB5ASID		0x33b	/* data breakpoint 5 asid */
++
++#define LOONGARCH_CSR_DB6ADDR		0x340	/* data breakpoint 6 address */
++#define LOONGARCH_CSR_DB6MASK		0x341	/* data breakpoint 6 mask */
++#define LOONGARCH_CSR_DB6CTRL		0x342	/* data breakpoint 6 control */
++#define LOONGARCH_CSR_DB6ASID		0x343	/* data breakpoint 6 asid */
++
++#define LOONGARCH_CSR_DB7ADDR		0x348	/* data breakpoint 7 address */
++#define LOONGARCH_CSR_DB7MASK		0x349	/* data breakpoint 7 mask */
++#define LOONGARCH_CSR_DB7CTRL		0x34a	/* data breakpoint 7 control */
++#define LOONGARCH_CSR_DB7ASID		0x34b	/* data breakpoint 7 asid */
++
++#define LOONGARCH_CSR_FWPC		0x380	/* instruction breakpoint config */
++#define LOONGARCH_CSR_FWPS		0x381	/* instruction breakpoint status */
++
++#define LOONGARCH_CSR_IB0ADDR		0x390	/* inst breakpoint 0 address */
++#define LOONGARCH_CSR_IB0MASK		0x391	/* inst breakpoint 0 mask */
++#define LOONGARCH_CSR_IB0CTRL		0x392	/* inst breakpoint 0 control */
++#define LOONGARCH_CSR_IB0ASID		0x393	/* inst breakpoint 0 asid */
++
++#define LOONGARCH_CSR_IB1ADDR		0x398	/* inst breakpoint 1 address */
++#define LOONGARCH_CSR_IB1MASK		0x399	/* inst breakpoint 1 mask */
++#define LOONGARCH_CSR_IB1CTRL		0x39a	/* inst breakpoint 1 control */
++#define LOONGARCH_CSR_IB1ASID		0x39b	/* inst breakpoint 1 asid */
++
++#define LOONGARCH_CSR_IB2ADDR		0x3a0	/* inst breakpoint 2 address */
++#define LOONGARCH_CSR_IB2MASK		0x3a1	/* inst breakpoint 2 mask */
++#define LOONGARCH_CSR_IB2CTRL		0x3a2	/* inst breakpoint 2 control */
++#define LOONGARCH_CSR_IB2ASID		0x3a3	/* inst breakpoint 2 asid */
++
++#define LOONGARCH_CSR_IB3ADDR		0x3a8	/* inst breakpoint 3 address */
++#define LOONGARCH_CSR_IB3MASK		0x3a9	/* breakpoint 3 mask */
++#define LOONGARCH_CSR_IB3CTRL		0x3aa	/* inst breakpoint 3 control */
++#define LOONGARCH_CSR_IB3ASID		0x3ab	/* inst breakpoint 3 asid */
++
++#define LOONGARCH_CSR_IB4ADDR		0x3b0	/* inst breakpoint 4 address */
++#define LOONGARCH_CSR_IB4MASK		0x3b1	/* inst breakpoint 4 mask */
++#define LOONGARCH_CSR_IB4CTRL		0x3b2	/* inst breakpoint 4 control */
++#define LOONGARCH_CSR_IB4ASID		0x3b3	/* inst breakpoint 4 asid */
++
++#define LOONGARCH_CSR_IB5ADDR		0x3b8	/* inst breakpoint 5 address */
++#define LOONGARCH_CSR_IB5MASK		0x3b9	/* inst breakpoint 5 mask */
++#define LOONGARCH_CSR_IB5CTRL		0x3ba	/* inst breakpoint 5 control */
++#define LOONGARCH_CSR_IB5ASID		0x3bb	/* inst breakpoint 5 asid */
++
++#define LOONGARCH_CSR_IB6ADDR		0x3c0	/* inst breakpoint 6 address */
++#define LOONGARCH_CSR_IB6MASK		0x3c1	/* inst breakpoint 6 mask */
++#define LOONGARCH_CSR_IB6CTRL		0x3c2	/* inst breakpoint 6 control */
++#define LOONGARCH_CSR_IB6ASID		0x3c3	/* inst breakpoint 6 asid */
++
++#define LOONGARCH_CSR_IB7ADDR		0x3c8	/* inst breakpoint 7 address */
++#define LOONGARCH_CSR_IB7MASK		0x3c9	/* inst breakpoint 7 mask */
++#define LOONGARCH_CSR_IB7CTRL		0x3ca	/* inst breakpoint 7 control */
++#define LOONGARCH_CSR_IB7ASID		0x3cb	/* inst breakpoint 7 asid */
++
++#define LOONGARCH_CSR_DEBUG		0x500	/* debug config */
++#define LOONGARCH_CSR_DERA		0x501	/* debug era */
++#define LOONGARCH_CSR_DESAVE		0x502	/* debug save */
++
++#define CSR_FWPC_SKIP_SHIFT		16
++#define CSR_FWPC_SKIP			(_ULCAST_(1) << CSR_FWPC_SKIP_SHIFT)
++
++/*
++ * CSR_ECFG IM
++ */
++#define ECFG0_IM		0x00001fff
++#define ECFGB_SIP0		0
++#define ECFGF_SIP0		(_ULCAST_(1) << ECFGB_SIP0)
++#define ECFGB_SIP1		1
++#define ECFGF_SIP1		(_ULCAST_(1) << ECFGB_SIP1)
++#define ECFGB_IP0		2
++#define ECFGF_IP0		(_ULCAST_(1) << ECFGB_IP0)
++#define ECFGB_IP1		3
++#define ECFGF_IP1		(_ULCAST_(1) << ECFGB_IP1)
++#define ECFGB_IP2		4
++#define ECFGF_IP2		(_ULCAST_(1) << ECFGB_IP2)
++#define ECFGB_IP3		5
++#define ECFGF_IP3		(_ULCAST_(1) << ECFGB_IP3)
++#define ECFGB_IP4		6
++#define ECFGF_IP4		(_ULCAST_(1) << ECFGB_IP4)
++#define ECFGB_IP5		7
++#define ECFGF_IP5		(_ULCAST_(1) << ECFGB_IP5)
++#define ECFGB_IP6		8
++#define ECFGF_IP6		(_ULCAST_(1) << ECFGB_IP6)
++#define ECFGB_IP7		9
++#define ECFGF_IP7		(_ULCAST_(1) << ECFGB_IP7)
++#define ECFGB_PMC		10
++#define ECFGF_PMC		(_ULCAST_(1) << ECFGB_PMC)
++#define ECFGB_TIMER		11
++#define ECFGF_TIMER		(_ULCAST_(1) << ECFGB_TIMER)
++#define ECFGB_IPI		12
++#define ECFGF_IPI		(_ULCAST_(1) << ECFGB_IPI)
++#define ECFGF(hwirq)		(_ULCAST_(1) << hwirq)
++
++#define ESTATF_IP		0x00003fff
++
++#define LOONGARCH_IOCSR_FEATURES	0x8
++#define  IOCSRF_TEMP			BIT_ULL(0)
++#define  IOCSRF_NODECNT			BIT_ULL(1)
++#define  IOCSRF_MSI			BIT_ULL(2)
++#define  IOCSRF_EXTIOI			BIT_ULL(3)
++#define  IOCSRF_CSRIPI			BIT_ULL(4)
++#define  IOCSRF_FREQCSR			BIT_ULL(5)
++#define  IOCSRF_FREQSCALE		BIT_ULL(6)
++#define  IOCSRF_DVFSV1			BIT_ULL(7)
++#define  IOCSRF_EIODECODE		BIT_ULL(9)
++#define  IOCSRF_FLATMODE		BIT_ULL(10)
++#define  IOCSRF_VM			BIT_ULL(11)
++
++#define LOONGARCH_IOCSR_VENDOR		0x10
++
++#define LOONGARCH_IOCSR_CPUNAME		0x20
++
++#define LOONGARCH_IOCSR_NODECNT		0x408
++
++#define LOONGARCH_IOCSR_MISC_FUNC	0x420
++#define  IOCSR_MISC_FUNC_TIMER_RESET	BIT_ULL(21)
++#define  IOCSR_MISC_FUNC_EXT_IOI_EN	BIT_ULL(48)
++
++#define LOONGARCH_IOCSR_CPUTEMP		0x428
++
++/* PerCore CSR, only accessible by local cores */
++#define LOONGARCH_IOCSR_IPI_STATUS	0x1000
++#define LOONGARCH_IOCSR_IPI_EN		0x1004
++#define LOONGARCH_IOCSR_IPI_SET		0x1008
++#define LOONGARCH_IOCSR_IPI_CLEAR	0x100c
++#define LOONGARCH_IOCSR_MBUF0		0x1020
++#define LOONGARCH_IOCSR_MBUF1		0x1028
++#define LOONGARCH_IOCSR_MBUF2		0x1030
++#define LOONGARCH_IOCSR_MBUF3		0x1038
++
++#define LOONGARCH_IOCSR_IPI_SEND	0x1040
++#define  IOCSR_IPI_SEND_IP_SHIFT	0
++#define  IOCSR_IPI_SEND_CPU_SHIFT	16
++#define  IOCSR_IPI_SEND_BLOCKING	BIT(31)
++
++#define LOONGARCH_IOCSR_MBUF_SEND	0x1048
++#define  IOCSR_MBUF_SEND_BLOCKING	BIT_ULL(31)
++#define  IOCSR_MBUF_SEND_BOX_SHIFT	2
++#define  IOCSR_MBUF_SEND_BOX_LO(box)	(box << 1)
++#define  IOCSR_MBUF_SEND_BOX_HI(box)	((box << 1) + 1)
++#define  IOCSR_MBUF_SEND_CPU_SHIFT	16
++#define  IOCSR_MBUF_SEND_BUF_SHIFT	32
++#define  IOCSR_MBUF_SEND_H32_MASK	0xFFFFFFFF00000000ULL
++
++#define LOONGARCH_IOCSR_ANY_SEND	0x1158
++#define  IOCSR_ANY_SEND_BLOCKING	BIT_ULL(31)
++#define  IOCSR_ANY_SEND_CPU_SHIFT	16
++#define  IOCSR_ANY_SEND_MASK_SHIFT	27
++#define  IOCSR_ANY_SEND_BUF_SHIFT	32
++#define  IOCSR_ANY_SEND_H32_MASK	0xFFFFFFFF00000000ULL
++
++/* Register offset and bit definition for CSR access */
++#define LOONGARCH_IOCSR_TIMER_CFG       0x1060
++#define LOONGARCH_IOCSR_TIMER_TICK      0x1070
++#define  IOCSR_TIMER_CFG_RESERVED       (_ULCAST_(1) << 63)
++#define  IOCSR_TIMER_CFG_PERIODIC       (_ULCAST_(1) << 62)
++#define  IOCSR_TIMER_CFG_EN             (_ULCAST_(1) << 61)
++#define  IOCSR_TIMER_MASK		0x0ffffffffffffULL
++#define  IOCSR_TIMER_INITVAL_RST        (_ULCAST_(0xffff) << 48)
++
++#define LOONGARCH_IOCSR_EXTIOI_NODEMAP_BASE	0x14a0
++#define LOONGARCH_IOCSR_EXTIOI_IPMAP_BASE	0x14c0
++#define LOONGARCH_IOCSR_EXTIOI_EN_BASE		0x1600
++#define LOONGARCH_IOCSR_EXTIOI_BOUNCE_BASE	0x1680
++#define LOONGARCH_IOCSR_EXTIOI_ISR_BASE		0x1800
++#define LOONGARCH_IOCSR_EXTIOI_ROUTE_BASE	0x1c00
++#define IOCSR_EXTIOI_VECTOR_NUM			256
++
++#ifndef __ASSEMBLY__
++
++static __always_inline u64 drdtime(void)
++{
++	u64 val = 0;
++
++	__asm__ __volatile__(
++		"rdtime.d %0, $zero\n\t"
++		: "=r"(val)
++		:
++		);
++	return val;
++}
++
++static __always_inline u32 rdtimeh(void)
++{
++	u32 val = 0;
++
++	__asm__ __volatile__(
++		"rdtimeh.w %0, $zero\n\t"
++		: "=r"(val)
++		:
++		);
++	return val;
++}
++
++static __always_inline u32 rdtimel(void)
++{
++	u32 val = 0;
++
++	__asm__ __volatile__(
++		"rdtimel.w %0, $zero\n\t"
++		: "=r"(val)
++		:
++		);
++	return val;
++}
++
++static inline unsigned int get_csr_cpuid(void)
++{
++	return csr_read32(LOONGARCH_CSR_CPUID);
++}
++
++static inline void csr_any_send(unsigned int addr, unsigned int data,
++				unsigned int data_mask, unsigned int cpu)
++{
++	uint64_t val = 0;
++
++	val = IOCSR_ANY_SEND_BLOCKING | addr;
++	val |= (cpu << IOCSR_ANY_SEND_CPU_SHIFT);
++	val |= (data_mask << IOCSR_ANY_SEND_MASK_SHIFT);
++	val |= ((uint64_t)data << IOCSR_ANY_SEND_BUF_SHIFT);
++	iocsr_write64(val, LOONGARCH_IOCSR_ANY_SEND);
++}
++
++static inline unsigned int read_csr_excode(void)
++{
++	return (csr_read32(LOONGARCH_CSR_ESTAT) & CSR_ESTAT_EXC) >> CSR_ESTAT_EXC_SHIFT;
++}
++
++static inline void write_csr_index(unsigned int idx)
++{
++	csr_xchg32(idx, CSR_TLBIDX_IDXM, LOONGARCH_CSR_TLBIDX);
++}
++
++static inline unsigned int read_csr_pagesize(void)
++{
++	return (csr_read32(LOONGARCH_CSR_TLBIDX) & CSR_TLBIDX_SIZEM) >> CSR_TLBIDX_SIZE;
++}
++
++static inline void write_csr_pagesize(unsigned int size)
++{
++	csr_xchg32(size << CSR_TLBIDX_SIZE, CSR_TLBIDX_SIZEM, LOONGARCH_CSR_TLBIDX);
++}
++
++static inline unsigned int read_csr_tlbrefill_pagesize(void)
++{
++	return (csr_read64(LOONGARCH_CSR_TLBREHI) & CSR_TLBREHI_PS) >> CSR_TLBREHI_PS_SHIFT;
++}
++
++static inline void write_csr_tlbrefill_pagesize(unsigned int size)
++{
++	csr_xchg64(size << CSR_TLBREHI_PS_SHIFT, CSR_TLBREHI_PS, LOONGARCH_CSR_TLBREHI);
++}
++
++#define read_csr_asid()			csr_read32(LOONGARCH_CSR_ASID)
++#define write_csr_asid(val)		csr_write32(val, LOONGARCH_CSR_ASID)
++#define read_csr_entryhi()		csr_read64(LOONGARCH_CSR_TLBEHI)
++#define write_csr_entryhi(val)		csr_write64(val, LOONGARCH_CSR_TLBEHI)
++#define read_csr_entrylo0()		csr_read64(LOONGARCH_CSR_TLBELO0)
++#define write_csr_entrylo0(val)		csr_write64(val, LOONGARCH_CSR_TLBELO0)
++#define read_csr_entrylo1()		csr_read64(LOONGARCH_CSR_TLBELO1)
++#define write_csr_entrylo1(val)		csr_write64(val, LOONGARCH_CSR_TLBELO1)
++#define read_csr_ecfg()			csr_read32(LOONGARCH_CSR_ECFG)
++#define write_csr_ecfg(val)		csr_write32(val, LOONGARCH_CSR_ECFG)
++#define read_csr_estat()		csr_read32(LOONGARCH_CSR_ESTAT)
++#define write_csr_estat(val)		csr_write32(val, LOONGARCH_CSR_ESTAT)
++#define read_csr_tlbidx()		csr_read32(LOONGARCH_CSR_TLBIDX)
++#define write_csr_tlbidx(val)		csr_write32(val, LOONGARCH_CSR_TLBIDX)
++#define read_csr_euen()			csr_read32(LOONGARCH_CSR_EUEN)
++#define write_csr_euen(val)		csr_write32(val, LOONGARCH_CSR_EUEN)
++#define read_csr_cpuid()		csr_read32(LOONGARCH_CSR_CPUID)
++#define read_csr_prcfg1()		csr_read64(LOONGARCH_CSR_PRCFG1)
++#define write_csr_prcfg1(val)		csr_write64(val, LOONGARCH_CSR_PRCFG1)
++#define read_csr_prcfg2()		csr_read64(LOONGARCH_CSR_PRCFG2)
++#define write_csr_prcfg2(val)		csr_write64(val, LOONGARCH_CSR_PRCFG2)
++#define read_csr_prcfg3()		csr_read64(LOONGARCH_CSR_PRCFG3)
++#define write_csr_prcfg3(val)		csr_write64(val, LOONGARCH_CSR_PRCFG3)
++#define read_csr_stlbpgsize()		csr_read32(LOONGARCH_CSR_STLBPGSIZE)
++#define write_csr_stlbpgsize(val)	csr_write32(val, LOONGARCH_CSR_STLBPGSIZE)
++#define read_csr_rvacfg()		csr_read32(LOONGARCH_CSR_RVACFG)
++#define write_csr_rvacfg(val)		csr_write32(val, LOONGARCH_CSR_RVACFG)
++#define write_csr_tintclear(val)	csr_write32(val, LOONGARCH_CSR_TINTCLR)
++#define read_csr_impctl1()		csr_read64(LOONGARCH_CSR_IMPCTL1)
++#define write_csr_impctl1(val)		csr_write64(val, LOONGARCH_CSR_IMPCTL1)
++#define write_csr_impctl2(val)		csr_write64(val, LOONGARCH_CSR_IMPCTL2)
++
++#define read_csr_perfctrl0()		csr_read64(LOONGARCH_CSR_PERFCTRL0)
++#define read_csr_perfcntr0()		csr_read64(LOONGARCH_CSR_PERFCNTR0)
++#define read_csr_perfctrl1()		csr_read64(LOONGARCH_CSR_PERFCTRL1)
++#define read_csr_perfcntr1()		csr_read64(LOONGARCH_CSR_PERFCNTR1)
++#define read_csr_perfctrl2()		csr_read64(LOONGARCH_CSR_PERFCTRL2)
++#define read_csr_perfcntr2()		csr_read64(LOONGARCH_CSR_PERFCNTR2)
++#define read_csr_perfctrl3()		csr_read64(LOONGARCH_CSR_PERFCTRL3)
++#define read_csr_perfcntr3()		csr_read64(LOONGARCH_CSR_PERFCNTR3)
++#define write_csr_perfctrl0(val)	csr_write64(val, LOONGARCH_CSR_PERFCTRL0)
++#define write_csr_perfcntr0(val)	csr_write64(val, LOONGARCH_CSR_PERFCNTR0)
++#define write_csr_perfctrl1(val)	csr_write64(val, LOONGARCH_CSR_PERFCTRL1)
++#define write_csr_perfcntr1(val)	csr_write64(val, LOONGARCH_CSR_PERFCNTR1)
++#define write_csr_perfctrl2(val)	csr_write64(val, LOONGARCH_CSR_PERFCTRL2)
++#define write_csr_perfcntr2(val)	csr_write64(val, LOONGARCH_CSR_PERFCNTR2)
++#define write_csr_perfctrl3(val)	csr_write64(val, LOONGARCH_CSR_PERFCTRL3)
++#define write_csr_perfcntr3(val)	csr_write64(val, LOONGARCH_CSR_PERFCNTR3)
++
++/*
++ * Manipulate bits in a register.
++ */
++#define __BUILD_CSR_COMMON(name)				\
++static inline unsigned long					\
++set_##name(unsigned long set)					\
++{								\
++	unsigned long res, new;					\
++								\
++	res = read_##name();					\
++	new = res | set;					\
++	write_##name(new);					\
++								\
++	return res;						\
++}								\
++								\
++static inline unsigned long					\
++clear_##name(unsigned long clear)				\
++{								\
++	unsigned long res, new;					\
++								\
++	res = read_##name();					\
++	new = res & ~clear;					\
++	write_##name(new);					\
++								\
++	return res;						\
++}								\
++								\
++static inline unsigned long					\
++change_##name(unsigned long change, unsigned long val)		\
++{								\
++	unsigned long res, new;					\
++								\
++	res = read_##name();					\
++	new = res & ~change;					\
++	new |= (val & change);					\
++	write_##name(new);					\
++								\
++	return res;						\
++}
++
++#define __BUILD_CSR_OP(name)	__BUILD_CSR_COMMON(csr_##name)
++
++__BUILD_CSR_OP(euen)
++__BUILD_CSR_OP(ecfg)
++__BUILD_CSR_OP(tlbidx)
++
++#define set_csr_estat(val)	\
++	csr_xchg32(val, val, LOONGARCH_CSR_ESTAT)
++#define clear_csr_estat(val)	\
++	csr_xchg32(~(val), val, LOONGARCH_CSR_ESTAT)
++
++#endif /* __ASSEMBLY__ */
++
++/* Generic EntryLo bit definitions */
++#define ENTRYLO_V		(_ULCAST_(1) << 0)
++#define ENTRYLO_D		(_ULCAST_(1) << 1)
++#define ENTRYLO_PLV_SHIFT	2
++#define ENTRYLO_PLV		(_ULCAST_(3) << ENTRYLO_PLV_SHIFT)
++#define ENTRYLO_C_SHIFT		4
++#define ENTRYLO_C		(_ULCAST_(3) << ENTRYLO_C_SHIFT)
++#define ENTRYLO_G		(_ULCAST_(1) << 6)
++#define ENTRYLO_NR		(_ULCAST_(1) << 61)
++#define ENTRYLO_NX		(_ULCAST_(1) << 62)
++
++/* Values for PageSize register */
++#define PS_4K		0x0000000c
++#define PS_8K		0x0000000d
++#define PS_16K		0x0000000e
++#define PS_32K		0x0000000f
++#define PS_64K		0x00000010
++#define PS_128K		0x00000011
++#define PS_256K		0x00000012
++#define PS_512K		0x00000013
++#define PS_1M		0x00000014
++#define PS_2M		0x00000015
++#define PS_4M		0x00000016
++#define PS_8M		0x00000017
++#define PS_16M		0x00000018
++#define PS_32M		0x00000019
++#define PS_64M		0x0000001a
++#define PS_128M		0x0000001b
++#define PS_256M		0x0000001c
++#define PS_512M		0x0000001d
++#define PS_1G		0x0000001e
++
++/* ExStatus.ExcCode */
++#define EXCCODE_RSV		0	/* Reserved */
++#define EXCCODE_TLBL		1	/* TLB miss on a load */
++#define EXCCODE_TLBS		2	/* TLB miss on a store */
++#define EXCCODE_TLBI		3	/* TLB miss on a ifetch */
++#define EXCCODE_TLBM		4	/* TLB modified fault */
++#define EXCCODE_TLBNR		5	/* TLB Read-Inhibit exception */
++#define EXCCODE_TLBNX		6	/* TLB Execution-Inhibit exception */
++#define EXCCODE_TLBPE		7	/* TLB Privilege Error */
++#define EXCCODE_ADE		8	/* Address Error */
++	#define EXSUBCODE_ADEF		0	/* Fetch Instruction */
++	#define EXSUBCODE_ADEM		1	/* Access Memory*/
++#define EXCCODE_ALE		9	/* Unalign Access */
++#define EXCCODE_BCE		10	/* Bounds Check Error */
++#define EXCCODE_SYS		11	/* System call */
++#define EXCCODE_BP		12	/* Breakpoint */
++#define EXCCODE_INE		13	/* Inst. Not Exist */
++#define EXCCODE_IPE		14	/* Inst. Privileged Error */
++#define EXCCODE_FPDIS		15	/* FPU Disabled */
++#define EXCCODE_LSXDIS		16	/* LSX Disabled */
++#define EXCCODE_LASXDIS		17	/* LASX Disabled */
++#define EXCCODE_FPE		18	/* Floating Point Exception */
++	#define EXCSUBCODE_FPE		0	/* Floating Point Exception */
++	#define EXCSUBCODE_VFPE		1	/* Vector Exception */
++#define EXCCODE_WATCH		19	/* WatchPoint Exception */
++	#define EXCSUBCODE_WPEF		0	/* ... on Instruction Fetch */
++	#define EXCSUBCODE_WPEM		1	/* ... on Memory Accesses */
++#define EXCCODE_BTDIS		20	/* Binary Trans. Disabled */
++#define EXCCODE_BTE		21	/* Binary Trans. Exception */
++#define EXCCODE_GSPR		22	/* Guest Privileged Error */
++#define EXCCODE_HVC		23	/* Hypercall */
++#define EXCCODE_GCM		24	/* Guest CSR modified */
++	#define EXCSUBCODE_GCSC		0	/* Software caused */
++	#define EXCSUBCODE_GCHC		1	/* Hardware caused */
++#define EXCCODE_SE		25	/* Security */
++
++/* Interrupt numbers */
++#define INT_SWI0	0	/* Software Interrupts */
++#define INT_SWI1	1
++#define INT_HWI0	2	/* Hardware Interrupts */
++#define INT_HWI1	3
++#define INT_HWI2	4
++#define INT_HWI3	5
++#define INT_HWI4	6
++#define INT_HWI5	7
++#define INT_HWI6	8
++#define INT_HWI7	9
++#define INT_PCOV	10	/* Performance Counter Overflow */
++#define INT_TI		11	/* Timer */
++#define INT_IPI		12
++#define INT_NMI		13
++
++/* ExcCodes corresponding to interrupts */
++#define EXCCODE_INT_NUM		(INT_NMI + 1)
++#define EXCCODE_INT_START	64
++#define EXCCODE_INT_END		(EXCCODE_INT_START + EXCCODE_INT_NUM - 1)
++
++/* FPU Status Register Names */
++#ifndef CONFIG_AS_HAS_FCSR_CLASS
++#define LOONGARCH_FCSR0	$r0
++#define LOONGARCH_FCSR1	$r1
++#define LOONGARCH_FCSR2	$r2
++#define LOONGARCH_FCSR3	$r3
++#else
++#define LOONGARCH_FCSR0	$fcsr0
++#define LOONGARCH_FCSR1	$fcsr1
++#define LOONGARCH_FCSR2	$fcsr2
++#define LOONGARCH_FCSR3	$fcsr3
++#endif
++
++/* FPU Status Register Values */
++#define FPU_CSR_RSVD	0xe0e0fce0
++
++/*
++ * X the exception cause indicator
++ * E the exception enable
++ * S the sticky/flag bit
++ */
++#define FPU_CSR_ALL_X	0x1f000000
++#define FPU_CSR_INV_X	0x10000000
++#define FPU_CSR_DIV_X	0x08000000
++#define FPU_CSR_OVF_X	0x04000000
++#define FPU_CSR_UDF_X	0x02000000
++#define FPU_CSR_INE_X	0x01000000
++
++#define FPU_CSR_ALL_S	0x001f0000
++#define FPU_CSR_INV_S	0x00100000
++#define FPU_CSR_DIV_S	0x00080000
++#define FPU_CSR_OVF_S	0x00040000
++#define FPU_CSR_UDF_S	0x00020000
++#define FPU_CSR_INE_S	0x00010000
++
++#define FPU_CSR_ALL_E	0x0000001f
++#define FPU_CSR_INV_E	0x00000010
++#define FPU_CSR_DIV_E	0x00000008
++#define FPU_CSR_OVF_E	0x00000004
++#define FPU_CSR_UDF_E	0x00000002
++#define FPU_CSR_INE_E	0x00000001
++
++/* Bits 8 and 9 of FPU Status Register specify the rounding mode */
++#define FPU_CSR_RM	0x300
++#define FPU_CSR_RN	0x000	/* nearest */
++#define FPU_CSR_RZ	0x100	/* towards zero */
++#define FPU_CSR_RU	0x200	/* towards +Infinity */
++#define FPU_CSR_RD	0x300	/* towards -Infinity */
++
++/* Bit 6 of FPU Status Register specify the LBT TOP simulation mode */
++#define FPU_CSR_TM_SHIFT	0x6
++#define FPU_CSR_TM		(_ULCAST_(1) << FPU_CSR_TM_SHIFT)
++
++#define read_fcsr(source)	\
++({	\
++	unsigned int __res;	\
++\
++	__asm__ __volatile__(	\
++	"	movfcsr2gr	%0, "__stringify(source)" \n"	\
++	: "=r" (__res));	\
++	__res;	\
++})
++
++#define write_fcsr(dest, val) \
++do {	\
++	__asm__ __volatile__(	\
++	"	movgr2fcsr	"__stringify(dest)", %0	\n"	\
++	: : "r" (val));	\
++} while (0)
++
++#endif /* _ASM_LOONGARCH_H */
+diff --git a/arch/loongarch/include/asm/posix_types.h b/arch/loongarch/include/asm/posix_types.h
+new file mode 100644
+index 00000000000..0ed5fa4c5fa
+--- /dev/null
++++ b/arch/loongarch/include/asm/posix_types.h
+@@ -0,0 +1,87 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * linux/include/asm-arm/posix_types.h
++ *
++ * Copyright (C) 1996-1998 Russell King.
++ *
++ * Copyright (C) 2011 Andes Technology Corporation
++ * Copyright (C) 2010 Shawn Lin (nobuhiro@andestech.com)
++ * Copyright (C) 2011 Macpaul Lin (macpaul@andestech.com)
++ * Copyright (C) 2017 Rick Chen (rick@andestech.com)
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++#ifndef __ARCH_LOONGARCH_POSIX_TYPES_H
++#define __ARCH_LOONGARCH_POSIX_TYPES_H
++
++/*
++ * This file is generally used by user-level software, so you need to
++ * be a little careful about namespace pollution etc.  Also, we cannot
++ * assume GCC is being used.
++ */
++
++typedef unsigned short		__kernel_dev_t;
++typedef unsigned long		__kernel_ino_t;
++typedef unsigned short		__kernel_mode_t;
++typedef unsigned short		__kernel_nlink_t;
++typedef long			__kernel_off_t;
++typedef int			__kernel_pid_t;
++typedef unsigned short		__kernel_ipc_pid_t;
++typedef unsigned short		__kernel_uid_t;
++typedef unsigned short		__kernel_gid_t;
++#ifdef __GNUC__
++typedef __SIZE_TYPE__		__kernel_size_t;
++#else
++typedef unsigned long		__kernel_size_t;
++#endif
++typedef long			__kernel_ssize_t;
++typedef long			__kernel_ptrdiff_t;
++typedef long			__kernel_time_t;
++typedef long			__kernel_suseconds_t;
++typedef long			__kernel_clock_t;
++typedef int			__kernel_daddr_t;
++typedef char			*__kernel_caddr_t;
++typedef unsigned short		__kernel_uid16_t;
++typedef unsigned short		__kernel_gid16_t;
++typedef unsigned int		__kernel_uid32_t;
++typedef unsigned int		__kernel_gid32_t;
++
++typedef unsigned short		__kernel_old_uid_t;
++typedef unsigned short		__kernel_old_gid_t;
++
++#ifdef __GNUC__
++typedef long long		__kernel_loff_t;
++#endif
++
++typedef struct {
++#if defined(__KERNEL__) || defined(__USE_ALL)
++	int	val[2];
++#else /* !defined(__KERNEL__) && !defined(__USE_ALL) */
++	int	__val[2];
++#endif /* !defined(__KERNEL__) && !defined(__USE_ALL) */
++} __kernel_fsid_t;
++
++#if defined(__KERNEL__) || !defined(__GLIBC__) || (__GLIBC__ < 2)
++
++#undef	__FD_SET
++#define __FD_SET(_fd, fdsetp) \
++	typeof(_fd) (fd) = (_fd); \
++	(((fd_set *)fdsetp)->fds_bits[fd >> 5] |= (1 << (fd & 31)))
++
++#undef	__FD_CLR
++#define __FD_CLR(_fd, fdsetp) \
++	typeof(_fd) (fd) = (_fd); \
++	(((fd_set *)fdsetp)->fds_bits[fd >> 5] &= ~(1 << (fd & 31)))
++
++#undef	__FD_ISSET
++#define __FD_ISSET(_fd, fdsetp) \
++	typeof(_fd) (fd) = (_fd); \
++	((((fd_set *)fdsetp)->fds_bits[fd >> 5] & (1 << (fd & 31))) != 0)
++
++#undef	__FD_ZERO
++#define __FD_ZERO(_fdsetp) \
++	typeof(_fdsetp) (fd) = (_fdsetp); \
++	(memset(fdsetp, 0, sizeof(*(fd_set *)fdsetp)))
++
++#endif
++
++#endif /* __ARCH_LOONGARCH_POSIX_TYPES_H */
+diff --git a/arch/loongarch/include/asm/processor.h b/arch/loongarch/include/asm/processor.h
+new file mode 100644
+index 00000000000..7242a3e6ca7
+--- /dev/null
++++ b/arch/loongarch/include/asm/processor.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_PROCESSOR_H
++#define __ASM_LOONGARCH_PROCESSOR_H
++
++/* Dummy header */
++
++#endif /* __ASM_LOONGARCH_PROCESSOR_H */
+diff --git a/arch/loongarch/include/asm/ptrace.h b/arch/loongarch/include/asm/ptrace.h
+new file mode 100644
+index 00000000000..1b3c2b5b8f1
+--- /dev/null
++++ b/arch/loongarch/include/asm/ptrace.h
+@@ -0,0 +1,33 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_PTRACE_H
++#define __ASM_LOONGARCH_PTRACE_H
++
++struct pt_regs {
++	/* Main processor registers. */
++	unsigned long regs[32];
++
++	/* Original syscall arg0. */
++	unsigned long orig_a0;
++
++	/* Special CSR registers. */
++	unsigned long csr_era;
++	unsigned long csr_badvaddr;
++	unsigned long csr_crmd;
++	unsigned long csr_prmd;
++	unsigned long csr_euen;
++	unsigned long csr_ecfg;
++	unsigned long csr_estat;
++	unsigned long __last[];
++} __aligned(8);
++
++#ifdef CONFIG_64BIT
++#define REG_FMT "%016lx"
++#else
++#define REG_FMT "%08lx"
++#endif
++
++#endif /* __ASM_LOONGARCH_PTRACE_H */
+diff --git a/arch/loongarch/include/asm/regdef.h b/arch/loongarch/include/asm/regdef.h
+new file mode 100644
+index 00000000000..5fbc0d4757e
+--- /dev/null
++++ b/arch/loongarch/include/asm/regdef.h
+@@ -0,0 +1,42 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++#ifndef _ASM_REGDEF_H
++#define _ASM_REGDEF_H
++
++#define zero	$r0	/* wired zero */
++#define ra	$r1	/* return address */
++#define tp	$r2
++#define sp	$r3	/* stack pointer */
++#define a0	$r4	/* argument registers, a0/a1 reused as v0/v1 for return value */
++#define a1	$r5
++#define a2	$r6
++#define a3	$r7
++#define a4	$r8
++#define a5	$r9
++#define a6	$r10
++#define a7	$r11
++#define t0	$r12	/* caller saved */
++#define t1	$r13
++#define t2	$r14
++#define t3	$r15
++#define t4	$r16
++#define t5	$r17
++#define t6	$r18
++#define t7	$r19
++#define t8	$r20
++#define u0	$r21
++#define fp	$r22	/* frame pointer */
++#define s0	$r23	/* callee saved */
++#define s1	$r24
++#define s2	$r25
++#define s3	$r26
++#define s4	$r27
++#define s5	$r28
++#define s6	$r29
++#define s7	$r30
++#define s8	$r31
++
++#endif /* _ASM_REGDEF_H */
+diff --git a/arch/loongarch/include/asm/sections.h b/arch/loongarch/include/asm/sections.h
+new file mode 100644
+index 00000000000..9f5009a1f23
+--- /dev/null
++++ b/arch/loongarch/include/asm/sections.h
+@@ -0,0 +1,8 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++
++#ifndef __ASM_LOONGARCH_SECTIONS_H
++#define __ASM_LOONGARCH_SECTIONS_H
++
++#include <asm-generic/sections.h>
++
++#endif
+diff --git a/arch/loongarch/include/asm/setjmp.h b/arch/loongarch/include/asm/setjmp.h
+new file mode 100644
+index 00000000000..295198a3896
+--- /dev/null
++++ b/arch/loongarch/include/asm/setjmp.h
+@@ -0,0 +1,25 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef _SETJMP_H_
++#define _SETJMP_H_
++
++/*
++ * This really should be opaque, but the EFI implementation wrongly
++ * assumes that a 'struct jmp_buf_data' is defined.
++ */
++struct jmp_buf_data {
++	unsigned long s_regs[9];	/* s0 - 8 */
++	unsigned long fp;
++	unsigned long sp;
++	unsigned long ra;
++};
++
++typedef struct jmp_buf_data jmp_buf[1];
++
++int setjmp(jmp_buf jmp);
++void longjmp(jmp_buf jmp, int ret);
++
++#endif /* _SETJMP_H_ */
+diff --git a/arch/loongarch/include/asm/spl.h b/arch/loongarch/include/asm/spl.h
+new file mode 100644
+index 00000000000..b8b19f65cb3
+--- /dev/null
++++ b/arch/loongarch/include/asm/spl.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_SPL_H
++#define __ASM_SPL_H
++
++/* Dummy header */
++
++#endif
+diff --git a/arch/loongarch/include/asm/string.h b/arch/loongarch/include/asm/string.h
+new file mode 100644
+index 00000000000..09877956de9
+--- /dev/null
++++ b/arch/loongarch/include/asm/string.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_STRING_H
++#define __ASM_STRING_H
++
++/* Dummy header */
++
++#endif
+diff --git a/arch/loongarch/include/asm/system.h b/arch/loongarch/include/asm/system.h
+new file mode 100644
+index 00000000000..79c47418d52
+--- /dev/null
++++ b/arch/loongarch/include/asm/system.h
+@@ -0,0 +1,74 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_SYSTEM_H
++#define __ASM_LOONGARCH_SYSTEM_H
++
++#include <asm/loongarch.h>
++
++struct event;
++
++/*
++ * Interrupt configuration macros
++ */
++
++static inline void arch_local_irq_enable(void)
++{
++	u32 flags = CSR_CRMD_IE;
++
++	__asm__ __volatile__(
++		"csrxchg %[val], %[mask], %[reg]\n\t"
++		: [val] "+r" (flags)
++		: [mask] "r" (CSR_CRMD_IE), [reg] "i" (LOONGARCH_CSR_CRMD)
++		: "memory");
++}
++
++#define local_irq_enable arch_local_irq_enable
++
++static inline void arch_local_irq_disable(void)
++{
++	u32 flags = 0;
++
++	__asm__ __volatile__(
++		"csrxchg %[val], %[mask], %[reg]\n\t"
++		: [val] "+r" (flags)
++		: [mask] "r" (CSR_CRMD_IE), [reg] "i" (LOONGARCH_CSR_CRMD)
++		: "memory");
++}
++
++#define local_irq_disable arch_local_irq_disable
++
++static inline unsigned long arch_local_irq_save(void)
++{
++	unsigned long flags = 0;
++
++	__asm__ __volatile__(
++		"csrxchg %[val], %[mask], %[reg]\n\t"
++		: [val] "+r" (flags)
++		: [mask] "r" (CSR_CRMD_IE), [reg] "i" (LOONGARCH_CSR_CRMD)
++		: "memory");
++	return flags;
++}
++
++#define local_irq_save(__flags)                                 \
++	do {                                                        \
++		__flags = arch_local_irq_save(CSR_SSTATUS, SR_SIE) & SR_SIE; \
++	} while (0)
++
++static inline void arch_local_irq_restore(unsigned long flags)
++{
++	__asm__ __volatile__(
++		"csrxchg %[val], %[mask], %[reg]\n\t"
++		: [val] "+r" (flags)
++		: [mask] "r" (CSR_CRMD_IE), [reg] "i" (LOONGARCH_CSR_CRMD)
++		: "memory");
++}
++
++#define local_irq_restore(__flags)              \
++	do {                                        \
++		arch_local_irq_restore(__flags); \
++	} while (0)
++
++#endif
+diff --git a/arch/loongarch/include/asm/types.h b/arch/loongarch/include/asm/types.h
+new file mode 100644
+index 00000000000..414e8f9160a
+--- /dev/null
++++ b/arch/loongarch/include/asm/types.h
+@@ -0,0 +1,37 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2011 Andes Technology Corporation
++ * Copyright (C) 2010 Shawn Lin (nobuhiro@andestech.com)
++ * Copyright (C) 2011 Macpaul Lin (macpaul@andestech.com)
++ * Copyright (C) 2017 Rick Chen (rick@andestech.com)
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_TYPES_H
++#define __ASM_LOONGARCH_TYPES_H
++
++#include <asm-generic/int-ll64.h>
++
++typedef unsigned short umode_t;
++
++/*
++ * These aren't exported outside the kernel to avoid name space clashes
++ */
++#ifdef __KERNEL__
++
++#define BITS_PER_LONG _LOONGARCH_SZLONG
++
++#include <stddef.h>
++
++#ifdef CONFIG_DMA_ADDR_T_64BIT
++typedef u64 dma_addr_t;
++#else
++typedef u32 dma_addr_t;
++#endif
++
++typedef unsigned long long phys_addr_t;
++typedef unsigned long long phys_size_t;
++
++#endif /* __KERNEL__ */
++
++#endif
+diff --git a/arch/loongarch/include/asm/u-boot-loongarch.h b/arch/loongarch/include/asm/u-boot-loongarch.h
+new file mode 100644
+index 00000000000..7f21d2a3e96
+--- /dev/null
++++ b/arch/loongarch/include/asm/u-boot-loongarch.h
+@@ -0,0 +1,23 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * (C) Copyright 2002
++ * Sysgo Real-Time Solutions, GmbH <www.elinos.com>
++ * Marius Groeger <mgroeger@sysgo.de>
++ *
++ * Copyright (C) 2017 Andes Technology Corporation
++ * Rick Chen, Andes Technology Corporation <rick@andestech.com>
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef _U_BOOT_LOONGARCH_H_
++#define _U_BOOT_LOONGARCH_H_
++
++/* cpu/.../cpu.c */
++int cleanup_before_linux(void);
++
++/* board/.../... */
++int board_init(void);
++void board_quiesce_devices(void);
++
++#endif
+diff --git a/arch/loongarch/include/asm/u-boot.h b/arch/loongarch/include/asm/u-boot.h
+new file mode 100644
+index 00000000000..123a7f09a01
+--- /dev/null
++++ b/arch/loongarch/include/asm/u-boot.h
+@@ -0,0 +1,30 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * (C) Copyright 2002
++ * Sysgo Real-Time Solutions, GmbH <www.elinos.com>
++ * Marius Groeger <mgroeger@sysgo.de>
++ *
++ * Copyright (C) 2017 Andes Technology Corporation
++ * Rick Chen, Andes Technology Corporation <rick@andestech.com>
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ *
++ ********************************************************************
++ * NOTE: This header file defines an interface to U-Boot. Including
++ * this (unmodified) header file in another file is considered normal
++ * use of U-Boot, and does *not* fall under the heading of "derived
++ * work".
++ ********************************************************************
++ */
++
++#ifndef _U_BOOT_H_
++#define _U_BOOT_H_	1
++
++/* Use the generic board which requires a unified bd_info */
++#include <asm-generic/u-boot.h>
++#include <asm/u-boot-loongarch.h>
++
++/* For image.h:image_check_target_arch() */
++#define IH_ARCH_DEFAULT IH_ARCH_LOONGARCH
++
++#endif	/* _U_BOOT_H_ */
+diff --git a/arch/loongarch/include/asm/unaligned.h b/arch/loongarch/include/asm/unaligned.h
+new file mode 100644
+index 00000000000..65cd4340ce9
+--- /dev/null
++++ b/arch/loongarch/include/asm/unaligned.h
+@@ -0,0 +1,11 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __ASM_LOONGARCH_UNALIGNED_H
++#define __ASM_LOONGARCH_UNALIGNED_H
++
++#include <asm-generic/unaligned.h>
++
++#endif
+diff --git a/arch/loongarch/lib/Makefile b/arch/loongarch/lib/Makefile
+new file mode 100644
+index 00000000000..3dbed94cc62
+--- /dev/null
++++ b/arch/loongarch/lib/Makefile
+@@ -0,0 +1,5 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
+diff --git a/include/host_arch.h b/include/host_arch.h
+index 261194bd7c6..ceeb61d6ad8 100644
+--- a/include/host_arch.h
++++ b/include/host_arch.h
+@@ -10,6 +10,7 @@
+ #if 0
+ export HOST_ARCH_AARCH64=0xaa64
+ export HOST_ARCH_ARM=0x00a7
++export HOST_ARCH_LOONGARCH64=0x6264
+ export HOST_ARCH_RISCV32=0x5032
+ export HOST_ARCH_RISCV64=0x5064
+ export HOST_ARCH_X86=0x0386
+@@ -20,6 +21,7 @@ export HOST_ARCH_X86_64=0x8664
+ 
+ #define HOST_ARCH_AARCH64 0xaa64
+ #define HOST_ARCH_ARM 0x00a7
++#define HOST_ARCH_LOONGARCH64 0x6264
+ #define HOST_ARCH_RISCV32 0x5032
+ #define HOST_ARCH_RISCV64 0x5064
+ #define HOST_ARCH_X86 0x0386
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0009-LoongArch-lib-General-routines.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0009-LoongArch-lib-General-routines.patch
@@ -1,0 +1,487 @@
+From 9898ca3740152daf53d9e40f3c5cd38c36873bae Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:50 +0100
+Subject: [PATCH 09/22] LoongArch: lib: General routines
+
+Add some common library routines for the architecture.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/include/asm/cache.h       |  10 ++
+ arch/loongarch/include/asm/global_data.h |   7 +
+ arch/loongarch/lib/Makefile              |   7 +
+ arch/loongarch/lib/asm-offsets.c         |  66 +++++++
+ arch/loongarch/lib/boot.c                |  14 ++
+ arch/loongarch/lib/cache.c               | 213 +++++++++++++++++++++++
+ arch/loongarch/lib/reset.c               |  14 ++
+ arch/loongarch/lib/setjmp.S              |  52 ++++++
+ 8 files changed, 383 insertions(+)
+ create mode 100644 arch/loongarch/lib/asm-offsets.c
+ create mode 100644 arch/loongarch/lib/boot.c
+ create mode 100644 arch/loongarch/lib/cache.c
+ create mode 100644 arch/loongarch/lib/reset.c
+ create mode 100644 arch/loongarch/lib/setjmp.S
+
+diff --git a/arch/loongarch/include/asm/cache.h b/arch/loongarch/include/asm/cache.h
+index 854dd0c0a02..2dd4e82340b 100644
+--- a/arch/loongarch/include/asm/cache.h
++++ b/arch/loongarch/include/asm/cache.h
+@@ -6,8 +6,11 @@
+ #ifndef _ASM_LOONGARCH_CACHE_H
+ #define _ASM_LOONGARCH_CACHE_H
+ 
++#include <linux/bitops.h>
++
+ /* cache */
+ void cache_flush(void);
++void probe_caches(void);
+ 
+ #define cache_op(op, addr)						\
+ 	__asm__ __volatile__(						\
+@@ -15,6 +18,13 @@ void cache_flush(void);
+ 	:								\
+ 	: "i" (op), "ZC" (*(unsigned char *)(addr)))
+ 
++#define CACHE_MAX_LEVEL		3
++#define CACHE_MAX_INDEX		6
++#define CACHE_OP		GENMASK(4, 3)
++#define  CACHE_INDEX_INVWB	0x1
++#define  CACHE_HIT_INVWB	0x2
++#define CACHE_INDEX		GENMASK(2, 0)
++
+ #ifdef CONFIG_SYS_CACHELINE_SIZE
+ #define ARCH_DMA_MINALIGN	CONFIG_SYS_CACHELINE_SIZE
+ #else
+diff --git a/arch/loongarch/include/asm/global_data.h b/arch/loongarch/include/asm/global_data.h
+index 2a9a525e2f3..7aab802ca04 100644
+--- a/arch/loongarch/include/asm/global_data.h
++++ b/arch/loongarch/include/asm/global_data.h
+@@ -10,6 +10,7 @@
+ #define __ASM_GBL_DATA_H
+ 
+ #include <linux/types.h>
++#include <asm/cache.h>
+ #include <asm/u-boot.h>
+ #include <compiler.h>
+ 
+@@ -24,6 +25,12 @@ struct arch_global_data {
+ #ifdef CONFIG_SMBIOS
+ 	ulong smbios_start;		/* Start address of SMBIOS table */
+ #endif
++	ushort dcache_ways[CACHE_MAX_INDEX];
++	ushort dcache_sets[CACHE_MAX_INDEX];
++	ushort dcache_linesizes[CACHE_MAX_INDEX];
++	ushort dcache_index[CACHE_MAX_INDEX];
++	ushort dcache_levels;
++	bool dcache_inclusive;
+ };
+ 
+ #include <asm-generic/global_data.h>
+diff --git a/arch/loongarch/lib/Makefile b/arch/loongarch/lib/Makefile
+index 3dbed94cc62..3c17b9cd85a 100644
+--- a/arch/loongarch/lib/Makefile
++++ b/arch/loongarch/lib/Makefile
+@@ -3,3 +3,10 @@
+ # Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
+ #
+ 
++obj-$(CONFIG_CMD_GO) += boot.o
++obj-y	+= cache.o
++obj-y	+= interrupts.o
++ifeq ($(CONFIG_$(SPL_)SYSRESET),)
++obj-y	+= reset.o
++endif
++obj-y	+= setjmp.o
+diff --git a/arch/loongarch/lib/asm-offsets.c b/arch/loongarch/lib/asm-offsets.c
+new file mode 100644
+index 00000000000..e3f4c629b63
+--- /dev/null
++++ b/arch/loongarch/lib/asm-offsets.c
+@@ -0,0 +1,66 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ *
++ * From arch/x86/lib/asm-offsets.c
++ *
++ * This program is used to generate definitions needed by
++ * assembly language modules.
++ */
++
++#include <asm/global_data.h>
++#include <asm/ptrace.h>
++#include <linux/kbuild.h>
++
++static void __used output_ptreg_defines(void)
++{
++	COMMENT("LoongArch pt_regs offsets.");
++	OFFSET(PT_R0, pt_regs, regs[0]);
++	OFFSET(PT_R1, pt_regs, regs[1]);
++	OFFSET(PT_R2, pt_regs, regs[2]);
++	OFFSET(PT_R3, pt_regs, regs[3]);
++	OFFSET(PT_R4, pt_regs, regs[4]);
++	OFFSET(PT_R5, pt_regs, regs[5]);
++	OFFSET(PT_R6, pt_regs, regs[6]);
++	OFFSET(PT_R7, pt_regs, regs[7]);
++	OFFSET(PT_R8, pt_regs, regs[8]);
++	OFFSET(PT_R9, pt_regs, regs[9]);
++	OFFSET(PT_R10, pt_regs, regs[10]);
++	OFFSET(PT_R11, pt_regs, regs[11]);
++	OFFSET(PT_R12, pt_regs, regs[12]);
++	OFFSET(PT_R13, pt_regs, regs[13]);
++	OFFSET(PT_R14, pt_regs, regs[14]);
++	OFFSET(PT_R15, pt_regs, regs[15]);
++	OFFSET(PT_R16, pt_regs, regs[16]);
++	OFFSET(PT_R17, pt_regs, regs[17]);
++	OFFSET(PT_R18, pt_regs, regs[18]);
++	OFFSET(PT_R19, pt_regs, regs[19]);
++	OFFSET(PT_R20, pt_regs, regs[20]);
++	OFFSET(PT_R21, pt_regs, regs[21]);
++	OFFSET(PT_R22, pt_regs, regs[22]);
++	OFFSET(PT_R23, pt_regs, regs[23]);
++	OFFSET(PT_R24, pt_regs, regs[24]);
++	OFFSET(PT_R25, pt_regs, regs[25]);
++	OFFSET(PT_R26, pt_regs, regs[26]);
++	OFFSET(PT_R27, pt_regs, regs[27]);
++	OFFSET(PT_R28, pt_regs, regs[28]);
++	OFFSET(PT_R29, pt_regs, regs[29]);
++	OFFSET(PT_R30, pt_regs, regs[30]);
++	OFFSET(PT_R31, pt_regs, regs[31]);
++	OFFSET(PT_CRMD, pt_regs, csr_crmd);
++	OFFSET(PT_PRMD, pt_regs, csr_prmd);
++	OFFSET(PT_EUEN, pt_regs, csr_euen);
++	OFFSET(PT_ECFG, pt_regs, csr_ecfg);
++	OFFSET(PT_ESTAT, pt_regs, csr_estat);
++	OFFSET(PT_ERA, pt_regs, csr_era);
++	OFFSET(PT_BVADDR, pt_regs, csr_badvaddr);
++	OFFSET(PT_ORIG_A0, pt_regs, orig_a0);
++	DEFINE(PT_SIZE, sizeof(struct pt_regs));
++	BLANK();
++}
++
++int main(void)
++{
++	output_ptreg_defines();
++	return 0;
++}
+diff --git a/arch/loongarch/lib/boot.c b/arch/loongarch/lib/boot.c
+new file mode 100644
+index 00000000000..327be16bb59
+--- /dev/null
++++ b/arch/loongarch/lib/boot.c
+@@ -0,0 +1,14 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <asm/u-boot.h>
++
++unsigned long do_go_exec(ulong (*entry)(int, char * const []),
++			 int argc, char *const argv[])
++{
++	cleanup_before_linux();
++
++	return entry(argc, argv);
++}
+diff --git a/arch/loongarch/lib/cache.c b/arch/loongarch/lib/cache.c
+new file mode 100644
+index 00000000000..ee27ec28b72
+--- /dev/null
++++ b/arch/loongarch/lib/cache.c
+@@ -0,0 +1,213 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ * Copyright (C) 2026 Yao Zi <me@ziyao.cc>
++ */
++
++#include <asm/cache.h>
++#include <asm/global_data.h>
++#include <asm/loongarch.h>
++#include <cpu_func.h>
++#include <linux/bitfield.h>
++#include <linux/bitops.h>
++
++#define CPUCFG_LX_IUPRE		BIT(0)
++#define CPUCFG_LX_IUUNIFY	BIT(1)
++#define CPUCFG_LX_IUINCL	BIT(3)
++
++DECLARE_GLOBAL_DATA_PTR;
++
++static inline void flush_cache_line_index(unsigned int index,
++					  unsigned long addr)
++{
++#define do_flush(index)							\
++	case index:							\
++		cache_op(FIELD_PREP(CACHE_OP, CACHE_INDEX_INVWB) |	\
++			 FIELD_PREP(CACHE_INDEX, index),		\
++			 index);					\
++		break;
++
++	switch (index) {
++		do_flush(0);
++		do_flush(1);
++		do_flush(2);
++		do_flush(3);
++		do_flush(4);
++		do_flush(5);
++	}
++
++#undef do_flush
++}
++
++static inline void flush_cache_line_hit(unsigned int index, unsigned long addr)
++{
++#define do_flush(index)							\
++	case index:							\
++		cache_op(FIELD_PREP(CACHE_OP, CACHE_HIT_INVWB) |	\
++			 FIELD_PREP(CACHE_INDEX, index),		\
++			 addr);						\
++		break;
++
++	switch (index) {
++		do_flush(0);
++		do_flush(1);
++		do_flush(2);
++		do_flush(3);
++		do_flush(4);
++		do_flush(5);
++	}
++
++#undef do_flush
++}
++
++void invalidate_icache_all(void)
++{
++	asm volatile ("\tibar 0\n"::);
++}
++
++static void flush_dcache_level_all(unsigned int level)
++{
++	unsigned int way, set;
++	unsigned long index = 0;
++
++	for (set = 0; set < gd->arch.dcache_sets[level]; set++) {
++		for (way = 0; way < gd->arch.dcache_ways[level]; way++) {
++			flush_cache_line_index(gd->arch.dcache_index[level],
++					       index);
++			index++;
++		}
++
++		index -= gd->arch.dcache_ways[level];
++		index += gd->arch.dcache_linesizes[level];
++	}
++}
++
++__weak void flush_dcache_all(void)
++{
++	unsigned int level;
++
++	if (gd->arch.dcache_inclusive) {
++		flush_dcache_level_all(gd->arch.dcache_levels - 1);
++		return;
++	}
++
++	for (level = 0; level < gd->arch.dcache_levels; level++)
++		flush_dcache_level_all(level);
++}
++
++static void flush_dcache_level(unsigned int level, unsigned long addr,
++			       unsigned long end)
++{
++	for (; addr < end; addr += gd->arch.dcache_linesizes[level])
++		flush_cache_line_hit(gd->arch.dcache_index[level], addr);
++}
++
++__weak void flush_dcache_range(unsigned long start, unsigned long end)
++{
++	unsigned int level;
++
++	if (gd->arch.dcache_inclusive) {
++		flush_dcache_level(gd->arch.dcache_levels - 1, start, end);
++		return;
++	}
++
++	for (level = 0; level < gd->arch.dcache_levels; level++)
++		flush_dcache_level(level, start, end);
++}
++
++__weak void invalidate_icache_range(unsigned long start, unsigned long end)
++{
++	/* LoongArch mandatory hardware I-Cache coherence */
++	invalidate_icache_all();
++}
++
++__weak void invalidate_dcache_range(unsigned long start, unsigned long end)
++{
++	flush_dcache_range(start, end);
++}
++
++__weak void cache_flush(void)
++{
++	flush_dcache_all();
++}
++
++__weak void cache_invalidate(void)
++{
++	flush_dcache_all();
++}
++
++__weak void flush_cache(unsigned long addr, unsigned long size)
++{
++	invalidate_icache_range(addr, addr + size);
++	flush_dcache_range(addr, addr + size);
++}
++
++__weak void dcache_enable(void)
++{
++}
++
++__weak void dcache_disable(void)
++{
++}
++
++__weak int dcache_status(void)
++{
++	return 0;
++}
++
++static void populate_dcache_properties(u32 cfg0, unsigned int level,
++				       unsigned int cfgoff)
++{
++	u32 cfg1 = read_cpucfg(cfgoff);
++
++	if (level != 0)
++		gd->arch.dcache_inclusive = cfg0 & CPUCFG_LX_IUINCL;
++
++	gd->arch.dcache_ways[level] = FIELD_GET(CPUCFG_CACHE_WAYS_M, cfg1) + 1;
++	gd->arch.dcache_sets[level] = 1 << FIELD_GET(CPUCFG_CACHE_SETS_M, cfg1);
++	gd->arch.dcache_linesizes[level] = 1 << FIELD_GET(CPUCFG_CACHE_LSIZE_M, cfg1);
++}
++
++void probe_caches(void)
++{
++	unsigned int level = 0, index = 0;
++	u32 cfg = read_cpucfg(LOONGARCH_CPUCFG16);
++
++	if (cfg & CPUCFG16_L1_IUPRE) {
++		if (cfg & CPUCFG16_L1_IUUNIFY) {
++			gd->arch.dcache_index[level] = index;
++			populate_dcache_properties(cfg, level++,
++						   LOONGARCH_CPUCFG17);
++		}
++
++		index++;
++	}
++
++	if (cfg & CPUCFG16_L1_DPRE) {
++		gd->arch.dcache_index[level] = index++;
++		populate_dcache_properties(cfg, level++, LOONGARCH_CPUCFG18);
++	}
++
++	cfg >>= 3;
++
++	for (; level < 3; level++) {
++		if (cfg & CPUCFG_LX_IUPRE && cfg & CPUCFG_LX_IUUNIFY) {
++			gd->arch.dcache_index[level] = index++;
++			populate_dcache_properties(cfg, level,
++						   LOONGARCH_CPUCFG17 + level);
++		} else {
++			break;
++		}
++
++		cfg >>= 7;
++	}
++
++	gd->arch.dcache_levels = level;
++}
++
++__weak void enable_caches(void)
++{
++	cache_invalidate();
++	/* Enable cache for direct address translation mode */
++	csr_xchg64(1 << CSR_CRMD_DACM_SHIFT, CSR_CRMD_DACM, LOONGARCH_CSR_CRMD);
++}
+diff --git a/arch/loongarch/lib/reset.c b/arch/loongarch/lib/reset.c
+new file mode 100644
+index 00000000000..ddf29ee41d9
+--- /dev/null
++++ b/arch/loongarch/lib/reset.c
+@@ -0,0 +1,14 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <command.h>
++#include <cpu_func.h>
++
++int do_reset(struct cmd_tbl *cmdtp, int flag, int argc, char *const argv[])
++{
++	reset_cpu();
++
++	return 0;
++}
+diff --git a/arch/loongarch/lib/setjmp.S b/arch/loongarch/lib/setjmp.S
+new file mode 100644
+index 00000000000..12981d0013f
+--- /dev/null
++++ b/arch/loongarch/lib/setjmp.S
+@@ -0,0 +1,52 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <config.h>
++#include <asm/asm.h>
++#include <linux/linkage.h>
++
++.pushsection .text.setjmp, "ax"
++ENTRY(setjmp)
++	LONG_S		s0, a0, 0
++	LONG_S 		s1, a0, (1 * LONGSIZE)
++	LONG_S		s2, a0, (2 * LONGSIZE)
++	LONG_S		s3, a0, (3 * LONGSIZE)
++	LONG_S		s4, a0, (4 * LONGSIZE)
++	LONG_S		s5, a0, (5 * LONGSIZE)
++	LONG_S		s6, a0, (6 * LONGSIZE)
++	LONG_S		s7, a0, (7 * LONGSIZE)
++	LONG_S		s8, a0, (8 * LONGSIZE)
++	LONG_S		fp, a0, (9 * LONGSIZE)
++	LONG_S		sp, a0, (10 * LONGSIZE)
++	LONG_S		ra, a0, (11 * LONGSIZE)
++
++	move		a0, zero
++	ret
++ENDPROC(setjmp)
++.popsection
++
++.pushsection .text.longjmp, "ax"
++ENTRY(longjmp)
++	LONG_L		s0, a0, 0
++	LONG_L 		s1, a0, (1 * LONGSIZE)
++	LONG_L		s2, a0, (2 * LONGSIZE)
++	LONG_L		s3, a0, (3 * LONGSIZE)
++	LONG_L		s4, a0, (4 * LONGSIZE)
++	LONG_L		s5, a0, (5 * LONGSIZE)
++	LONG_L		s6, a0, (6 * LONGSIZE)
++	LONG_L		s7, a0, (7 * LONGSIZE)
++	LONG_L		s8, a0, (8 * LONGSIZE)
++	LONG_L		fp, a0, (9 * LONGSIZE)
++	LONG_L		sp, a0, (10 * LONGSIZE)
++	LONG_L		ra, a0, (11 * LONGSIZE)
++
++	/* Move the return value in place, but return 1 if passed 0. */
++	li.w		a0, 1
++	beqz		a1, 1f
++	move		a0, a1
++1:
++	jr		ra
++ENDPROC(longjmp)
++.popsection
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0010-LoongArch-CPU-assembly-routines.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0010-LoongArch-CPU-assembly-routines.patch
@@ -1,0 +1,305 @@
+From 2a4f6d1af7d2f0257de3988546a455134de6e111 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:51 +0100
+Subject: [PATCH 10/22] LoongArch: CPU assembly routines
+
+start.S for initialisation, smp_secondary routine for
+a spin-table like interface for secondary cpus.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/cpu/Makefile        |   4 +
+ arch/loongarch/cpu/cpu.c           |  27 +++++
+ arch/loongarch/cpu/smp_secondary.S |  55 ++++++++++
+ arch/loongarch/cpu/start.S         | 170 +++++++++++++++++++++++++++++
+ 4 files changed, 256 insertions(+)
+ create mode 100644 arch/loongarch/cpu/cpu.c
+ create mode 100644 arch/loongarch/cpu/smp_secondary.S
+ create mode 100644 arch/loongarch/cpu/start.S
+
+diff --git a/arch/loongarch/cpu/Makefile b/arch/loongarch/cpu/Makefile
+index 3dbed94cc62..d3c38a16d05 100644
+--- a/arch/loongarch/cpu/Makefile
++++ b/arch/loongarch/cpu/Makefile
+@@ -3,3 +3,7 @@
+ # Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
+ #
+ 
++extra-y = start.o
++
++obj-y += cpu.o
++obj-y += smp_secondary.o
+diff --git a/arch/loongarch/cpu/cpu.c b/arch/loongarch/cpu/cpu.c
+new file mode 100644
+index 00000000000..1f03fff964f
+--- /dev/null
++++ b/arch/loongarch/cpu/cpu.c
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2018, Bin Meng <bmeng.cn@gmail.com>
++ */
++
++#include <command.h>
++#include <cpu.h>
++#include <cpu_func.h>
++#include <dm.h>
++#include <dm/lists.h>
++#include <event.h>
++#include <hang.h>
++#include <init.h>
++#include <log.h>
++#include <asm/system.h>
++#include <dm/uclass-internal.h>
++#include <linux/bitops.h>
++
++#if !CONFIG_IS_ENABLED(SYSRESET)
++void reset_cpu(void)
++{
++	printf("resetting ...\n");
++
++	printf("reset not supported yet\n");
++	hang();
++}
++#endif
+diff --git a/arch/loongarch/cpu/smp_secondary.S b/arch/loongarch/cpu/smp_secondary.S
+new file mode 100644
+index 00000000000..4ef4b16a3fb
+--- /dev/null
++++ b/arch/loongarch/cpu/smp_secondary.S
+@@ -0,0 +1,55 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Loop to run on secondary cores for LoongArch CPU
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <linux/linkage.h>
++#include <asm/asm.h>
++#include <asm/loongarch.h>
++#include <asm/arch/entry-init.h>
++
++ENTRY(secondary_core_loop)
++	smp_secondary_setup
++
++	PTR_LI		t0, LOONGARCH_IOCSR_MBUF0
++	LONG_IOCSRWR	zero, t0
++
++	/* Enable IPI interrupt for wakeup */
++	LONG_LI		t0, ECFGF_IPI
++	csrxchg		t0, t0, LOONGARCH_CSR_ECFG
++
++	LONG_LI		t0, 0xffffffff
++	li.w		t1, LOONGARCH_IOCSR_IPI_CLEAR
++	iocsrwr.w	t0, t1
++	li.w		t1, LOONGARCH_IOCSR_IPI_EN
++	iocsrwr.w	t0, t1
++
++	/* t1 for spin table */
++	PTR_LI		t1, LOONGARCH_IOCSR_MBUF0
++
++1:
++	/* Query spin table */
++	idle 0
++	nop
++	iocsrrd.w	t0, t1
++	beqz		t0, 1b
++
++	/* Clear IPI interrupt */
++	PTR_LI		t1, LOONGARCH_IOCSR_IPI_STATUS
++	iocsrrd.w	t0, t1
++	PTR_LI		t1, LOONGARCH_IOCSR_IPI_CLEAR
++	iocsrwr.w	t0, t1
++
++	/* Mask all interrupts */
++	LONG_LI		t0, ECFG0_IM
++	csrxchg		zero, t0, LOONGARCH_CSR_ECFG
++
++	/* Jump to secondary core */
++	PTR_LI		t1, LOONGARCH_IOCSR_MBUF0
++	LONG_IOCSRRD	t0, t1
++	/* If we ever return, put us back to the loop */
++	la.pcrel	ra, secondary_core_loop
++	jirl		zero, t0, 0
++END(secondary_core_loop)
+diff --git a/arch/loongarch/cpu/start.S b/arch/loongarch/cpu/start.S
+new file mode 100644
+index 00000000000..57a1a61fc28
+--- /dev/null
++++ b/arch/loongarch/cpu/start.S
+@@ -0,0 +1,170 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Startup Code for LoongArch CPU
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <asm-offsets.h>
++#include <config.h>
++#include <elf.h>
++#include <system-constants.h>
++#include <asm/addrspace.h>
++#include <asm/asm.h>
++#include <asm/loongarch.h>
++#include <asm/arch/entry-init.h>
++
++#define BOOTCORE_ID		0
++
++.section .text
++.globl _start
++_start:
++	/* Allow arch specific setup code for MCSR stuff */
++	entry_setup
++
++	/* Disable interrupt */
++	LONG_LI		t0, CSR_CRMD_IE
++	csrxchg		zero, t0, LOONGARCH_CSR_CRMD
++
++	/* Configure reset ebase */
++	la.pcrel	t0, exception_entry
++	csrwr		t0, LOONGARCH_CSR_EENTRY
++
++	/* Setup direct map window for later use */
++	PTR_LI		t0, CSR_DMW0_INIT
++	csrwr		t0, LOONGARCH_CSR_DMWIN0
++	PTR_LI		t0, CSR_DMW1_INIT
++	csrwr		t0, LOONGARCH_CSR_DMWIN1
++
++	/* Branch out for nonboot core */
++	csrrd		t0, LOONGARCH_CSR_CPUID
++	andi		t0, t0, CSR_CPUID_COREID
++	LONG_LI		t1, BOOTCORE_ID
++	bne			t1, t0, secondary_core_loop
++
++/*
++ * Set stackpointer in internal/ex RAM to call board_init_f
++ */
++call_board_init_f:
++	PTR_LI		t0, (SYS_INIT_SP_ADDR & STACK_ALIGN)
++	move		sp, t0			/* save stack pointer */
++/*
++ * Now sp points to the right stack belonging to current CPU.
++ * It's essential before any function call, otherwise, we get data-race.
++ */
++
++call_board_init_f_0:
++	/* find top of reserve space */
++	PTR_LI		t1, 1
++	PTR_SLL		t1, t1, CONFIG_STACK_SIZE_SHIFT
++	PTR_SUB		a0, t0, t1		/* t1 -> size of all CPU stacks */
++	bl		board_init_f_alloc_reserve
++
++	/* Set global pointer to u0 ($r21) */
++	move		u0, a0
++	bl		board_init_f_init_reserve
++
++	/* Probe and enable cache */
++	bl		probe_caches
++	bl		enable_caches
++
++#ifdef CONFIG_DEBUG_UART
++	bl		debug_uart_init
++#endif
++
++	move		a0, zero		/* a0 <-- boot_flags = 0 */
++	la.pcrel	t5, board_init_f
++	jirl		ra, t5, 0		/* jump to board_init_f() */
++
++	move		sp, s0
++
++/*
++ * void relocate_code(addr_sp, gd, addr_moni)
++ *
++ * This "function" does not return, instead it continues in RAM
++ * after relocating the monitor code.
++ *
++ */
++.globl relocate_code
++relocate_code:
++	move		s2, a0			/* save addr_sp */
++	move		s3, a1			/* save addr of gd */
++	move		s4, a2			/* save addr of destination */
++
++/*
++ *Set up the stack
++ */
++stack_setup:
++	move		sp, s2
++	la.pcrel	t0, _start
++	PTR_SUB		s5, s4, t0		/* s5 <- relocation offset */
++	beq		t0, s4, clear_bss	/* skip relocation */
++
++	move		t1, s4			/* t1 <- scratch for copy_loop */
++	la.pcrel	t2, __bss_start		/* t2 <- source end address */
++
++copy_loop:
++	LONG_L		t5, t0, 0
++	PTR_ADDI	t0, t0, LONGSIZE
++	LONG_S		t5, t1, 0
++	PTR_ADDI	t1, t1, LONGSIZE
++	blt		t0, t2, copy_loop
++
++/*
++ * Update dynamic relocations after board_init_f
++ */
++fix_rela_dyn:
++	la.pcrel	t1, __rel_dyn_start
++	la.pcrel	t2, __rel_dyn_end
++	beq		t1, t2, clear_bss
++	PTR_ADD		t1, t1, s5		/* t1 <- rela_dyn_start in RAM */
++	PTR_ADD		t2, t2, s5		/* t2 <- rela_dyn_end in RAM */
++
++6:
++	PTR_L		t5, t1, PTRSIZE		/* t5 <-- relocation info:type */
++	PTR_LI		t3, R_LARCH_RELATIVE	/* reloc type R_LARCH_RELATIVE */
++	bne		t5, t3, 8f		/* skip non-RELATIVE entries */
++	PTR_L		t3, t1, 0
++	PTR_L		t5, t1, (PTRSIZE * 2)	/* t5 <-- addend */
++	PTR_ADD		t5, t5, s5		/* t5 <-- location to fix up in RAM */
++	PTR_ADD		t3, t3, s5		/* t3 <-- location to fix up in RAM */
++	PTR_S		t5, t3, 0
++8:
++	PTR_ADDI	t1, t1, (PTRSIZE * 3)
++	blt		t1, t2, 6b
++
++
++	/* Update exception entry */
++	la.pcrel	t0, exception_entry
++	PTR_ADD		t0, t0, s5
++	csrwr		t0, LOONGARCH_CSR_EENTRY
++
++clear_bss:
++	la.pcrel	t0, __bss_start		/* t0 <- rel __bss_start in FLASH */
++	PTR_ADD		t0, t0, s5		/* t0 <- rel __bss_start in RAM */
++	la.pcrel	t1, __bss_end		/* t1 <- rel __bss_end in FLASH */
++	PTR_ADD		t1, t1, s5		/* t1 <- rel __bss_end in RAM */
++
++clbss_l:
++	LONG_S		zero, t0, 0		/* clear loop... */
++	PTR_ADDI	t0, t0, LONGSIZE
++	blt		t0, t1, clbss_l
++
++
++/*
++ * We are done. Do not return, instead branch to second part of board
++ * initialization, now running from RAM.
++ */
++call_board_init_r:
++	bl		invalidate_icache_all
++	bl		flush_dcache_all
++	la.pcrel	t0, board_init_r        /* offset of board_init_r() */
++	PTR_ADD		t4, t0, s5		/* real address of board_init_r() */
++/*
++ * setup parameters for board_init_r
++ */
++	move		a0, s3			/* gd_t */
++	move		a1, s4			/* dest_addr */
++	move		s0, zero		/* fp == NULL */
++	jirl		ra, t4, 0		/* jump to board_init_r() */
++
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0011-LoongArch-Exception-handling.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0011-LoongArch-Exception-handling.patch
@@ -1,0 +1,451 @@
+From 652dbb72b0f7dfb3660f1d0c62b3f6b2dddcbbe9 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:52 +0100
+Subject: [PATCH 11/22] LoongArch: Exception handling
+
+Add exception entry assembly code, import stackframe.h
+from Linux, provide debug prints when exception happens.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/Kconfig                  |   3 +
+ arch/loongarch/cpu/Makefile             |   2 +-
+ arch/loongarch/cpu/genex.S              |  21 +++
+ arch/loongarch/include/asm/stackframe.h | 175 ++++++++++++++++++++++
+ arch/loongarch/lib/interrupts.c         | 189 ++++++++++++++++++++++++
+ 5 files changed, 389 insertions(+), 1 deletion(-)
+ create mode 100644 arch/loongarch/cpu/genex.S
+ create mode 100644 arch/loongarch/include/asm/stackframe.h
+ create mode 100644 arch/loongarch/lib/interrupts.c
+
+diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
+index 4e8e9d4ee88..109d37d8e2c 100644
+--- a/arch/loongarch/Kconfig
++++ b/arch/loongarch/Kconfig
+@@ -30,6 +30,9 @@ config DMA_ADDR_T_64BIT
+ 	bool
+ 	default y if 64BIT
+ 
++config SHOW_REGS
++	bool "Show registers on unhandled exception"
++
+ config STACK_SIZE_SHIFT
+ 	int
+ 	default 14
+diff --git a/arch/loongarch/cpu/Makefile b/arch/loongarch/cpu/Makefile
+index d3c38a16d05..6b3dd7ad7d6 100644
+--- a/arch/loongarch/cpu/Makefile
++++ b/arch/loongarch/cpu/Makefile
+@@ -6,4 +6,4 @@
+ extra-y = start.o
+ 
+ obj-y += cpu.o
+-obj-y += smp_secondary.o
++obj-y += smp_secondary.o genex.o
+diff --git a/arch/loongarch/cpu/genex.S b/arch/loongarch/cpu/genex.S
+new file mode 100644
+index 00000000000..18d183a352b
+--- /dev/null
++++ b/arch/loongarch/cpu/genex.S
+@@ -0,0 +1,21 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Exception entry for LoongArch CPU
++ *
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <linux/linkage.h>
++#include <asm/asm.h>
++#include <asm/loongarch.h>
++#include <asm/stackframe.h>
++
++.align 12
++ENTRY(exception_entry)
++	BACKUP_T0T1
++	SAVE_ALL
++	move		a0, sp
++	la.pcrel	t0, do_exceptions
++	jirl		ra, t0, 0
++	RESTORE_ALL_AND_RET
++END(exception_entry)
+diff --git a/arch/loongarch/include/asm/stackframe.h b/arch/loongarch/include/asm/stackframe.h
+new file mode 100644
+index 00000000000..932150afdfa
+--- /dev/null
++++ b/arch/loongarch/include/asm/stackframe.h
+@@ -0,0 +1,175 @@
++/* SPDX-License-Identifier: GPL-2.0 */
++/*
++ * Copyright (C) 2020-2022 Loongson Technology Corporation Limited
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++#ifndef _ASM_STACKFRAME_H
++#define _ASM_STACKFRAME_H
++
++#include <asm/addrspace.h>
++#include <asm/asm.h>
++#include <generated/asm-offsets.h>
++#include <asm/loongarch.h>
++
++/* Make the addition of cfi info a little easier. */
++	.macro cfi_rel_offset reg offset=0 docfi=0
++	.if \docfi
++	.cfi_rel_offset \reg, \offset
++	.endif
++	.endm
++
++	.macro cfi_st reg offset=0 docfi=0
++	cfi_rel_offset \reg, \offset, \docfi
++	LONG_S	\reg, sp, \offset
++	.endm
++
++	.macro cfi_restore reg offset=0 docfi=0
++	.if \docfi
++	.cfi_restore \reg
++	.endif
++	.endm
++
++	.macro cfi_ld reg offset=0 docfi=0
++	LONG_L	\reg, sp, \offset
++	cfi_restore \reg \offset \docfi
++	.endm
++
++	.macro BACKUP_T0T1
++	csrwr	t0, EXCEPTION_KS0
++	csrwr	t1, EXCEPTION_KS1
++	.endm
++
++	.macro RELOAD_T0T1
++	csrrd   t0, EXCEPTION_KS0
++	csrrd   t1, EXCEPTION_KS1
++	.endm
++
++	.macro	SAVE_TEMP docfi=0
++	RELOAD_T0T1
++	cfi_st	t0, PT_R12, \docfi
++	cfi_st	t1, PT_R13, \docfi
++	cfi_st	t2, PT_R14, \docfi
++	cfi_st	t3, PT_R15, \docfi
++	cfi_st	t4, PT_R16, \docfi
++	cfi_st	t5, PT_R17, \docfi
++	cfi_st	t6, PT_R18, \docfi
++	cfi_st	t7, PT_R19, \docfi
++	cfi_st	t8, PT_R20, \docfi
++	.endm
++
++	.macro	SAVE_STATIC docfi=0
++	cfi_st	s0, PT_R23, \docfi
++	cfi_st	s1, PT_R24, \docfi
++	cfi_st	s2, PT_R25, \docfi
++	cfi_st	s3, PT_R26, \docfi
++	cfi_st	s4, PT_R27, \docfi
++	cfi_st	s5, PT_R28, \docfi
++	cfi_st	s6, PT_R29, \docfi
++	cfi_st	s7, PT_R30, \docfi
++	cfi_st	s8, PT_R31, \docfi
++	.endm
++
++	.macro	SAVE_SOME docfi=0
++	PTR_ADDI sp, sp, -PT_SIZE
++	.if \docfi
++	.cfi_def_cfa sp, 0
++	.endif
++	cfi_st	t0, PT_R3, \docfi
++	cfi_rel_offset  sp, PT_R3, \docfi
++	LONG_S	zero, sp, PT_R0
++	csrrd	t0, LOONGARCH_CSR_PRMD
++	LONG_S	t0, sp, PT_PRMD
++	csrrd	t0, LOONGARCH_CSR_CRMD
++	LONG_S	t0, sp, PT_CRMD
++	csrrd	t0, LOONGARCH_CSR_EUEN
++	LONG_S  t0, sp, PT_EUEN
++	csrrd	t0, LOONGARCH_CSR_ECFG
++	LONG_S	t0, sp, PT_ECFG
++	csrrd	t0, LOONGARCH_CSR_ESTAT
++	PTR_S	t0, sp, PT_ESTAT
++	cfi_st	ra, PT_R1, \docfi
++	cfi_st	a0, PT_R4, \docfi
++	cfi_st	a1, PT_R5, \docfi
++	cfi_st	a2, PT_R6, \docfi
++	cfi_st	a3, PT_R7, \docfi
++	cfi_st	a4, PT_R8, \docfi
++	cfi_st	a5, PT_R9, \docfi
++	cfi_st	a6, PT_R10, \docfi
++	cfi_st	a7, PT_R11, \docfi
++	csrrd	ra, LOONGARCH_CSR_ERA
++	LONG_S	ra, sp, PT_ERA
++	.if \docfi
++	.cfi_rel_offset ra, PT_ERA
++	.endif
++	cfi_st	tp, PT_R2, \docfi
++	cfi_st	fp, PT_R22, \docfi
++	/* Save U0 for sanity */
++	cfi_st  u0, PT_R21, \docfi
++	.endm
++
++	.macro	SAVE_ALL docfi=0
++	SAVE_SOME \docfi
++	SAVE_TEMP \docfi
++	SAVE_STATIC \docfi
++	.endm
++
++	.macro	RESTORE_TEMP docfi=0
++	cfi_ld	t0, PT_R12, \docfi
++	cfi_ld	t1, PT_R13, \docfi
++	cfi_ld	t2, PT_R14, \docfi
++	cfi_ld	t3, PT_R15, \docfi
++	cfi_ld	t4, PT_R16, \docfi
++	cfi_ld	t5, PT_R17, \docfi
++	cfi_ld	t6, PT_R18, \docfi
++	cfi_ld	t7, PT_R19, \docfi
++	cfi_ld	t8, PT_R20, \docfi
++	.endm
++
++	.macro	RESTORE_STATIC docfi=0
++	cfi_ld	s0, PT_R23, \docfi
++	cfi_ld	s1, PT_R24, \docfi
++	cfi_ld	s2, PT_R25, \docfi
++	cfi_ld	s3, PT_R26, \docfi
++	cfi_ld	s4, PT_R27, \docfi
++	cfi_ld	s5, PT_R28, \docfi
++	cfi_ld	s6, PT_R29, \docfi
++	cfi_ld	s7, PT_R30, \docfi
++	cfi_ld	s8, PT_R31, \docfi
++	.endm
++
++	.macro	RESTORE_SOME docfi=0
++	LONG_L	a0, sp, PT_PRMD
++	andi    a0, a0, 0x3	/* extract pplv bit */
++	beqz    a0, 8f
++	cfi_ld  u0, PT_R21, \docfi
++8:
++	LONG_L	a0, sp, PT_ERA
++	csrwr	a0, LOONGARCH_CSR_ERA
++	LONG_L	a0, sp, PT_PRMD
++	csrwr	a0, LOONGARCH_CSR_PRMD
++	cfi_ld	ra, PT_R1, \docfi
++	cfi_ld	a0, PT_R4, \docfi
++	cfi_ld	a1, PT_R5, \docfi
++	cfi_ld	a2, PT_R6, \docfi
++	cfi_ld	a3, PT_R7, \docfi
++	cfi_ld	a4, PT_R8, \docfi
++	cfi_ld	a5, PT_R9, \docfi
++	cfi_ld	a6, PT_R10, \docfi
++	cfi_ld	a7, PT_R11, \docfi
++	cfi_ld	tp, PT_R2, \docfi
++	cfi_ld	fp, PT_R22, \docfi
++	.endm
++
++	.macro	RESTORE_SP_AND_RET docfi=0
++	cfi_ld	sp, PT_R3, \docfi
++	ertn
++	.endm
++
++	.macro	RESTORE_ALL_AND_RET docfi=0
++	RESTORE_STATIC \docfi
++	RESTORE_TEMP \docfi
++	RESTORE_SOME \docfi
++	RESTORE_SP_AND_RET \docfi
++	.endm
++
++#endif /* _ASM_STACKFRAME_H */
+diff --git a/arch/loongarch/lib/interrupts.c b/arch/loongarch/lib/interrupts.c
+new file mode 100644
+index 00000000000..4fbd3dea140
+--- /dev/null
++++ b/arch/loongarch/lib/interrupts.c
+@@ -0,0 +1,189 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <linux/compat.h>
++#include <linux/bitfield.h>
++#include <linux/linkage.h>
++#include <hang.h>
++#include <interrupt.h>
++#include <irq_func.h>
++#include <asm/global_data.h>
++#include <asm/ptrace.h>
++#include <asm/system.h>
++#include <asm/regdef.h>
++#include <asm/loongarch.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++static struct resume_data *resume;
++
++void set_resume(struct resume_data *data)
++{
++	resume = data;
++}
++
++static void show_regs(struct pt_regs *regs)
++{
++#if IS_ENABLED(CONFIG_SHOW_REGS)
++	const int field = 2 * sizeof(unsigned long);
++
++#define GPR_FIELD(x) field, regs->regs[x]
++	printf("pc %0*lx ra %0*lx tp %0*lx sp %0*lx\n",
++	       field, regs->csr_era, GPR_FIELD(1), GPR_FIELD(2), GPR_FIELD(3));
++	printf("a0 %0*lx a1 %0*lx a2 %0*lx a3 %0*lx\n",
++	       GPR_FIELD(4), GPR_FIELD(5), GPR_FIELD(6), GPR_FIELD(7));
++	printf("a4 %0*lx a5 %0*lx a6 %0*lx a7 %0*lx\n",
++	       GPR_FIELD(8), GPR_FIELD(9), GPR_FIELD(10), GPR_FIELD(11));
++	printf("t0 %0*lx t1 %0*lx t2 %0*lx t3 %0*lx\n",
++	       GPR_FIELD(12), GPR_FIELD(13), GPR_FIELD(14), GPR_FIELD(15));
++	printf("t4 %0*lx t5 %0*lx t6 %0*lx t7 %0*lx\n",
++	       GPR_FIELD(16), GPR_FIELD(17), GPR_FIELD(18), GPR_FIELD(19));
++	printf("t8 %0*lx u0 %0*lx s9 %0*lx s0 %0*lx\n",
++	       GPR_FIELD(20), GPR_FIELD(21), GPR_FIELD(22), GPR_FIELD(23));
++	printf("s1 %0*lx s2 %0*lx s3 %0*lx s4 %0*lx\n",
++	       GPR_FIELD(24), GPR_FIELD(25), GPR_FIELD(26), GPR_FIELD(27));
++	printf("s5 %0*lx s6 %0*lx s7 %0*lx s8 %0*lx\n",
++	       GPR_FIELD(28), GPR_FIELD(29), GPR_FIELD(30), GPR_FIELD(31));
++#endif
++}
++
++static void __maybe_unused show_backtrace(struct pt_regs *regs)
++{
++	uintptr_t *fp = (uintptr_t *)regs->regs[0x16];
++	unsigned int count = 0;
++	ulong ra;
++
++	printf("\nbacktrace:\n");
++
++	/*
++	 * there are a few entry points where the s0 register is
++	 * set to gd, so to avoid changing those, just abort if
++	 * the value is the same.
++	 */
++	while (fp && fp != (uintptr_t *)gd) {
++		ra = fp[-1];
++		printf("%3d: fp: " REG_FMT " ra: " REG_FMT,
++		       count, (ulong)fp, ra);
++
++		if (gd && gd->flags & GD_FLG_RELOC)
++			printf(" - ra: " REG_FMT " reloc adjusted\n",
++			       ra - gd->reloc_off);
++		else
++			printf("\n");
++
++		fp = (uintptr_t *)fp[-2];
++		count++;
++	}
++}
++
++static const char *humanize_exc_name(unsigned int ecode, unsigned int esubcode)
++{
++	/*
++	 * LoongArch users and developers are probably more familiar with
++	 * those names found in the ISA manual, so we are going to print out
++	 * the latter. This will require some mapping.
++	 */
++	switch (ecode) {
++	case EXCCODE_RSV: return "INT";
++	case EXCCODE_TLBL: return "PIL";
++	case EXCCODE_TLBS: return "PIS";
++	case EXCCODE_TLBI: return "PIF";
++	case EXCCODE_TLBM: return "PME";
++	case EXCCODE_TLBNR: return "PNR";
++	case EXCCODE_TLBNX: return "PNX";
++	case EXCCODE_TLBPE: return "PPI";
++	case EXCCODE_ADE:
++		switch (esubcode) {
++		case EXSUBCODE_ADEF: return "ADEF";
++		case EXSUBCODE_ADEM: return "ADEM";
++		}
++		break;
++	case EXCCODE_ALE: return "ALE";
++	case EXCCODE_BCE: return "BCE";
++	case EXCCODE_SYS: return "SYS";
++	case EXCCODE_BP: return "BRK";
++	case EXCCODE_INE: return "INE";
++	case EXCCODE_IPE: return "IPE";
++	case EXCCODE_FPDIS: return "FPD";
++	case EXCCODE_LSXDIS: return "SXD";
++	case EXCCODE_LASXDIS: return "ASXD";
++	case EXCCODE_FPE:
++		switch (esubcode) {
++		case EXCSUBCODE_FPE: return "FPE";
++		case EXCSUBCODE_VFPE: return "VFPE";
++		}
++		break;
++	case EXCCODE_WATCH:
++		switch (esubcode) {
++		case EXCSUBCODE_WPEF: return "WPEF";
++		case EXCSUBCODE_WPEM: return "WPEM";
++		}
++		break;
++	case EXCCODE_BTDIS: return "BTD";
++	case EXCCODE_BTE: return "BTE";
++	case EXCCODE_GSPR: return "GSPR";
++	case EXCCODE_HVC: return "HVC";
++	case EXCCODE_GCM:
++		switch (esubcode) {
++		case EXCSUBCODE_GCSC: return "GCSC";
++		case EXCSUBCODE_GCHC: return "GCHC";
++		}
++		break;
++	/*
++	 * The manual did not mention the EXCCODE_SE case, but print out it
++	 * nevertheless.
++	 */
++	case EXCCODE_SE: return "SE";
++	}
++
++	return "???";
++}
++
++asmlinkage void do_exceptions(struct pt_regs *regs)
++{
++	unsigned int ecode = FIELD_GET(CSR_ESTAT_EXC, regs->csr_estat);
++	unsigned int esubcode = FIELD_GET(CSR_ESTAT_ESUBCODE, regs->csr_estat);
++
++	printf("Unhandled exception: %s\n", humanize_exc_name(ecode, esubcode));
++
++	printf("ERA: " REG_FMT " ra: " REG_FMT "\n",
++	       regs->csr_era, regs->regs[1]);
++	/* Print relocation adjustments, but only if gd is initialized */
++	if (gd && gd->flags & GD_FLG_RELOC)
++		printf("ERA: " REG_FMT " ra: " REG_FMT " reloc adjusted\n",
++		       regs->csr_era - gd->reloc_off, regs->regs[1] - gd->reloc_off);
++
++	printf("CRMD: " REG_FMT "\n", regs->csr_crmd);
++	if (ecode >= EXCCODE_TLBL && ecode <= EXCCODE_ALE)
++		printf("BADV: " REG_FMT "\n", regs->csr_badvaddr);
++
++	printf("\n");
++	show_regs(regs);
++
++	if (CONFIG_IS_ENABLED(FRAMEPOINTER))
++		show_backtrace(regs);
++
++	panic("\n");
++}
++
++int interrupt_init(void)
++{
++	return 0;
++}
++
++/*
++ * enable interrupts
++ */
++void enable_interrupts(void)
++{
++}
++
++/*
++ * disable interrupts
++ */
++int disable_interrupts(void)
++{
++	return 0;
++}
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0012-LoongArch-Boot-Image-bits.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0012-LoongArch-Boot-Image-bits.patch
@@ -1,0 +1,296 @@
+From 9f284c2e456179f0d13e91fa89107cb239450e11 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:53 +0100
+Subject: [PATCH 12/22] LoongArch: Boot Image bits
+
+Implement loading and booting functions for LoongArch
+standard kernel image as per spec.
+
+LoongArch kernel do expect us to fake a efi systemtable
+for passing fdt to kernel, we don't need to implement any
+EFI functions for kernel because it won't look into anything
+beside devicetree from that table if we tell kernel we are
+not efi compatible by setting a0 boot argument to zero.
+
+Link: https://docs.kernel.org/arch/loongarch/booting.html
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/lib/Makefile |   2 +
+ arch/loongarch/lib/bootm.c  | 163 ++++++++++++++++++++++++++++++++++++
+ arch/loongarch/lib/image.c  |  66 +++++++++++++++
+ cmd/Kconfig                 |   2 +-
+ 4 files changed, 232 insertions(+), 1 deletion(-)
+ create mode 100644 arch/loongarch/lib/bootm.c
+ create mode 100644 arch/loongarch/lib/image.c
+
+diff --git a/arch/loongarch/lib/Makefile b/arch/loongarch/lib/Makefile
+index 3c17b9cd85a..e65e66357a9 100644
+--- a/arch/loongarch/lib/Makefile
++++ b/arch/loongarch/lib/Makefile
+@@ -3,6 +3,8 @@
+ # Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
+ #
+ 
++obj-$(CONFIG_CMD_BOOTM) += bootm.o
++obj-$(CONFIG_CMD_BOOTI) += bootm.o image.o
+ obj-$(CONFIG_CMD_GO) += boot.o
+ obj-y	+= cache.o
+ obj-y	+= interrupts.o
+diff --git a/arch/loongarch/lib/bootm.c b/arch/loongarch/lib/bootm.c
+new file mode 100644
+index 00000000000..432ad1cfe97
+--- /dev/null
++++ b/arch/loongarch/lib/bootm.c
+@@ -0,0 +1,163 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <bootstage.h>
++#include <bootm.h>
++#include <command.h>
++#include <dm.h>
++#include <efi.h>
++#include <efi_api.h>
++#include <fdt_support.h>
++#include <hang.h>
++#include <log.h>
++#include <linux/sizes.h>
++#include <memalign.h>
++#include <asm/global_data.h>
++#include <dm/root.h>
++#include <image.h>
++#include <asm/byteorder.h>
++#include <dm/device.h>
++#include <dm/root.h>
++#include <u-boot/zlib.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++static const efi_guid_t efi_guid_fdt = EFI_FDT_GUID;
++
++__weak void board_quiesce_devices(void)
++{
++}
++
++/**
++ * announce_and_cleanup() - Print message and prepare for kernel boot
++ *
++ * @fake: non-zero to do everything except actually boot
++ */
++static void announce_and_cleanup(int fake)
++{
++	printf("\nStarting kernel ...%s\n\n", fake ?
++		"(fake run for tracing)" : "");
++	bootstage_mark_name(BOOTSTAGE_ID_BOOTM_HANDOFF, "start_kernel");
++#if CONFIG_IS_ENABLED(BOOTSTAGE_FDT)
++	bootstage_fdt_add_report();
++#endif
++#if CONFIG_IS_ENABLED(BOOTSTAGE_REPORT)
++	bootstage_report();
++#endif
++
++#if CONFIG_IS_ENABLED(USB_DEVICE)
++	udc_disconnect();
++#endif
++
++	board_quiesce_devices();
++
++	/*
++	 * Call remove function of all devices with a removal flag set.
++	 * This may be useful for last-stage operations, like cancelling
++	 * of DMA operation or releasing device internal buffers.
++	 */
++	dm_remove_devices_flags(DM_REMOVE_ACTIVE_ALL);
++
++	cleanup_before_linux();
++}
++
++/* LoongArch do expect a EFI style systab */
++static int generate_systab(struct bootm_headers *images)
++{
++	const int nr_cfgtab = 1;
++	struct bd_info *kbd = images->kbd;
++	struct efi_system_table *systab;
++	struct efi_configuration_table *cfgtab;
++	size_t table_size = sizeof(struct efi_system_table) +
++			    nr_cfgtab * sizeof(struct efi_configuration_table);
++
++	systab = memalign(SZ_64K, table_size);
++	if (!systab) {
++		log_warning("Failed to allocate memory for systab\n");
++		return -ENOMEM;
++	}
++	memset(systab, 0, table_size);
++
++	cfgtab = (void *)systab + sizeof(struct efi_system_table);
++
++	systab->hdr.signature = EFI_SYSTEM_TABLE_SIGNATURE;
++	systab->hdr.headersize = sizeof(struct efi_system_table);
++	systab->nr_tables = nr_cfgtab;
++	systab->tables = cfgtab;
++	systab->hdr.crc32 = crc32(0, (const unsigned char *)systab,
++				systab->hdr.headersize);
++
++	cfgtab[0].guid = efi_guid_fdt;
++	cfgtab[0].table = images->ft_addr;
++
++	kbd->bi_boot_params = (phys_addr_t)systab;
++
++	return 0;
++}
++
++static void boot_prep_linux(struct bootm_headers *images)
++{
++	if (CONFIG_IS_ENABLED(OF_LIBFDT) && IS_ENABLED(CONFIG_LMB) && images->ft_len) {
++		debug("using: FDT\n");
++		if (image_setup_linux(images)) {
++			printf("FDT creation failed! hanging...");
++			hang();
++		}
++		if (generate_systab(images)) {
++			printf("Failed to generate EFI systab\n");
++			hang();
++		}
++	} else {
++		printf("Device tree not found or missing FDT support\n");
++		hang();
++	}
++}
++
++static void boot_jump_linux(struct bootm_headers *images, int flag)
++{
++	void (*kernel)(ulong efi_boot, char *argc, void *dtb);
++	int fake = (flag & BOOTM_STATE_OS_FAKE_GO);
++
++	kernel = (void (*)(ulong efi_boot, char *argc, void *dtb))images->ep;
++
++	bootstage_mark(BOOTSTAGE_ID_RUN_OS);
++
++	debug("## Transferring control to kernel (at address %08lx) ...\n",
++	      (ulong)kernel);
++
++	announce_and_cleanup(fake);
++
++	if (!fake) {
++		if (CONFIG_IS_ENABLED(OF_LIBFDT) && images->ft_len)
++			kernel(0, NULL, (void *)images->kbd->bi_boot_params);
++	}
++}
++
++int do_bootm_linux(int flag, struct bootm_info *bmi)
++{
++	struct bootm_headers *images = bmi->images;
++
++	if (flag & BOOTM_STATE_OS_BD_T || flag & BOOTM_STATE_OS_CMDLINE)
++		return -1;
++
++	if (flag & BOOTM_STATE_OS_PREP) {
++		boot_prep_linux(images);
++		return 0;
++	}
++
++	if (flag & (BOOTM_STATE_OS_GO | BOOTM_STATE_OS_FAKE_GO)) {
++		boot_jump_linux(images, flag);
++		return 0;
++	}
++
++	boot_prep_linux(images);
++	boot_jump_linux(images, flag);
++	return 0;
++}
++
++int do_bootm_vxworks(int flag, struct bootm_info *bmi)
++{
++	return do_bootm_linux(flag, bmi);
++}
+diff --git a/arch/loongarch/lib/image.c b/arch/loongarch/lib/image.c
+new file mode 100644
+index 00000000000..a10a35f6e90
+--- /dev/null
++++ b/arch/loongarch/lib/image.c
+@@ -0,0 +1,66 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ *
++ * Based on riscv/lib/image.c
++ */
++
++#include <image.h>
++#include <mapmem.h>
++#include <errno.h>
++#include <asm/global_data.h>
++#include <linux/sizes.h>
++#include <linux/stddef.h>
++#include <asm/addrspace.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++#define LINUX_LOONGARCH_IMAGE_MAGIC	0x818223cd
++
++struct linux_image_h {
++	uint32_t	code0;			/* Executable code */
++	uint32_t	code1;			/* Executable code */
++	uint64_t	kernel_entry;	/* Kernel entry point */
++	uint64_t	image_size;		/* Effective Image size */
++	uint64_t	load_offset;	/* load offset */
++	uint64_t	res1;			/* reserved */
++	uint64_t	res2;			/* reserved */
++	uint64_t	res3;			/* reserved */
++	uint32_t	magic;			/* Magic number */
++	uint32_t	pe_header;		/* Offset to the PE header */
++};
++
++int booti_setup(ulong image, ulong *relocated_addr, ulong *size, ulong *ep,
++		bool force_reloc)
++{
++	struct linux_image_h *lhdr;
++	phys_addr_t ep_phys;
++
++	lhdr = (struct linux_image_h *)map_sysmem(image, 0);
++
++	if (lhdr->magic != LINUX_LOONGARCH_IMAGE_MAGIC) {
++		puts("Bad Linux LoongArch Image magic!\n");
++		return -EINVAL;
++	}
++
++	if (lhdr->image_size == 0) {
++		puts("Image lacks image_size field, error!\n");
++		return -EINVAL;
++	}
++
++	*size = lhdr->image_size;
++	if (force_reloc ||
++	    (gd->ram_base <= image && image < gd->ram_base + gd->ram_size)) {
++		*relocated_addr = gd->ram_base + lhdr->load_offset;
++	} else {
++		*relocated_addr = image;
++	}
++
++	/* To workaround kernel supplying DMW based virtual address */
++	ep_phys = TO_PHYS(lhdr->kernel_entry);
++	*ep = *relocated_addr + (ep_phys - lhdr->load_offset);
++
++	unmap_sysmem(lhdr);
++
++	return 0;
++}
+diff --git a/cmd/Kconfig b/cmd/Kconfig
+index c71c6824a19..7225a3a8e3c 100644
+--- a/cmd/Kconfig
++++ b/cmd/Kconfig
+@@ -395,7 +395,7 @@ config CMD_BOOTZ
+ 
+ config CMD_BOOTI
+ 	bool "booti"
+-	depends on ARM64 || RISCV || SANDBOX
++	depends on ARM64 || LOONGARCH || RISCV || SANDBOX
+ 	depends on LMB
+ 	default y
+ 	select LIB_BOOTI
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0013-LoongArch-Generic-CPU-type.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0013-LoongArch-Generic-CPU-type.patch
@@ -1,0 +1,124 @@
+From d40ebce7ba936bd1c532292abd5997c4e80e43f4 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:54 +0100
+Subject: [PATCH 13/22] LoongArch: Generic CPU type
+
+Provide a generic CPU type with some common routines
+that expected to be implemented at CPU level.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/Kconfig              |  1 +
+ arch/loongarch/cpu/generic/Kconfig  | 13 +++++++++++++
+ arch/loongarch/cpu/generic/Makefile |  7 +++++++
+ arch/loongarch/cpu/generic/cpu.c    | 22 ++++++++++++++++++++++
+ arch/loongarch/cpu/generic/dram.c   | 21 +++++++++++++++++++++
+ 5 files changed, 64 insertions(+)
+ create mode 100644 arch/loongarch/cpu/generic/Kconfig
+ create mode 100644 arch/loongarch/cpu/generic/Makefile
+ create mode 100644 arch/loongarch/cpu/generic/cpu.c
+ create mode 100644 arch/loongarch/cpu/generic/dram.c
+
+diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
+index 109d37d8e2c..5254afb2cd0 100644
+--- a/arch/loongarch/Kconfig
++++ b/arch/loongarch/Kconfig
+@@ -12,6 +12,7 @@ endchoice
+ # board-specific options below
+ 
+ # platform-specific options below
++source "arch/loongarch/cpu/generic/Kconfig"
+ 
+ # architecture-specific options below
+ choice
+diff --git a/arch/loongarch/cpu/generic/Kconfig b/arch/loongarch/cpu/generic/Kconfig
+new file mode 100644
+index 00000000000..ac7556d6d4d
+--- /dev/null
++++ b/arch/loongarch/cpu/generic/Kconfig
+@@ -0,0 +1,13 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
++config GENERIC_LOONGARCH
++	bool
++	select SYS_CACHE_SHIFT_6
++	imply CPU
++	imply CPU_LOONGARCH
++	imply LOONGARCH_TIMER
++	imply CMD_CPU
++
+diff --git a/arch/loongarch/cpu/generic/Makefile b/arch/loongarch/cpu/generic/Makefile
+new file mode 100644
+index 00000000000..c98d63b4f83
+--- /dev/null
++++ b/arch/loongarch/cpu/generic/Makefile
+@@ -0,0 +1,7 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
++obj-y += dram.o
++obj-y += cpu.o
+diff --git a/arch/loongarch/cpu/generic/cpu.c b/arch/loongarch/cpu/generic/cpu.c
+new file mode 100644
+index 00000000000..5c849faf2ba
+--- /dev/null
++++ b/arch/loongarch/cpu/generic/cpu.c
+@@ -0,0 +1,22 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <irq_func.h>
++#include <asm/cache.h>
++
++/*
++ * cleanup_before_linux() is called just before we call linux
++ * it prepares the processor for linux
++ *
++ * we disable interrupt and caches.
++ */
++int cleanup_before_linux(void)
++{
++	disable_interrupts();
++
++	cache_flush();
++
++	return 0;
++}
+diff --git a/arch/loongarch/cpu/generic/dram.c b/arch/loongarch/cpu/generic/dram.c
+new file mode 100644
+index 00000000000..101b4578619
+--- /dev/null
++++ b/arch/loongarch/cpu/generic/dram.c
+@@ -0,0 +1,21 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <fdtdec.h>
++#include <init.h>
++#include <asm/global_data.h>
++#include <linux/sizes.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++int dram_init(void)
++{
++	return fdtdec_setup_mem_size_base_lowest();
++}
++
++int dram_init_banksize(void)
++{
++	return fdtdec_setup_memory_banksize();
++}
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0014-cpu-Add-loongarch_cpu-driver.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0014-cpu-Add-loongarch_cpu-driver.patch
@@ -1,0 +1,203 @@
+From 3b55bb81c86515a1ec68a864a061d0a5dd036590 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:55 +0100
+Subject: [PATCH 14/22] cpu: Add loongarch_cpu driver
+
+Implement a driver for LoongArch CPU solely for gathering
+some information bits from FDT and CPU level config registers.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ drivers/cpu/Kconfig         |   6 ++
+ drivers/cpu/Makefile        |   1 +
+ drivers/cpu/loongarch_cpu.c | 148 ++++++++++++++++++++++++++++++++++++
+ 3 files changed, 155 insertions(+)
+ create mode 100644 drivers/cpu/loongarch_cpu.c
+
+diff --git a/drivers/cpu/Kconfig b/drivers/cpu/Kconfig
+index c805c0bbfa1..9fd43ff88fd 100644
+--- a/drivers/cpu/Kconfig
++++ b/drivers/cpu/Kconfig
+@@ -13,6 +13,12 @@ config CPU_IMX
+ 	help
+ 	  Support CPU cores for SoCs of the i.MX series.
+ 
++config CPU_LOONGARCH
++	bool "Enable LoongArch CPU driver"
++	depends on CPU && LOONGARCH
++	help
++	  Support CPU cores for LoongArch processors.
++
+ config CPU_MPC83XX
+ 	bool "Enable MPC83xx CPU driver"
+ 	depends on CPU && MPC83xx
+diff --git a/drivers/cpu/Makefile b/drivers/cpu/Makefile
+index eaf494706e2..d9c0db74dd5 100644
+--- a/drivers/cpu/Makefile
++++ b/drivers/cpu/Makefile
+@@ -13,6 +13,7 @@ obj-$(CONFIG_ARCH_AT91) += at91_cpu.o
+ obj-$(CONFIG_ARCH_MEDIATEK) += mtk_cpu.o
+ obj-$(CONFIG_CPU_ARMV8) += armv8_cpu.o
+ obj-$(CONFIG_CPU_IMX) += imx8_cpu.o
++obj-$(CONFIG_CPU_LOONGARCH) += loongarch_cpu.o
+ obj-$(CONFIG_CPU_MPC83XX) += mpc83xx_cpu.o
+ obj-$(CONFIG_CPU_RISCV) += riscv_cpu.o
+ obj-$(CONFIG_CPU_MICROBLAZE) += microblaze_cpu.o
+diff --git a/drivers/cpu/loongarch_cpu.c b/drivers/cpu/loongarch_cpu.c
+new file mode 100644
+index 00000000000..f168ae23cf6
+--- /dev/null
++++ b/drivers/cpu/loongarch_cpu.c
+@@ -0,0 +1,148 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <clk.h>
++#include <cpu.h>
++#include <dm.h>
++#include <errno.h>
++#include <log.h>
++#include <asm/loongarch.h>
++#include <dm/device-internal.h>
++#include <dm/lists.h>
++#include <linux/bitops.h>
++#include <linux/err.h>
++
++static int loongarch_cpu_get_desc(const struct udevice *dev, char *buf, int size)
++{
++	const char *cpu;
++
++	/* We try to get CPU name from IOCSR first */
++	if ((read_cpucfg(LOONGARCH_CPUCFG1) & CPUCFG1_IOCSR)) {
++		int i;
++		char vendor_buf[9] = { 0 };
++		char name_buf[9] = { 0 };
++		u64 vendor = iocsr_read64(LOONGARCH_IOCSR_VENDOR);
++		u64 name = iocsr_read64(LOONGARCH_IOCSR_CPUNAME);
++
++		if (!vendor || !name)
++			goto get_desc_dt;
++
++		for (i = 0; i < sizeof(u64); i++) {
++			vendor_buf[i] = vendor & 0xff;
++			name_buf[i] = name & 0xff;
++			vendor >>= 8;
++			name >>= 8;
++		}
++
++		snprintf(buf, size, "%s-%s", vendor_buf, name_buf);
++
++		return 0;
++	}
++
++get_desc_dt:
++	cpu = dev_read_string(dev, "compatible");
++	if (!cpu || size < (strlen(cpu) + 1))
++		return -ENOSPC;
++
++	strcpy(buf, cpu);
++
++	return 0;
++}
++
++static int loongarch_cpu_get_info(const struct udevice *dev, struct cpu_info *info)
++{
++	int ret;
++	struct clk clk;
++
++	/* First try getting the frequency from the assigned clock */
++	ret = clk_get_by_index((struct udevice *)dev, 0, &clk);
++	if (!ret) {
++		ret = clk_get_rate(&clk);
++		if (!IS_ERR_VALUE(ret))
++			info->cpu_freq = ret;
++	}
++
++	if (!info->cpu_freq)
++		dev_read_u32(dev, "clock-frequency", (u32 *)&info->cpu_freq);
++
++	if (read_cpucfg(LOONGARCH_CPUCFG1) & CPUCFG1_PAGING)
++		info->features |= BIT(CPU_FEAT_MMU);
++
++	if (read_cpucfg(LOONGARCH_CPUCFG16) & CPUCFG16_L1_IUPRE)
++		info->features |= BIT(CPU_FEAT_L1_CACHE);
++
++	return 0;
++}
++
++static int loongarch_cpu_get_count(const struct udevice *dev)
++{
++	ofnode node;
++	int num = 0;
++
++	ofnode_for_each_subnode(node, dev_ofnode(dev->parent)) {
++		const char *device_type;
++
++		/* skip if core is marked as not available in the device tree */
++		if (!ofnode_is_enabled(node))
++			continue;
++
++		device_type = ofnode_read_string(node, "device_type");
++		if (!device_type)
++			continue;
++		if (strcmp(device_type, "cpu") == 0)
++			num++;
++	}
++
++	return num;
++}
++
++static int loongarch_cpu_bind(struct udevice *dev)
++{
++	struct cpu_plat *plat = dev_get_parent_plat(dev);
++
++	plat->cpu_id = dev_read_addr(dev);
++
++	return 0;
++}
++
++static int loongarch_cpu_probe(struct udevice *dev)
++{
++	int ret = 0;
++	struct clk clk;
++
++	/* Get a clock if it exists */
++	ret = clk_get_by_index(dev, 0, &clk);
++	if (ret)
++		return 0;
++
++	ret = clk_enable(&clk);
++	if (ret == -ENOSYS)
++		return 0;
++	else
++		return ret;
++}
++
++static const struct cpu_ops loongarch_cpu_ops = {
++	.get_desc	= loongarch_cpu_get_desc,
++	.get_info	= loongarch_cpu_get_info,
++	.get_count	= loongarch_cpu_get_count,
++};
++
++static const struct udevice_id loongarch_cpu_ids[] = {
++	{ .compatible = "loongarch,Loongson-3A5000" }, /* From QEMU, undocumented */
++	{ .compatible = "loongson,la264" },
++	{ .compatible = "loongson,la364" },
++	{ }
++};
++
++U_BOOT_DRIVER(loongarch_cpu) = {
++	.name = "loongarch_cpu",
++	.id = UCLASS_CPU,
++	.of_match = loongarch_cpu_ids,
++	.bind = loongarch_cpu_bind,
++	.probe = loongarch_cpu_probe,
++	.ops = &loongarch_cpu_ops,
++	.flags = DM_FLAG_PRE_RELOC,
++};
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0015-timer-Add-loongarch_timer-driver.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0015-timer-Add-loongarch_timer-driver.patch
@@ -1,0 +1,169 @@
+From f1256902e6b267b76b7fd24fc8224f7a524e3422 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:56 +0100
+Subject: [PATCH 15/22] timer: Add loongarch_timer driver
+
+Implement a timer driver for LoongArch architecture driver.
+
+It's synced in hardware for every core in a system, and frequency
+information can be gathered from CPUCFG instruction.
+
+It is not described in fdt, thus I have to declare a DRVINFO
+for it.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ drivers/timer/Kconfig           |   8 +++
+ drivers/timer/Makefile          |   1 +
+ drivers/timer/loongarch_timer.c | 112 ++++++++++++++++++++++++++++++++
+ 3 files changed, 121 insertions(+)
+ create mode 100644 drivers/timer/loongarch_timer.c
+
+diff --git a/drivers/timer/Kconfig b/drivers/timer/Kconfig
+index 500a25638a9..6feb5332814 100644
+--- a/drivers/timer/Kconfig
++++ b/drivers/timer/Kconfig
+@@ -348,4 +348,12 @@ config GOLDFISH_TIMER
+ 	  It uses the Goldfish RTC hardware to provide a nanosecond-resolution
+ 	  timer, commonly found in QEMU virt machines.
+ 
++config LOONGARCH_TIMER
++	bool "LoongArch CPU timer support"
++	depends on TIMER
++	depends on LOONGARCH
++	help
++	  Select this to enable support for the timer found on
++	  LoongArch CPUs.
++
+ endmenu
+diff --git a/drivers/timer/Makefile b/drivers/timer/Makefile
+index d8b3f2b65d4..0b70b915bfe 100644
+--- a/drivers/timer/Makefile
++++ b/drivers/timer/Makefile
+@@ -37,3 +37,4 @@ obj-$(CONFIG_IMX_GPT_TIMER)	+= imx-gpt-timer.o
+ obj-$(CONFIG_XILINX_TIMER)	+= xilinx-timer.o
+ obj-$(CONFIG_STARFIVE_TIMER)	+= starfive-timer.o
+ obj-$(CONFIG_GOLDFISH_TIMER)	+= goldfish_timer.o
++obj-$(CONFIG_LOONGARCH_TIMER)	+= loongarch_timer.o
+diff --git a/drivers/timer/loongarch_timer.c b/drivers/timer/loongarch_timer.c
+new file mode 100644
+index 00000000000..4b9f9307511
+--- /dev/null
++++ b/drivers/timer/loongarch_timer.c
+@@ -0,0 +1,112 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <dm.h>
++#include <errno.h>
++#include <timer.h>
++#include <asm/loongarch.h>
++
++static u64 notrace loongarch_timer_get_count(struct udevice *dev)
++{
++	u32 hi, lo;
++
++	if (IS_ENABLED(CONFIG_64BIT))
++		return drdtime();
++
++	do {
++		hi = rdtimeh();
++		lo = rdtimel();
++	} while (hi != rdtimeh());
++
++	return ((u64)hi << 32) | lo;
++}
++
++static unsigned int loongarch_timer_get_freq_cpucfg(void)
++{
++	unsigned int res;
++	unsigned int base_freq;
++	unsigned int cfm, cfd;
++
++	res = read_cpucfg(LOONGARCH_CPUCFG2);
++	if (!(res & CPUCFG2_LLFTP))
++		return 0;
++
++	base_freq = read_cpucfg(LOONGARCH_CPUCFG4);
++	res = read_cpucfg(LOONGARCH_CPUCFG5);
++	cfm = res & 0xffff;
++	cfd = (res >> 16) & 0xffff;
++
++	if (!base_freq || !cfm || !cfd)
++		return 0;
++
++	return (base_freq * cfm / cfd);
++}
++
++#if IS_ENABLED(CONFIG_TIMER_EARLY)
++/**
++ * timer_early_get_rate() - Get the timer rate before driver model
++ */
++unsigned long notrace timer_early_get_rate(void)
++{
++	return loongarch_timer_get_freq_cpucfg();
++}
++
++/**
++ * timer_early_get_count() - Get the timer count before driver model
++ *
++ */
++u64 notrace timer_early_get_count(void)
++{
++	return loongarch_timer_get_count(NULL);
++}
++#endif
++
++#if CONFIG_IS_ENABLED(BOOTSTAGE)
++ulong timer_get_boot_us(void)
++{
++	int ret;
++	u64 ticks = 0;
++	u32 rate;
++
++	ret = dm_timer_init();
++	if (!ret) {
++		rate = timer_get_rate(gd->timer);
++		timer_get_count(gd->timer, &ticks);
++	} else {
++		rate = loongarch_timer_get_freq_cpucfg();
++		ticks = loongarch_timer_get_count(NULL);
++	}
++
++	/* Below is converted from time(us) = (tick / rate) * 10000000 */
++	return lldiv(ticks * 1000, (rate / 1000));
++}
++#endif
++
++static int loongarch_timer_bind(struct udevice *dev)
++{
++	struct timer_dev_priv *uc_priv = dev_get_uclass_priv(dev);
++	u32 rate;
++
++	rate = loongarch_timer_get_freq_cpucfg();
++	uc_priv->clock_rate = rate;
++
++	return 0;
++}
++
++static const struct timer_ops loongarch_timer_ops = {
++	.get_count = loongarch_timer_get_count,
++};
++
++U_BOOT_DRIVER(loongarch_timer) = {
++	.name = "loongarch_timer",
++	.id = UCLASS_TIMER,
++	.probe = loongarch_timer_bind,
++	.ops = &loongarch_timer_ops,
++	.flags = DM_FLAG_PRE_RELOC,
++};
++
++U_BOOT_DRVINFO(loongarch_timer) = {
++	.name = "loongarch_timer",
++};
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0016-board-emulation-Add-qemu-loongarch.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0016-board-emulation-Add-qemu-loongarch.patch
@@ -1,0 +1,313 @@
+From 399ea760b212da671105dfb73bd0a22b54c1a4f9 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:57 +0100
+Subject: [PATCH 16/22] board: emulation: Add qemu-loongarch
+
+Yet another generic QEMU VIRT machine.
+QEMU placed FDT in memory before launching U-Boot, so we
+can just obtian FDT here.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/Kconfig                        |  5 ++
+ arch/loongarch/dts/qemu-loongarch64.dts       |  9 +++
+ board/emulation/qemu-loongarch/Kconfig        | 68 +++++++++++++++++++
+ board/emulation/qemu-loongarch/MAINTAINERS    |  7 ++
+ board/emulation/qemu-loongarch/Makefile       |  6 ++
+ .../emulation/qemu-loongarch/qemu-loongarch.c | 67 ++++++++++++++++++
+ .../qemu-loongarch/qemu-loongarch.env         |  6 ++
+ configs/qemu-loongarch64_defconfig            | 36 ++++++++++
+ include/configs/qemu-loongarch.h              | 13 ++++
+ 9 files changed, 217 insertions(+)
+ create mode 100644 arch/loongarch/dts/qemu-loongarch64.dts
+ create mode 100644 board/emulation/qemu-loongarch/Kconfig
+ create mode 100644 board/emulation/qemu-loongarch/MAINTAINERS
+ create mode 100644 board/emulation/qemu-loongarch/Makefile
+ create mode 100644 board/emulation/qemu-loongarch/qemu-loongarch.c
+ create mode 100644 board/emulation/qemu-loongarch/qemu-loongarch.env
+ create mode 100644 configs/qemu-loongarch64_defconfig
+ create mode 100644 include/configs/qemu-loongarch.h
+
+diff --git a/arch/loongarch/Kconfig b/arch/loongarch/Kconfig
+index 5254afb2cd0..6cf7ad9b3a4 100644
+--- a/arch/loongarch/Kconfig
++++ b/arch/loongarch/Kconfig
+@@ -7,9 +7,14 @@ config SYS_ARCH
+ choice
+ 	prompt "Target select"
+ 
++config TARGET_QEMU_LOONGARCH_VIRT
++	bool "Support QEMU Virt Board"
++	select BOARD_LATE_INIT
++
+ endchoice
+ 
+ # board-specific options below
++source "board/emulation/qemu-loongarch/Kconfig"
+ 
+ # platform-specific options below
+ source "arch/loongarch/cpu/generic/Kconfig"
+diff --git a/arch/loongarch/dts/qemu-loongarch64.dts b/arch/loongarch/dts/qemu-loongarch64.dts
+new file mode 100644
+index 00000000000..39d303798fc
+--- /dev/null
++++ b/arch/loongarch/dts/qemu-loongarch64.dts
+@@ -0,0 +1,9 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++/dts-v1/;
++
++/ {
++};
+diff --git a/board/emulation/qemu-loongarch/Kconfig b/board/emulation/qemu-loongarch/Kconfig
+new file mode 100644
+index 00000000000..188cd6967bf
+--- /dev/null
++++ b/board/emulation/qemu-loongarch/Kconfig
+@@ -0,0 +1,68 @@
++if TARGET_QEMU_LOONGARCH_VIRT
++
++config SYS_BOARD
++	default "qemu-loongarch"
++
++config SYS_VENDOR
++	default "emulation"
++
++config SYS_CPU
++	default "generic"
++
++config SYS_CONFIG_NAME
++	default "qemu-loongarch"
++
++config TEXT_BASE
++	default 0x1c000000
++
++config BOARD_SPECIFIC_OPTIONS # dummy
++	def_bool y
++	select GENERIC_LOONGARCH
++	imply AHCI
++	imply BOARD_LATE_INIT
++	imply PCI_INIT_R
++	imply CMD_PCI
++	imply CMD_POWEROFF
++	imply CMD_SCSI
++	imply CMD_PING
++	imply CMD_EXT2
++	imply CMD_EXT4
++	imply CMD_FAT
++	imply CMD_FS_GENERIC
++	imply DOS_PARTITION
++	imply ISO_PARTITION
++	imply EFI_PARTITION
++	imply SCSI_AHCI
++	imply AHCI_PCI
++	imply E1000
++	imply PCI
++	imply NVME_PCI
++	imply PCIE_ECAM_GENERIC
++	imply DM_RNG
++	imply DM_RTC
++	imply QFW
++	imply QFW_MMIO
++	imply SCSI
++	imply SYS_NS16550
++	imply SYSRESET
++	imply SYSRESET_CMD_POWEROFF
++	imply SYSRESET_SYSCON
++	imply VIRTIO_MMIO
++	imply VIRTIO_PCI
++	imply VIRTIO_NET
++	imply VIRTIO_BLK
++	imply MTD_NOR_FLASH
++	imply CFI_FLASH
++	imply OF_HAS_PRIOR_STAGE
++	imply VIDEO
++	imply VIDEO_BOCHS
++	imply SYS_WHITE_ON_BLACK
++	imply USB
++	imply USB_XHCI_HCD
++	imply USB_XHCI_PCI
++	imply USB_KEYBOARD
++	imply CMD_USB
++	imply UFS
++	imply UFS_PCI
++
++endif
+diff --git a/board/emulation/qemu-loongarch/MAINTAINERS b/board/emulation/qemu-loongarch/MAINTAINERS
+new file mode 100644
+index 00000000000..0ecd8201fb9
+--- /dev/null
++++ b/board/emulation/qemu-loongarch/MAINTAINERS
+@@ -0,0 +1,7 @@
++QEMU LOONGARCH 'VIRT' BOARD
++M:	Jiaxun Yang <jiaxun.yang@flygoat.com>
++S:	Maintained
++F:	board/emulation/qemu-loongarch/
++F:	board/emulation/common/
++F:	include/configs/qemu-loongarch.h
++F:	configs/qemu-loongarch64_defconfig
+diff --git a/board/emulation/qemu-loongarch/Makefile b/board/emulation/qemu-loongarch/Makefile
+new file mode 100644
+index 00000000000..a928b90780e
+--- /dev/null
++++ b/board/emulation/qemu-loongarch/Makefile
+@@ -0,0 +1,6 @@
++# SPDX-License-Identifier: GPL-2.0+
++#
++# Copyright (C) 2024 Jiaxun yang <jiaxun.yang@flygoat.com>
++#
++
++obj-y	+= qemu-loongarch.o
+diff --git a/board/emulation/qemu-loongarch/qemu-loongarch.c b/board/emulation/qemu-loongarch/qemu-loongarch.c
+new file mode 100644
+index 00000000000..834a3634501
+--- /dev/null
++++ b/board/emulation/qemu-loongarch/qemu-loongarch.c
+@@ -0,0 +1,67 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <dm.h>
++#include <dm/ofnode.h>
++#include <env.h>
++#include <fdtdec.h>
++#include <image.h>
++#include <linux/sizes.h>
++#include <lmb.h>
++#include <log.h>
++#include <spl.h>
++#include <init.h>
++#include <usb.h>
++#include <virtio_types.h>
++#include <virtio.h>
++
++DECLARE_GLOBAL_DATA_PTR;
++
++#if IS_ENABLED(CONFIG_MTD_NOR_FLASH)
++int is_flash_available(void)
++{
++	if (!ofnode_equal(ofnode_by_compatible(ofnode_null(), "cfi-flash"),
++			  ofnode_null()))
++		return 1;
++
++	return 0;
++}
++#endif
++
++phys_addr_t board_get_usable_ram_top(phys_size_t total_size)
++{
++	/* Limit RAM used by U-Boot to the DDR low region */
++	if (gd->ram_top > 0x10000000)
++		return 0x10000000;
++
++	return gd->ram_top;
++}
++
++int board_init(void)
++{
++	return 0;
++}
++
++int board_late_init(void)
++{
++	/* start usb so that usb keyboard can be used as input device */
++	if (CONFIG_IS_ENABLED(USB_KEYBOARD))
++		usb_init();
++
++	/*
++	 * Make sure virtio bus is enumerated so that peripherals
++	 * on the virtio bus can be discovered by their drivers
++	 */
++	virtio_init();
++
++	return 0;
++}
++
++int board_fdt_blob_setup(void **fdtp)
++{
++	/* Stored the DTB address there during our init */
++	*fdtp = (void *)(ulong)0x100000;
++	return 0;
++}
+diff --git a/board/emulation/qemu-loongarch/qemu-loongarch.env b/board/emulation/qemu-loongarch/qemu-loongarch.env
+new file mode 100644
+index 00000000000..2d130510607
+--- /dev/null
++++ b/board/emulation/qemu-loongarch/qemu-loongarch.env
+@@ -0,0 +1,6 @@
++
++stdin=serial,usbkbd
++stdout=serial,vidconsole
++stderr=serial,vidconsole
++
++boot_targets=qfw usb scsi virtio nvme dhcp
+diff --git a/configs/qemu-loongarch64_defconfig b/configs/qemu-loongarch64_defconfig
+new file mode 100644
+index 00000000000..d7f9c433848
+--- /dev/null
++++ b/configs/qemu-loongarch64_defconfig
+@@ -0,0 +1,36 @@
++CONFIG_LOONGARCH=y
++CONFIG_SYS_MALLOC_LEN=0x800000
++CONFIG_SYS_MALLOC_F_LEN=0x4000
++CONFIG_NR_DRAM_BANKS=8
++CONFIG_ENV_SIZE=0x20000
++CONFIG_DEFAULT_DEVICE_TREE="qemu-loongarch64"
++CONFIG_DM_RESET=y
++CONFIG_SYS_LOAD_ADDR=0x02000000
++CONFIG_SHOW_REGS=y
++# CONFIG_OF_BOARD_FIXUP is not set
++CONFIG_SYS_PCI_64BIT=y
++CONFIG_FIT=y
++CONFIG_BOOTSTD_FULL=y
++CONFIG_SYS_BOOTM_LEN=0x4000000
++CONFIG_USE_BOOTARGS=y
++CONFIG_BOOTARGS_SUBST=y
++CONFIG_DISPLAY_CPUINFO=y
++CONFIG_DISPLAY_BOARDINFO=y
++# CONFIG_CMD_MII is not set
++CONFIG_CMD_2048=y
++CONFIG_CMD_RTC=y
++CONFIG_CMD_TIME=y
++CONFIG_CMD_SYSBOOT=y
++CONFIG_CMD_QFW=y
++CONFIG_PARTITION_TYPE_GUID=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_BLKMAP=y
++CONFIG_EFI_MEDIA=y
++CONFIG_DM_MMC=y
++CONFIG_DM_MTD=y
++CONFIG_FLASH_SHOW_PROGRESS=0
++CONFIG_SYS_MAX_FLASH_BANKS=2
++CONFIG_PCI_REGION_MULTI_ENTRY=y
++CONFIG_DM_REBOOT_MODE=y
++CONFIG_RESET_SYSCON=y
++CONFIG_HEXDUMP=y
+diff --git a/include/configs/qemu-loongarch.h b/include/configs/qemu-loongarch.h
+new file mode 100644
+index 00000000000..c1af4fee83f
+--- /dev/null
++++ b/include/configs/qemu-loongarch.h
+@@ -0,0 +1,13 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (c) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#ifndef __CONFIG_H
++#define __CONFIG_H
++
++/* Those values are chosen by LoongArchQemuPkg */
++#define CFG_SYS_INIT_RAM_ADDR	0x10000
++#define CFG_SYS_INIT_RAM_SIZE	0x10000
++
++#endif
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0017-efi-LoongArch-Define-LoongArch-bits-everywhere.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0017-efi-LoongArch-Define-LoongArch-bits-everywhere.patch
@@ -1,0 +1,140 @@
+From 11ad2170b2c614379030512d34409bdc5fe19310 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:58 +0100
+Subject: [PATCH 17/22] efi: LoongArch: Define LoongArch bits everywhere
+
+They are all coming from UEFI specification, PE-COFF specification,
+or IANA websites.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ include/asm-generic/pe.h                          | 2 ++
+ include/config_distro_bootcmd.h                   | 5 +++++
+ include/pe.h                                      | 1 +
+ lib/efi_loader/efi_helper.c                       | 4 ++++
+ lib/efi_loader/efi_image_loader.c                 | 7 +++++++
+ lib/efi_loader/efi_runtime.c                      | 4 ++++
+ lib/efi_selftest/efi_selftest_miniapp_exception.c | 3 +++
+ 7 files changed, 26 insertions(+)
+
+diff --git a/include/asm-generic/pe.h b/include/asm-generic/pe.h
+index cd5b6ad62bf..fb93f262171 100644
+--- a/include/asm-generic/pe.h
++++ b/include/asm-generic/pe.h
+@@ -38,6 +38,8 @@
+ #define IMAGE_FILE_MACHINE_ARM64		0xaa64
+ #define IMAGE_FILE_MACHINE_RISCV32		0x5032
+ #define IMAGE_FILE_MACHINE_RISCV64		0x5064
++#define IMAGE_FILE_MACHINE_LOONGARCH32	0x6232
++#define IMAGE_FILE_MACHINE_LOONGARCH64	0x6264
+ 
+ /* Header magic constants */
+ #define IMAGE_NT_OPTIONAL_HDR32_MAGIC		0x010b
+diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
+index 8d6f80a0ce5..7722ba7627f 100644
+--- a/include/config_distro_bootcmd.h
++++ b/include/config_distro_bootcmd.h
+@@ -118,6 +118,8 @@
+ #define BOOTEFI_NAME "bootriscv32.efi"
+ #elif defined(CONFIG_ARCH_RV64I)
+ #define BOOTEFI_NAME "bootriscv64.efi"
++#elif defined(CONFIG_ARCH_LA64)
++#define BOOTEFI_NAME "bootloongarch64.efi"
+ #endif
+ #endif
+ 
+@@ -371,6 +373,9 @@
+ #elif defined(CONFIG_ARCH_RV64I) || ((defined(__riscv) && __riscv_xlen == 64))
+ #define BOOTENV_EFI_PXE_ARCH "0x1b"
+ #define BOOTENV_EFI_PXE_VCI "PXEClient:Arch:00027:UNDI:003000"
++#elif defined(CONFIG_ARCH_LA64) || (defined(__loongarch__) && __loongarch_grlen == 64))
++#define BOOTENV_EFI_PXE_ARCH "0x27"
++#define BOOTENV_EFI_PXE_VCI "PXEClient:Arch:00039:UNDI:003000"
+ #elif defined(CONFIG_SANDBOX)
+ # error "sandbox EFI support is only supported on ARM and x86"
+ #else
+diff --git a/include/pe.h b/include/pe.h
+index 086f2b860e9..2340631f82f 100644
+--- a/include/pe.h
++++ b/include/pe.h
+@@ -194,6 +194,7 @@ typedef struct _IMAGE_RELOCATION
+ #define IMAGE_REL_BASED_THUMB_MOV32             7 /* yes, 7 too */
+ #define IMAGE_REL_BASED_RISCV_LOW12I		7 /* yes, 7 too */
+ #define IMAGE_REL_BASED_RISCV_LOW12S		8
++#define IMAGE_REL_BASED_LOONGARCH64_MARK_LA	8 /* yes, 8 too */
+ #define IMAGE_REL_BASED_MIPS_JMPADDR16          9
+ #define IMAGE_REL_BASED_IA64_IMM64              9 /* yes, 9 too */
+ #define IMAGE_REL_BASED_DIR64                   10
+diff --git a/lib/efi_loader/efi_helper.c b/lib/efi_loader/efi_helper.c
+index 44b806aadc4..bc48e265b90 100644
+--- a/lib/efi_loader/efi_helper.c
++++ b/lib/efi_loader/efi_helper.c
+@@ -62,6 +62,8 @@
+ #define BOOTEFI_NAME "BOOTRISCV32.EFI"
+ #elif defined(CONFIG_ARCH_RV64I)
+ #define BOOTEFI_NAME "BOOTRISCV64.EFI"
++#elif defined(CONFIG_ARCH_LA64)
++#define BOOTEFI_NAME "BOOTLOONGARCH64.EFI"
+ #else
+ #error Unsupported UEFI architecture
+ #endif
+@@ -94,6 +96,8 @@ int efi_get_pxe_arch(void)
+ 		return 0x19;
+ 	else if (IS_ENABLED(CONFIG_ARCH_RV64I))
+ 		return 0x1b;
++	else if (IS_ENABLED(CONFIG_ARCH_LA64))
++		return 0x27;
+ 
+ 	return -EINVAL;
+ }
+diff --git a/lib/efi_loader/efi_image_loader.c b/lib/efi_loader/efi_image_loader.c
+index f9a2d2df405..bed5f181726 100644
+--- a/lib/efi_loader/efi_image_loader.c
++++ b/lib/efi_loader/efi_image_loader.c
+@@ -51,6 +51,13 @@ static int machines[] = {
+ #if defined(__riscv) && (__riscv_xlen == 64)
+ 	IMAGE_FILE_MACHINE_RISCV64,
+ #endif
++
++#if defined(__loongarch__) && __loongarch_grlen == 64
++	IMAGE_FILE_MACHINE_LOONGARCH64,
++#endif
++#if defined(__loongarch__) && __loongarch_grlen == 32
++	IMAGE_FILE_MACHINE_LOONGARCH32,
++#endif
+ 	0 };
+ 
+ /**
+diff --git a/lib/efi_loader/efi_runtime.c b/lib/efi_loader/efi_runtime.c
+index 73d4097464c..de50d72d634 100644
+--- a/lib/efi_loader/efi_runtime.c
++++ b/lib/efi_loader/efi_runtime.c
+@@ -78,6 +78,10 @@ struct dyn_sym {
+ #else
+ #error unknown riscv target
+ #endif
++#elif defined(__loongarch__)
++#define R_RELATIVE	R_LARCH_RELATIVE
++#define R_MASK		0xffffffffULL
++#define IS_RELA		1
+ #else
+ #error Need to add relocation awareness
+ #endif
+diff --git a/lib/efi_selftest/efi_selftest_miniapp_exception.c b/lib/efi_selftest/efi_selftest_miniapp_exception.c
+index f668cdac4ab..648206c1709 100644
+--- a/lib/efi_selftest/efi_selftest_miniapp_exception.c
++++ b/lib/efi_selftest/efi_selftest_miniapp_exception.c
+@@ -35,6 +35,9 @@ efi_status_t EFIAPI efi_main(efi_handle_t handle,
+ 	asm volatile (".word 0xffffffff\n");
+ #elif defined(CONFIG_X86)
+ 	asm volatile (".word 0xffff\n");
++#elif defined(CONFIG_LOONGARCH)
++	/* ud 31 */
++	asm volatile (".word 0x386007ff\n");
+ #elif defined(CONFIG_SANDBOX)
+ #if (HOST_ARCH == HOST_ARCH_ARM || HOST_ARCH == HOST_ARCH_AARCH64)
+ 	asm volatile (".word 0xe7f7defb\n");
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0018-efi-LoongArch-Implement-everything.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0018-efi-LoongArch-Implement-everything.patch
@@ -1,0 +1,520 @@
+From a2a39e6389b52a0ec98b895990e494d3a5cc7a07 Mon Sep 17 00:00:00 2001
+From: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Date: Wed, 22 May 2024 16:34:59 +0100
+Subject: [PATCH 18/22] efi: LoongArch: Implement everything
+
+Implement crt, reloc, linker scripts, wire things up in
+Makefiles and Kconfig.
+
+Signed-off-by: Jiaxun Yang <jiaxun.yang@flygoat.com>
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/config.mk                 |   4 +
+ arch/loongarch/lib/Makefile              |  12 ++
+ arch/loongarch/lib/crt0_loongarch_efi.S  | 182 +++++++++++++++++++++++
+ arch/loongarch/lib/elf_loongarch_efi.lds |  76 ++++++++++
+ arch/loongarch/lib/reloc_loongarch_efi.c | 107 +++++++++++++
+ lib/efi_loader/Kconfig                   |   2 +-
+ lib/efi_loader/efi_helper.c              |   3 +
+ lib/efi_loader/efi_image_loader.c        |  26 ++++
+ 8 files changed, 411 insertions(+), 1 deletion(-)
+ create mode 100644 arch/loongarch/lib/crt0_loongarch_efi.S
+ create mode 100644 arch/loongarch/lib/elf_loongarch_efi.lds
+ create mode 100644 arch/loongarch/lib/reloc_loongarch_efi.c
+
+diff --git a/arch/loongarch/config.mk b/arch/loongarch/config.mk
+index 7c247400e36..bae4566e9b6 100644
+--- a/arch/loongarch/config.mk
++++ b/arch/loongarch/config.mk
+@@ -21,3 +21,7 @@ endif
+ PLATFORM_CPPFLAGS	+= -fpic
+ PLATFORM_RELFLAGS	+= -fno-common -ffunction-sections -fdata-sections
+ LDFLAGS_u-boot		+= --gc-sections -static -pie
++
++EFI_LDS				:= elf_loongarch_efi.lds
++EFI_CRT0			:= crt0_loongarch_efi.o
++EFI_RELOC			:= reloc_loongarch_efi.o
+diff --git a/arch/loongarch/lib/Makefile b/arch/loongarch/lib/Makefile
+index e65e66357a9..17d2b1160b4 100644
+--- a/arch/loongarch/lib/Makefile
++++ b/arch/loongarch/lib/Makefile
+@@ -12,3 +12,15 @@ ifeq ($(CONFIG_$(SPL_)SYSRESET),)
+ obj-y	+= reset.o
+ endif
+ obj-y	+= setjmp.o
++
++# For building EFI apps
++CFLAGS_NON_EFI := -fstack-protector-strong
++CFLAGS_$(EFI_CRT0) := $(CFLAGS_EFI)
++CFLAGS_REMOVE_$(EFI_CRT0) := $(CFLAGS_NON_EFI)
++
++CFLAGS_$(EFI_RELOC) := $(CFLAGS_EFI)
++CFLAGS_REMOVE_$(EFI_RELOC) := $(CFLAGS_NON_EFI)
++
++extra-$(CONFIG_CMD_BOOTEFI_HELLO_COMPILE) += $(EFI_CRT0) $(EFI_RELOC)
++extra-$(CONFIG_CMD_BOOTEFI_SELFTEST) += $(EFI_CRT0) $(EFI_RELOC)
++extra-$(CONFIG_EFI) += $(EFI_CRT0) $(EFI_RELOC)
+diff --git a/arch/loongarch/lib/crt0_loongarch_efi.S b/arch/loongarch/lib/crt0_loongarch_efi.S
+new file mode 100644
+index 00000000000..2048d3b515c
+--- /dev/null
++++ b/arch/loongarch/lib/crt0_loongarch_efi.S
+@@ -0,0 +1,182 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * crt0-efi-loongarch.S - PE/COFF header for LoongArch EFI applications
++ *
++ * Copright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
++ */
++
++#include <asm-generic/pe.h>
++#include <asm/asm.h>
++
++#if __loongarch_grlen == 64
++#define PE_MACHINE	IMAGE_FILE_MACHINE_LOONGARCH64
++#define PE_MAGIC    IMAGE_NT_OPTIONAL_HDR64_MAGIC
++#define IMG_CHARACTERISTICS \
++	(IMAGE_FILE_EXECUTABLE_IMAGE | \
++	 IMAGE_FILE_LINE_NUMS_STRIPPED | \
++	 IMAGE_FILE_LOCAL_SYMS_STRIPPED | \
++	 IMAGE_FILE_LARGE_ADDRESS_AWARE | \
++	 IMAGE_FILE_DEBUG_STRIPPED)
++#else
++#define PE_MACHINE	IMAGE_FILE_MACHINE_LOONGARCH32
++#define PE_MAGIC    IMAGE_NT_OPTIONAL_HDR32_MAGIC
++#define IMG_CHARACTERISTICS \
++	(IMAGE_FILE_EXECUTABLE_IMAGE | \
++	 IMAGE_FILE_LINE_NUMS_STRIPPED | \
++	 IMAGE_FILE_LOCAL_SYMS_STRIPPED | \
++	 IMAGE_FILE_DEBUG_STRIPPED)
++#endif
++
++	.section	.text.head
++
++	/*
++	 * Magic "MZ" signature for PE/COFF
++	 */
++	.globl	ImageBase
++ImageBase:
++	.short	IMAGE_DOS_SIGNATURE		/* 'MZ' */
++	.skip	58
++	.long	pe_header - ImageBase		/* Offset to the PE header */
++pe_header:
++	.long	IMAGE_NT_SIGNATURE		/* 'PE' */
++coff_header:
++	.short	PE_MACHINE			/* LoongArch 64/32-bit */
++	.short	3				/* nr_sections */
++	.long	0				/* TimeDateStamp */
++	.long	0				/* PointerToSymbolTable */
++	.long	0				/* NumberOfSymbols */
++	.short	section_table - optional_header	/* SizeOfOptionalHeader */
++	.short	IMG_CHARACTERISTICS		/* Characteristics */
++optional_header:
++	.short	PE_MAGIC			/* PE32(+) format */
++	.byte	0x02				/* MajorLinkerVersion */
++	.byte	0x14				/* MinorLinkerVersion */
++	.long	_edata - _start			/* SizeOfCode */
++	.long	0				/* SizeOfInitializedData */
++	.long	0				/* SizeOfUninitializedData */
++	.long	_start - ImageBase		/* AddressOfEntryPoint */
++	.long	_start - ImageBase		/* BaseOfCode */
++#if __loongarch_grlen != 64
++	.long	0				/* BaseOfData */
++#endif
++
++extra_header_fields:
++	LONG	0
++	.long	0x200				/* SectionAlignment */
++	.long	0x200				/* FileAlignment */
++	.short	0				/* MajorOperatingSystemVersion */
++	.short	0				/* MinorOperatingSystemVersion */
++	.short	1				/* MajorImageVersion */
++	.short	0				/* MinorImageVersion */
++	.short	0				/* MajorSubsystemVersion */
++	.short	0				/* MinorSubsystemVersion */
++	.long	0				/* Win32VersionValue */
++
++	.long	_edata - ImageBase		/* SizeOfImage */
++
++	/*
++	 * Everything before the kernel image is considered part of the header
++	 */
++	.long	_start - ImageBase		/* SizeOfHeaders */
++	.long	0				/* CheckSum */
++	.short	IMAGE_SUBSYSTEM_EFI_APPLICATION /* Subsystem */
++#if CONFIG_VENDOR_EFI
++	.short	0				/* DllCharacteristics */
++#else
++	.short	IMAGE_DLLCHARACTERISTICS_NX_COMPAT
++#endif
++	LONG	0				/* SizeOfStackReserve */
++	LONG	0				/* SizeOfStackCommit */
++	LONG	0				/* SizeOfHeapReserve */
++	LONG	0				/* SizeOfHeapCommit */
++
++	.long	0				/* LoaderFlags */
++	.long	0x6				/* NumberOfRvaAndSizes */
++
++	.quad	0				/* ExportTable */
++	.quad	0				/* ImportTable */
++	.quad	0				/* ResourceTable */
++	.quad	0				/* ExceptionTable */
++	.quad	0				/* CertificationTable */
++	.quad	0				/* BaseRelocationTable */
++
++	/* Section table */
++section_table:
++
++	/*
++	 * The EFI application loader requires a relocation section
++	 * because EFI applications must be relocatable.  This is a
++	 * dummy section as far as we are concerned.
++	 */
++	.ascii	".reloc"
++	.byte	0
++	.byte	0			/* end of 0 padding of section name */
++	.long	0
++	.long	0
++	.long	0			/* SizeOfRawData */
++	.long	0			/* PointerToRawData */
++	.long	0			/* PointerToRelocations */
++	.long	0			/* PointerToLineNumbers */
++	.short	0			/* NumberOfRelocations */
++	.short	0			/* NumberOfLineNumbers */
++	.long	0x42100040		/* Characteristics (section flags) */
++
++
++	.ascii	".text"
++	.byte	0
++	.byte	0
++	.byte	0			/* end of 0 padding of section name */
++	.long	_etext - _start		/* VirtualSize */
++	.long	_start - ImageBase	/* VirtualAddress */
++	.long	_etext - _start		/* SizeOfRawData */
++	.long	_start - ImageBase	/* PointerToRawData */
++	.long	0			/* PointerToRelocations (0 for executables) */
++	.long	0			/* PointerToLineNumbers (0 for executables) */
++	.short	0			/* NumberOfRelocations  (0 for executables) */
++	.short	0			/* NumberOfLineNumbers  (0 for executables) */
++	/* Characteristics (section flags) */
++	.long	(IMAGE_SCN_MEM_READ | \
++		 IMAGE_SCN_MEM_EXECUTE | \
++		 IMAGE_SCN_CNT_CODE)
++
++	.ascii	".data"
++	.byte	0
++	.byte	0
++	.byte	0			/* end of 0 padding of section name */
++	.long	_edata - _data		/* VirtualSize */
++	.long	_data - ImageBase	/* VirtualAddress */
++	.long	_edata - _data		/* SizeOfRawData */
++	.long	_data - ImageBase	/* PointerToRawData */
++	.long	0			/* PointerToRelocations */
++	.long	0			/* PointerToLineNumbers */
++	.short	0			/* NumberOfRelocations */
++	.short	0			/* NumberOfLineNumbers */
++	/* Characteristics (section flags) */
++	.long	(IMAGE_SCN_MEM_WRITE | \
++		 IMAGE_SCN_MEM_READ | \
++		 IMAGE_SCN_CNT_INITIALIZED_DATA)
++
++	.align		12
++	.globl	_start
++	.type	_start, @function
++_start:
++	PTR_ADDI	sp, sp, -(3 * LONGSIZE)
++	LONG_S		ra, sp, 0
++	LONG_S		a0, sp, (1 * LONGSIZE)
++	LONG_S		a1, sp, (2 * LONGSIZE)
++
++	move		a2, a0		/* a2: ImageHandle */
++	move		a3, a1		/* a3: SystemTable */
++	la.local	a0, ImageBase	/* a0: ImageBase */
++	la.local	a1, _DYNAMIC	/* a1: DynamicSection */
++	bl 	  	_relocate
++	bnez		a0, 0f
++
++	LONG_L		a0, sp, (1 * LONGSIZE)
++	LONG_L		a1, sp, (2 * LONGSIZE)
++	bl		efi_main
++
++0:	LONG_L		ra, sp, 0
++	PTR_ADDI	sp, sp, (3 * LONGSIZE)
++	jr			ra
++	.end	  _start
+diff --git a/arch/loongarch/lib/elf_loongarch_efi.lds b/arch/loongarch/lib/elf_loongarch_efi.lds
+new file mode 100644
+index 00000000000..050e5a52a0b
+--- /dev/null
++++ b/arch/loongarch/lib/elf_loongarch_efi.lds
+@@ -0,0 +1,76 @@
++/* SPDX-License-Identifier: BSD-2-Clause */
++/*
++ * U-Boot LoongArch
++ *
++ * Modified from arch/riscv/lib/elf_riscv64_efi.lds
++ */
++
++OUTPUT_ARCH(loongarch)
++
++PHDRS
++{
++	data PT_LOAD FLAGS(3); /* SHF_WRITE | SHF_ALLOC */
++}
++
++ENTRY(_start)
++SECTIONS
++{
++	.text 0x0 : {
++		_text = .;
++		*(.text.head)
++		*(.text)
++		*(.text.*)
++		*(.gnu.linkonce.t.*)
++		*(.srodata)
++		*(.rodata*)
++		. = ALIGN(16);
++		*(.dynamic);
++		. = ALIGN(512);
++	}
++	.rela.dyn : { *(.rela.dyn) }
++	.rela.plt : { *(.rela.plt) }
++	.rela.got : { *(.rela.got) }
++	.rela.data : { *(.rela.data) *(.rela.data*) }
++	_etext = .;
++	_text_size = . - _text;
++	. = ALIGN(4096);
++	.data : {
++		_data = .;
++		*(.sdata)
++		*(.data)
++		*(.data1)
++		*(.data.*)
++		*(.got.plt)
++		*(.got)
++
++		/*
++		 * The EFI loader doesn't seem to like a .bss section, so we
++		 * stick it all into .data:
++		 */
++		. = ALIGN(16);
++		_bss = .;
++		*(.sbss)
++		*(.scommon)
++		*(.dynbss)
++		*(.bss)
++		*(.bss.*)
++		*(COMMON)
++		. = ALIGN(512);
++		_bss_end = .;
++		_edata = .;
++	} :data
++	_data_size = _edata - _data;
++
++	. = ALIGN(4096);
++	.dynsym   : { *(.dynsym) }
++	. = ALIGN(4096);
++	.dynstr   : { *(.dynstr) }
++	. = ALIGN(4096);
++	.note.gnu.build-id : { *(.note.gnu.build-id) }
++	/DISCARD/ : {
++		*(.rel.reloc)
++		*(.eh_frame)
++		*(.note.GNU-stack)
++	}
++	.comment 0 : { *(.comment) }
++}
+diff --git a/arch/loongarch/lib/reloc_loongarch_efi.c b/arch/loongarch/lib/reloc_loongarch_efi.c
+new file mode 100644
+index 00000000000..2985da268d8
+--- /dev/null
++++ b/arch/loongarch/lib/reloc_loongarch_efi.c
+@@ -0,0 +1,107 @@
++// SPDX-License-Identifier: GPL-2.0+
++/* reloc_loongarch.c - position independent ELF shared object relocator
++   Copyright (C) 2018 Alexander Graf <agraf@suse.de>
++   Copyright (C) 2014 Linaro Ltd. <ard.biesheuvel@linaro.org>
++   Copyright (C) 1999 Hewlett-Packard Co.
++	Contributed by David Mosberger <davidm@hpl.hp.com>.
++
++    All rights reserved.
++
++    Redistribution and use in source and binary forms, with or without
++    modification, are permitted provided that the following conditions
++    are met:
++
++    * Redistributions of source code must retain the above copyright
++      notice, this list of conditions and the following disclaimer.
++    * Redistributions in binary form must reproduce the above
++      copyright notice, this list of conditions and the following
++      disclaimer in the documentation and/or other materials
++      provided with the distribution.
++    * Neither the name of Hewlett-Packard Co. nor the names of its
++      contributors may be used to endorse or promote products derived
++      from this software without specific prior written permission.
++
++    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
++    CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
++    INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
++    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
++    BE LIABLE FOR ANYDIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
++    OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
++    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
++    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
++    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
++    TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
++    THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
++    SUCH DAMAGE.
++*/
++
++#include <efi.h>
++
++#include <elf.h>
++
++#if __loongarch_grlen == 64
++#define Elf_Dyn		Elf64_Dyn
++#define Elf_Rela	Elf64_Rela
++#define ELF_R_TYPE	ELF64_R_TYPE
++#else
++#define Elf_Dyn		Elf32_Dyn
++#define Elf_Rela	Elf32_Rela
++#define ELF_R_TYPE	ELF32_R_TYPE
++#endif
++
++efi_status_t EFIAPI _relocate(long ldbase, Elf_Dyn *dyn)
++{
++	long relsz = 0, relent = 0;
++	Elf_Rela *rel = 0;
++	unsigned long *addr;
++	int i;
++
++	for (i = 0; dyn[i].d_tag != DT_NULL; ++i) {
++		switch (dyn[i].d_tag) {
++		case DT_RELA:
++			rel = (Elf_Rela *)
++				((unsigned long)dyn[i].d_un.d_ptr
++					+ ldbase);
++			break;
++		case DT_RELASZ:
++			relsz = dyn[i].d_un.d_val;
++			break;
++		case DT_RELAENT:
++			relent = dyn[i].d_un.d_val;
++			break;
++		case DT_PLTGOT:
++			addr = (unsigned long *)
++				((unsigned long)dyn[i].d_un.d_ptr
++					+ ldbase);
++			break;
++		default:
++			break;
++		}
++	}
++
++	if (!rel && relent == 0)
++		return EFI_SUCCESS;
++
++	if (!rel || relent == 0)
++		return EFI_LOAD_ERROR;
++
++	while (relsz > 0) {
++		/* apply the relocs */
++		switch (ELF_R_TYPE(rel->r_info)) {
++		case R_LARCH_NONE:
++			break;
++		case R_LARCH_RELATIVE:
++			addr = (unsigned long *)
++				(ldbase + rel->r_offset);
++			*addr += ldbase;
++			break;
++		default:
++			break;
++		}
++		rel = (Elf_Rela *)((char *)rel + relent);
++		relsz -= relent;
++	}
++	return EFI_SUCCESS;
++}
++
+diff --git a/lib/efi_loader/Kconfig b/lib/efi_loader/Kconfig
+index 4cb13ae7c8a..89988f199f7 100644
+--- a/lib/efi_loader/Kconfig
++++ b/lib/efi_loader/Kconfig
+@@ -7,7 +7,7 @@ config EFI_LOADER
+ 			SYS_CPU = arm1176 || \
+ 			SYS_CPU = armv7   || \
+ 			SYS_CPU = armv8)  || \
+-		X86 || RISCV || SANDBOX)
++		X86 || RISCV || LOONGARCH || SANDBOX)
+ 	# We have not fully removed the requirement for some block device
+ 	depends on BLK
+ 	# We need EFI_STUB_64BIT to be set on x86_64 with EFI_STUB
+diff --git a/lib/efi_loader/efi_helper.c b/lib/efi_loader/efi_helper.c
+index bc48e265b90..641b001a9a1 100644
+--- a/lib/efi_loader/efi_helper.c
++++ b/lib/efi_loader/efi_helper.c
+@@ -44,6 +44,9 @@
+ #elif HOST_ARCH == HOST_ARCH_RISCV64
+ #define HOST_BOOTEFI_NAME "BOOTRISCV64.EFI"
+ #define HOST_PXE_ARCH 0x1b
++#elif HOST_ARCH == HOST_ARCH_LOONGARCH64
++#define HOST_BOOTEFI_NAME "BOOTLOONGARCH64.EFI"
++#define HOST_PXE_ARCH 0x27
+ #else
+ #error Unsupported Host architecture
+ #endif
+diff --git a/lib/efi_loader/efi_image_loader.c b/lib/efi_loader/efi_image_loader.c
+index bed5f181726..3c28923003d 100644
+--- a/lib/efi_loader/efi_image_loader.c
++++ b/lib/efi_loader/efi_image_loader.c
+@@ -19,6 +19,7 @@
+ #include <crypto/mscode.h>
+ #include <crypto/pkcs7_parser.h>
+ #include <linux/err.h>
++#include <linux/bitfield.h>
+ 
+ const efi_guid_t efi_global_variable_guid = EFI_GLOBAL_VARIABLE_GUID;
+ const efi_guid_t efi_guid_device_path = EFI_DEVICE_PATH_PROTOCOL_GUID;
+@@ -165,6 +166,7 @@ static efi_status_t efi_loader_relocate(const IMAGE_BASE_RELOCATION *rel,
+ 			uint32_t entry_offset = *relocs & 0xfff;
+ 			unsigned long offset;
+ 			int type = *relocs >> EFI_PAGE_SHIFT;
++			__maybe_unused uint64_t tmp;
+ 			uint64_t *x64;
+ 			uint32_t *x32;
+ 			uint16_t *x16;
+@@ -230,6 +232,30 @@ static efi_status_t efi_loader_relocate(const IMAGE_BASE_RELOCATION *rel,
+ 					log_err("Unsupported reloc offset\n");
+ 					return EFI_LOAD_ERROR;
+ 				}
++				break;
++#elif defined(__loongarch__) && __loongarch_grlen == 64
++			case IMAGE_REL_BASED_LOONGARCH64_MARK_LA:
++				if (virt_size - offset < 16) {
++					log_debug("relocation address out of bounds\n");
++					return EFI_LOAD_ERROR;
++				}
++
++				tmp = FIELD_GET(GENMASK(24, 5), x32[0]) << 12;
++				tmp |= FIELD_GET(GENMASK(21, 10), x32[1]);
++				tmp |= FIELD_GET(GENMASK(24, 5), x32[2]) << 32;
++				tmp |= FIELD_GET(GENMASK(21, 10), x32[3]) << 52;
++				tmp += (uint64_t)delta;
++
++				x32[0] &= ~GENMASK(24, 5);
++				x32[0] |= FIELD_PREP(GENMASK(24, 5), tmp >> 12);
++				x32[1] &= ~GENMASK(21, 10);
++				x32[1] |= FIELD_PREP(GENMASK(21, 10), tmp);
++				x32[2] &= ~GENMASK(24, 5);
++				x32[2] |= FIELD_PREP(GENMASK(24, 5), tmp >> 32);
++				x32[3] &= ~GENMASK(21, 10);
++				x32[3] |= FIELD_PREP(GENMASK(21, 10),
++						     tmp >> 52);
++
+ 				break;
+ #endif
+ 			default:
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0019-Select-HAVE_SETMP.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0019-Select-HAVE_SETMP.patch
@@ -1,0 +1,25 @@
+From d1ddeda7c9cdf93549d1a6d0da9d6ccc86ee4e88 Mon Sep 17 00:00:00 2001
+From: Yao Zi <me@ziyao.cc>
+Date: Thu, 23 Jul 2026 06:01:08 +0000
+Subject: [PATCH 19/22] Select HAVE_SETMP
+
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/Kconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/arch/Kconfig b/arch/Kconfig
+index 98e1e58c619..bf6520def20 100644
+--- a/arch/Kconfig
++++ b/arch/Kconfig
+@@ -112,6 +112,7 @@ config ARM
+ 
+ config LOONGARCH
+ 	bool "LoongArch architecture"
++	select HAVE_SETJMP
+ 	select CREATE_ARCH_SYMLINK
+ 	select SUPPORT_OF_CONTROL
+ 	select OF_CONTROL
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0020-Clean-up-setjmp.h.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0020-Clean-up-setjmp.h.patch
@@ -1,0 +1,38 @@
+From 7e30bce5b186ce098df42b03ebcf33f5c6639b3c Mon Sep 17 00:00:00 2001
+From: Yao Zi <me@ziyao.cc>
+Date: Thu, 23 Jul 2026 06:01:25 +0000
+Subject: [PATCH 20/22] Clean up setjmp.h
+
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ arch/loongarch/include/asm/setjmp.h | 9 ++-------
+ 1 file changed, 2 insertions(+), 7 deletions(-)
+
+diff --git a/arch/loongarch/include/asm/setjmp.h b/arch/loongarch/include/asm/setjmp.h
+index 295198a3896..4fec81fdc41 100644
+--- a/arch/loongarch/include/asm/setjmp.h
++++ b/arch/loongarch/include/asm/setjmp.h
+@@ -3,8 +3,8 @@
+  * Copyright (C) 2024 Jiaxun Yang <jiaxun.yang@flygoat.com>
+  */
+ 
+-#ifndef _SETJMP_H_
+-#define _SETJMP_H_
++#ifndef _ASM_SETJMP_H_
++#define _ASM_SETJMP_H_
+ 
+ /*
+  * This really should be opaque, but the EFI implementation wrongly
+@@ -17,9 +17,4 @@ struct jmp_buf_data {
+ 	unsigned long ra;
+ };
+ 
+-typedef struct jmp_buf_data jmp_buf[1];
+-
+-int setjmp(jmp_buf jmp);
+-void longjmp(jmp_buf jmp, int ret);
+-
+ #endif /* _SETJMP_H_ */
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0021-CI-Wire-up-qemu-loongarch64.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0021-CI-Wire-up-qemu-loongarch64.patch
@@ -1,0 +1,72 @@
+From f394b7d32901c53c9d8830e3c90c4af3067c612e Mon Sep 17 00:00:00 2001
+From: Yao Zi <me@ziyao.cc>
+Date: Thu, 23 Jul 2026 08:35:16 +0000
+Subject: [PATCH 21/22] CI: Wire up qemu-loongarch64
+
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ .azure-pipelines.yml | 9 ++++++---
+ .gitlab-ci.yml       | 6 ++++++
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/.azure-pipelines.yml b/.azure-pipelines.yml
+index 5bda11a0309..260826c0cb7 100644
+--- a/.azure-pipelines.yml
++++ b/.azure-pipelines.yml
+@@ -20,7 +20,7 @@ variables:
+   k3_64b: "k3 -x armv7,phytec,toradex"
+   kirkwood_mvebu: "kirkwood mvebu"
+   layerscape_vf610: "ls1 ls2 lx2 vf610 -x phytec,toradex"
+-  m68k_remaining_mx_xtensa: "m68k imxrt mx xtensa -x mx6,aarch64"
++  loongarch_m68k_remaining_mx_xtensa: "loongarch m68k imxrt mx xtensa -x mx6,aarch64"
+   mips_x86: "mips x86 -x mediatek"
+   mx6: "mx6 -x engicam,phytec,toradex"
+   imx8: "imx8 -x engicam,phytec,toradex"
+@@ -240,7 +240,7 @@ stages:
+           built="$built $(tools/buildman/buildman ${BMANARGS} $(k3_64b) | grep '^   ')"
+           built="$built $(tools/buildman/buildman ${BMANARGS} $(kirkwood_mvebu) | grep '^   ')"
+           built="$built $(tools/buildman/buildman ${BMANARGS} $(layerscape_vf610) | grep '^   ')"
+-          built="$built $(tools/buildman/buildman ${BMANARGS} $(m68k_remaining_mx_xtensa) | grep '^   ')"
++          built="$built $(tools/buildman/buildman ${BMANARGS} $(loongarch_m68k_remaining_mx_xtensa) | grep '^   ')"
+           built="$built $(tools/buildman/buildman ${BMANARGS} $(mips_x86) | grep '^   ')"
+           built="$built $(tools/buildman/buildman ${BMANARGS} $(mx6) | grep '^   ')"
+           built="$built $(tools/buildman/buildman ${BMANARGS} $(imx8) | grep '^   ')"
+@@ -518,6 +518,9 @@ stages:
+         qemu_arm_sbsa_ref:
+           TEST_PY_BD: "qemu-arm-sbsa"
+           TEST_PY_TEST_SPEC: "not sleep"
++        qemu_loongarch64:
++          TEST_PY_BD: "qemu-loongarch64"
++          TEST_PY_TEST_SPEC: "not sleep"
+         qemu_m68k:
+           TEST_PY_BD: "M5208EVBE"
+           TEST_PY_ID: "--id qemu"
+@@ -685,7 +688,7 @@ stages:
+           BUILDMAN: $(kirkwood_mvebu)
+         layerscape_vf610:
+           BUILDMAN: $(layerscape_vf610)
+-        m68k_remaining_mx_xtensa:
++        loongarch_m68k_remaining_mx_xtensa:
+           BUILDMAN: $(m68k_remaining_mx_xtensa)
+         mips_x86:
+           BUILDMAN: $(mips_x86)
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index c2716af1904..167feffe324 100644
+--- a/.gitlab-ci.yml
++++ b/.gitlab-ci.yml
+@@ -414,6 +414,12 @@ qemu_arm_sbsa test.py:
+     TEST_PY_TEST_SPEC: "not sleep"
+   <<: *buildman_and_testpy_dfn
+ 
++qemu_loongarch64 test.py:
++  variables:
++    TEST_PY_BD: "qemu-loongarch64"
++    TEST_PY_TEST_SPEC: "not sleep"
++  <<: *buildman_and_testpy_dfn
++
+ qemu_m68k test.py:
+   variables:
+     TEST_PY_BD: "M5208EVBE"
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/autobuild/patches/0022-NFU-CI-Switch-to-Yao-Zi-s-docker-image.patch
+++ b/app-utils/uboot-tools/autobuild/patches/0022-NFU-CI-Switch-to-Yao-Zi-s-docker-image.patch
@@ -1,0 +1,40 @@
+From 510511901dce0167abaf4923316222cd73d63e30 Mon Sep 17 00:00:00 2001
+From: Yao Zi <me@ziyao.cc>
+Date: Thu, 23 Jul 2026 08:36:19 +0000
+Subject: [PATCH 22/22] NFU: CI: Switch to Yao Zi's docker image
+
+Signed-off-by: Yao Zi <me@ziyao.cc>
+---
+ .azure-pipelines.yml | 2 +-
+ .gitlab-ci.yml       | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/.azure-pipelines.yml b/.azure-pipelines.yml
+index 260826c0cb7..40b2c99ec97 100644
+--- a/.azure-pipelines.yml
++++ b/.azure-pipelines.yml
+@@ -2,7 +2,7 @@ variables:
+   windows_vm: windows-2022
+   ubuntu_vm: ubuntu-24.04
+   macos_vm: macOS-14
+-  ci_runner_image: trini/u-boot-gitlab-ci-runner:noble-20251013-23Jan2026
++  ci_runner_image: ghcr.io/ziyao233/u-boot-test:202607231206
+   # Ensure we do a shallow clone
+   Agent.Source.Git.ShallowFetchDepth: 1
+   # Add '-u 0' options for Azure pipelines, otherwise we get "permission
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index 167feffe324..3712c5909d8 100644
+--- a/.gitlab-ci.yml
++++ b/.gitlab-ci.yml
+@@ -19,7 +19,7 @@ workflow:
+ 
+ # Grab our configured image.  The source for this is found
+ # in the u-boot tree at tools/docker/Dockerfile
+-image: ${MIRROR_DOCKER}/trini/u-boot-gitlab-ci-runner:noble-20251013-23Jan2026
++image: ghcr.io/ziyao233/u-boot-test:202607231206
+ 
+ # We run some tests in different order, to catch some failures quicker.
+ stages:
+-- 
+2.55.0
+

--- a/app-utils/uboot-tools/spec
+++ b/app-utils/uboot-tools/spec
@@ -1,4 +1,4 @@
-VER=2026.04
+VER=2026.07
 SRCS="tbl::https://ftp.denx.de/pub/u-boot/u-boot-$VER.tar.bz2"
-CHKSUMS="sha256::ac7c04b8b7004923b00a4e5d6699c5df4d21233bac9fda690d8cfbc209fff2fd"
+CHKSUMS="sha256::78e8bfc382fe388f9b55aa1daf8c563522a037779b5d4c349d1415e381f1243e"
 CHKUPDATE="anitya::id=5022"


### PR DESCRIPTION
Topic Description
-----------------

- uboot-tools: update to 2026.07 and add loongarch64 support
    - Rebase pre-upstream patch series:
    https://git.u-boot-project.org/u-boot/custodians/u-boot-loongarch/-/tree/loongarch/port-v3-ci?ref_type=heads
    - Track patches at AOSC-Tracking/u-boot @ aosc/v2026.07
    \(HEAD: 510511901dce0167abaf4923316222cd73d63e30\)
    Co-authored-by: Ilikara \(@AirFortressIlikara\)
    Signed-off-by: Ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- uboot-tools: 2026.07

Security Update?
----------------

No

Build Order
-----------

```
#buildit uboot-tools
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
