### PR TITLE
ptyprocess: fix build with flit-core 4

### DIFF
--- a/lang-python/ptyprocess/autobuild/defines
+++ b/lang-python/ptyprocess/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=ptyprocess
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="setuptools"
+BUILDDEP="setuptools flit-core"
 PKGDES="Run a subprocess in a pseudo-terminal"
 
 ABHOST=noarch

--- a/lang-python/ptyprocess/autobuild/patches/0001-GENTOO-flit-core-4.patch
+++ b/lang-python/ptyprocess/autobuild/patches/0001-GENTOO-flit-core-4.patch
@@ -1,0 +1,51 @@
+From c7fcf9ea8414c2815f7f1b1ae8baf92b1cad9ef4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20G=C3=B3rny?= <mgorny@gentoo.org>
+Date: Fri, 7 Aug 2026 17:10:13 +0200
+Subject: [PATCH] Use PEP 621 metadata to fix flit-core-4 compatibility
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Górny <mgorny@gentoo.org>
+---
+ pyproject.toml | 17 ++++++++++-------
+ 1 file changed, 10 insertions(+), 7 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 5228534..bca7599 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,13 +1,15 @@
+ [build-system]
+-requires = ["flit_core >=2,<4"]
++requires = ["flit_core >=2,<5"]
+ build-backend = "flit_core.buildapi"
+ 
+-[tool.flit.metadata]
+-module = "ptyprocess"
+-author = "Thomas Kluyver"
+-author-email = "thomas@kluyver.me.uk"
+-home-page = "https://github.com/pexpect/ptyprocess"
+-description-file = "README.rst"
++[project]
++name = "ptyprocess"
++authors = [
++    { name = "Thomas Kluyver", email = "thomas@kluyver.me.uk" },
++]
++readme = "README.rst"
++requires-python = ">=3.7"
++dynamic = ["version", "description"]
+ classifiers = [
+     "Development Status :: 5 - Production/Stable",
+     "Environment :: Console",
+@@ -17,8 +19,9 @@ classifiers = [
+     "Operating System :: POSIX",
+     "Operating System :: MacOS :: MacOS X",
+     "Programming Language :: Python",
+-    "Programming Language :: Python :: 2.7",
+     "Programming Language :: Python :: 3",
+     "Topic :: Terminals"
+ ]
+ 
++[project.urls]
++Homepage = "https://github.com/pexpect/ptyprocess"

--- a/lang-python/ptyprocess/spec
+++ b/lang-python/ptyprocess/spec
@@ -1,4 +1,5 @@
 VER=0.7.0
+REL=1
 SRCS="pypi::version=$VER::ptyprocess"
 CHKSUMS="sha256::5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
 CHKUPDATE="anitya::id=6447"


### PR DESCRIPTION
Topic Description
-----------------

- ptyprocess: fix build with flit-core 4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- ptyprocess: 0.7.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ptyprocess
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
