### PR TITLE
mypy: enable mypyc compilation

### DIFF
--- a/lang-python/mypy/autobuild/defines
+++ b/lang-python/mypy/autobuild/defines
@@ -1,9 +1,8 @@
 PKGNAME=mypy
 PKGSEC=python
-PKGDEP="python-3 ast-serialize librt pathspec typing-extensions mypy-extensions"
+PKGDEP="python-3 ast-serialize librt pathspec typing-extensions mypy-extensions glibc psutil"
 BUILDDEP="setuptools types-psutil types-setuptools"
 PKGDES="Optional static typing for Python"
 
 ABTYPE=pep517
-ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/mypy/autobuild/prepare
+++ b/lang-python/mypy/autobuild/prepare
@@ -1,0 +1,3 @@
+abinfo "Enabling mypyc compilation for mypy ..."
+
+export MYPY_USE_MYPYC=1

--- a/lang-python/mypy/spec
+++ b/lang-python/mypy/spec
@@ -2,3 +2,4 @@ VER=2.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/python/mypy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8453"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- mypy: enable mypyc compilation
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- mypy: 2.3.1-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit mypy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
