### PR TITLE
dsda-doom: update to 0.29.4

### DIFF
--- a/app-games/dsda-doom/autobuild/defines
+++ b/app-games/dsda-doom/autobuild/defines
@@ -1,4 +1,4 @@
 PKGNAME=dsda-doom
 PKGSEC=games
-PKGDES="An engine for DOOM, Heretic and Hexen"
-PKGDEP="sdl2 sdl2-image sdl2-mixer sdl2-net fluidsynth portmidi libmad dumb libvorbis libzip glu"
+PKGDES="Game engine for DOOM, Heretic, and Hexen"
+PKGDEP="sdl2 sdl2-image sdl2-mixer sdl2-net fluidsynth portmidi libmad libvorbis libzip glu"

--- a/app-games/dsda-doom/spec
+++ b/app-games/dsda-doom/spec
@@ -1,4 +1,4 @@
-VER=0.28.3
+VER=0.29.4
 SRCS="git::commit=tags/v$VER::https://github.com/kraflab/dsda-doom"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=337710"


### PR DESCRIPTION
Topic Description
-----------------

- dsda-doom: update to 0.29.4
    Co-authored-by: BenderBlog "SuperBart" Rodriguez \(@BenderBlog\) <superbart_chen@qq.com>

Package(s) Affected
-------------------

- dsda-doom: 0.29.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit dsda-doom
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
