### PR TITLE
ccache: update to 4.14

### DIFF
--- a/app-devel/ccache/spec
+++ b/app-devel/ccache/spec
@@ -1,4 +1,4 @@
-VER=4.12.2
+VER=4.14
 SRCS="tbl::https://github.com/ccache/ccache/releases/download/v$VER/ccache-$VER.tar.xz"
-CHKSUMS="sha256::96ad53c76ecdb9c7a78e28a9bfdf2c95d7eece28546510fde7e16e5a13e2f7f8"
+CHKSUMS="sha256::b093ac5d38204cb4d9f29b0bbd570675aa5a592a78e6675b2c506dbe045234e7"
 CHKUPDATE="anitya::id=257"


### PR DESCRIPTION
Topic Description
-----------------

- ccache: update to 4.14
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- ccache: 4.14

Security Update?
----------------

No

Build Order
-----------

```
#buildit ccache
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
