### PR TITLE
lynx: update to 2.9.3

### DIFF
--- a/app-web/lynx/autobuild/beyond
+++ b/app-web/lynx/autobuild/beyond
@@ -1,6 +1,5 @@
-sed -i -e "s|^HELPFILE.*$|HELPFILE:file:///usr/share/doc/lynx/lynx_help/lynx_help_main.html|" abdist/etc/lynx.cfg
+abinfo "Installing documents ..."
+install -dv "$PKGDIR"/usr/share/doc/lynx
+cp -rfv lynx_help "$PKGDIR"/usr/share/doc/lynx
 
-install -d abdist/usr/share/doc/lynx
-cp -rf lynx_help abdist/usr/share/doc/lynx
-
-make install-doc DESTDIR=`pwd`/abdist
+make install-doc DESTDIR="$PKGDIR"

--- a/app-web/lynx/autobuild/defines
+++ b/app-web/lynx/autobuild/defines
@@ -1,33 +1,18 @@
 PKGNAME=lynx
 PKGSEC=web
 PKGDEP="openssl libidn"
-PKGDEP__RETRO="openssl"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
-PKGDES="A text browser for the World Wide Web"
+PKGDES="Text-based browser for the World Wide Web"
 
-AUTOTOOLS_AFTER="--with-ssl=/usr \
-                 --enable-nls \
-                 --enable-ipv6 \
-                 --with-screen=ncurses \
-                 --with-curses-dir=/usr \
-                 --with-pkg-config \
-                 --mandir=/usr/share/man"
-AUTOTOOLS_AFTER__RETRO="${AUTOTOOLS_AFTER} --disable-idna"
-AUTOTOOLS_AFTER__ARMV4="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV6HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__ARMV7HF="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__I486="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__LOONGSON2F="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__M68K="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__POWERPC="${AUTOTOOLS_AFTER__RETRO}"
-AUTOTOOLS_AFTER__PPC64="${AUTOTOOLS_AFTER__RETRO}"
+AUTOTOOLS_AFTER=(
+	--with-ssl=/usr
+	--enable-nls
+	--enable-ipv6
+	# Note: wide character version of ncurses is required for correctly display CJK text
+	--with-screen=ncursesw
+	--with-curses-dir=/usr
+	--with-pkg-config
+	--mandir=/usr/share/man
+)
 
 ABSHADOW=0
 RECONF=0

--- a/app-web/lynx/autobuild/patches/0001-use-local-help-file.patch
+++ b/app-web/lynx/autobuild/patches/0001-use-local-help-file.patch
@@ -1,0 +1,25 @@
+From f7e1a4791029f8e5cddf7cb641b6aee99a241fde Mon Sep 17 00:00:00 2001
+From: Student Main <studentmain@aosc.io>
+Date: Tue, 1 Sep 2026 07:42:26 +0800
+Subject: [PATCH] use local help file
+
+---
+ lynx.cfg | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lynx.cfg b/lynx.cfg
+index 55848b8..780d6ac 100644
+--- a/lynx.cfg
++++ b/lynx.cfg
+@@ -129,7 +129,7 @@ STARTFILE:https://lynx.invisible-island.net/
+ # This definition will be overridden if the "LYNX_HELPFILE" environment
+ # variable has been set.
+ #
+-HELPFILE:https://lynx.invisible-island.net/lynx_help/lynx_help_main.html
++HELPFILE:file://localhost/usr/share/doc/lynx/lynx_help/lynx_help_main.html
+ .ex
+ #HELPFILE:file://localhost/PATH_TO/lynx_help/lynx_help_main.html
+ 
+-- 
+2.55.0
+

--- a/app-web/lynx/spec
+++ b/app-web/lynx/spec
@@ -1,4 +1,4 @@
-VER=2.9.2
+VER=2.9.3
 SRCS="tbl::https://invisible-mirror.net/archives/lynx/tarballs/lynx${VER/rel/rel.}.tar.gz"
-CHKSUMS="sha256::99f8f28f860094c533100d1cedf058c27fb242ce25e991e2d5f30ece4457a3bf"
+CHKSUMS="sha256::6e99e46980974a6d89eceefbb26ca8c7aa7702b78ecb5bad383b859af225d052"
 CHKUPDATE="anitya::id=1863"


### PR DESCRIPTION
Topic Description
-----------------

- lynx: update to 2.9.3

Package(s) Affected
-------------------

- lynx: 1:2.9.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit lynx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
