### PR TITLE
uv: update to 0.12.6

### DIFF
--- a/lang-python/uv/spec
+++ b/lang-python/uv/spec
@@ -1,4 +1,4 @@
-VER=0.12.4
+VER=0.12.6
 SRCS="git::commit=tags/$VER::https://github.com/astral-sh/uv"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=372636"


### PR DESCRIPTION
Topic Description
-----------------

- uv: update to 0.12.6
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- uv: 0.12.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit uv
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
