### PR TITLE
ayugram-desktop: carry over AOSCOS patches from telegram-desktop

### DIFF
--- a/app-web/ayugram-desktop/autobuild/patches/0001-AOSCOS-fix-window.style-set-default-window-width-to-.patch
+++ b/app-web/ayugram-desktop/autobuild/patches/0001-AOSCOS-fix-window.style-set-default-window-width-to-.patch
@@ -1,0 +1,36 @@
+From e87571b185bbaa4103510ed862e38e4d74765c52 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 9 Apr 2024 16:36:00 +0800
+Subject: [PATCH 1/5] AOSCOS: fix(window.style): set default window width to
+ 360px
+
+This allows the Telegram window to scale properly on the PinePhone.
+---
+ Telegram/SourceFiles/window/window.style | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Telegram/SourceFiles/window/window.style b/Telegram/SourceFiles/window/window.style
+index 3f1e2b1e7..3a4985896 100644
+--- a/Telegram/SourceFiles/window/window.style
++++ b/Telegram/SourceFiles/window/window.style
+@@ -10,7 +10,7 @@ using "ui/widgets/widgets.style";
+ using "chat_helpers/chat_helpers.style";
+ using "boxes/boxes.style"; // UserpicButton
+ 
+-windowMinWidth: 380px;
++windowMinWidth: 360px;
+ windowMinHeight: 480px;
+ windowDefaultWidth: 800px;
+ windowDefaultHeight: 600px;
+@@ -19,7 +19,7 @@ windowBigDefaultHeight: 768px;
+ 
+ columnMinimalWidthLeft: 260px;
+ columnMaximalWidthLeft: 540px;
+-columnMinimalWidthMain: 380px;
++columnMinimalWidthMain: 360px;
+ columnMinimalWidthThird: 292px;
+ columnMaximalWidthThird: 392px;
+ 
+-- 
+2.55.0
+

--- a/app-web/ayugram-desktop/autobuild/patches/0002-AOSCOS-fix-core_settings.h-use-system-window-decorat.patch
+++ b/app-web/ayugram-desktop/autobuild/patches/0002-AOSCOS-fix-core_settings.h-use-system-window-decorat.patch
@@ -1,0 +1,26 @@
+From 47907b8aeb31a00a898ebcef1f06b245c2e49b2e Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 9 Apr 2024 17:43:49 +0800
+Subject: [PATCH 2/5] AOSCOS: fix(core_settings.h): use system window
+ decoration by default
+
+---
+ Telegram/SourceFiles/core/core_settings.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
+index a3fd0482e..c21e7a577 100644
+--- a/Telegram/SourceFiles/core/core_settings.h
++++ b/Telegram/SourceFiles/core/core_settings.h
+@@ -1166,7 +1166,7 @@ private:
+ 	rpl::variable<float64> _dialogsNoChatWidthRatio; // per-window
+ 	rpl::variable<int> _thirdColumnWidth = kDefaultThirdColumnWidth; // p-w
+ 	bool _notifyFromAll = true;
+-	rpl::variable<bool> _nativeWindowFrame = false;
++	rpl::variable<bool> _nativeWindowFrame = true;
+ 	rpl::variable<std::optional<bool>> _systemDarkMode = std::nullopt;
+ 	rpl::variable<bool> _systemDarkModeEnabled = true;
+ 	bool _systemAccentColorEnabled = false;
+-- 
+2.55.0
+

--- a/app-web/ayugram-desktop/autobuild/patches/0003-AOSCOS-fix-settings-use-system-fonts-by-default.patch
+++ b/app-web/ayugram-desktop/autobuild/patches/0003-AOSCOS-fix-settings-use-system-fonts-by-default.patch
@@ -1,0 +1,33 @@
+From 6e55d5542dce4949842ff097c5a18bb685368c56 Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Mon, 6 May 2024 00:06:32 -0700
+Subject: [PATCH 3/5] AOSCOS: fix(settings): use system fonts by default
+
+---
+ Telegram/SourceFiles/core/core_settings.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
+index c21e7a577..2d69540c3 100644
+--- a/Telegram/SourceFiles/core/core_settings.h
++++ b/Telegram/SourceFiles/core/core_settings.h
+@@ -13,6 +13,7 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
+ #include "ui/widgets/chat_filters_tabs_mode.h"
+ #include "window/themes/window_themes_embedded.h"
+ #include "ui/chat/attach/attach_send_files_way.h"
++#include "ui/style/style_core_font.h"
+ #include "base/flags.h"
+ #include "emoji.h"
+ 
+@@ -1203,7 +1204,7 @@ private:
+ 	rpl::variable<bool> _ttlVoiceClickTooltipHidden = false;
+ 	WindowPosition _ivPosition;
+ 	WindowPosition _callPanelPosition;
+-	QString _customFontFamily;
++	QString _customFontFamily = style::SystemFontTag();
+ 	bool _systemUnlockEnabled = false;
+ 	std::optional<bool> _weatherInCelsius;
+ 	QByteArray _tonsiteStorageToken;
+-- 
+2.55.0
+

--- a/app-web/ayugram-desktop/autobuild/patches/0004-AOSCOS-Remove-the-confusing-Default-option-from-sele.patch
+++ b/app-web/ayugram-desktop/autobuild/patches/0004-AOSCOS-Remove-the-confusing-Default-option-from-sele.patch
@@ -1,0 +1,49 @@
+From 9d014781e597e7a6e9555a1c5cb61c8521808c29 Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Mon, 6 May 2024 17:15:17 -0700
+Subject: [PATCH 4/5] AOSCOS: Remove the confusing "Default" option from
+ selectable fonts
+
+---
+ Telegram/SourceFiles/ui/boxes/choose_font_box.cpp | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
+index dd504635c..83bfafc7c 100644
+--- a/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
++++ b/Telegram/SourceFiles/ui/boxes/choose_font_box.cpp
+@@ -535,7 +535,7 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
+ 	auto database = QFontDatabase();
+ 	auto families = database.families();
+ 	auto result = std::vector<Entry>();
+-	result.reserve(families.size() + 3);
++	result.reserve(families.size() + 2);
+ 	const auto add = [&](const QString &text, const QString &id = {}) {
+ 		result.push_back({
+ 			.id = id,
+@@ -543,7 +543,6 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
+ 			.keywords = PrepareSearchWords(text),
+ 		});
+ 	};
+-	add(tr::lng_font_default(tr::now));
+ 	add(tr::lng_font_system(tr::now), style::SystemFontTag());
+ 	for (const auto &family : families) {
+ 		if (database.isScalable(family)) {
+@@ -555,12 +554,12 @@ std::vector<Selector::Entry> Selector::FullList(const QString &now) {
+ 		result.push_back({ .id = now });
+ 		nowIt = end(result) - 1;
+ 	}
+-	for (auto i = begin(result) + 2; i != end(result); ++i) {
++	for (auto i = begin(result) + 1; i != end(result); ++i) {
+ 		i->key = TextUtilities::RemoveAccents(i->id).toLower();
+ 		i->text = i->id;
+ 		i->keywords = TextUtilities::PrepareSearchWords(i->id);
+ 	}
+-	auto skip = 2;
++	auto skip = 1;
+ 	if (nowIt - begin(result) >= skip) {
+ 		std::swap(result[2], *nowIt);
+ 		++skip;
+-- 
+2.55.0
+

--- a/app-web/ayugram-desktop/autobuild/patches/0005-AOSCOS-fix-core_settings.h-enable-video-hardware-acc.patch
+++ b/app-web/ayugram-desktop/autobuild/patches/0005-AOSCOS-fix-core_settings.h-enable-video-hardware-acc.patch
@@ -1,0 +1,30 @@
+From f9d6fa3dfe843b1937f26e323766c90edccff143 Mon Sep 17 00:00:00 2001
+From: Kaiyang Wu <origincode@aosc.io>
+Date: Mon, 15 Jun 2026 17:12:22 +0800
+Subject: [PATCH 5/5] AOSCOS: fix(core_settings.h): enable video hardware
+ acceleration by default
+
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
+---
+ Telegram/SourceFiles/core/core_settings.h | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/Telegram/SourceFiles/core/core_settings.h b/Telegram/SourceFiles/core/core_settings.h
+index 2d69540c3..8b1c6d0ed 100644
+--- a/Telegram/SourceFiles/core/core_settings.h
++++ b/Telegram/SourceFiles/core/core_settings.h
+@@ -1183,11 +1183,7 @@ private:
+ 	rpl::variable<Media::OrderMode> _playerOrderMode;
+ 	bool _macWarnBeforeQuit = true;
+ 	std::vector<uint64> _accountsOrder;
+-#ifdef Q_OS_MAC
+ 	bool _hardwareAcceleratedVideo = true;
+-#else // Q_OS_MAC
+-	bool _hardwareAcceleratedVideo = false;
+-#endif // Q_OS_MAC
+ 	HistoryView::DoubleClickQuickAction _chatQuickAction
+ 		= HistoryView::DoubleClickQuickAction();
+ 	bool _translateButtonEnabled = false;
+-- 
+2.55.0
+

--- a/app-web/ayugram-desktop/spec
+++ b/app-web/ayugram-desktop/spec
@@ -20,3 +20,5 @@ ENVREQ__ARM64="total_mem_per_core=3"
 ENVREQ__LOONGARCH64="total_mem_per_core=4"
 ENVREQ__LOONGSON3="total_mem_per_core=4"
 ENVREQ__PPC64EL="total_mem_per_core=4"
+ENVREQ__RISCV64="total_mem_per_core=3"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ayugram-desktop: carry over AOSCOS patches from telegram-desktop
 
Package(s) Affected
-------------------

- ayugram-desktop: 7.0.9-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ayugram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
