### PR TITLE
hamlib: new, 4.7.2

### DIFF
--- a/runtime-electronics/hamlib/autobuild/defines
+++ b/runtime-electronics/hamlib/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=hamlib
+PKGSEC=hamradio
+PKGDEP="gcc-runtime glibc libusb readline"
+BUILDDEP="pkgconf"
+PKGDES="Library for controlling amateur radio transceivers and radio equipment"
+
+ABTYPE=autotools

--- a/runtime-electronics/hamlib/spec
+++ b/runtime-electronics/hamlib/spec
@@ -1,0 +1,7 @@
+VER=4.7.2
+
+SRCS="tbl::https://github.com/Hamlib/Hamlib/releases/download/${VER}/hamlib-${VER}.tar.gz"
+
+CHKSUMS="sha256::ae1fcf2dbc80ea0786ea8f047b09399c3f7737d1930442f61a031708ed33e88f"
+
+CHKUPDATE="anitya::id=1292"


### PR DESCRIPTION
## Topic Description

Introduce Hamlib 4.7.2, a library for controlling amateur radio transceivers and other radio equipment.

## Package(s) Affected

* `hamlib`

## Security Update?

No

## Build Order

```text
#buildit hamlib
```

## Test Build(s) Done

**Primary Architectures**

* [ ] AMD64 `amd64`
* [ ] AArch64 `arm64`
* [ ] LoongArch 64-bit `loongarch64`
* [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

* [ ] Loongson 3 `loongson3`
* [ ] PowerPC 64-bit (Little Endian) `ppc64el`
* [ ] RISC-V 64-bit `riscv64`
