### PR TITLE
wine-emukit: update to 11.15+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

### DIFF
--- a/app-emulation/wine-emukit/spec
+++ b/app-emulation/wine-emukit/spec
@@ -1,12 +1,13 @@
-# Note: Sync with main `wine' package.
+# Note: EPOCH and REL sync with main `wine' package.
 EPOCH=3
+REL=1
 __GECKO_VER=2.47.4
 __MONO_VER=11.2.0
 __DXVK_VER=3.0.2
 __VKD3D_PROTON_VER=3.0.1
-UPSTREAM_VER=11.14
+UPSTREAM_VER=11.15
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}+dxvk${__DXVK_VER}+vkd3dproton${__VKD3D_PROTON_VER}
-SRCS="file::rename=wine.deb::https://repo.aosc.io/anthon/debs/pool/stable/main/w/wine_${VER//+/%2B}-0_amd64.deb"
-CHKSUMS="sha256::744877466cd49ea01dff524c20041cd83f7dfe58a889f7ad34fcb1a1a18d7ba2"
+SRCS="file::rename=wine.deb::https://repo.aosc.io/anthon/debs/pool/stable/main/w/wine_${VER//+/%2B}-${REL}_amd64.deb"
+CHKSUMS="sha256::d92e498cf83ebfa4370ff9a09cc4fe2b796cb05a4cfb564fbf85e6d4674d9399"
 # Note: Binary repack from AOSC OS, no need to check update.
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- wine-emukit: update to 11.15+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

Package(s) Affected
-------------------

- wine: 11.15+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine-emukit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
