### PR TITLE
zeroconf: security update to 0.150.0

### DIFF
--- a/lang-python/zeroconf/autobuild/defines
+++ b/lang-python/zeroconf/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=zeroconf
 PKGSEC=python
-PKGDEP="ifaddr netifaces python-3 six"
-BUILDDEP="setuptools-python3"
-PKGDES="A pure-Python implementation of multicast DNS service discovery"
+PKGDEP="ifaddr python-3"
+BUILDDEP="setuptools-python3 cython poetry-core"
+PKGDES="Pure-Python implementation of multicast DNS service discovery"
 
-ABHOST=noarch
-ABTYPE=python
+ABTYPE=pep517
 
 NOPYTHON2=1

--- a/lang-python/zeroconf/spec
+++ b/lang-python/zeroconf/spec
@@ -1,5 +1,4 @@
-VER=0.28.6
-SRCS="tbl::https://pypi.io/packages/source/z/zeroconf/zeroconf-$VER.tar.gz"
-CHKSUMS="sha256::70f10f0f16e3a8c4eb5e1a106b812b8d052253041cf1ee1195933df706f5261c"
+VER=0.150.0
+SRCS="pypi::version=$VER::zeroconf"
+CHKSUMS="sha256::a5fe7feab1de6ef5e541e0a3d07e534fd91629b813fc27281593584100f63164"
 CHKUPDATE="anitya::id=46161"
-REL="4"

--- a/topics/zeroconf-0.150.0.toml
+++ b/topics/zeroconf-0.150.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "zeroconf 0.150.0"
+
+[caution]
+default = "Fixes 5 security vulnerabilities"
+zh_CN = "修复 5 个安全漏洞"
+
+[packages-v2]
+"zeroconf" = "< 0.149.16"


### PR DESCRIPTION
Topic Description
-----------------

- zeroconf: security update to 0.150.0
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- zeroconf: 0.150.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit zeroconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
