### PR TITLE
edit: allow build on retro, remove internal tools from package

### DIFF
--- a/app-editors/edit/autobuild/defines
+++ b/app-editors/edit/autobuild/defines
@@ -9,6 +9,13 @@ PKGSEC="editors"
 ABTYPE=rust
 USECLANG=1
 
+CARGO_AFTER=(
+	-p edit
+)
+
 # FIXME: ld.lld: error: Unknown attribute kind (105)
 NOLTO__LOONGARCH64=1
 NOLTO__LOONGARCH64_NOSIMD=1
+
+# Note: limited by rustc
+FAIL_ARCH="@(armv4)"

--- a/app-editors/edit/spec
+++ b/app-editors/edit/spec
@@ -1,4 +1,5 @@
 VER=2.0.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/microsoft/edit"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378257"


### PR DESCRIPTION
Topic Description
-----------------

- edit: allow build on retro, remove internal tools from package

Package(s) Affected
-------------------

- edit: 2.0.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit edit
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
