### PR TITLE
Spiral fixes for wxHexEditor

### DIFF
--- a/runtime-common/libdisasm/autobuild/defines
+++ b/runtime-common/libdisasm/autobuild/defines
@@ -1,0 +1,6 @@
+PKGNAME=libdisasm
+PKGSEC=libs
+PKGDEP="glibc"
+PKGDES="Library to disassemble Intel x86 instructions from a binary stream"
+
+ABTYPE=autotools

--- a/runtime-common/libdisasm/autobuild/patches/0001-DEBIAN-Remove-unused-autogen.sh-Closes-829908.patch
+++ b/runtime-common/libdisasm/autobuild/patches/0001-DEBIAN-Remove-unused-autogen.sh-Closes-829908.patch
@@ -1,0 +1,180 @@
+From 92745990d5f12d822a6e610695ab2879b5a1886e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=BD=D0=B0=D0=B1?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Fri, 31 Jan 2025 12:52:53 +0100
+Subject: [PATCH 1/4] DEBIAN: Remove unused autogen.sh (Closes: #829908)
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ autogen.sh | 160 -----------------------------------------------------
+ 1 file changed, 160 deletions(-)
+ delete mode 100755 autogen.sh
+
+diff --git a/autogen.sh b/autogen.sh
+deleted file mode 100755
+index 7699750..0000000
+--- a/autogen.sh
++++ /dev/null
+@@ -1,160 +0,0 @@
+-#!/bin/sh
+-set -e
+-# Run this to generate all the initial makefiles, etc.
+-
+-srcdir=`dirname $0`
+-test -z "$srcdir" && srcdir=.
+-
+-DIE=0
+-
+-if [ -n "$GNOME2_DIR" ]; then
+-	ACLOCAL_FLAGS="-I $GNOME2_DIR/share/aclocal $ACLOCAL_FLAGS"
+-	LD_LIBRARY_PATH="$GNOME2_DIR/lib:$LD_LIBRARY_PATH"
+-	PATH="$GNOME2_DIR/bin:$PATH"
+-	export PATH
+-	export LD_LIBRARY_PATH
+-fi
+-
+-(test -f $srcdir/configure.ac) || {
+-    echo -n "**Error**: Directory "\`$srcdir\'" does not look like the"
+-    echo " top-level package directory"
+-    exit 1
+-}
+-
+-(autoconf --version) < /dev/null > /dev/null 2>&1 || {
+-  echo
+-  echo "**Error**: You must have \`autoconf' installed."
+-  echo "Download the appropriate package for your distribution,"
+-  echo "or get the source tarball at ftp://ftp.gnu.org/pub/gnu/"
+-  DIE=1
+-}
+-
+-(grep "^AC_PROG_INTLTOOL" $srcdir/configure.ac >/dev/null) && {
+-  (intltoolize --version) < /dev/null > /dev/null 2>&1 || {
+-    echo
+-    echo "**Error**: You must have \`intltool' installed."
+-    echo "You can get it from:"
+-    echo "  ftp://ftp.gnome.org/pub/GNOME/"
+-    DIE=1
+-  }
+-}
+-
+-(grep "^AM_PROG_XML_I18N_TOOLS" $srcdir/configure.ac >/dev/null) && {
+-  (xml-i18n-toolize --version) < /dev/null > /dev/null 2>&1 || {
+-    echo
+-    echo "**Error**: You must have \`xml-i18n-toolize' installed."
+-    echo "You can get it from:"
+-    echo "  ftp://ftp.gnome.org/pub/GNOME/"
+-    DIE=1
+-  }
+-}
+-
+-(grep "^AM_PROG_LIBTOOL" $srcdir/configure.ac >/dev/null) && {
+-  (libtool --version) < /dev/null > /dev/null 2>&1 || {
+-    echo
+-    echo "**Error**: You must have \`libtool' installed."
+-    echo "You can get it from: ftp://ftp.gnu.org/pub/gnu/"
+-    DIE=1
+-  }
+-}
+-
+-(grep "^AM_GLIB_GNU_GETTEXT" $srcdir/configure.ac >/dev/null) && {
+-  (grep "sed.*POTFILES" $srcdir/configure.ac) > /dev/null || \
+-  (glib-gettextize --version) < /dev/null > /dev/null 2>&1 || {
+-    echo
+-    echo "**Error**: You must have \`glib' installed."
+-    echo "You can get it from: ftp://ftp.gtk.org/pub/gtk"
+-    DIE=1
+-  }
+-}
+-
+-(automake --version) < /dev/null > /dev/null 2>&1 || {
+-  echo
+-  echo "**Error**: You must have \`automake' installed."
+-  echo "You can get it from: ftp://ftp.gnu.org/pub/gnu/"
+-  DIE=1
+-  NO_AUTOMAKE=yes
+-}
+-
+-
+-# if no automake, don't bother testing for aclocal
+-test -n "$NO_AUTOMAKE" || (aclocal --version) < /dev/null > /dev/null 2>&1 || {
+-  echo
+-  echo "**Error**: Missing \`aclocal'.  The version of \`automake'"
+-  echo "installed doesn't appear recent enough."
+-  echo "You can get automake from ftp://ftp.gnu.org/pub/gnu/"
+-  DIE=1
+-}
+-
+-if test "$DIE" -eq 1; then
+-  exit 1
+-fi
+-
+-if test -z "$*"; then
+-  echo "**Warning**: I am going to run \`configure' with no arguments."
+-  echo "If you wish to pass any to it, please specify them on the"
+-  echo \`$0\'" command line."
+-  echo
+-fi
+-
+-case $CC in
+-xlc )
+-  am_opt=--include-deps;;
+-esac
+-
+-for coin in `find $srcdir -path $srcdir/CVS -prune -o -name configure.ac -print`
+-do
+-  dr=`dirname $coin`
+-  if test -f $dr/NO-AUTO-GEN; then
+-    echo skipping $dr -- flagged as no auto-gen
+-  else
+-    echo processing $dr
+-    ( cd $dr
+-
+-      aclocalinclude="$ACLOCAL_FLAGS"
+-
+-      if grep "^AM_GLIB_GNU_GETTEXT" configure.ac >/dev/null; then
+-	echo "Creating $dr/aclocal.m4 ..."
+-	test -r $dr/aclocal.m4 || touch $dr/aclocal.m4
+-	echo "Running glib-gettextize...  Ignore non-fatal messages."
+-	echo "no" | glib-gettextize --force --copy
+-	echo "Making $dr/aclocal.m4 writable ..."
+-	test -r $dr/aclocal.m4 && chmod u+w $dr/aclocal.m4
+-      fi
+-      if grep "^AC_PROG_INTLTOOL" configure.ac >/dev/null; then
+-        echo "Running intltoolize..."
+-	intltoolize --copy --force --automake
+-      fi
+-      if grep "^AM_PROG_XML_I18N_TOOLS" configure.ac >/dev/null; then
+-        echo "Running xml-i18n-toolize..."
+-	xml-i18n-toolize --copy --force --automake
+-      fi
+-      if grep "^AM_PROG_LIBTOOL" configure.ac >/dev/null; then
+-	if test -z "$NO_LIBTOOLIZE" ; then
+-	  echo "Running libtoolize..."
+-	  libtoolize --force --copy
+-	fi
+-      fi
+-      echo "Running aclocal $aclocalinclude ..."
+-      aclocal $aclocalinclude
+-      if grep "^AM_CONFIG_HEADER" configure.ac >/dev/null; then
+-	echo "Running autoheader..."
+-	autoheader
+-      fi
+-      echo "Running automake --gnu $am_opt ..."
+-      automake --copy --force --add-missing --gnu $am_opt
+-      echo "Running autoconf ..."
+-      autoconf
+-    )
+-  fi
+-done
+-
+-conf_flags="--enable-maintainer-mode"
+-
+-if test x$NOCONFIGURE = x; then
+-  echo Running $srcdir/configure $conf_flags "$@" ...
+-  $srcdir/configure $conf_flags "$@" \
+-  && echo Now type \`make\' to compile. || exit 1
+-else
+-  echo Skipping configure process.
+-fi
+-- 
+2.55.0
+

--- a/runtime-common/libdisasm/autobuild/patches/0002-DEBIAN-Fix-length-accounting-in-format_expr-Closes-8.patch
+++ b/runtime-common/libdisasm/autobuild/patches/0002-DEBIAN-Fix-length-accounting-in-format_expr-Closes-8.patch
@@ -1,0 +1,37 @@
+From 7d3271bc75e5b99fa513c40032ebc0a4cb7a0d74 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=BD=D0=B0=D0=B1?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Fri, 31 Jan 2025 13:18:22 +0100
+Subject: [PATCH 2/4] DEBIAN: Fix length accounting in format_expr() (Closes:
+ #807183)
+
+Matches format_seg() now
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libdisasm/x86_format.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/libdisasm/x86_format.c b/libdisasm/x86_format.c
+index b5b47e3..2b6944c 100644
+--- a/libdisasm/x86_format.c
++++ b/libdisasm/x86_format.c
+@@ -161,6 +161,7 @@ static void get_operand_regtype_str( int regtype, char *str, int len )
+ static int format_expr( x86_ea_t *ea, char *buf, int len,
+                         enum x86_asm_format format ) {
+         char str[MAX_OP_STRING];
++        int len_orig = len;
+ 
+         if ( format == att_syntax ) {
+ 		if (ea->base.name[0] || ea->index.name[0] || ea->scale) {
+@@ -279,7 +280,7 @@ static int format_expr( x86_ea_t *ea, char *buf, int len,
+                 STRNCAT( buf, "]", len );
+         }
+ 
+-        return( strlen(buf) );
++        return( len_orig - len ); /* return length of appended string */
+ }
+ 
+ static int format_seg( x86_op_t *op, char *buf, int len,
+-- 
+2.55.0
+

--- a/runtime-common/libdisasm/autobuild/patches/0003-DEBIAN-Fix-broken-negation-for-bitwise-and.patch
+++ b/runtime-common/libdisasm/autobuild/patches/0003-DEBIAN-Fix-broken-negation-for-bitwise-and.patch
@@ -1,0 +1,49 @@
+From d99bf2fe1dc97011dba8d1d74e5e494aaa1499c6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=BD=D0=B0=D0=B1?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Fri, 31 Jan 2025 14:38:34 +0100
+Subject: [PATCH 3/4] DEBIAN: Fix broken negation for bitwise and
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ libdisasm/x86_format.c | 11 ++---------
+ 1 file changed, 2 insertions(+), 9 deletions(-)
+
+diff --git a/libdisasm/x86_format.c b/libdisasm/x86_format.c
+index 2b6944c..8642cd9 100644
+--- a/libdisasm/x86_format.c
++++ b/libdisasm/x86_format.c
+@@ -286,7 +286,7 @@ static int format_expr( x86_ea_t *ea, char *buf, int len,
+ static int format_seg( x86_op_t *op, char *buf, int len,
+                        enum x86_asm_format format ) {
+         int len_orig = len;
+-        char *reg = "";
++        char *reg;
+ 
+         if (! op || ! buf || ! len || ! op->flags) {
+                 return(0);
+@@ -294,9 +294,6 @@ static int format_seg( x86_op_t *op, char *buf, int len,
+         if ( op->type != op_offset && op->type != op_expression ){
+                 return(0);
+         }
+-        if (! (int) op->flags & 0xF00 ) {
+-                return(0);
+-        }
+ 
+         switch (op->flags & 0xF00) {
+                 case op_es_seg: reg = "es"; break;
+@@ -306,11 +303,7 @@ static int format_seg( x86_op_t *op, char *buf, int len,
+                 case op_fs_seg: reg = "fs"; break;
+                 case op_gs_seg: reg = "gs"; break;
+                 default:
+-                        break;
+-        }
+-
+-        if (! reg[0] ) {
+-                return( 0 );
++                        return( 0 );
+         }
+ 
+         switch( format ) {
+-- 
+2.55.0
+

--- a/runtime-common/libdisasm/autobuild/patches/0004-DEBIAN-Limit-ranges-to-INT_MAX-they-re-stored-in-an-.patch
+++ b/runtime-common/libdisasm/autobuild/patches/0004-DEBIAN-Limit-ranges-to-INT_MAX-they-re-stored-in-an-.patch
@@ -1,0 +1,43 @@
+From ca5b038e045b30381922029ae17bea1acab3e817 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=D0=BD=D0=B0=D0=B1?= <nabijaczleweli@nabijaczleweli.xyz>
+Date: Fri, 31 Jan 2025 12:29:24 +0100
+Subject: [PATCH 4/4] DEBIAN: Limit ranges to INT_MAX (they're stored in an int
+ later), else x86dis rMAAAAAAAA 0x -5 segfaults (Closes: #716481)
+
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ x86dis/x86dis.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/x86dis/x86dis.c b/x86dis/x86dis.c
+index 0bc4e83..2cfe032 100644
+--- a/x86dis/x86dis.c
++++ b/x86dis/x86dis.c
+@@ -20,6 +20,7 @@
+ #include <fcntl.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <limits.h>
+ #include <stdio.h>
+ #include <sys/mman.h>
+ #include <sys/stat.h>
+@@ -712,10 +713,13 @@ int main( int argc, char **argv ) {
+ 				x+=2;
+ 				if ( x < argc ) {
+ 					off = strtoul( argv[x-1], NULL, 0 );
+-					len = (unsigned int) 
++					len = (unsigned int)
+ 					      strtoul(argv[x], NULL, 0);
+-					add_request( req_range, off, 
+-						     len );
++					if ( len >= INT_MAX )
++						error = 1;
++					else
++						add_request( req_range, off,
++							     len );
+ 				} else {
+ 					error = 1;
+ 				}
+-- 
+2.55.0
+

--- a/runtime-common/libdisasm/spec
+++ b/runtime-common/libdisasm/spec
@@ -1,0 +1,7 @@
+VER=0.23
+SRCS="tbl::https://sourceforge.net/projects/bastard/files/libdisasm/$VER/libdisasm-$VER.tar.gz/download"
+CHKSUMS="sha256::de3e578aa582af6e1d7729f39626892fb72dc6573658a221e0905f42a65433da"
+# FIXME: No release was made since 2008 (truthful: SourceForge version
+# tracking is a pain in the ass, especially for multi-sub-project projects).
+#
+#CHKUPDATE=""

--- a/runtime-common/mhash/autobuild/defines
+++ b/runtime-common/mhash/autobuild/defines
@@ -1,6 +1,9 @@
 PKGNAME=mhash
 PKGSEC=libs
 PKGDEP="glibc"
-PKGDES="Thread-safe hash library to provide a uniform interface to hash algorithms"
+PKGDES="Thread-safe library to provide a uniform interface to hash algorithms"
 
+ABTYPE=autotools
+
+# FIXME: configure: error: source directory already configured; run "make distclean" there first
 ABSHADOW=0

--- a/runtime-common/mhash/spec
+++ b/runtime-common/mhash/spec
@@ -1,5 +1,5 @@
 VER=0.9.9.9
-REL=3
-SRCS="tbl::https://sourceforge.net/projects/mhash/files/mhash/$VER/mhash-$VER.tar.gz"
+REL=4
+SRCS="tbl::https://sourceforge.net/projects/mhash/files/mhash/$VER/mhash-$VER.tar.gz/download"
 CHKSUMS='sha256::3dcad09a63b6f1f634e64168dd398e9feb9925560f9b671ce52283a79604d13e'
 CHKUPDATE="anitya::id=21488"


### PR DESCRIPTION
Topic Description
-----------------

- libdisasm: new, 0.23
    - Introduce Debian patches for general fixes.
    - Track patches at AOSC-Tracking/libdisasm @ aosc/v0.23
    \(HEAD: ca5b038e045b30381922029ae17bea1acab3e817\).
- mhash: rebuild for Spiral markers; lint scripts

Package(s) Affected
-------------------

- libdisasm: 0.23
- mhash: 0.9.9.9-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit mhash libdisasm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
