### PR TITLE
dracut-ng: update to 112

### DIFF
--- a/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0001-AOSCOS-LOONGSON3-45drm-limit-DRM-module-installation.patch
@@ -1,7 +1,7 @@
-From ee19b825a3371e0ab503c0cbaf2152879e6edbea Mon Sep 17 00:00:00 2001
+From 8834e7164cbac63f1b8e89bd1058e9a2e1d3fe99 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 23 Jan 2025 11:45:36 +0800
-Subject: [PATCH 1/7] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
+Subject: [PATCH 1/9] AOSCOS: LOONGSON3: 45drm: limit DRM module installation
  to amdgpu, loongson, and radeon
 
 If we are using mips64el (assumed to be MIPS-based Loongson), only install
@@ -15,7 +15,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 18 insertions(+), 5 deletions(-)
 
 diff --git a/modules.d/45drm/module-setup.sh b/modules.d/45drm/module-setup.sh
-index 6bb4f8a8..816e6670 100755
+index 17f7ebc2..927dfaac 100755
 --- a/modules.d/45drm/module-setup.sh
 +++ b/modules.d/45drm/module-setup.sh
 @@ -18,7 +18,11 @@ installkernel() {
@@ -55,5 +55,5 @@ index 6bb4f8a8..816e6670 100755
      fi
  }
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-11systemd-crypsetup-remove-TPM2-dep.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0002-AOSCOS-LOONGSON3-11systemd-crypsetup-remove-TPM2-dep.patch
@@ -1,7 +1,7 @@
-From 8154fbd46377a3496e9b180a1921174c5fd59394 Mon Sep 17 00:00:00 2001
+From 7868531b9c44b2cdf50618f7efde2d49f4c579f9 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:55:49 +0800
-Subject: [PATCH 2/7] AOSCOS: LOONGSON3: 11systemd-crypsetup: remove TPM2
+Subject: [PATCH 2/9] AOSCOS: LOONGSON3: 11systemd-crypsetup: remove TPM2
  dependency
 
 There is just no way that we will get TPM2 on MIPS-based Loongson 3
@@ -15,18 +15,18 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  1 file changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/modules.d/71systemd-cryptsetup/module-setup.sh b/modules.d/71systemd-cryptsetup/module-setup.sh
-index 46df291e..d5295cb2 100755
+index 4bad1eff..7083a9bc 100755
 --- a/modules.d/71systemd-cryptsetup/module-setup.sh
 +++ b/modules.d/71systemd-cryptsetup/module-setup.sh
 @@ -33,8 +33,14 @@ depends() {
          if grep -q "tpm2-device=" "${dracutsysrootdir-}"/etc/crypttab; then
              deps+=" tpm2-tss"
          fi
--    elif [[ ! $hostonly ]]; then
+-    else
 -        for module in fido2 pkcs11 tpm2-tss; do
 +    elif [[ ! ${hostonly-} ]]; then
 +        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
-+            modules=(fido pkcs11 tpm2-tss)
++            modules=(fido2 pkcs11 tpm2-tss)
 +        else
 +            # MIPS64: No chance for TPM2 on these platforms.
 +            modules=()
@@ -36,5 +36,5 @@ index 46df291e..d5295cb2 100755
              if [[ $? == 255 ]] && ! [[ " $omit_dracutmodules " == *\ $module\ * ]]; then
                  deps+=" $module"
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-70kernel-modules-minimise-default-k.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0003-AOSCOS-LOONGSON3-70kernel-modules-minimise-default-k.patch
@@ -1,7 +1,7 @@
-From d077763d2e7d1cc3c787a3fb085a6c18e8f9b723 Mon Sep 17 00:00:00 2001
+From 43eabd8820e391dcfdc0a9b79e088b7d59704967 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:56:34 +0800
-Subject: [PATCH 3/7] AOSCOS: LOONGSON3: 70kernel-modules: minimise default
+Subject: [PATCH 3/9] AOSCOS: LOONGSON3: 70kernel-modules: minimise default
  kernel drivers
 
 Make sure that only drivers that were likely needed at early-boot were
@@ -12,11 +12,11 @@ Saves about 5MiB post-XZ.
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
 Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
- modules.d/70kernel-modules/module-setup.sh | 89 ++++++++++++++--------
- 1 file changed, 59 insertions(+), 30 deletions(-)
+ modules.d/70kernel-modules/module-setup.sh | 93 ++++++++++++++--------
+ 1 file changed, 61 insertions(+), 32 deletions(-)
 
 diff --git a/modules.d/70kernel-modules/module-setup.sh b/modules.d/70kernel-modules/module-setup.sh
-index 975a6f02..b335640b 100755
+index 716a5b5e..f516e32b 100755
 --- a/modules.d/70kernel-modules/module-setup.sh
 +++ b/modules.d/70kernel-modules/module-setup.sh
 @@ -25,12 +25,22 @@ installkernel() {
@@ -48,23 +48,25 @@ index 975a6f02..b335640b 100755
  
          dracut_instmods -o -s "${_blockfuncs}" "=drivers"
      }
-@@ -39,30 +49,49 @@ installkernel() {
+@@ -39,32 +49,51 @@ installkernel() {
          hostonly='' instmods \
              hid_generic unix
  
--        # xhci-pci-renesas is needed for the USB to be available during
--        # initrd on platforms with such USB controllers since Linux
--        # 6.12-rc1 (commit 25f51b76f90f).
+-        # Some xHCI PCI controllers are handled by sibling glue drivers
+-        # instead of plain xhci-pci. Include them so USB is available
+-        # during initrd when those drivers are built as modules.
 -        hostonly=$(optional_hostonly) instmods \
 -            ehci-hcd ehci-pci ehci-platform \
 -            ohci-hcd ohci-pci \
 -            uhci-hcd \
 -            usbhid \
--            xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
+-            xhci-hcd xhci-pci xhci-pci-prom21 xhci-pci-renesas xhci-plat-hcd \
 -            "=drivers/hid" \
 -            "=drivers/tty/serial" \
 -            "=drivers/input/serio" \
 -            "=drivers/input/keyboard" \
+-            "=drivers/mmc/core" \
+-            "=drivers/mmc/host" \
 -            "=drivers/pci/host" \
 -            "=drivers/pci/controller" \
 -            "=drivers/pinctrl" \
@@ -77,19 +79,21 @@ index 975a6f02..b335640b 100755
 -            virtio virtio_ring virtio_pci pci_hyperv \
 -            surface_aggregator_registry psmouse
 +        if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
-+            # xhci-pci-renesas is needed for the USB to be available during
-+            # initrd on platforms with such USB controllers since Linux
-+            # 6.12-rc1 (commit 25f51b76f90f).
++            # Some xHCI PCI controllers are handled by sibling glue drivers
++            # instead of plain xhci-pci. Include them so USB is available
++            # during initrd when those drivers are built as modules.
 +            hostonly=$(optional_hostonly) instmods \
 +                ehci-hcd ehci-pci ehci-platform \
 +                ohci-hcd ohci-pci \
 +                uhci-hcd \
 +                usbhid \
-+                xhci-hcd xhci-pci xhci-pci-renesas xhci-plat-hcd \
++                xhci-hcd xhci-pci xhci-pci-prom21 xhci-pci-renesas xhci-plat-hcd \
 +                "=drivers/hid" \
 +                "=drivers/tty/serial" \
 +                "=drivers/input/serio" \
 +                "=drivers/input/keyboard" \
++                "=drivers/mmc/core" \
++                "=drivers/mmc/host" \
 +                "=drivers/pci/host" \
 +                "=drivers/pci/controller" \
 +                "=drivers/pinctrl" \
@@ -120,8 +124,8 @@ index 975a6f02..b335640b 100755
 +                virtio virtio_ring virtio_pci
 +        fi
  
-         if [[ ${DRACUT_ARCH:-$(uname -m)} == arm* || ${DRACUT_ARCH:-$(uname -m)} == aarch64 || ${DRACUT_ARCH:-$(uname -m)} == riscv* ]]; then
+         if [[ ${DRACUT_ARCH} == arm* || ${DRACUT_ARCH} == aarch64 || ${DRACUT_ARCH} == riscv* ]]; then
              # arm/aarch64 specific modules
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0004-fix-70kernel-modules-Explicitly-include-xhci-pci-ren.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0004-fix-70kernel-modules-Explicitly-include-xhci-pci-ren.patch
@@ -1,7 +1,7 @@
-From 66ec58fcfcf26f45375a64c282c3d92c9933aa9b Mon Sep 17 00:00:00 2001
+From 3d9f2acf2b9da7d8e06bd63c8d2b43ad61443044 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sat, 1 Mar 2025 00:54:31 +0800
-Subject: [PATCH 4/7] fix(70kernel-modules): Explicitly include
+Subject: [PATCH 4/9] fix(70kernel-modules): Explicitly include
  xhci-pci-renesas
 
 Since Linux v6.12-rc1 (commit 25f51b76f90f), xhci-pci no longer depends
@@ -52,7 +52,7 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/modules.d/70kernel-modules/module-setup.sh b/modules.d/70kernel-modules/module-setup.sh
-index b335640b..b30aa197 100755
+index f516e32b..097c74a8 100755
 --- a/modules.d/70kernel-modules/module-setup.sh
 +++ b/modules.d/70kernel-modules/module-setup.sh
 @@ -49,6 +49,12 @@ installkernel() {
@@ -66,9 +66,9 @@ index b335640b..b30aa197 100755
 +        # This makes platforms with such xHCI controllers unavailable
 +        # during initrd, and unable to boot from a USB drive.
          if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
-             # xhci-pci-renesas is needed for the USB to be available during
-             # initrd on platforms with such USB controllers since Linux
-@@ -76,7 +82,7 @@ installkernel() {
+             # Some xHCI PCI controllers are handled by sibling glue drivers
+             # instead of plain xhci-pci. Include them so USB is available
+@@ -78,7 +84,7 @@ installkernel() {
                  ohci-hcd ohci-pci \
                  uhci-hcd \
                  usbhid \
@@ -78,5 +78,5 @@ index b335640b..b30aa197 100755
  
          if [[ ${DRACUT_ARCH:-$(uname -m)} != mips64 ]]; then
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0005-dracut_functions.sh-confirm-if-the-UUID-matches-befo.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0005-dracut_functions.sh-confirm-if-the-UUID-matches-befo.patch
@@ -1,7 +1,7 @@
-From 29e19edbffc51067293d00edbad6dde660d17219 Mon Sep 17 00:00:00 2001
+From 97144c85d334f4ca68499c064f4881ce0960dc07 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Thu, 4 Dec 2025 19:10:43 +0800
-Subject: [PATCH 5/7] dracut_functions.sh: confirm if the UUID matches before
+Subject: [PATCH 5/9] dracut_functions.sh: confirm if the UUID matches before
  returning
 
 Sometimes the information read from udev may be outdated, for example a
@@ -22,7 +22,7 @@ Signed-off-by: Xinhui Yang <cyan@cyano.uk>
  1 file changed, 53 insertions(+), 2 deletions(-)
 
 diff --git a/dracut-functions.sh b/dracut-functions.sh
-index f430a28e..e3bdfd00 100755
+index 15b952ea..245e9c77 100755
 --- a/dracut-functions.sh
 +++ b/dracut-functions.sh
 @@ -286,9 +286,59 @@ get_devpath_block() {
@@ -97,5 +97,5 @@ index f430a28e..e3bdfd00 100755
          fi
      done
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0006-BACKPORT-FROMLIST-feat-decompress-kernel-modules-and.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0006-BACKPORT-FROMLIST-feat-decompress-kernel-modules-and.patch
@@ -1,7 +1,7 @@
-From 04823ea17d98d6bb1bcdca61a76d85761de7d243 Mon Sep 17 00:00:00 2001
+From 31b9b29ff61c559be807e14637a0a0c83268f1a2 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Mon, 27 Jan 2025 04:58:49 +0800
-Subject: [PATCH 6/7] BACKPORT: FROMLIST: feat: decompress kernel modules and
+Subject: [PATCH 6/9] BACKPORT: FROMLIST: feat: decompress kernel modules and
  firmware before final compression
 
 Decompress all kernel modules and firmware (if compressed), this allows
@@ -16,10 +16,10 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 48 insertions(+)
 
 diff --git a/dracut.sh b/dracut.sh
-index 9819b793..b44565bf 100755
+index 803c01e7..d5dae028 100755
 --- a/dracut.sh
 +++ b/dracut.sh
-@@ -1980,6 +1980,54 @@ dracut_kernel_post() {
+@@ -2007,6 +2007,54 @@ dracut_kernel_post() {
          fi
      fi
  
@@ -75,5 +75,5 @@ index 9819b793..b44565bf 100755
          [[ -e $srcmods/$_f ]] && inst_simple "$srcmods/$_f" "/lib/modules/$kernel/$_f"
      done
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0007-AOSCOS-70kernel-modules-add-megaraid-_sas-and-mpt3sa.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0007-AOSCOS-70kernel-modules-add-megaraid-_sas-and-mpt3sa.patch
@@ -1,7 +1,7 @@
-From 305affdc97f5c70986e1318468fdef46f2c0ca84 Mon Sep 17 00:00:00 2001
+From 5cc215a4278ec44f66a05e754e16003ae66c6dcb Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Thu, 18 Jun 2026 23:01:12 +0800
-Subject: [PATCH 7/7] AOSCOS: 70kernel-modules: add megaraid{,_sas} and mpt3sas
+Subject: [PATCH 7/9] AOSCOS: 70kernel-modules: add megaraid{,_sas} and mpt3sas
  for block modules
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
@@ -10,7 +10,7 @@ Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/modules.d/70kernel-modules/module-setup.sh b/modules.d/70kernel-modules/module-setup.sh
-index b30aa197..d8545062 100755
+index 097c74a8..d66b5d77 100755
 --- a/modules.d/70kernel-modules/module-setup.sh
 +++ b/modules.d/70kernel-modules/module-setup.sh
 @@ -31,7 +31,8 @@ installkernel() {
@@ -34,5 +34,5 @@ index b30aa197..d8545062 100755
  
          dracut_instmods -o -s "${_blockfuncs}" "=drivers"
 -- 
-2.52.0
+2.55.0
 

--- a/app-admin/dracut-ng/autobuild/patches/0008-FROMLIST-test-provide-default-test_setup-hook.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0008-FROMLIST-test-provide-default-test_setup-hook.patch
@@ -1,0 +1,29 @@
+From 258c25db886ec87dd6984e1206f12c975c9dfda7 Mon Sep 17 00:00:00 2001
+From: Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
+Date: Mon, 25 May 2026 21:35:42 +0200
+Subject: [PATCH 8/9] FROMLIST: test: provide default test_setup hook
+
+Link: https://github.com/dracut-ng/dracut/pull/2451
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ test/test-functions | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/test/test-functions b/test/test-functions
+index 52c2bfdd..6764e79b 100644
+--- a/test/test-functions
++++ b/test/test-functions
+@@ -298,6 +298,10 @@ command -v test_check &> /dev/null || test_check() {
+     :
+ }
+ 
++command -v test_setup &> /dev/null || test_setup() {
++    :
++}
++
+ command -v test_cleanup &> /dev/null || test_cleanup() {
+     :
+ }
+-- 
+2.55.0
+

--- a/app-admin/dracut-ng/autobuild/patches/0009-FROMLIST-feat-busybox-run-before-80base-so-applets-r.patch
+++ b/app-admin/dracut-ng/autobuild/patches/0009-FROMLIST-feat-busybox-run-before-80base-so-applets-r.patch
@@ -1,0 +1,290 @@
+From 53513329ce2fd59b658b2fd8b1d65c5f3f943efd Mon Sep 17 00:00:00 2001
+From: Nadzeya Hutsko <nadzeya.hutsko@canonical.com>
+Date: Wed, 22 Jul 2026 11:05:51 +0200
+Subject: [PATCH 9/9] FROMLIST: feat(busybox): run before 80base so applets
+ replace host binaries
+
+Distros that ship large coreutils binaries (e.g. Ubuntu 25.10 with
+rust-coreutils) inflate the initrd because 80base copies the host's binaries
+like cp, ls, mv in full.
+
+Rename modules.d/81busybox to modules.d/10busybox so the busybox module
+runs first. It lays down /usr/bin/busybox and applet symlinks before
+80base's inst_multiple calls.
+
+The host's util-linux switch_root is still preferred.
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2150657
+
+Link: https://github.com/dracut-ng/dracut/pull/2451
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ .github/workflows/daily-basic.yml     |  6 ++++
+ .github/workflows/integration.yml     |  5 +++
+ modules.d/10busybox/module-setup.sh   | 46 +++++++++++++++++++++++++
+ modules.d/80base/module-setup.sh      | 26 ++++++++++----
+ modules.d/81busybox/module-setup.sh   | 38 ---------------------
+ test/TEST-83-BUSYBOX-APPLETS/Makefile |  1 +
+ test/TEST-83-BUSYBOX-APPLETS/test.sh  | 49 +++++++++++++++++++++++++++
+ 7 files changed, 127 insertions(+), 44 deletions(-)
+ create mode 100755 modules.d/10busybox/module-setup.sh
+ delete mode 100755 modules.d/81busybox/module-setup.sh
+ create mode 100644 test/TEST-83-BUSYBOX-APPLETS/Makefile
+ create mode 100755 test/TEST-83-BUSYBOX-APPLETS/test.sh
+
+diff --git a/.github/workflows/daily-basic.yml b/.github/workflows/daily-basic.yml
+index e0ab08a2..a1a505b8 100644
+--- a/.github/workflows/daily-basic.yml
++++ b/.github/workflows/daily-basic.yml
+@@ -49,6 +49,7 @@ jobs:
+                     - "80"
+                     - "81"
+                     - "82"
++                    - "83"
+                 exclude:
+                     # https://github.com/dracut-ng/dracut/issues/1988
+                     - container: debian:sid
+@@ -100,10 +101,14 @@ jobs:
+                     - "80"
+                     - "81"
+                     - "82"
++                    - "83"
+                 exclude:
+                     # btrfs kernel module is not available on CentOS Stream 10
+                     - container: centos:latest
+                       test: "11"
++                    # busybox is not installed in the azurelinux image
++                    - container: azurelinux:3.0
++                      test: "83"
+         container:
+             image: ghcr.io/dracut-ng/${{ matrix.container }}
+             options: '--device=/dev/kvm --privileged'
+@@ -141,6 +146,7 @@ jobs:
+                     - "80"
+                     - "81"
+                     - "82"
++                    - "83"
+         container:
+             image: ghcr.io/dracut-ng/${{ matrix.container }}
+             options: '--device=/dev/kvm --privileged'
+diff --git a/.github/workflows/integration.yml b/.github/workflows/integration.yml
+index aa5c8de8..b079badc 100644
+--- a/.github/workflows/integration.yml
++++ b/.github/workflows/integration.yml
+@@ -98,6 +98,11 @@ jobs:
+                     - "50"
+                     - "80"
+                     - "81"
++                    - "83"
++                exclude:
++                    # busybox applet symlinks regress on Fedora, see #2454
++                    - container: fedora:latest
++                      test: "83"
+         container:
+             image: ghcr.io/dracut-ng/${{ matrix.container }}
+             options: '--device=/dev/kvm'
+diff --git a/modules.d/10busybox/module-setup.sh b/modules.d/10busybox/module-setup.sh
+new file mode 100755
+index 00000000..44181d13
+--- /dev/null
++++ b/modules.d/10busybox/module-setup.sh
+@@ -0,0 +1,46 @@
++#!/bin/bash
++
++# called by dracut
++check() {
++    require_binaries busybox || return 1
++
++    return 255
++}
++
++# This module installs busybox and its applet symlinks before the base dracut
++# module. Later modules that call inst_multiple for names busybox provides will
++# see the symlinks already in $initdir and skip the install. Modules that
++# specifically need the host's real binary must explicitly remove the symlink
++# first and reinstall (`[ -L "$initdir$bin" ] && rm "$initdir$bin"; inst "$bin"`)
++
++# called by dracut
++install() {
++    local _i _path _busybox
++    local _dstdir="${dstdir:-"$initdir"}"
++    local _progs=()
++    _busybox=$(find_binary busybox)
++    inst "$_busybox" /usr/bin/busybox
++
++    # do not depend on CONFIG_FEATURE_INSTALLER
++    # install busybox symlinks manually
++    for _i in $($_busybox --list); do
++        [[ ${_i} == busybox ]] && continue
++        _progs+=("${_i}")
++    done
++
++    for _i in "${_progs[@]}"; do
++        _path=$(find_binary "$_i")
++        [ -z "$_path" ] && continue
++
++        # An existing symlink (e.g. another applet alias) is left alone. A real
++        # file at this path comes from install_items, which dracut.sh processes
++        # before module install(). Replace it with the busybox applet so the
++        # module's "busybox wins" contract holds even when downstream configs
++        # pre-stage host binaries (e.g. Fedora's 01-dist.conf, see #2454).
++        # Modules that need the host binary must drop the symlink and reinstall
++        [ -L "${_dstdir}/$_path" ] && continue
++        [ -e "${_dstdir}/$_path" ] && rm -f "${_dstdir}/$_path"
++
++        ln_r /usr/bin/busybox "$_path"
++    done
++}
+diff --git a/modules.d/80base/module-setup.sh b/modules.d/80base/module-setup.sh
+index dfe81ec3..a7f86181 100755
+--- a/modules.d/80base/module-setup.sh
++++ b/modules.d/80base/module-setup.sh
+@@ -15,12 +15,17 @@ depends() {
+     return 0
+ }
+ 
+-# we prefer the non-busybox implementation of switch_root
+-# due to the dependency, this dracut module needs to be ordered before the busybox dracut module
+-# as this dracut module would install the non-busybox implementation of switch_root, if available
+-
+-# this dracut module needs to be ordered after the systemd-sysusers dracut module, so make sure
+-# that the root password set in for the emergency console in host-only mode
++# The busybox dracut module runs before this module and lays down its applet
++# symlinks. inst_multiple calls for those names then no-op because the
++# destinations already exist
++#
++# Exception: switch_root is preferred from the host (util-linux) over the
++# busybox applet, so the inst_multiple switch_root call below first removes any
++# busybox applet symlink the busybox dracut module may have left in place
++
++# This dracut module needs to be ordered after the systemd-sysusers dracut
++# module so the root password is set for the emergency console in host-only
++# mode
+ 
+ # called by dracut
+ install() {
+@@ -101,6 +106,15 @@ install() {
+     inst_simple "$moddir/insmodpost.sh" /sbin/insmodpost.sh
+ 
+     if ! dracut_module_included "systemd"; then
++        # Prefer the host's util-linux switch_root over the busybox
++        # applet. When the busybox dracut module is included it runs first and
++        # may have symlinked switch_root to its applet. Drop that symlink so
++        # the host binary is installed instead
++        if dracut_module_included "busybox"; then
++            local _sr
++            _sr=$(find_binary switch_root)
++            [[ -n $_sr && -L ${initdir}${_sr} ]] && rm -f "${initdir}${_sr}"
++        fi
+         inst_multiple switch_root || dfatal "Failed to install switch_root"
+         inst_script "$moddir/init.sh" "/init"
+         inst_hook cmdline 01 "$moddir/parse-kernel.sh"
+diff --git a/modules.d/81busybox/module-setup.sh b/modules.d/81busybox/module-setup.sh
+deleted file mode 100755
+index 402e1fc2..00000000
+--- a/modules.d/81busybox/module-setup.sh
++++ /dev/null
+@@ -1,38 +0,0 @@
+-#!/bin/bash
+-
+-# called by dracut
+-check() {
+-    require_binaries busybox || return 1
+-
+-    return 255
+-}
+-
+-# we prefer the non-busybox implementation of switch_root
+-# due to the dependency, the busybox dracut module needs to be order later than the base dracut module
+-# as the base dracut module would install the non-busybox implementation of switch_root, if available
+-
+-# called by dracut
+-install() {
+-    local _i _path _busybox
+-    local _dstdir="${dstdir:-"$initdir"}"
+-    local _progs=()
+-    _busybox=$(find_binary busybox)
+-    inst "$_busybox" /usr/bin/busybox
+-
+-    # do not depend on CONFIG_FEATURE_INSTALLER
+-    # install busybox symlinks manually
+-    for _i in $($_busybox --list); do
+-        [[ ${_i} == busybox ]] && continue
+-        _progs+=("${_i}")
+-    done
+-
+-    for _i in "${_progs[@]}"; do
+-        _path=$(find_binary "$_i")
+-        [ -z "$_path" ] && continue
+-
+-        # do not remove existing destination files
+-        [ -e "${_dstdir}/$_path" ] && continue
+-
+-        ln_r /usr/bin/busybox "$_path"
+-    done
+-}
+diff --git a/test/TEST-83-BUSYBOX-APPLETS/Makefile b/test/TEST-83-BUSYBOX-APPLETS/Makefile
+new file mode 100644
+index 00000000..2dcab816
+--- /dev/null
++++ b/test/TEST-83-BUSYBOX-APPLETS/Makefile
+@@ -0,0 +1 @@
++-include ../Makefile.testdir
+diff --git a/test/TEST-83-BUSYBOX-APPLETS/test.sh b/test/TEST-83-BUSYBOX-APPLETS/test.sh
+new file mode 100755
+index 00000000..e9a3ba18
+--- /dev/null
++++ b/test/TEST-83-BUSYBOX-APPLETS/test.sh
+@@ -0,0 +1,49 @@
++#!/usr/bin/env bash
++
++set -eu
++
++# shellcheck disable=SC2034
++TEST_DESCRIPTION="busybox applets win over host binaries when busybox module is included"
++
++test_check() {
++    if ! command -v busybox &> /dev/null; then
++        echo "Test needs busybox on host... Skipping"
++        return 1
++    fi
++}
++
++test_run() {
++    set -x
++    local initrd="$TESTDIR/initramfs"
++
++    test_dracut \
++        --no-hostonly --no-kernel --drivers "" \
++        --modules "base busybox" \
++        "$initrd"
++
++    # Applets the base module would otherwise install from the host. Each must
++    # resolve to busybox in the resulting initrd. Match layout-agnostically:
++    # the applet may live under bin/ or usr/bin/, and the symlink target may be
++    # relative (e.g. bin/cp -> ../usr/bin/busybox on alpine) or just "busybox"
++    local _applet ret=0
++    local _listing
++    _listing=$(lsinitrd "$initrd")
++    for _applet in cp ls mv rm mkdir sleep tr; do
++        if ! grep -qE "(^|/)$_applet -> ([^ ]*/)?busybox\$" <<< "$_listing"; then
++            echo "FAIL: $_applet is not a busybox symlink in the initrd" >&2
++            ret=1
++        fi
++    done
++
++    # switch_root must NOT be a busybox symlink as the base module reinstalls
++    # the host util-linux version on top of any symlink the busybox module left
++    if grep -E '^l.* switch_root -> .*busybox' <<< "$_listing"; then
++        echo "FAIL: switch_root is a busybox symlink, host version was not preserved" >&2
++        ret=1
++    fi
++
++    return "$ret"
++}
++
++# shellcheck disable=SC1090
++. "$testdir"/test-functions
+-- 
+2.55.0
+

--- a/app-admin/dracut-ng/spec
+++ b/app-admin/dracut-ng/spec
@@ -1,5 +1,4 @@
-VER=110
-REL=1
+VER=112
 SRCS="git::commit=tags/$VER::https://github.com/dracut-ng/dracut-ng"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372171"


### PR DESCRIPTION
Topic Description
-----------------

- dracut-ng: update to 112
    - Introduce patches to prefer BusyBox applets over host binaries.
    - Track patches at AOSC-Tracking/dracut-ng @ aosc/112
    \(HEAD: 53513329ce2fd59b658b2fd8b1d65c5f3f943efd\).

Package(s) Affected
-------------------

- dracut-ng: 112

Security Update?
----------------

No

Build Order
-----------

```
#buildit dracut-ng
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
