### PR TITLE
acpica-unix: update to 20260408

### DIFF
--- a/app-devel/acpica-unix/spec
+++ b/app-devel/acpica-unix/spec
@@ -1,7 +1,5 @@
-VER=20250404
-REL=1
-__VER="${VER:0:4}_${VER:4:2}_${VER:6:2}"
-SRCS="tbl::https://github.com/acpica/acpica/releases/download/R${__VER}/acpica-unix-${VER}.tar.gz"
-CHKSUMS="sha256::c0895489e6cb2dc92e49dc60cdf94ac02b0d33602166354267b8f4b6586c2315"
+VER=20260408
+SRCS="tbl::https://github.com/open-acpica/acpica/releases/download/${VER}/acpica-unix-$VER.tar.gz"
+CHKSUMS="sha256::e66ceb26d6d514ce164fe22f5a4f7ca165cc38349d7a97f41a21f19b364647a2"
 CHKUPDATE="anitya::id=18"
 SUBDIR="acpica-unix-${VER}/generate/unix"


### PR DESCRIPTION
Topic Description
-----------------

- acpica-unix: update to 20260408

Package(s) Affected
-------------------

- acpica-unix: 20260408

Security Update?
----------------

No

Build Order
-----------

```
#buildit acpica-unix
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
