### PR TITLE
anubis: update to 1.27.0

### DIFF
--- a/app-web/anubis/autobuild/defines
+++ b/app-web/anubis/autobuild/defines
@@ -4,5 +4,9 @@ PKGDES="Web firewall that analyzes incoming HTTP requests to stop scraper bots"
 PKGDEP="glibc"
 BUILDDEP="brotli go gzip nodejs zstd"
 
+# FIXME: nodejs 26 segment fault
+# make: *** [Makefile:10: deps] Segmentation fault (core dumped) 
+BUILDDEP__LOONGSON3="brotli go gzip nodejs-24 zstd"
+
 # FIXME: Autobuild does not yet support splitting debug symbols from Go executables.
 ABSPLITDBG=0

--- a/app-web/anubis/spec
+++ b/app-web/anubis/spec
@@ -1,5 +1,4 @@
-VER=1.25.0
-REL=1
+VER=1.27.0
 SRCS="git::commit=tags/v$VER::https://github.com/TecharoHQ/anubis"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=377999"


### PR DESCRIPTION
Topic Description
-----------------

- anubis: update to 1.27.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- anubis: 1.27.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit anubis
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
