### PR TITLE
llvm-20: fix conditional statement for creating clang versioned symlink

### DIFF
--- a/app-devel/llvm-20/02-compiler/build
+++ b/app-devel/llvm-20/02-compiler/build
@@ -60,7 +60,7 @@ strip \
     "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/*.a
 
 # Note: May not always be available, especially if no runtime is enabled.
-if [ -e "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}" ]; then
+if [ -e "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER%%.*}" ]; then
     abinfo "Making compatible version symlinks ..."
     ln -sv "${PKGVER%%.*}" \
         "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"

--- a/app-devel/llvm-20/02-compiler/build.stage2
+++ b/app-devel/llvm-20/02-compiler/build.stage2
@@ -25,7 +25,7 @@ for i in "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/lib{LLVMgold,unwind,c++}*.so*;
 done
 
 # Note: May not always be available, especially if no runtime is enabled.
-if [ -e "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}" ]; then
+if [ -e "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER%%.*}" ]; then
     abinfo "Making compatible version symlinks ..."
     ln -sv "${PKGVER%%.*}" \
         "$PKGDIR"/usr/lib/llvm-${PKGVER%%.*}/lib/clang/"${PKGVER}"

--- a/app-devel/llvm-20/spec
+++ b/app-devel/llvm-20/spec
@@ -1,5 +1,5 @@
 VER=20.1.8
-REL=12
+REL=13
 
 # Use tarball-based source when possible
 SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"


### PR DESCRIPTION
Topic Description
-----------------

- llvm-20: fix conditional statement for creating clang versioned symlink

Package(s) Affected
-------------------

- llvm-20: 20.1.8-13
- llvm-runtime-20: 20.1.8-13

Security Update?
----------------

No

Build Order
-----------

```
#buildit llvm-20
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
