### PR TITLE
libuninameslist: update to 20260107

### DIFF
--- a/runtime-i18n/libuninameslist/autobuild/defines
+++ b/runtime-i18n/libuninameslist/autobuild/defines
@@ -1,4 +1,5 @@
 PKGNAME=libuninameslist
 PKGSEC=libs
 PKGDEP=""
-PKGDES="A library with a large (sparse) array mapping each Unicode code point to the annotation data"
+PKGDES="Library with a large (sparse) array mapping each Unicode code point to the annotation data"
+ABTYPE=autotools

--- a/runtime-i18n/libuninameslist/spec
+++ b/runtime-i18n/libuninameslist/spec
@@ -1,4 +1,4 @@
-VER=20240910
+VER=20260107
 SRCS="tbl::https://github.com/fontforge/libuninameslist/releases/download/$VER/libuninameslist-dist-$VER.tar.gz"
-CHKSUMS="sha256::e59aab324ca0a3a713fe85c09a56c40c680a8458438d90624597920b3ef0be26"
+CHKSUMS="sha256::aadfaf62a96f20914d8dd248e8f19325471ead0cf3133b2f8ae0624c2da3657b"
 CHKUPDATE="anitya::id=1746"


### PR DESCRIPTION
Topic Description
-----------------

- libuninameslist: update to 20260107
    Co-authored-by: 雨ノ宮 あめ \(@BillZhou233\)

Package(s) Affected
-------------------

- libuninameslist: 20260107

Security Update?
----------------

No

Build Order
-----------

```
#buildit libuninameslist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
