### PR TITLE
mypy: fix psutil dependency

### DIFF
--- a/lang-python/mypy/autobuild/defines
+++ b/lang-python/mypy/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=mypy
 PKGSEC=python
-PKGDEP="python-3 ast-serialize librt pathspec typing-extensions mypy-extensions glibc psutil"
+PKGDEP="python-3 ast-serialize librt pathspec typing-extensions mypy-extensions glibc pypsutil"
 BUILDDEP="setuptools types-psutil types-setuptools"
 PKGDES="Optional static typing for Python"
 

--- a/lang-python/mypy/spec
+++ b/lang-python/mypy/spec
@@ -2,4 +2,4 @@ VER=2.3.1
 SRCS="git::commit=tags/v$VER::https://github.com/python/mypy"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8453"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- mypy: fix psutil dependency
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- mypy: 2.3.1-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit mypy
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
