### PR TITLE
ostree: update to 2026.4

### DIFF
--- a/app-admin/ostree/spec
+++ b/app-admin/ostree/spec
@@ -1,4 +1,4 @@
-VER=2026.3
+VER=2026.4
 SRCS="tbl::https://github.com/ostreedev/ostree/releases/download/v$VER/libostree-$VER.tar.xz"
-CHKSUMS="sha256::e560e47631d1f703e9ed3425e8909ccd87fa2992422c07348ca88ec98943c8fb"
+CHKSUMS="sha256::b26c9016eb03bb4ee52cc00c642d56e00fc79ae7faac6bf4aa317d7451339ef7"
 CHKUPDATE="anitya::id=10899"


### PR DESCRIPTION
Topic Description
-----------------

- ostree: update to 2026.4
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ostree: 2026.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit ostree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
