### PR TITLE
86box: backport patch to add RISC-V and Loongarch64 support

### DIFF
--- a/app-emulation/86box/autobuild/patches/0002-Add-RISC-V-and-Loongarch64-support.patch
+++ b/app-emulation/86box/autobuild/patches/0002-Add-RISC-V-and-Loongarch64-support.patch
@@ -1,0 +1,55 @@
+From 357766f4aa46a6551adb7598bbc15119018af885 Mon Sep 17 00:00:00 2001
+From: chun-awa <chun-awa@aosc.io>
+Date: Tue, 25 Aug 2026 14:49:08 +0800
+Subject: [PATCH] Add RISC-V and Loongarch64 support
+
+Backport patch from upstream commit 50c2ffb and 2fa21cb.
+---
+ src/cpu/386_common.h   | 2 +-
+ src/include/shathree.h | 3 ++-
+ src/sio/sio_um8669f.c  | 2 +-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/src/cpu/386_common.h b/src/cpu/386_common.h
+index 1efda9d4f..999cced1d 100644
+--- a/src/cpu/386_common.h
++++ b/src/cpu/386_common.h
+@@ -539,7 +539,7 @@ fastreadl_fetch(uint32_t a)
+             pccache2 = t;
+             pccache  = a >> 12;
+         }
+-#    if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64)
++#    if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64 || (defined(__riscv) && (__SIZEOF_POINTER__ == 8)) || defined(__loongarch_lp64))
+         return *((uint32_t *) (((uintptr_t) &pccache2[a] & 0x00000000ffffffffULL) | ((uintptr_t) &pccache2[0] & 0xffffffff00000000ULL)));
+ #    else
+         return AS_U32(pccache2[a]);
+diff --git a/src/include/shathree.h b/src/include/shathree.h
+index 98e804b33..d5e39a19a 100644
+--- a/src/include/shathree.h
++++ b/src/include/shathree.h
+@@ -38,7 +38,8 @@
+ # if defined(i386)     || defined(__i386__)   || defined(_M_IX86) ||    \
+      defined(__x86_64) || defined(__x86_64__) || defined(_M_X64)  ||    \
+      defined(_M_AMD64) || defined(_M_ARM)     || defined(__x86)   ||    \
+-     defined(__arm__)
++     defined(__arm__)  || (defined(__riscv) && (__SIZEOF_POINTER__ == 8)) || \
++     defined(__loongarch_lp64)
+ #   define SHA3_BYTEORDER    1234
+ # elif defined(sparc)    || defined(__ppc__)
+ #   define SHA3_BYTEORDER    4321
+diff --git a/src/sio/sio_um8669f.c b/src/sio/sio_um8669f.c
+index 3431ae63e..88d0ad805 100644
+--- a/src/sio/sio_um8669f.c
++++ b/src/sio/sio_um8669f.c
+@@ -225,7 +225,7 @@ um8669f_pnp_config_changed(uint8_t ld, isapnp_device_config_t *config, void *pri
+ 
+             if (dev->ide < IDE_BUS_MAX) {
+                 config->io[1].base = config->io[0].base + 0x206; /* status port apparently fixed */
+-#if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64)
++#if (defined __amd64__ || defined _M_X64 || defined __aarch64__ || defined _M_ARM64 || (defined(__riscv) && (__SIZEOF_POINTER__ == 8)) || defined(__loongarch_lp64))
+                 ide_pnp_config_changed(0, config, (void *) (int64_t) dev->ide);
+ #else
+                 ide_pnp_config_changed(0, config, (void *) (int) dev->ide);
+-- 
+2.55.0
+

--- a/app-emulation/86box/spec
+++ b/app-emulation/86box/spec
@@ -1,5 +1,5 @@
 VER=6.0
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/86Box/86Box"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=268422"


### PR DESCRIPTION
<!-- For description on topic creation and maintenance, please refer to
     [this Wiki article](https://wiki.aosc.io/developer/packaging/topic-based-maintenance-guideline/). -->

Topic Description
-----------------

Backport patch from upstream commit [`50c2ffb`](https://github.com/86Box/86Box/commit/50c2ffb01fecc3e7fca387d76036bb0bf7bf4bca) and [`2fa21cb`](https://github.com/86Box/86Box/commit/2fa21cb60f3bcded2fb1203fdc97db2bd412892c).

Package(s) Affected
-------------------

- 86box: 6.0-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit 86box
```

Test Build(s) Done
------------------

<!-- The check boxes in this section should ONLY be set by the buildit
     infrastructure. Under no circumstances a person can set any of them
     by hand. Keep them unset for new pull requests, and unset them if
     you've made a change to the pull request after buildit set them. -->

**Primary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`
<!-- If the pull request involves a `+32` counterpart, please uncomment the
     line below. -->
<!-- - [ ] 32-bit Optional Environment `optenv32` -->

<!-- If all package(s) affected by this topic is `noarch`, please use the
     following and remove all other architectures. -->
<!-- - [ ] Architecture-independent `noarch` -->

**Secondary Architectures**

<!-- Please remove any architecture to which this topic does not apply. -->

<!-- Should build failures amongst secondary architectures be found as
     difficult to resolve, please mark them as FAIL_ARCH and/or notify a
     maintainer for assistance. -->

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

<!-- Maintainers should review file changes and make sure that the change(s)
     complies with our
     [Package Styling Manual](https://wiki.aosc.io/developer/packaging/package-styling-manual/) -->

<!-- Maintainers and users may now test the packages in this topic and, once
     user/maintainer feedback indicates that the update(s) work as expected and
     find its quality satisfactory, another maintainer may now review this pull
     request and mark it as "Approved."

     After which, the maintainer will build affected package(s) and upload them
     to the `stable` repository. -->
