### PR TITLE
lzlib: update to 1.16

### DIFF
--- a/runtime-common/lzlib/autobuild/build
+++ b/runtime-common/lzlib/autobuild/build
@@ -15,3 +15,6 @@ make
 abinfo "Installing lzlib ..."
 make install \
     DESTDIR="$PKGDIR"
+
+abinfo "Setting executable bits on shared objects ..."
+chmod -v +x "$PKGDIR"/usr/lib/*.so*

--- a/runtime-common/lzlib/autobuild/defines
+++ b/runtime-common/lzlib/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=lzlib
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="A compression library for the lzip file format"
+PKGDES="Compression library for the lzip file format"

--- a/runtime-common/lzlib/spec
+++ b/runtime-common/lzlib/spec
@@ -1,5 +1,4 @@
-VER=1.11
-REL=2
+VER=1.16
 SRCS="tbl::https://download.savannah.gnu.org/releases/lzip/lzlib/lzlib-$VER.tar.lz"
-CHKSUMS="sha256::f0e878f0d8ffe3a81f2009d05fc27152760341e19c38290b618ef923320e2a3b"
+CHKSUMS="sha256::cd2a96fbc685f7e3dc32b9f0e5e34046a77e3c10fcfebe62f9951e317d0a8cf4"
 CHKUPDATE="anitya::id=229544"


### PR DESCRIPTION
Topic Description
-----------------

- lzlib: update to 1.16
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- lzlib: 1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit lzlib
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
