### PR TITLE
amo: install APT Post-Invoke trigger

### DIFF
--- a/app-admin/amo/autobuild/beyond
+++ b/app-admin/amo/autobuild/beyond
@@ -15,3 +15,7 @@ install -Dvm644 "$SRCDIR"/data/io.aosc.Amo.conf \
 abinfo "Installing polkit policy ..."
 install -Dvm644 "$SRCDIR"/data/io.aosc.amo.apply.policy \
     "$PKGDIR"/usr/share/polkit-1/actions/io.aosc.amo.apply.policy
+
+abinfo "Installing APT Post-Invoke configuration ..."
+install -Dvm644 "$SRCDIR"/data/20amo \
+    "$PKGDIR"/etc/apt/apt.conf.d/20amo

--- a/app-admin/amo/spec
+++ b/app-admin/amo/spec
@@ -1,4 +1,5 @@
 VER=0.5.0
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/amo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391048"


### PR DESCRIPTION
Topic Description
-----------------

- amo: install APT Post-Invoke trigger

Package(s) Affected
-------------------

- amo: 0.5.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit amo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
