### PR TITLE
dankmaterialshell: fix wrong PKGCRECCOM

### DIFF
--- a/runtime-desktop/dankmaterialshell/autobuild/defines
+++ b/runtime-desktop/dankmaterialshell/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=dankmaterialshell
 PKGSEC=libs
 PKGDES="Desktop shell for Wayland compositors built with Quickshell and Go"
 PKGDEP="quickshell glibc"
-PKGCRECCOM="cava cliphist wl-clipboard matugun dgop danksearch"
+PKGRECOM="cava cliphist wl-clipboard matugen dgop danksearch"
 PKGSUG="i2c-tools accountsservice tuned cups-pk-helper greetd"
 PKGPROV="dms dms-shell"
 

--- a/runtime-desktop/dankmaterialshell/spec
+++ b/runtime-desktop/dankmaterialshell/spec
@@ -1,4 +1,5 @@
 VER=1.5.3
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AvengeMedia/DankMaterialShell.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388076"


### PR DESCRIPTION
Topic Description
-----------------

- dankmaterialshell: fix wrong PKGCRECCOM

Package(s) Affected
-------------------

- dankmaterialshell: 1.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit dankmaterialshell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
