### PR TITLE
zfs: update to 2.4.4

### DIFF
--- a/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
+++ b/app-admin/zfs/autobuild/patches/0003-Explicitly-load-the-ZFS-module-via-systemd-service.patch
@@ -1,9 +1,12 @@
-From 8a273632de0894f26db01d0c47c6764e4767668c Mon Sep 17 00:00:00 2001
+From d6338b308affcca8a0021e95341fd1ed5563e5db Mon Sep 17 00:00:00 2001
 From: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
-Date: Tue, 16 Jul 2024 15:35:34 +0800
+Date: Fri, 28 Aug 2026 02:23:49 +0800
 Subject: [PATCH 3/4] Explicitly load the ZFS module via systemd service
 
-See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd01921cfaa7ce1bad87/debian/patches/2100-zfs-load-module.patch
+Add zfs-load-module.service to explicitly load the ZFS kernel module
+before importing pools.
+
+AOSC: Refresh the change against the current upstream systemd units.
 ---
  contrib/dracut/90zfs/module-setup.sh.in        |  3 ++-
  etc/Makefile.am                                |  1 +
@@ -15,24 +18,24 @@ See: https://salsa.debian.org/zfsonlinux-team/zfs/-/blob/0b542b085ec0a4070392bd0
  create mode 100644 etc/systemd/system/zfs-load-module.service.in
 
 diff --git a/contrib/dracut/90zfs/module-setup.sh.in b/contrib/dracut/90zfs/module-setup.sh.in
-index acad468ed..58a98d77a 100755
+index 130d94c70..f765cb26c 100755
 --- a/contrib/dracut/90zfs/module-setup.sh.in
 +++ b/contrib/dracut/90zfs/module-setup.sh.in
-@@ -95,7 +95,8 @@ install() {
+@@ -96,7 +96,8 @@ install() {
  
  		for _service in \
  			"zfs-import-scan.service" \
 -			"zfs-import-cache.service"; do
 +			"zfs-import-cache.service" \
-+            "zfs-load-module.service"; do
++			"zfs-load-module.service"; do
  			inst_simple "${systemdsystemunitdir}/${_service}"
  			systemctl -q --root "${initdir}" add-wants zfs-import.target "${_service}"
  
 diff --git a/etc/Makefile.am b/etc/Makefile.am
-index 808c729cd..cd127ae66 100644
+index a795bec16..cafd51ebb 100644
 --- a/etc/Makefile.am
 +++ b/etc/Makefile.am
-@@ -52,6 +52,7 @@ dist_systemdpreset_DATA = \
+@@ -47,6 +47,7 @@ dist_systemdpreset_DATA = \
  	%D%/systemd/system/50-zfs.preset
  
  systemdunit_DATA = \
@@ -50,33 +53,33 @@ index e4056a92c..b53e2c8a8 100644
  enable zfs.target
 +enable zfs-load-module.service
 diff --git a/etc/systemd/system/zfs-import-cache.service.in b/etc/systemd/system/zfs-import-cache.service.in
-index fd822989d..7e1fea5f8 100644
+index c7aa34ccb..a86695dec 100644
 --- a/etc/systemd/system/zfs-import-cache.service.in
 +++ b/etc/systemd/system/zfs-import-cache.service.in
 @@ -3,7 +3,9 @@ Description=Import ZFS pools by cache file
  Documentation=man:zpool(8)
  DefaultDependencies=no
- Requires=systemd-udev-settle.service
+ Wants=systemd-udev-settle.service
 +Requires=zfs-load-module.service
  After=systemd-udev-settle.service
 +After=zfs-load-module.service
+ After=systemd-udev-trigger.service
+ After=systemd-modules-load.service
  After=cryptsetup.target
- After=multipathd.service
- After=systemd-remount-fs.service
 diff --git a/etc/systemd/system/zfs-import-scan.service.in b/etc/systemd/system/zfs-import-scan.service.in
-index c5dd45d87..ca506891a 100644
+index b83476771..ac20a77e2 100644
 --- a/etc/systemd/system/zfs-import-scan.service.in
 +++ b/etc/systemd/system/zfs-import-scan.service.in
 @@ -3,7 +3,9 @@ Description=Import ZFS pools by device scanning
  Documentation=man:zpool(8)
  DefaultDependencies=no
- Requires=systemd-udev-settle.service
+ Wants=systemd-udev-settle.service
 +Requires=zfs-load-module.service
  After=systemd-udev-settle.service
 +After=zfs-load-module.service
+ After=systemd-udev-trigger.service
+ After=systemd-modules-load.service
  After=cryptsetup.target
- After=multipathd.service
- Before=zfs-import.target
 diff --git a/etc/systemd/system/zfs-load-module.service.in b/etc/systemd/system/zfs-load-module.service.in
 new file mode 100644
 index 000000000..d74af0468
@@ -101,5 +104,5 @@ index 000000000..d74af0468
 +WantedBy=zfs-mount.service
 +WantedBy=zfs.target
 -- 
-2.51.0
+2.55.0
 

--- a/app-admin/zfs/spec
+++ b/app-admin/zfs/spec
@@ -1,4 +1,4 @@
-VER=2.4.3
+VER=2.4.4
 SRCS="git::commit=tags/zfs-$VER::https://github.com/openzfs/zfs"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11706"


### PR DESCRIPTION
Topic Description
-----------------

- zfs: update to 2.4.4
    Co-authored-by: Gray David \(@grayawa\)

Package(s) Affected
-------------------

- zfs: 2.4.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit zfs
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
