### PR TITLE
docker-buildx: update to 0.36.1

### DIFF
--- a/app-containers/docker-buildx/autobuild/beyond
+++ b/app-containers/docker-buildx/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Moving docker-buildx ..."
+mkdir -pv "$PKGDIR"/usr/libexec/docker/cli-plugins/
+mv -v "$PKGDIR"/usr/bin/buildx "$PKGDIR"/usr/libexec/docker/cli-plugins/docker-buildx

--- a/app-containers/docker-buildx/autobuild/build
+++ b/app-containers/docker-buildx/autobuild/build
@@ -1,6 +1,0 @@
-abinfo "Building docker-buildx..."
-cd "$SRCDIR"
-make build
-
-abinfo "Installing docker-buildx ..."
-install -Dvm755 "$SRCDIR"/bin/build/docker-buildx "$PKGDIR"/usr/libexec/docker/cli-plugins/docker-buildx

--- a/app-containers/docker-buildx/autobuild/defines
+++ b/app-containers/docker-buildx/autobuild/defines
@@ -4,5 +4,12 @@ PKGSEC=admin
 PKGDEP="docker"
 BUILDDEP="go"
 
+ABTYPE=gomod
+GO_PACKAGES=("cmd/buildx")
+GO_LDFLAGS=(
+    "-X github.com/docker/buildx/version.Version=${PKGVER}"
+    "-X github.com/docker/buildx/version.Revision=$(git rev-parse HEAD)"
+    "-X github.com/docker/buildx/version.Package=github.com/docker/buildx"
+)
 # FIXME: loongson3: Missing docker support
-FAIL_ARCH="!(amd64|arm64|ppc64el|loongarch64|loongarch64_nosimd|riscv64)"
+FAIL_ARCH="@(loongson3|retro)"

--- a/app-containers/docker-buildx/spec
+++ b/app-containers/docker-buildx/spec
@@ -1,5 +1,4 @@
-VER=0.22.0
-REL=8
+VER=0.36.1
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/docker/buildx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=325723"


### PR DESCRIPTION
Topic Description
-----------------

- docker-buildx: update to 0.36.1
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- docker-buildx: 0.36.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit docker-buildx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
