### PR TITLE
virtiofsd: update to 1.14.0

### DIFF
--- a/app-virtualization/virtiofsd/spec
+++ b/app-virtualization/virtiofsd/spec
@@ -1,4 +1,4 @@
-VER=1.13.2
+VER=1.14.0
 SRCS="git::commit=tags/v${VER}::https://gitlab.com/virtio-fs/virtiofsd.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=347345"


### PR DESCRIPTION
Topic Description
-----------------

- virtiofsd: update to 1.14.0
    Co-authored-by: \(@stdmnpkg\)

Package(s) Affected
-------------------

- virtiofsd: 1.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit virtiofsd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
