### PR TITLE
allegro: update to 5.2.11.3

### DIFF
--- a/runtime-games/allegro/spec
+++ b/runtime-games/allegro/spec
@@ -1,5 +1,4 @@
-VER=5.2.6.0
-REL=2
+VER=5.2.11.3
 SRCS="https://github.com/liballeg/allegro5/releases/download/$VER/allegro-$VER.tar.gz"
-CHKSUMS="sha256::5de8189ec051e1865f359654f86ec68e2a12a94edd00ad06d1106caa5ff27763"
+CHKSUMS="sha256::aba4679a5b1f2bf62482eba6e8814a94de7ffc86de5f8587ba199fcc61b4a04f"
 CHKUPDATE="anitya::id=13982"


### PR DESCRIPTION
Topic Description
-----------------

- allegro: update to 5.2.11.3
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- allegro: 1:5.2.11.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit allegro
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
