### PR TITLE
weston: bump REL to fix core dump caused by binutils on arm64

### DIFF
--- a/runtime-display/weston/spec
+++ b/runtime-display/weston/spec
@@ -1,4 +1,5 @@
 VER=16.0.0
+REL=1
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/wayland/weston.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=13745"


### PR DESCRIPTION
Topic Description
-----------------

- weston: bump REL to fix core dump caused by binutils on arm64
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- weston: 16.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit weston
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
