### PR TITLE
highway: update to 1.4.0

### DIFF
--- a/runtime-common/highway/autobuild/defines
+++ b/runtime-common/highway/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=highway
 PKGSEC=libs
 PKGDEP="gcc-runtime"
 BUILDDEP="gtest"
-PKGDES="A C++ library that provides portable SIMD/vector intrinsics"
+PKGDES="C++ library to provide portable SIMD/vector intrinsics"
 
 ABTYPE=cmakeninja
 # NOTE: Set HWY_ENABLE_TESTS=ON to generate hwy_gtest.h for libjxl.
@@ -17,7 +17,8 @@ CMAKE_AFTER__ARMV7HF=(
     "-DHWY_CMAKE_ARM7=ON"
 )
 
-# FIXME: lto1: fatal error: target specific builtin not available.
-NOLTO__RISCV64=1
 
 PKGBREAK="libjxl<=0.7.0"
+
+# Note: broken since https://github.com/google/highway/commit/817e9b85b1a07803ba4f9d93434cb994c0e7e9a6
+FAIL_ARCH="@(loongson3)"

--- a/runtime-common/highway/spec
+++ b/runtime-common/highway/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.4.0
 SRCS="git::commit=tags/$VER::https://github.com/google/highway"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=205809"


### PR DESCRIPTION
Topic Description
-----------------

- highway: update to 1.4.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- highway: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit highway
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
