### PR TITLE
amo: update to 0.5.1

### DIFF
--- a/app-admin/amo/spec
+++ b/app-admin/amo/spec
@@ -1,4 +1,4 @@
-VER=0.4.3
+VER=0.5.1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/amo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391048"


### PR DESCRIPTION
Topic Description
-----------------

- amo: update to 0.5.1
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- amo: 0.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit amo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
