### PR TITLE
dust: update to 1.2.5

### DIFF
--- a/app-utils/dust/autobuild/defines
+++ b/app-utils/dust/autobuild/defines
@@ -1,10 +1,8 @@
 PKGNAME=dust
 PKGSEC=utils
-BUILDDEP="llvm-20 rustc"
+BUILDDEP="llvm rustc"
 PKGDEP="glibc gcc-runtime"
-PKGDES="A CLI disk usage analyzer"
+PKGDES="CLI disk usage analyzer"
+ABTYPE=rust
 
 USECLANG=1
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGSON3=1

--- a/app-utils/dust/spec
+++ b/app-utils/dust/spec
@@ -1,4 +1,4 @@
-VER=1.2.4
+VER=1.2.5
 SRCS="git::commit=tags/v$VER::https://github.com/bootandy/dust"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141344"


### PR DESCRIPTION
Topic Description
-----------------

- dust: update to 1.2.5
    Co-authored-by: Chi_Tang \(@chitang233\) <me@chitang.dev>

Package(s) Affected
-------------------

- dust: 1.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit dust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
