### PR TITLE
reasonix: update to 1.31.2

### DIFF
--- a/app-vibe/reasonix/spec
+++ b/app-vibe/reasonix/spec
@@ -1,4 +1,4 @@
-VER=1.17.21
+VER=1.31.2
 SRCS="git::commit=tags/v$VER::https://github.com/esengine/DeepSeek-Reasonix"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391437"


### PR DESCRIPTION
Topic Description
-----------------

- reasonix: update to 1.31.2
    Co-authored-by: Ilikara \(@AirFortressIlikara\)

Package(s) Affected
-------------------

- reasonix: 1.31.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit reasonix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
