### PR TITLE
crush: update to 0.90.0

### DIFF
--- a/app-utils/crush/spec
+++ b/app-utils/crush/spec
@@ -1,4 +1,4 @@
-VER=0.89.0
+VER=0.90.0
 SRCS="git::commit=tags/v$VER::https://github.com/charmbracelet/crush"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=382294"


### PR DESCRIPTION
Topic Description
-----------------

- crush: update to 0.90.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- crush: 0.90.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit crush
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
