### PR TITLE
rime-ice: update to 2026.06.30

### DIFF
--- a/app-i18n/rime-ice/autobuild/build
+++ b/app-i18n/rime-ice/autobuild/build
@@ -3,8 +3,10 @@ rm -v "$SRCDIR"/default.yaml
 
 abinfo "Installing Schema to rime-ice..."
 install -Dvm644 "$SRCDIR"/*.yaml -t "$PKGDIR"/usr/share/rime-data/
+install -Dvm644 "$SRCDIR"/*.txt -t "$PKGDIR"/usr/share/rime-data/
 install -Dvm644 "$SRCDIR"/cn_dicts/* -t "$PKGDIR"/usr/share/rime-data/cn_dicts/
 install -Dvm644 "$SRCDIR"/en_dicts/* -t "$PKGDIR"/usr/share/rime-data/en_dicts/
+# Note: lua and others have sub directory,so we can't use install
 mkdir -pv "$PKGDIR"/usr/share/rime-data/lua
 mkdir -pv  "$PKGDIR"/usr/share/rime-data/others
 cp -rv "$SRCDIR"/lua/* "$PKGDIR"/usr/share/rime-data/lua/

--- a/app-i18n/rime-ice/spec
+++ b/app-i18n/rime-ice/spec
@@ -1,4 +1,4 @@
-VER=2025.12.08
+VER=2026.06.30
 SRCS="git::commit=tags/$VER::https://github.com/iDvel/rime-ice.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377230"


### PR DESCRIPTION
Topic Description
-----------------

- rime-ice: update to 2026.06.30
    Co-authored-by: Alan Lin \(@miwu04\)

Package(s) Affected
-------------------

- rime-ice: 2026.06.30

Security Update?
----------------

No

Build Order
-----------

```
#buildit rime-ice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
