### PR TITLE
Python FTBFS Survey

### DIFF
--- a/lang-python/charset-normalizer/spec
+++ b/lang-python/charset-normalizer/spec
@@ -1,4 +1,4 @@
-VER=3.4.9
+VER=3.5.1
 SRCS="pypi::version=$VER::charset-normalizer"
-CHKSUMS="sha256::673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b"
+CHKSUMS="sha256::6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3"
 CHKUPDATE="anitya::id=55366"

--- a/lang-python/py-filelock/spec
+++ b/lang-python/py-filelock/spec
@@ -1,4 +1,4 @@
-VER=3.32.3
-SRCS="pypi::ver=$VER::filelock"
-CHKSUMS="sha256::0ffa185a3540854c95caa7fa76b76cb219d907415e2c5dc9af25fd970563487f"
+VER=3.32.4
+SRCS="pypi::version=$VER::filelock"
+CHKSUMS="sha256::2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30"
 CHKUPDATE="anitya::id=11739"


### PR DESCRIPTION
Topic Description
-----------------

- charset-normalizer: update to 3.5.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- py-filelock: update to 3.32.4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit py-filelock charset-normalizer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
