### PR TITLE
libffi: update to 3.8.0

### DIFF
--- a/runtime-common/libffi/spec
+++ b/runtime-common/libffi/spec
@@ -1,4 +1,4 @@
-VER=3.6.0
+VER=3.8.0
 SRCS="tbl::https://github.com/libffi/libffi/releases/download/v${VER}/libffi-${VER}.tar.gz"
-CHKSUMS="sha256::31ff1fe32deaebfbb388727f32677bb254bf2a41382c51464c0b1837c9ee9828"
+CHKSUMS="sha256::7da3e2d9a171eb0a038f592ecad3ff2bb2550f3496d87b3b29ad0cf4430c0db4"
 CHKUPDATE="anitya::id=1611"


### PR DESCRIPTION
Topic Description
-----------------

- libffi: update to 3.8.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libffi: 3.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libffi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
