### PR TITLE
uwsm: update to 0.26.7

### DIFF
--- a/desktop-displaymanagers/uwsm/spec
+++ b/desktop-displaymanagers/uwsm/spec
@@ -1,4 +1,4 @@
-VER=0.26.6
+VER=0.26.7
 SRCS="git::commit=tags/v$VER::https://github.com/Vladimir-csp/uwsm"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388878"


### PR DESCRIPTION
Topic Description
-----------------

- uwsm: update to 0.26.7

Package(s) Affected
-------------------

- uwsm: 0.26.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit uwsm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
