### PR TITLE
rtl-sdr: update to 2.0.3

### DIFF
--- a/app-devices/rtl-sdr/autobuild/defines
+++ b/app-devices/rtl-sdr/autobuild/defines
@@ -3,3 +3,4 @@ PKGDES="Driver for Realtek RTL2832U that enables general-purpose, software-defin
 PKGDEP="glibc libusb"
 BUILDDEP="cmake"
 PKGSEC="hamradio"
+ABTYPE=cmakeninja

--- a/app-devices/rtl-sdr/spec
+++ b/app-devices/rtl-sdr/spec
@@ -1,4 +1,4 @@
-VER=2.0.2
+VER=2.0.3
 SRCS="git::commit=tags/v${VER}::https://gitea.osmocom.org/sdr/rtl-sdr.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=17786"


### PR DESCRIPTION
## Topic Description

Update rtl-sdr from 2.0.2 to 2.0.3.

## Package(s) Affected

rtl-sdr

## Security Update?

No

## Build Order

```text
#buildit rtl-sdr
```

## Test Build(s) Done

**Primary Architectures**

* [ ] AMD64 `amd64`
* [ ] AArch64 `arm64`
* [ ] LoongArch 64-bit `loongarch64`
* [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

* [ ] Loongson 3 `loongson3`
* [ ] PowerPC 64-bit (Little Endian) `ppc64el`
* [ ] RISC-V 64-bit `riscv64`
