### PR TITLE
publicsuffixlist: update to 1.0.2.20260821

### DIFF
--- a/lang-python/publicsuffixlist/spec
+++ b/lang-python/publicsuffixlist/spec
@@ -1,5 +1,4 @@
-VER=1.0.2.20250809
+VER=1.0.2.20260821
 SRCS="git::commit=v${VER}-gha::https://github.com/ko-zu/psl.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=70367"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- publicsuffixlist: update to 1.0.2.20260821
    Co-authored-by: Colinxu2020 \(@colinxu2020\)

Package(s) Affected
-------------------

- publicsuffixlist: 1.0.2.20260821

Security Update?
----------------

No

Build Order
-----------

```
#buildit publicsuffixlist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
