### PR TITLE
codex: update to 0.149.0

### DIFF
--- a/app-utils/codex/autobuild/defines
+++ b/app-utils/codex/autobuild/defines
@@ -1,20 +1,29 @@
 PKGNAME=codex
 PKGSEC=utils
 PKGDES="Coding agent that runs in terminal"
-PKGDEP="bzip2 gcc-runtime git glibc libcap openssl ripgrep xz zlib"
-BUILDDEP="rustc llvm gn ninja python-3"
+PKGDEP="bzip2 gcc-runtime git glibc openssl ripgrep xz"
+BUILDDEP="rustc llvm-22 gn ninja python-3 protobuf rust-bindgen"
 
 ABTYPE=rust
 USECLANG=1
 CARGO_AFTER=(
     '--bin' 'codex'
     '--bin' 'codex-responses-api-proxy'
+    '--bin' 'codex-code-mode-host'
 )
 
 # FIXME: error: undefined symbol: aws_lc_0_39_0_SHA256
 NOLTO=1
 
+# FIXME: -fexception breaks build.
+#
+# ../../../../../rusty_v8/third_party/partition_alloc/src/partition_alloc/shim/allocator_shim.cc:65:2: error: This code cannot be used when exceptions are turned on.
+# 65 | #error This code cannot be used when exceptions are turned on.
+# | ^ 
+AB_FLAGS_EXC=0
+
 # loongson3:
+#
 # ERROR at //build/config/rust.gni:363:3: Assertion failed.
 # assert(_is_rust_abi_target_a_known_triple,
 # ^-----
@@ -24,5 +33,15 @@ NOLTO=1
 # ^-------------------------------
 # See //build/config/BUILDCONFIG.gn:369:3: which caused the file to be included.
 # "//build/config/sanitizers:default_sanitizer_flags",
-# ^-------------------------------------------------- 
-FAIL_ARCH="loongson3"
+# ^--------------------------------------------------
+
+# ppc64el:
+#
+# ld.lld: error: undefined symbol: v8::internal::baseline::BaselineAssembler::JumpIfStaticRootToBoolean(v8::internal::Register, v8::internal::Label*, v8::internal::Label::Distance, v8::internal::Label*, v8::internal::Label::Distance)
+# >>> referenced by baseline-compiler.cc:2401 (../../../../../rusty_v8/v8/src/baseline/baseline-compiler.cc:2401)
+# >>> obj/v8/v8_base_without_compiler/baseline-compiler.o:(v8::internal::baseline::BaselineCompiler::VisitJumpIfToBooleanTrue())
+# >>> referenced by baseline-compiler.cc:2408 (../../../../../rusty_v8/v8/src/baseline/baseline-compiler.cc:2408)
+# >>> obj/v8/v8_base_without_compiler/baseline-compiler.o:(v8::internal::baseline::BaselineCompiler::VisitJumpIfToBooleanFalse())
+# >>> referenced by function.h:443 (../../../../../rusty_v8/third_party/libc++/src/include/__functional/function.h:443)
+# >>> obj/v8/v8_base_without_compiler/baseline-compiler.o:(void std::__Cr::__function::__policy_func<void (v8::internal::Label*, v8::internal::Label::Distance)>::__call_func<v8::internal::baseline::BaselineCompiler::VisitToBooleanLogicalNot()::$_0>(std::__Cr::__function::__policy_storage const*, v8::internal::Label*, v8::internal::Label::Distance))
+FAIL_ARCH="@(loongson3|ppc64el|retro)"

--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,20 +1,18 @@
-From 7ba4eb8405b0db7b3760b74ccda7105389a1fe36 Mon Sep 17 00:00:00 2001
+From 8a44414f0498722559dcc60717755440ace12415 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Tue, 23 Jun 2026 13:51:19 +0800
-Subject: [PATCH 1/2] AOSCOS: use local patched rusty_v8
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
+Date: Sat, 22 Aug 2026 09:31:57 +0800
+Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
+
 ---
  codex-rs/Cargo.lock | 2 --
  codex-rs/Cargo.toml | 2 ++
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 70880f3..d7fae91 100644
+index 471c342ff9..56d68e6c56 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -14620,8 +14620,6 @@ dependencies = [
+@@ -14874,8 +14874,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "150.4.0"
@@ -24,10 +22,10 @@ index 70880f3..d7fae91 100644
   "bindgen",
   "bitflags 2.13.1",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index c0945d9..adf526d 100644
+index 6e5fa01dda..7e4675e55b 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -582,5 +582,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -590,5 +590,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  
@@ -36,5 +34,5 @@ index c0945d9..adf526d 100644
  [patch."ssh://git@github.com/openai-oss-forks/tungstenite-rs.git"]
  tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "4fffad30fe373adbdcffab9545e9e9bf4f2fc19f" }
 -- 
-2.52.0
+2.55.0
 

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-use-system-protobuf.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-use-system-protobuf.patch
@@ -1,0 +1,121 @@
+From 8e5ae3a74c0ac23d96180324ef16aa11bba2535e Mon Sep 17 00:00:00 2001
+From: CAB233 <yidaduizuoye@outlook.com>
+Date: Sat, 22 Aug 2026 19:41:19 +0800
+Subject: [PATCH 2/3] AOSCOS: use system protobuf
+
+---
+ codex-rs/Cargo.lock                    | 65 --------------------------
+ codex-rs/code-mode-protocol/Cargo.toml |  1 -
+ codex-rs/code-mode-protocol/build.rs   |  1 -
+ 3 files changed, 67 deletions(-)
+
+diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
+index 56d68e6c56..f0217bacd1 100644
+--- a/codex-rs/Cargo.lock
++++ b/codex-rs/Cargo.lock
+@@ -2607,7 +2607,6 @@ dependencies = [
+  "glob",
+  "pretty_assertions",
+  "prost",
+- "protoc-bin-vendored",
+  "serde",
+  "serde_json",
+  "tokio",
+@@ -10837,70 +10836,6 @@ dependencies = [
+  "prost",
+ ]
+ 
+-[[package]]
+-name = "protoc-bin-vendored"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+-dependencies = [
+- "protoc-bin-vendored-linux-aarch_64",
+- "protoc-bin-vendored-linux-ppcle_64",
+- "protoc-bin-vendored-linux-s390_64",
+- "protoc-bin-vendored-linux-x86_32",
+- "protoc-bin-vendored-linux-x86_64",
+- "protoc-bin-vendored-macos-aarch_64",
+- "protoc-bin-vendored-macos-x86_64",
+- "protoc-bin-vendored-win32",
+-]
+-
+-[[package]]
+-name = "protoc-bin-vendored-linux-aarch_64"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+-
+-[[package]]
+-name = "protoc-bin-vendored-linux-ppcle_64"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+-
+-[[package]]
+-name = "protoc-bin-vendored-linux-s390_64"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+-
+-[[package]]
+-name = "protoc-bin-vendored-linux-x86_32"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+-
+-[[package]]
+-name = "protoc-bin-vendored-linux-x86_64"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+-
+-[[package]]
+-name = "protoc-bin-vendored-macos-aarch_64"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+-
+-[[package]]
+-name = "protoc-bin-vendored-macos-x86_64"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+-
+-[[package]]
+-name = "protoc-bin-vendored-win32"
+-version = "3.2.0"
+-source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+-
+ [[package]]
+ name = "psl"
+ version = "2.1.184"
+diff --git a/codex-rs/code-mode-protocol/Cargo.toml b/codex-rs/code-mode-protocol/Cargo.toml
+index cad10b47eb..60f86fcaf9 100644
+--- a/codex-rs/code-mode-protocol/Cargo.toml
++++ b/codex-rs/code-mode-protocol/Cargo.toml
+@@ -24,7 +24,6 @@ tonic-prost = { workspace = true }
+ 
+ [build-dependencies]
+ glob = { workspace = true }
+-protoc-bin-vendored = "3.2.0"
+ tonic-prost-build = { version = "=0.14.3", default-features = false, features = ["transport"] }
+ 
+ # Cargo-shear cannot inspect the prost and tonic-prost references in generated gRPC bindings.
+diff --git a/codex-rs/code-mode-protocol/build.rs b/codex-rs/code-mode-protocol/build.rs
+index d8d8bbff32..34d197cadf 100644
+--- a/codex-rs/code-mode-protocol/build.rs
++++ b/codex-rs/code-mode-protocol/build.rs
+@@ -5,7 +5,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
+     println!("cargo:rerun-if-changed=src/grpc");
+ 
+     let mut config = tonic_prost_build::Config::new();
+-    config.protoc_executable(protoc_bin_vendored::protoc_bin_path()?);
+     let proto_files = glob::glob("src/grpc/*.proto")?.collect::<Result<Vec<_>, _>>()?;
+ 
+     tonic_prost_build::configure()
+-- 
+2.55.0
+

--- a/app-utils/codex/autobuild/patches/0003-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0003-AOSCOS-fix-cargo.lock.patch
@@ -1,16 +1,14 @@
-From 8b0d1043250c7cd26d0042127cc9d9f1404eb505 Mon Sep 17 00:00:00 2001
+From 5b6f05d97c4f3f6a4993dc288e76504823bf5770 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
-Date: Tue, 23 Jun 2026 13:52:20 +0800
-Subject: [PATCH 2/2] AOSCOS: fix cargo.lock
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
+Date: Sat, 22 Aug 2026 09:32:23 +0800
+Subject: [PATCH 3/3] AOSCOS: fix cargo.lock
+
 ---
- codex-rs/Cargo.lock | 270 ++++++++++++++++++++++----------------------
- 1 file changed, 135 insertions(+), 135 deletions(-)
+ codex-rs/Cargo.lock | 278 ++++++++++++++++++++++----------------------
+ 1 file changed, 139 insertions(+), 139 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index d7fae91..3bdceb3 100644
+index f0217bacd1..66d0ecb4d2 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -394,7 +394,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
@@ -18,953 +16,980 @@ index d7fae91..3bdceb3 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1876,7 +1876,7 @@ dependencies = [
+@@ -1870,7 +1870,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-core",
-@@ -1888,7 +1888,7 @@ dependencies = [
+@@ -1882,7 +1882,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-graph-store"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
   "codex-state",
-@@ -1903,7 +1903,7 @@ dependencies = [
+@@ -1897,7 +1897,7 @@ dependencies = [
  
  [[package]]
  name = "codex-agent-identity"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -1923,7 +1923,7 @@ dependencies = [
+@@ -1917,7 +1917,7 @@ dependencies = [
  
  [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1944,7 +1944,7 @@ dependencies = [
+@@ -1938,7 +1938,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1953,7 +1953,7 @@ dependencies = [
+@@ -1947,7 +1947,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1988,7 +1988,7 @@ dependencies = [
+@@ -1982,7 +1982,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -2086,7 +2086,7 @@ dependencies = [
+@@ -2082,7 +2082,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -2113,7 +2113,7 @@ dependencies = [
+@@ -2109,7 +2109,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-daemon"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2134,7 +2134,7 @@ dependencies = [
+@@ -2130,7 +2130,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol-noop-macros",
-@@ -2165,11 +2165,11 @@ dependencies = [
+@@ -2163,11 +2163,11 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol-noop-macros"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2191,7 +2191,7 @@ dependencies = [
+@@ -2189,7 +2189,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-transport"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2233,7 +2233,7 @@ dependencies = [
+@@ -2231,7 +2231,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2253,7 +2253,7 @@ dependencies = [
+@@ -2251,7 +2251,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -2273,7 +2273,7 @@ dependencies = [
+@@ -2271,7 +2271,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
   "tokio",
-@@ -2282,7 +2282,7 @@ dependencies = [
+@@ -2280,7 +2280,7 @@ dependencies = [
  
  [[package]]
  name = "codex-aws-auth"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "aws-config",
   "aws-credential-types",
-@@ -2297,7 +2297,7 @@ dependencies = [
+@@ -2295,7 +2295,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -2317,7 +2317,7 @@ dependencies = [
+@@ -2315,7 +2315,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "serde",
   "serde_json",
-@@ -2326,7 +2326,7 @@ dependencies = [
+@@ -2324,7 +2324,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-build-info"
+-version = "0.0.0"
++version = "0.149.0"
+ dependencies = [
+  "codex-install-context",
+  "pretty_assertions",
+@@ -2336,7 +2336,7 @@ dependencies = [
  
  [[package]]
  name = "codex-bwrap"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "cc",
   "libc",
-@@ -2335,7 +2335,7 @@ dependencies = [
+@@ -2345,7 +2345,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2357,7 +2357,7 @@ dependencies = [
+@@ -2367,7 +2367,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -2443,7 +2443,7 @@ dependencies = [
+@@ -2455,7 +2455,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-http-client",
   "eventsource-stream",
-@@ -2455,7 +2455,7 @@ dependencies = [
+@@ -2468,7 +2468,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-config"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "chrono",
-@@ -2480,7 +2480,7 @@ dependencies = [
+@@ -2493,7 +2493,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2513,7 +2513,7 @@ dependencies = [
+@@ -2526,7 +2526,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2528,7 +2528,7 @@ dependencies = [
+@@ -2541,7 +2541,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "chrono",
   "codex-cloud-tasks-client",
-@@ -2537,7 +2537,7 @@ dependencies = [
+@@ -2550,7 +2550,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-code-mode-protocol",
   "codex-http-client",
-@@ -2554,7 +2554,7 @@ dependencies = [
+@@ -2574,7 +2574,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-host"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2578,7 +2578,7 @@ dependencies = [
+@@ -2601,7 +2601,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-protocol"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
-  "pretty_assertions",
-@@ -2590,7 +2590,7 @@ dependencies = [
+  "glob",
+@@ -2618,7 +2618,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-runtime"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-code-mode-protocol",
   "codex-protocol",
-@@ -2606,11 +2606,11 @@ dependencies = [
+@@ -2634,11 +2634,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -2658,7 +2658,7 @@ dependencies = [
+@@ -2686,7 +2686,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2680,7 +2680,7 @@ dependencies = [
+@@ -2708,7 +2708,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-connectors",
   "codex-core-plugins",
-@@ -2693,7 +2693,7 @@ dependencies = [
+@@ -2722,7 +2722,7 @@ dependencies = [
  
  [[package]]
  name = "codex-context-fragments"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -2701,7 +2701,7 @@ dependencies = [
+@@ -2730,7 +2730,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2830,7 +2830,7 @@ dependencies = [
+@@ -2861,7 +2861,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-api"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-analytics",
   "codex-app-server-protocol",
-@@ -2852,7 +2852,7 @@ dependencies = [
+@@ -2884,7 +2884,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-plugins"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2906,7 +2906,7 @@ dependencies = [
+@@ -2940,7 +2940,7 @@ dependencies = [
  
  [[package]]
- name = "codex-core-skills"
+ name = "codex-diagnostics"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
-  "anyhow",
-  "codex-analytics",
-@@ -2937,7 +2937,7 @@ dependencies = [
+  "libc",
+  "pretty_assertions",
+@@ -2948,7 +2948,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2983,7 +2983,7 @@ dependencies = [
+@@ -2995,7 +2995,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -3037,7 +3037,7 @@ dependencies = [
+@@ -3053,7 +3053,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server-protocol"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "codex-file-system",
-@@ -3052,7 +3052,7 @@ dependencies = [
+@@ -3068,7 +3068,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server-test-support"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-exec-server",
   "codex-http-client",
-@@ -3060,7 +3060,7 @@ dependencies = [
+@@ -3076,7 +3076,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3078,7 +3078,7 @@ dependencies = [
+@@ -3094,7 +3094,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -3087,7 +3087,7 @@ dependencies = [
+@@ -3103,7 +3103,7 @@ dependencies = [
  
  [[package]]
  name = "codex-extension-api"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-config",
   "codex-context-fragments",
-@@ -3103,7 +3103,7 @@ dependencies = [
+@@ -3120,7 +3120,7 @@ dependencies = [
  
  [[package]]
  name = "codex-extension-items"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-utils-absolute-path",
   "pretty_assertions",
-@@ -3115,7 +3115,7 @@ dependencies = [
+@@ -3132,7 +3132,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-migration"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "chrono",
   "codex-analytics",
-@@ -3144,7 +3144,7 @@ dependencies = [
+@@ -3162,7 +3162,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -3157,7 +3157,7 @@ dependencies = [
+@@ -3175,7 +3175,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
-  "codex-login",
-@@ -3171,7 +3171,7 @@ dependencies = [
+  "codex-http-client",
+@@ -3193,7 +3193,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3187,7 +3187,7 @@ dependencies = [
+@@ -3209,7 +3209,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-system"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "bytes",
   "codex-protocol",
-@@ -3199,7 +3199,7 @@ dependencies = [
+@@ -3221,7 +3221,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-watcher"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "notify",
   "pretty_assertions",
-@@ -3210,7 +3210,7 @@ dependencies = [
+@@ -3232,7 +3232,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-attribution"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-backend-client",
   "codex-extension-api",
-@@ -3223,7 +3223,7 @@ dependencies = [
+@@ -3245,7 +3245,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3249,7 +3249,7 @@ dependencies = [
+@@ -3271,7 +3271,7 @@ dependencies = [
  
  [[package]]
  name = "codex-goal-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3272,7 +3272,7 @@ dependencies = [
+@@ -3295,7 +3295,7 @@ dependencies = [
  
  [[package]]
- name = "codex-guardian"
+ name = "codex-guardian-v2"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
-  "codex-core",
-  "codex-extension-api",
-@@ -3281,7 +3281,7 @@ dependencies = [
+  "anyhow",
+  "codex-api",
+@@ -3317,7 +3317,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-history"
+-version = "0.0.0"
++version = "0.149.0"
+ dependencies = [
+  "anyhow",
+  "codex-protocol",
+@@ -3329,7 +3329,7 @@ dependencies = [
  
  [[package]]
  name = "codex-home"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-extension-api",
   "codex-utils-absolute-path",
-@@ -3292,7 +3292,7 @@ dependencies = [
+@@ -3340,7 +3340,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
-  "chrono",
-@@ -3315,7 +3315,7 @@ dependencies = [
+  "async-channel",
+@@ -3365,7 +3365,7 @@ dependencies = [
  
  [[package]]
  name = "codex-http-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "bytes",
   "codex-utils-cargo-bin",
-@@ -3346,7 +3346,7 @@ dependencies = [
+@@ -3397,7 +3397,7 @@ dependencies = [
  
  [[package]]
  name = "codex-image-generation-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3373,7 +3373,7 @@ dependencies = [
+@@ -3424,7 +3424,7 @@ dependencies = [
  
  [[package]]
  name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-utils-absolute-path",
   "codex-utils-home-dir",
-@@ -3383,7 +3383,7 @@ dependencies = [
+@@ -3437,7 +3437,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "keyring",
   "tracing",
-@@ -3391,7 +3391,7 @@ dependencies = [
+@@ -3445,7 +3445,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "clap",
   "codex-core",
-@@ -3416,7 +3416,7 @@ dependencies = [
+@@ -3470,7 +3470,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-core",
   "codex-http-client",
-@@ -3430,7 +3430,7 @@ dependencies = [
+@@ -3484,7 +3484,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3472,7 +3472,7 @@ dependencies = [
+@@ -3527,7 +3527,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -3509,7 +3509,7 @@ dependencies = [
+@@ -3565,7 +3565,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-config",
   "codex-connectors",
-@@ -3535,7 +3535,7 @@ dependencies = [
+@@ -3591,7 +3591,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -3575,7 +3575,7 @@ dependencies = [
+@@ -3630,7 +3630,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-core",
   "codex-extension-api",
-@@ -3596,7 +3596,7 @@ dependencies = [
+@@ -3651,7 +3651,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-read"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -3606,7 +3606,7 @@ dependencies = [
+@@ -3661,7 +3661,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-write"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3643,7 +3643,7 @@ dependencies = [
+@@ -3698,7 +3698,7 @@ dependencies = [
  
  [[package]]
  name = "codex-message-history"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-config",
   "memchr",
-@@ -3657,7 +3657,7 @@ dependencies = [
+@@ -3712,7 +3712,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-agent-identity",
   "codex-api",
-@@ -3680,7 +3680,7 @@ dependencies = [
+@@ -3735,7 +3735,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider-info"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-api",
   "codex-protocol",
-@@ -3696,7 +3696,7 @@ dependencies = [
+@@ -3751,7 +3751,7 @@ dependencies = [
  
  [[package]]
  name = "codex-models-manager"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "chrono",
   "codex-collaboration-mode-templates",
-@@ -3716,7 +3716,7 @@ dependencies = [
+@@ -3771,7 +3771,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3754,7 +3754,7 @@ dependencies = [
+@@ -3809,7 +3809,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -3774,7 +3774,7 @@ dependencies = [
+@@ -3829,7 +3829,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -3805,7 +3805,7 @@ dependencies = [
+@@ -3862,7 +3862,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-config",
   "codex-protocol",
-@@ -3818,7 +3818,7 @@ dependencies = [
+@@ -3875,7 +3875,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -3826,7 +3826,7 @@ dependencies = [
+@@ -3883,7 +3883,7 @@ dependencies = [
  
  [[package]]
  name = "codex-prompts"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-context-fragments",
-@@ -3840,7 +3840,7 @@ dependencies = [
+@@ -3897,7 +3897,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -3882,7 +3882,7 @@ dependencies = [
+@@ -3939,7 +3939,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-queue-extension"
+-version = "0.0.0"
++version = "0.149.0"
+ dependencies = [
+  "anyhow",
+  "codex-core",
+@@ -3960,7 +3960,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3893,7 +3893,7 @@ dependencies = [
+@@ -3971,7 +3971,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3910,7 +3910,7 @@ dependencies = [
+@@ -3988,7 +3988,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "axum",
-@@ -3953,7 +3953,7 @@ dependencies = [
+@@ -4034,7 +4034,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3979,7 +3979,7 @@ dependencies = [
+@@ -4061,7 +4061,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout-trace"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-code-mode",
-@@ -3995,7 +3995,7 @@ dependencies = [
+@@ -4077,7 +4077,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-network-proxy",
-@@ -4019,7 +4019,7 @@ dependencies = [
+@@ -4101,7 +4101,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "age",
   "anyhow",
-@@ -4040,7 +4040,7 @@ dependencies = [
+@@ -4122,7 +4122,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4061,7 +4061,7 @@ dependencies = [
+@@ -4145,7 +4145,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -4081,7 +4081,7 @@ dependencies = [
+@@ -4165,7 +4165,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -4098,7 +4098,7 @@ dependencies = [
+@@ -4182,7 +4182,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
+  "codex-analytics",
   "codex-config",
-  "codex-core-skills",
-@@ -4134,7 +4134,7 @@ dependencies = [
+@@ -4218,7 +4218,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -4157,7 +4157,7 @@ dependencies = [
+@@ -4242,7 +4242,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-uds",
-@@ -4169,7 +4169,7 @@ dependencies = [
+@@ -4254,7 +4254,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -4177,7 +4177,7 @@ dependencies = [
+@@ -4262,7 +4262,7 @@ dependencies = [
  
  [[package]]
  name = "codex-test-binary-support"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-arg0",
   "tempfile",
-@@ -4185,7 +4185,7 @@ dependencies = [
+@@ -4270,7 +4270,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-manager-sample"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "clap",
-@@ -4196,7 +4196,7 @@ dependencies = [
+@@ -4281,7 +4281,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-store"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "chrono",
   "codex-app-server-protocol",
-@@ -4225,7 +4225,7 @@ dependencies = [
+@@ -4311,7 +4311,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "bitflags 2.13.1",
   "codex-code-mode",
-@@ -4251,7 +4251,7 @@ dependencies = [
+@@ -4337,7 +4337,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -4363,7 +4363,7 @@ dependencies = [
+@@ -4449,7 +4449,7 @@ dependencies = [
  
  [[package]]
  name = "codex-uds"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "async-io",
   "pretty_assertions",
-@@ -4375,7 +4375,7 @@ dependencies = [
+@@ -4461,7 +4461,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "dirs",
   "dunce",
-@@ -4389,14 +4389,14 @@ dependencies = [
+@@ -4475,14 +4475,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
  ]
@@ -972,143 +997,143 @@ index d7fae91..3bdceb3 100644
  [[package]]
  name = "codex-utils-audio"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "codex-protocol",
-@@ -4410,7 +4410,7 @@ dependencies = [
+@@ -4496,7 +4496,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
-  "lru 0.16.3",
+  "lru",
   "sha1 0.10.6",
-@@ -4419,7 +4419,7 @@ dependencies = [
+@@ -4505,7 +4505,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -4428,7 +4428,7 @@ dependencies = [
+@@ -4514,7 +4514,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -4440,15 +4440,15 @@ dependencies = [
+@@ -4526,15 +4526,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dirs",
-@@ -4458,7 +4458,7 @@ dependencies = [
+@@ -4544,7 +4544,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -4471,7 +4471,7 @@ dependencies = [
+@@ -4557,7 +4557,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -4480,7 +4480,7 @@ dependencies = [
+@@ -4566,7 +4566,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -4490,7 +4490,7 @@ dependencies = [
+@@ -4576,7 +4576,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -4499,7 +4499,7 @@ dependencies = [
+@@ -4585,7 +4585,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -4509,7 +4509,7 @@ dependencies = [
+@@ -4595,7 +4595,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path-uri"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-absolute-path",
-@@ -4525,7 +4525,7 @@ dependencies = [
+@@ -4611,7 +4611,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-exec-server",
   "codex-exec-server-protocol",
-@@ -4539,7 +4539,7 @@ dependencies = [
+@@ -4625,7 +4625,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -4555,7 +4555,7 @@ dependencies = [
+@@ -4641,7 +4641,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "assert_matches",
   "thiserror 2.0.18",
-@@ -4565,14 +4565,14 @@ dependencies = [
+@@ -4651,14 +4651,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "rustls",
  ]
@@ -1116,25 +1141,25 @@ index d7fae91..3bdceb3 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-protocol",
   "codex-utils-absolute-path",
-@@ -4581,7 +4581,7 @@ dependencies = [
+@@ -4667,7 +4667,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -4591,14 +4591,14 @@ dependencies = [
+@@ -4677,14 +4677,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1142,16 +1167,16 @@ index d7fae91..3bdceb3 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -4608,14 +4608,14 @@ dependencies = [
+@@ -4694,14 +4694,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1159,55 +1184,64 @@ index d7fae91..3bdceb3 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -4623,7 +4623,7 @@ dependencies = [
+@@ -4709,7 +4709,7 @@ dependencies = [
  
  [[package]]
  name = "codex-web-search-extension"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-api",
   "codex-core",
-@@ -4644,7 +4644,7 @@ dependencies = [
+@@ -4730,7 +4730,7 @@ dependencies = [
  
  [[package]]
  name = "codex-websocket-client"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "codex-http-client",
   "codex-utils-rustls-provider",
-@@ -4660,7 +4660,7 @@ dependencies = [
+@@ -4746,7 +4746,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4911,7 +4911,7 @@ dependencies = [
+@@ -4772,7 +4772,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-workload-identity"
+-version = "0.0.0"
++version = "0.149.0"
+ dependencies = [
+  "codex-http-client",
+  "pretty_assertions",
+@@ -5012,7 +5012,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -9120,7 +9120,7 @@ dependencies = [
+@@ -9274,7 +9274,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.147.0"
++version = "0.149.0"
  dependencies = [
   "anyhow",
   "codex-login",
 -- 
-2.52.0
+2.55.0
 

--- a/app-utils/codex/autobuild/patches/0004-AOSCOS-Disable-cross-compilation-setup.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0004-AOSCOS-Disable-cross-compilation-setup.patch.deferred
@@ -1,7 +1,7 @@
-From 2d47c64178e68a4ba58dd789f162bc23a08fc7e2 Mon Sep 17 00:00:00 2001
+From 08b3f73dc3da3f51441cf6237c4d93cfc30b76cc Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Wed, 29 Apr 2026 19:29:06 +0800
-Subject: [PATCH 3/5] AOSCOS: Disable cross-compilation setup
+Subject: [PATCH 4/6] AOSCOS: Disable cross-compilation setup
 
 Because we builds these targets natively, the cross-compilation sysroot setup is unnecessary.
 
@@ -12,7 +12,7 @@ Signed-off-by: Suyun <suyun@aosc.io>
  1 file changed, 26 deletions(-)
 
 diff --git a/build.rs b/build.rs
-index d570790..f11a8f2 100644
+index d570790bb..f11a8f2dc 100644
 --- a/build.rs
 +++ b/build.rs
 @@ -407,32 +407,6 @@ fn build_v8(is_asan: bool) {
@@ -49,5 +49,5 @@ index d570790..f11a8f2 100644
    // musl libc. V8's build targets glibc by default; the vendored build config
    // grows a target-scoped `use_musl` arg (see //build/config/rust.gni,
 -- 
-2.52.0
+2.55.0
 

--- a/app-utils/codex/autobuild/patches/0005-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0005-AOSCOS-build-correct-Clang-builtins-path.patch.deferred
@@ -1,7 +1,7 @@
-From c9f49a911a855ae46c4c5bf98b063c7876f087f8 Mon Sep 17 00:00:00 2001
+From 436df74cae133cc3dc6b4c5327eb76a8eca4e027 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Fri, 30 Jan 2026 19:43:16 +0800
-Subject: [PATCH 4/5] AOSCOS: build: correct Clang builtins path
+Subject: [PATCH 5/6] AOSCOS: build: correct Clang builtins path
 
 With AOSC OS, LLVM is installed in a versioned prefix: /usr/lib/llvm-$VER.
 
@@ -13,7 +13,7 @@ Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
  1 file changed, 10 insertions(+), 9 deletions(-)
 
 diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index f429120f4..d75fbc007 100644
+index c38670a24..703aa1b02 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
 @@ -188,22 +188,23 @@ template("clang_lib") {
@@ -58,5 +58,5 @@ index f429120f4..d75fbc007 100644
        libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
      }
 -- 
-2.52.0
+2.55.0
 

--- a/app-utils/codex/autobuild/patches/0006-AOSCOS-drop-unknown-argument.patch.deferred
+++ b/app-utils/codex/autobuild/patches/0006-AOSCOS-drop-unknown-argument.patch.deferred
@@ -1,7 +1,7 @@
-From 975957febe3eb82ad3ef55ad2c70dc902b62dbef Mon Sep 17 00:00:00 2001
+From d173e1d759839a5e9dd85eab2cc1ad97c6ca874d Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 23 May 2026 00:26:17 +0800
-Subject: [PATCH 5/5] AOSCOS: drop unknown argument
+Subject: [PATCH 6/6] AOSCOS: drop unknown argument
 
 Ref: https://github.com/cions/termux-deno/blob/7068f1fc4d8817045cbe4c65934df9646cd78368/rusty_v8-fix-unknown-options.patch
 Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
@@ -11,10 +11,10 @@ Signed-off-by: Kirikaze Chiyuki <me@chyk.ink>
  2 files changed, 20 deletions(-)
 
 diff --git a/build/config/compiler/BUILD.gn b/build/config/compiler/BUILD.gn
-index 1b53cb1d4..53b6092b7 100644
+index 11ddb4916..7ac613c29 100644
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -600,12 +600,6 @@ config("compiler") {
+@@ -588,12 +588,6 @@ config("compiler") {
    if (is_clang) {
      # Flags for diagnostics.
      cflags += [ "-fcolor-diagnostics" ]
@@ -27,7 +27,7 @@ index 1b53cb1d4..53b6092b7 100644
      if (diagnostics_print_source_range_info && !is_win) {
        cflags += [ "-fdiagnostics-print-source-range-info" ]
      }
-@@ -636,13 +630,6 @@ config("compiler") {
+@@ -624,13 +618,6 @@ config("compiler") {
        ]
      }
  
@@ -42,10 +42,10 @@ index 1b53cb1d4..53b6092b7 100644
      # by default. https://crbug.com/765793
      cflags += [
 diff --git a/build/config/sanitizers/sanitizers.gni b/build/config/sanitizers/sanitizers.gni
-index 329a2fc8b..903b87c7b 100644
+index 04d86c566..0aa43c24b 100644
 --- a/build/config/sanitizers/sanitizers.gni
 +++ b/build/config/sanitizers/sanitizers.gni
-@@ -534,13 +534,6 @@ template("ubsan_hardening") {
+@@ -535,13 +535,6 @@ template("ubsan_hardening") {
        cflags = [
          "-fsanitize=${invoker.sanitizer}",
          "-fsanitize-trap=${invoker.sanitizer}",
@@ -60,5 +60,5 @@ index 329a2fc8b..903b87c7b 100644
        if (defined(invoker.cflags)) {
          cflags += invoker.cflags
 -- 
-2.52.0
+2.55.0
 

--- a/app-utils/codex/autobuild/prepare
+++ b/app-utils/codex/autobuild/prepare
@@ -2,15 +2,21 @@
 # binaries for the architectures we support.
 abinfo "Setting up environment for rusty_v8 ..."
 CLANG_VERSION=$(clang --version | sed -n 's/clang version //p' | cut -d. -f1)
+RUSTC_VERSION="$(rustc --version | cut -d' ' -f2)"
+# Temporarily disable `v8_enable_sandbox`.
+# Ref: https://github.com/denoland/rusty_v8/issues/2070
 __GN_ARGS=(
     'chrome_pgo_phase=0'
     'fatal_linker_warnings=false'
     'treat_warnings_as_errors=false'
-    'v8_enable_temporal_support=false'
     'is_debug=false'
     'use_sysroot=false'
+    'v8_enable_sandbox=false'
     "clang_version=\"${CLANG_VERSION}\""
     'clang_base_path="/usr"'
+    "rustc_version=\"$RUSTC_VERSION\""
+    'rust_sysroot_absolute="/usr"'
+    'rust_bindgen_root="/usr"'
     "custom_toolchain=\"//build/toolchain/linux/unbundle:default\""
     "host_toolchain=\"//build/toolchain/linux/unbundle:default\""
 )
@@ -19,10 +25,17 @@ export GN_ARGS="${__GN_ARGS[@]}"
 export GN="/usr/bin/gn"
 export AR="/usr/bin/llvm-ar"
 export NM="/usr/bin/llvm-nm"
+export BUILD_AR="/usr/bin/llvm-ar"
+export BUILD_NM="/usr/bin/llvm-nm"
 export NINJA="/usr/bin/ninja"
 export PYTHON="/usr/bin/python3"
 export CLANG_BASE_PATH="/usr"
 export V8_FROM_SOURCE=1
+
+# FIXME: Chromium wants nightly rustc for some reason...
+#
+# error: the option `Z` is only accepted on the nightly compiler
+export RUSTC_BOOTSTRAP=1
 
 # FIXME:
 # [...]/codex/codex-rs/linux-sandbox/../vendor/bubblewrap/bind-mount.c:398:(.text.bind_mount+0x7c): relocation truncated to fit: R_LARCH_B26 against symbol `mount@@GLIBC_2.36' defined in .text section in /usr/lib/libc.so.6

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.147.0
+VER=0.149.0
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=150.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.149.0
    - Add missing codex-code-mode-host.

Package(s) Affected
-------------------

- codex: 0.149.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
