### PR TITLE
pytest: security update 9.1.1

### DIFF
--- a/lang-python/pytest-timeout/spec
+++ b/lang-python/pytest-timeout/spec
@@ -1,4 +1,4 @@
-VER=2.4.0
+VER=2.5.0
 SRCS="git::commit=tags/${VER};copy-repo=true::https://github.com/pytest-dev/pytest-timeout"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15174"

--- a/lang-python/pytest/autobuild/defines
+++ b/lang-python/pytest/autobuild/defines
@@ -1,9 +1,10 @@
 PKGNAME=pytest
 PKGSEC=python
-PKGDEP="py setuptools attrs iniconfig packaging pluggy tomli exceptiongroup"
-BUILDDEP="pip setuptools setuptools-scm tomli wheel python-build python-installer"
-PKGDES="A simple but powerful testing framework for Python"
+PKGDEP="pygments iniconfig packaging pluggy"
+BUILDDEP="setuptools setuptools-scm"
+PKGDES="Testing framework for Python"
 
 ABHOST=noarch
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/pytest/spec
+++ b/lang-python/pytest/spec
@@ -1,5 +1,4 @@
-VER=8.2.2
-SRCS="tbl::https://pypi.io/packages/source/p/pytest/pytest-$VER.tar.gz"
-CHKSUMS="sha256::de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
+VER=9.1.1
+SRCS="pypi::version=$VER::pytest"
+CHKSUMS="sha256::1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"
 CHKUPDATE="anitya::id=3765"
-REL="1"

--- a/runtime-ros/ros-jazzy-launch-testing-ros/autobuild/patches/0001-Fix-Pytest-8-9-compatibility-in-launch_testing_ros-hooks.patch
+++ b/runtime-ros/ros-jazzy-launch-testing-ros/autobuild/patches/0001-Fix-Pytest-8-9-compatibility-in-launch_testing_ros-hooks.patch
@@ -1,0 +1,40 @@
+From: Michael Carroll <mjcarroll.oss@gmail.com>
+Date: Tue, 5 May 2026 02:26:40 -0500
+Subject: [PATCH] Fix Pytest 8/9 compatibility in launch_testing_ros hooks
+
+Rename deprecated path argument to module_path to avoid warnings and failures in newer pytest versions.
+
+Assisted-by: Gemini CLI:2.0-Flash [run_shell_command, replace, git, gh]
+
+Signed-off-by: Michael Carroll <mjcarroll.oss@gmail.com>
+---
+ ../launch_testing_ros_pytest_entrypoint.py         | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/launch_testing_ros_pytest_entrypoint.py b/launch_testing_ros_pytest_entrypoint.py
+index 20f9d8b23..ce3606609 100644
+--- a/launch_testing_ros_pytest_entrypoint.py
++++ b/launch_testing_ros_pytest_entrypoint.py
+@@ -20,11 +20,20 @@
+ import pytest
+ 
+ 
+-def pytest_launch_collect_makemodule(path, parent, entrypoint):
++def _pytest_version_ge(major, minor=0, patch=0):
++    """Return True if pytest version is >= the given version."""
++    pytest_version = tuple([int(v) for v in pytest.__version__.split('.')])
++    return pytest_version >= (major, minor, patch)
++
++
++def pytest_launch_collect_makemodule(module_path, parent, entrypoint):
+     marks = getattr(entrypoint, 'pytestmark', [])
+     if marks and any(m.name == 'rostest' for m in marks):
+         from launch_testing_ros.pytest.hooks import LaunchROSTestModule
+-        module = LaunchROSTestModule.from_parent(parent=parent, fspath=path)
++        if _pytest_version_ge(7):
++            module = LaunchROSTestModule.from_parent(parent=parent, path=module_path)
++        else:
++            module = LaunchROSTestModule.from_parent(parent=parent, fspath=module_path)
+         for mark in marks:
+             decorator = getattr(pytest.mark, mark.name)
+             decorator = decorator.with_args(*mark.args, **mark.kwargs)

--- a/runtime-ros/ros-jazzy-launch-testing-ros/spec
+++ b/runtime-ros/ros-jazzy-launch-testing-ros/spec
@@ -2,3 +2,4 @@ VER=0.26.12+1
 SRCS="git::commit=tags/release/jazzy/launch_testing_ros/${VER/+/-}::https://github.com/ros2-gbp/launch_ros-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/launch_ros-release;pattern=release/jazzy/launch_testing_ros/.*"
+REL=1

--- a/runtime-ros/ros-jazzy-launch-testing/autobuild/patches/0001-Fix-Pytest-8-9-compatibility-in-hooks.patch
+++ b/runtime-ros/ros-jazzy-launch-testing/autobuild/patches/0001-Fix-Pytest-8-9-compatibility-in-hooks.patch
@@ -1,0 +1,72 @@
+From: Michael Carroll <mjcarroll.oss@gmail.com>
+Date: Tue, 5 May 2026 02:26:44 -0500
+Subject: [PATCH] Fix Pytest 8/9 compatibility in hooks
+
+Backport of upstream commit 06308316b46a734188a6688603763185d2b3de54.
+
+Trimmed to the launch_testing package and adjusted for the package source layout.
+
+Signed-off-by: Michael Carroll <mjcarroll.oss@gmail.com>
+Signed-off-by: Xu Colin <colinxu2020@gmail.com>
+---
+ launch_testing/pytest/hooks.py             | 18 +++++++++++++-----
+ launch_testing/pytest/hookspecs.py         |  2 +-
+ 2 files changed, 14 insertions(+), 6 deletions(-)
+
+diff --git a/launch_testing/pytest/hooks.py b/launch_testing/pytest/hooks.py
+index 174c4c476..3726d9570 100644
+--- a/launch_testing/pytest/hooks.py
++++ b/launch_testing/pytest/hooks.py
+@@ -189,12 +189,20 @@ def find_launch_test_entrypoint(path):
+         return None
+ 
+ 
+-def pytest_pycollect_makemodule(path, parent):
++if _pytest_version_ge(8):
++    def pytest_pycollect_makemodule(module_path, parent):
++        return _pytest_pycollect_makemodule(module_path, parent)
++else:
++    def pytest_pycollect_makemodule(path, parent):
++        return _pytest_pycollect_makemodule(path, parent)
++
++
++def _pytest_pycollect_makemodule(path, parent):
+     entrypoint = find_launch_test_entrypoint(path)
+     if entrypoint is not None:
+         ihook = parent.session.gethookproxy(path)
+         module = ihook.pytest_launch_collect_makemodule(
+-            path=path, parent=parent, entrypoint=entrypoint
++            module_path=path, parent=parent, entrypoint=entrypoint
+         )
+         if module is not None:
+             return module
+@@ -216,14 +224,14 @@ def pytest_pycollect_makemodule(path, parent):
+ 
+ 
+ @pytest.hookimpl(trylast=True)
+-def pytest_launch_collect_makemodule(path, parent, entrypoint):
++def pytest_launch_collect_makemodule(module_path, parent, entrypoint):
+     marks = getattr(entrypoint, 'pytestmark', [])
+     if marks and any(m.name == 'launch_test' for m in marks):
+         if _pytest_version_ge(7):
+-            path = pathlib.Path(path)
++            path = pathlib.Path(module_path)
+             module = LaunchTestModule.from_parent(parent=parent, path=path)
+         else:
+-            module = LaunchTestModule.from_parent(parent=parent, fspath=path)
++            module = LaunchTestModule.from_parent(parent=parent, fspath=module_path)
+         for mark in marks:
+             decorator = getattr(pytest.mark, mark.name)
+             decorator = decorator.with_args(*mark.args, **mark.kwargs)
+diff --git a/launch_testing/pytest/hookspecs.py b/launch_testing/pytest/hookspecs.py
+index 89249d5ea..52912415e 100644
+--- a/launch_testing/pytest/hookspecs.py
++++ b/launch_testing/pytest/hookspecs.py
+@@ -16,6 +16,6 @@
+ 
+ 
+ @pytest.hookspec(firstresult=True)
+-def pytest_launch_collect_makemodule(path, parent, entrypoint):
++def pytest_launch_collect_makemodule(module_path, parent, entrypoint):
+     """Make launch test module appropriate for the found test entrypoint."""
+     pass

--- a/runtime-ros/ros-jazzy-launch-testing/spec
+++ b/runtime-ros/ros-jazzy-launch-testing/spec
@@ -2,3 +2,4 @@ VER=3.4.11+1
 SRCS="git::commit=tags/release/jazzy/launch_testing/${VER/+/-}::https://github.com/ros2-gbp/launch-release.git"
 CHKSUMS="SKIP"
 CHKUPDATE="github::repo=ros2-gbp/launch-release;pattern=release/jazzy/launch_testing/.*"
+REL=1

--- a/topics/pytest-9.1.1.toml
+++ b/topics/pytest-9.1.1.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Pytest 9.1.1"
+
+[caution]
+default = "Fixes a Creation of Temporary File in Directory with Insecure Permissions vulnerability (CVE-2025-71176, Severity: Moderate)"
+zh_CN = "修复 1 个以不安全的权限创建临时文件漏洞（漏洞编号 CVE-2025-71176，严重性：中）"
+
+[packages-v2]
+"pytest" = "< 9.0.3"


### PR DESCRIPTION
Topic Description
-----------------

- ros-jazzy-launch-testing-ros: (upstream patch) fix pytest 8/9 compatibility
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- ros-jazzy-launch-testing: (upstream patch) fix pytest 8/9 compatibility
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- pytest-timeout: update to 2.5.0
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- pytest: security update to 9.1.1
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- `ros-jazzy-launch-testing-ros`
- `ros-jazzy-launch-testing`
- `pytest-timeout`
- `pytest`

Security Update?
----------------

Yes

Fixes #17280 

Build Order
-----------

```
#buildit pytest pytest-timeout ros-jazzy-launch-testing-ros ros-jazzy-launch-testing
```

Test Build(s) Done
------------------

- [x] Architecture-independent `noarch`
