### PR TITLE
python-installer: update to 1.0.1

### DIFF
--- a/lang-python/python-installer/autobuild/defines
+++ b/lang-python/python-installer/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=python-installer
 PKGSEC=python
 PKGDEP="python-3"
 BUILDDEP="python-build"
-PKGDES="A low-level library for installing from a Python wheel distribution"
+PKGDES="Low-level library for installing from a Python wheel distribution"
 
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/python-installer/autobuild/defines.stage2
+++ b/lang-python/python-installer/autobuild/defines.stage2
@@ -2,7 +2,7 @@ PKGNAME=python-installer
 PKGSEC=python
 PKGDEP="python-3"
 BUILDDEP="flit-core"
-PKGDES="A low-level library for installing from a Python wheel distribution"
+PKGDES="Low-level library for installing from a Python wheel distribution"
 
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/python-installer/autobuild/patches/0001-AOSC-flit-core-4.patch
+++ b/lang-python/python-installer/autobuild/patches/0001-AOSC-flit-core-4.patch
@@ -1,0 +1,11 @@
+--- a/pyproject.toml	2026-08-24 21:07:20.280284834 +0800
++++ b/pyproject.toml	2026-08-24 21:07:20.283282838 +0800
+@@ -1,7 +1,7 @@
+ [build-system]
+ build-backend = "flit_core.buildapi"
+ requires = [
+-    "flit_core<4,>=3.11",
++    "flit_core>=3.11",
+ ]
+ 
+ [project]

--- a/lang-python/python-installer/spec
+++ b/lang-python/python-installer/spec
@@ -1,5 +1,4 @@
-VER=0.7.0
-SRCS="tbl::https://pypi.io/packages/source/i/installer/installer-$VER.tar.gz"
-CHKSUMS="sha256::a26d3e3116289bb08216e0d0f7d925fcef0b0194eedfa0c944bcaaa106c4b631"
+VER=1.0.1
+SRCS="pypi::version=$VER::installer"
+CHKSUMS="sha256::052c7fc3721d54c696e2dea019be67539d7b144e924f559f54beb3121831c364"
 CHKUPDATE="anitya::id=197662"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- python-installer: update to 1.0.1

Package(s) Affected
-------------------

- python-installer: 1.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit python-installer
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
