### PR TITLE
lazygit: update to 0.64.1

### DIFF
--- a/app-vcs/lazygit/spec
+++ b/app-vcs/lazygit/spec
@@ -1,4 +1,4 @@
-VER=0.62.2
+VER=0.64.1
 SRCS="git::commit=tags/v$VER::https://github.com/jesseduffield/lazygit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268930"


### PR DESCRIPTION
Topic Description
-----------------

- lazygit: update to 0.64.1
    Co-authored-by: Kimmy \(@KimmyXYC\)

Package(s) Affected
-------------------

- lazygit: 0.64.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit lazygit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
