### PR TITLE
vscode: update to 1.135.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.134.0
+VER=1.135.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::dcd3a2f52d53df079cd389662ff1fdbeb629938331d3a63655fed929f8d49f19"
-CHKSUMS__ARM64="sha256::b30f5bda4855231681cc7fe22d4a59e7dbee2be170b0e4fb04c7e83b9f9affe5"
+CHKSUMS__AMD64="sha256::e8101720f0a48f8e6ae5a4112d10ffea5f13d298e7d0a7012b4e36eebc53022c"
+CHKSUMS__ARM64="sha256::20f1717805ed723c8846e14df3280c6132a663ff71e32068aaa70f3e4c8b1ca4"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.135.0
    Co-authored-by: LJL \(@ljlofficial\) <lkjmlk@aosc.io>

Package(s) Affected
-------------------

- vscode: 1.135.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
