### PR TITLE
nanobind: update to 3.0.0

### DIFF
--- a/app-creativity/blender/spec
+++ b/app-creativity/blender/spec
@@ -3,3 +3,4 @@ SRCS="git::commit=tags/v$VER;copy-repo=true::https://projects.blender.org/blende
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=201"
 ENVREQ__LOONGSON3="total_mem=60"
+REL=1

--- a/lang-python/nanobind/autobuild/defines
+++ b/lang-python/nanobind/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME="nanobind"
 PKGSEC="python"
-PKGDEP="python-3 typing-extensions exceptiongroup robin-map"
-BUILDDEP="scikit-build-core setuptools-python3"
+PKGDEP="python-3 robin-map"
+BUILDDEP="scikit-build-core"
 PKGDES="Binding library that exposes C++ types in Python and vice versa"
 
 ABTYPE=pep517

--- a/lang-python/nanobind/spec
+++ b/lang-python/nanobind/spec
@@ -1,4 +1,4 @@
-VER=2.12.0
+VER=3.0.0
 SRCS="git::commit=tags/v$VER::https://github.com/wjakob/nanobind"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=297734"

--- a/runtime-common/openvdb/spec
+++ b/runtime-common/openvdb/spec
@@ -3,4 +3,4 @@ SRCS="git::commit=tags/v${VER}::https://github.com/AcademySoftwareFoundation/ope
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21124"
 ENVREQ__ARM64="total_mem=30"
-REL=1
+REL=2

--- a/runtime-display/manifold/autobuild/defines
+++ b/runtime-display/manifold/autobuild/defines
@@ -5,6 +5,8 @@ BUILDDEP="python-3"
 PKGSUG="python-3"
 PKGDES="Geometry library for topological robustness"
 
+PKGBREAK="blender<=5.2.0"
+
 ABTYPE=cmakeninja
 CMAKE_AFTER=(
     '-DBUILD_SHARED_LIBS=ON'

--- a/runtime-display/manifold/spec
+++ b/runtime-display/manifold/spec
@@ -1,5 +1,4 @@
-VER=3.4.1
+VER=3.5.2
 SRCS="tbl::https://github.com/elalish/manifold/releases/download/v$VER/manifold-$VER.tar.gz"
-CHKSUMS="sha256::c0283695648886df3a0ab35ead473622338782a05a247664925eb3c41ced0181"
+CHKSUMS="sha256::ce5f4d87877daca99a910d0af73c028f2a36b9288dd2bf3cd1cecf8faff9f7c8"
 CHKUPDATE="anitya::id=379833"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- blender: rebuild for manifold 3.5.2
- openvdb: rebuild for nanobind 3.0.0
- manifold: update to 3.5.2
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- nanobind: update to 3.0.0
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- blender: 5.2.0-1
- manifold: 3.5.2
- nanobind: 3.0.0
- openvdb: 13.0.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit nanobind manifold openvdb blender
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
