### PR TITLE
vscode: update to 1.134.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.133.0
+VER=1.134.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::d064e87e22f556b8a91e1354b5227e340597324e52886dbb288551596b00e34a"
-CHKSUMS__ARM64="sha256::b20bfb21c5b3656e3411391c5c18df1782aedd7cd3bda0b9c08363ea261fca4b"
+CHKSUMS__AMD64="sha256::dcd3a2f52d53df079cd389662ff1fdbeb629938331d3a63655fed929f8d49f19"
+CHKSUMS__ARM64="sha256::b30f5bda4855231681cc7fe22d4a59e7dbee2be170b0e4fb04c7e83b9f9affe5"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.134.0
    Co-authored-by: LJL \(@ljlofficial\) <lkjmlk@aosc.io>

Package(s) Affected
-------------------

- vscode: 1.134.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
