### PR TITLE
libreoffice: update to 26.8.0.3

### DIFF
--- a/app-productivity/libreoffice/spec
+++ b/app-productivity/libreoffice/spec
@@ -1,4 +1,4 @@
-VER=26.8.0.1
+VER=26.8.0.3
 SRCS="git::commit=tags/libreoffice-$VER;copy-repo=true::https://github.com/LibreOffice/core"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=6506"


### PR DESCRIPTION
Topic Description
-----------------

- libreoffice: update to 26.8.0.3
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libreoffice: 26.8.0.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit libreoffice
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
