### PR TITLE
imagemagick: bring back UPSTREAM_VER

### DIFF
--- a/app-utils/imagemagick/spec
+++ b/app-utils/imagemagick/spec
@@ -1,4 +1,5 @@
-VER=7.1.2+27
-SRCS="git::commit=tags/${VER/+/-}::https://github.com/imagemagick/imagemagick"
+UPSTREAM_VER=7.1.2-27
+VER=${UPSTREAM_VER/\-/+}
+SRCS="git::commit=tags/${UPSTREAM_VER}::https://github.com/imagemagick/imagemagick"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1372"


### PR DESCRIPTION
Topic Description
-----------------

- imagemagick: bring back UPSTREAM_VER
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
