### PR TITLE
openssl: security update to 3.6.4

### DIFF
--- a/runtime-cryptography/openssl/01-shared/build
+++ b/runtime-cryptography/openssl/01-shared/build
@@ -48,6 +48,5 @@ make
 abinfo "Installing files ..."
 make MANDIR=/usr/share/man MANSUFFIX=ssl DESTDIR="$PKGDIR" install
 
-if ab_match_arch "+(i486|powerpc)"; then
-    rm -rv "$PKGDIR"/usr/share/doc/openssl/html
-fi
+abinfo "Dropping docs ..."
+rm -rv "$PKGDIR"/usr/share/doc/openssl/html

--- a/runtime-cryptography/openssl/01-shared/defines
+++ b/runtime-cryptography/openssl/01-shared/defines
@@ -2,17 +2,10 @@ PKGNAME=openssl
 PKGDEP="glibc zlib perl"
 # Use c_rehash's C implementation from Sabotage Linux, spare 10% of size off Base.
 PKGDEP__RETRO="glibc zlib"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Security"
 PKGSEC=libs
 
+ABTYPE=self
 AB_FLAGS_O3=1
 
 PKGBREAK="""

--- a/runtime-cryptography/openssl/02-static/defines
+++ b/runtime-cryptography/openssl/02-static/defines
@@ -3,6 +3,7 @@ PKGDEP="glibc"
 PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Security (static libraries)"
 PKGSEC=libs
 
+ABTYPE=self
 AB_FLAGS_O3=1
 
 NOSTATIC=0

--- a/runtime-cryptography/openssl/spec
+++ b/runtime-cryptography/openssl/spec
@@ -1,4 +1,4 @@
-VER=3.6.3
+VER=3.6.4
 SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2566"

--- a/runtime-optenv32/openssl+32/autobuild/build
+++ b/runtime-optenv32/openssl+32/autobuild/build
@@ -7,7 +7,7 @@ abinfo "Configuring openssl+32 ..."
     --prefix=/opt/32 \
     --openssldir=/opt/32/etc/ssl \
     --libdir=lib \
-    shared zlib enable-ssl2 no-tests\
+    shared zlib enable-ssl2 no-tests disable-docs \
     -Wa,--noexecstack linux-x86
 
 abinfo "Building openssl+32 ..."

--- a/runtime-optenv32/openssl+32/autobuild/defines
+++ b/runtime-optenv32/openssl+32/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="aosc-aaa+32 glibc+32 zlib+32 ca-certs"
 BUILDDEP="devel-base+32"
 PKGDES="Open Source toolkit for Secure Sockets Layer and Transport Layer Security (32-bit x86 runtime)"
 
+ABTYPE=self
 ABHOST=optenv32
 
 PKGBREAK="""

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,4 @@
-VER=3.6.3
+VER=3.6.4
 SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2566"

--- a/topics/openssl-3.6.4.toml
+++ b/topics/openssl-3.6.4.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "OpenSSL 3.6.4"
+
+[caution]
+default = "Fixes 11 security vulnerabilities disclosed in OpenSSL Security Advisory on August 25, 2026 (including 3 of Medium severity)"
+zh_CN = "修复 OpenSSL 在 2026 年 8 月 25 日发布的安全公告中披露的 11 个安全漏洞（含 3 个中危漏洞）"
+
+[packages-v2]
+"openssl" = "< 3.6.4"
+"openssl+32" = "< 3.6.4"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add openssl-3.6.4.toml
    Signed-off-by: stydxm <stydxm@outlook.com>
- openssl+32: security update to 3.6.4
    Signed-off-by: stydxm <stydxm@outlook.com>
- openssl: security update to 3.6.4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- openssl: 3.6.4
- openssl-static: 3.6.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit openssl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
