### PR TITLE
gzip: fix CVE-2026-41992

### DIFF
--- a/app-utils/gzip/autobuild/defines
+++ b/app-utils/gzip/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=gzip
-PKGDES="A compression utility designed to be a replacement for compress (UNIX)"
+PKGDES="Compression utility designed to be a replacement for compress (UNIX)"
 PKGSEC=utils
 PKGDEP="glibc"
 PKGEPOCH=1
 
-RECONF=0
 AB_FLAGS_O3=1
 
 PKGESS=1

--- a/app-utils/gzip/autobuild/patches/0001-BACKPORT-CVE-2026-41992.patch
+++ b/app-utils/gzip/autobuild/patches/0001-BACKPORT-CVE-2026-41992.patch
@@ -1,0 +1,82 @@
+From 63dbf6b3b9e6e781df1a6a64e609b10e23969681 Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Wed, 15 Apr 2026 12:00:17 -0700
+Subject: [PATCH] =?UTF-8?q?gzip:=20don=E2=80=99t=20mishandle=20.lzh=20afte?=
+ =?UTF-8?q?r=20.Z?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Problem reported by Michał Majchrowicz.
+* unlzh.c (read_c_len): Clear left and right when n == 0.
+
+Signed-off-by: stydxm <stydxm@outlook.com>
+---
+ NEWS    | 21 +++++++++++++++++++++
+ THANKS  |  1 +
+ unlzh.c |  6 ++++++
+ 3 files changed, 28 insertions(+)
+
+diff --git a/NEWS b/NEWS
+index 53bdf56..da5e75f 100644
+--- a/NEWS
++++ b/NEWS
+@@ -1,5 +1,26 @@
+ GNU gzip NEWS                                    -*- outline -*-
+ 
++* Noteworthy changes in release ?.? (????-??-??) [?]
++
++** Bug fixes
++
++  gzip -d no longer rejects PKZIP signatures, local header, and data
++  descriptors.  These can appear in well-formed streamed zip files.
++  [bug present since the beginning]
++
++  A use of uninitialized memory on some malformed inputs has been fixed.
++  [bug present since the beginning]
++
++  A buffer overflow has been fixed when decompressing an .lzh file
++  after decompressing a .Z file.
++  [bug present since the beginning]
++
++** Changes in behavior
++
++  gzip -l now reports "-Inf%" instead of "0.0%" for the infinite
++  compression ratio of an empty file.
++
++
+ * Noteworthy changes in release 1.14 (2025-04-09) [stable]
+ 
+ ** Bug fixes
+diff --git a/THANKS b/THANKS
+index 6373fea..b4e373c 100644
+--- a/THANKS
++++ b/THANKS
+@@ -186,6 +186,7 @@ Jamie Lokier            u90jl@ecs.oxford.ac.uk
+ Richard Lloyd           R.K.Lloyd@csc.liv.ac.uk
+ David J. MacKenzie	djm@eng.umd.edu
+ John R MacMillan        john@chance.gts.org
++Michał Majchrowicz	mmajchrowicz@afine.com
+ Ron Male                male@eso.mc.xerox.com
+ Jakub Martisko		jamartis@redhat.com
+ Don R. Maszle           maze@bea.lbl.gov
+diff --git a/unlzh.c b/unlzh.c
+index 3320196..a6cf109 100644
+--- a/unlzh.c
++++ b/unlzh.c
+@@ -232,6 +232,12 @@ read_c_len ()
+         c = getbits(CBIT);
+         for (i = 0; i < NC; i++) c_len[i] = 0;
+         for (i = 0; i < 4096; i++) c_table[i] = c;
++
++        /* Needed in case LEFT and RIGHT are reused from a previous
++           LZW decompression.  It may be overkill to clear all of both
++           arrays, but nobody has had time to analyze this carefully.  */
++        memzero(left, (2 * NC - 1) * sizeof *left);
++        memzero(right, (2 * NC - 1) * sizeof *left);
+     } else {
+         i = 0;
+         while (i < n) {
+-- 
+2.34.1
+

--- a/app-utils/gzip/spec
+++ b/app-utils/gzip/spec
@@ -1,4 +1,5 @@
 VER=1.14
+REL=1
 SRCS="tbl::https://ftp.gnu.org/gnu/gzip/gzip-$VER.tar.xz"
 CHKSUMS="sha256::01a7b881bd220bfdf615f97b8718f80bdfd3f6add385b993dcf6efd14e8c0ac6"
 CHKUPDATE="anitya::id=1290"

--- a/topics/gzip-1.14-1.toml
+++ b/topics/gzip-1.14-1.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "GNU zip 1.14, Revision 1"
+zh_CN = "GNU zip 1.14，修订版本 1"
+
+[caution]
+default = "Fixes a Buffer Over-read vulnerability (CVE-2026-41992, severity: High)"
+zh_CN = "修复 1 个缓冲区越界读取漏洞（CVE-2026-41992，严重性：高）"
+
+[packages-v2]
+"gzip" = "< 1.14-1"


### PR DESCRIPTION
Topic Description
-----------------

- gzip: fix CVE-2026-41992
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- gzip: 1:1.14-1

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit gzip
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
