### PR TITLE
vim: update to 9.2.1014

### DIFF
--- a/app-editors/vim/spec
+++ b/app-editors/vim/spec
@@ -1,4 +1,4 @@
-VER=9.2.0993
+VER=9.2.1014
 SRCS="git::commit=tags/v$VER::https://github.com/vim/vim.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5092"

--- a/topics/vim-9.2.1014.toml
+++ b/topics/vim-9.2.1014.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Vim 9.2.1014"
+
+[caution]
+default = "Fixes an Out-of-bounds Write vulnerability (Severity: Moderate) and an Incorrect Calculation of Buffer Size vulnerability (Severity: Low)"
+zh_CN = "修复 1 个越界写入漏洞（严重性：中）和 1 个缓冲区大小计算错误漏洞（严重性：低）"
+
+[packages-v2]
+"vim" = "< 9.2.1014"


### PR DESCRIPTION
Topic Description
-----------------

- vim: update to 9.2.1014
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- gvim: 9.2.1014
- vim: 9.2.1014

Security Update?
----------------

No

Build Order
-----------

```
#buildit vim
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
