### PR TITLE
flit-core 4 Survey

### DIFF
--- a/lang-python/mypy-extensions/autobuild/patches/0001-AOSC-flit-core-4.patch
+++ b/lang-python/mypy-extensions/autobuild/patches/0001-AOSC-flit-core-4.patch
@@ -1,0 +1,11 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 9bf3493..d7fc90b 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires      = ["flit_core>=3.11,<4"]
++requires      = ["flit_core>=3.11"]
+ build-backend = "flit_core.buildapi"
+ 
+ [project]

--- a/lang-python/mypy-extensions/spec
+++ b/lang-python/mypy-extensions/spec
@@ -1,5 +1,5 @@
 VER=1.1.0
+REL=2
 SRCS="git::commit=tags/$VER::https://github.com/python/mypy_extensions"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=23367"
-REL="1"

--- a/lang-python/pep517/autobuild/patches/0001-BACKPORT-flit-core-4.patch
+++ b/lang-python/pep517/autobuild/patches/0001-BACKPORT-flit-core-4.patch
@@ -1,0 +1,53 @@
+From 84802fe3dd17ce904f8a4293f49bcdfd7e98564a Mon Sep 17 00:00:00 2001
+From: Thomas Kluyver <thomas@kluyver.me.uk>
+Date: Mon, 31 Oct 2022 11:09:53 +0000
+Subject: [PATCH] Convert pyproject.toml to PEP-621 [project] style metadata
+
+---
+ pyproject.toml | 26 +++++++++++++++-----------
+ 1 file changed, 15 insertions(+), 11 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 9f407a3..e61bb92 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,24 +1,28 @@
+ [build-system]
+-requires = ["flit_core >=2,<4"]
++requires = ["flit_core >=3.2"]
+ build-backend = "flit_core.buildapi"
+ 
+-[tool.flit.metadata]
+-module = "pep517"
+-author = "Thomas Kluyver"
+-author-email = "thomas@kluyver.me.uk"
+-home-page = "https://github.com/pypa/pep517"
+-description-file = "README.rst"
+-requires = [
+-    "tomli >=1.1.0;python_version<'3.11'",
+-    "importlib_metadata;python_version<'3.8'",
+-    "zipp;python_version<'3.8'",
++[project]
++name = "pep517"
++authors = [
++    {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
+ ]
++readme = "README.rst"
+ requires-python = ">=3.6"
++dependencies = [
++    "tomli >=1.1.0 ; python_version<'3.11'",
++    "importlib_metadata ; python_version<'3.8'",
++    "zipp ; python_version<'3.8'",
++]
+ classifiers = [
+     "License :: OSI Approved :: MIT License",
+     "Programming Language :: Python :: 3",
+     "Programming Language :: Python :: 3 :: Only",
+ ]
++dynamic = ["version", "description"]
++
++[project.urls]
++Homepage = "https://github.com/pypa/pep517"
+ 
+ [tool.isort]
+ profile = "black"

--- a/lang-python/pep517/spec
+++ b/lang-python/pep517/spec
@@ -1,4 +1,5 @@
 VER=0.13.1
+REL=1
 SRCS="pypi::version=$VER::pep517"
 CHKSUMS="sha256::1b2fa2ffd3938bb4beffe5d6146cbcb2bda996a5a4da9f31abffd8b24e07b317"
 CHKUPDATE="anitya::id=47623"

--- a/lang-python/pypdf/autobuild/defines
+++ b/lang-python/pypdf/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=pypdf
 PKGSEC=python
 PKGDEP="python-3"
-BUILDDEP="wheel python-build python-installer"
-PKGDES="Python3 library built as a PDF toolkit"
+BUILDDEP="flit-core"
+PKGDES="Python PDF library capable of splitting, merging, cropping, and transforming the pages of PDF files"
 
 ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/pypdf/spec
+++ b/lang-python/pypdf/spec
@@ -1,5 +1,4 @@
-VER=6.5.0
+VER=6.16.2
 SRCS="git::commit=$VER::https://github.com/py-pdf/pypdf.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=315408"
-REL="1"

--- a/lang-python/socksio/spec
+++ b/lang-python/socksio/spec
@@ -1,5 +1,4 @@
-VER=1.0.0+git20240301
-SRCS="git::commit=b326406915fd98a8185c1c160165c5b8963b30c1::https://github.com/sethmlarson/socksio.git"
+VER=1.0.0+git20260824
+SRCS="git::commit=3ab79556aa7c4757d461a436507f2109db0f6a9e::https://github.com/sethmlarson/socksio.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=51593"
-REL="1"


### PR DESCRIPTION
Topic Description
-----------------

- pypdf: update to 6.16.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- pep517: fix build with flit-core 4
    Signed-off-by: stydxm <stydxm@outlook.com>
- socksio: update to 1.0.0+git20260824
    Signed-off-by: stydxm <stydxm@outlook.com>
- mypy-extensions: fix build with flit-core 4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit mypy-extensions socksio pep517 pypdf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
