### PR TITLE
wxbase: revert --enable-glcanvasegl

### DIFF
--- a/runtime-desktop/wxwidgets/01-wxbase/defines
+++ b/runtime-desktop/wxwidgets/01-wxbase/defines
@@ -14,7 +14,7 @@ AUTOTOOLS_AFTER=(
     '--enable-mediactrl'
     '--enable-webview'
     '--disable-precomp-headers'
-    '--enable-glcanvasegl'
+    '--disable-glcanvasegl'
     '--with-libpng=sys'
     '--with-libxpm=sys'
     '--with-libjpeg=sys'

--- a/runtime-desktop/wxwidgets/spec
+++ b/runtime-desktop/wxwidgets/spec
@@ -1,5 +1,5 @@
 VER=3.2.10
-REL=1
+REL=2
 SRCS="tbl::https://github.com/wxWidgets/wxWidgets/releases/download/v$VER/wxWidgets-$VER.tar.bz2"
 CHKSUMS="sha256::d66e929569947a4a5920699539089a9bda83a93e5f4917fb313a61f0c344b896"
 CHKUPDATE="anitya::id=5150"


### PR DESCRIPTION
Topic Description
-----------------

- wxbase: revert --disable-glcanvasegl

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit wxbase wxgtk3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
