### PR TITLE
kitty: update to 0.48.2

### DIFF
--- a/app-utils/kitty/spec
+++ b/app-utils/kitty/spec
@@ -1,5 +1,4 @@
-VER=0.47.4
-REL=1
+VER=0.48.2
 SRCS="tbl::https://github.com/kovidgoyal/kitty/releases/download/v${VER}/kitty-${VER}.tar.xz"
-CHKSUMS="sha256::7dede3743ab614409903a839ba1f264f772f4271ddf251e7d60b333cb4e51278"
+CHKSUMS="sha256::792a2bbde715bb26839677875a44202f1c30e91a20351842e0a61b5c6a1e666e"
 CHKUPDATE="anitya::id=17405"


### PR DESCRIPTION
Topic Description
-----------------

- kitty: update to 0.48.2
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- kitty: 0.48.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit kitty
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
