### PR TITLE
ed: update to 1.22.6

### DIFF
--- a/app-editors/ed/spec
+++ b/app-editors/ed/spec
@@ -1,4 +1,4 @@
-VER=1.22.5
+VER=1.22.6
 SRCS="tbl::https://ftp.gnu.org/gnu/ed/ed-$VER.tar.lz"
-CHKSUMS="sha256::56e107ddc2f29dad6690376c15bf9751509e1ee3b8241710e44edbe5c3a158cc"
+CHKSUMS="sha256::3f33b22135219c39c3c695f7b7171c2567d3e2a17c798c0a90607320cbb268f2"
 CHKUPDATE="anitya::id=659"


### PR DESCRIPTION
Topic Description
-----------------

- ed: update to 1.22.6
    Co-authored-by: 白铭骢 \(Mingcong Bai\) \(@MingcongBai\) <jeffbai@aosc.io>

Package(s) Affected
-------------------

- ed: 1.22.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit ed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
