### PR TITLE
cherrytree: update to 1.7.2

### DIFF
--- a/app-productivity/cherrytree/spec
+++ b/app-productivity/cherrytree/spec
@@ -1,4 +1,4 @@
-VER=1.7.1
+VER=1.7.2
 SRCS="git::commit=tags/v$VER::https://github.com/giuspen/cherrytree"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279"


### PR DESCRIPTION
Topic Description
-----------------

- cherrytree: update to 1.7.2

Package(s) Affected
-------------------

- cherrytree: 1.7.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit cherrytree
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
