### PR TITLE
erlang: security update to 29.0.5

### DIFF
--- a/lang-erlang/erlang/spec
+++ b/lang-erlang/erlang/spec
@@ -1,4 +1,4 @@
-VER=29.0.3
+VER=29.0.5
 SRCS="tbl::https://github.com/erlang/otp/releases/download/OTP-$VER/otp_src_$VER.tar.gz"
-CHKSUMS="sha256::f920c660b16794bcb7270d1cbf680f7747c719650bcd6ac449508a32c2a8972a"
+CHKSUMS="sha256::86f6f40d4638852b0383235b02a70d8450184e441e83a06a108bf8e5bf1b2e04"
 CHKUPDATE="anitya::id=707"

--- a/topics/erlang-29.0.5.toml
+++ b/topics/erlang-29.0.5.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Erlang 29.0.5"
+
+[caution]
+default = "Fixes 8 security vulnerabilities (including 1 of Critical, 6 of High and 1 of Medium severity)"
+zh_CN = "修复 8 个安全漏洞（含 1 个严重漏洞、6 个高危漏洞和 1 个中危漏洞）"
+
+[packages-v2]
+"erlang" = "< 29.0.5"


### PR DESCRIPTION
Topic Description
-----------------

- erlang: security update to 29.0.5

Package(s) Affected
-------------------

- erlang: 29.0.5

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit erlang
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
