### PR TITLE
bubblewrap: security update to 0.12.0

### DIFF
--- a/app-admin/bubblewrap/autobuild/defines
+++ b/app-admin/bubblewrap/autobuild/defines
@@ -2,4 +2,4 @@ PKGNAME=bubblewrap
 PKGSEC=admin
 PKGDEP="glibc libcap"
 BUILDDEP="docbook-xsl"
-PKGDES="Unprivileged sandboxing tool."
+PKGDES="Unprivileged sandboxing tool"

--- a/app-admin/bubblewrap/spec
+++ b/app-admin/bubblewrap/spec
@@ -1,4 +1,4 @@
-VER=0.11.0
-SRCS="tbl::https://github.com/projectatomic/bubblewrap/releases/download/v$VER/bubblewrap-$VER.tar.xz"
-CHKSUMS="sha256::988fd6b232dafa04b8b8198723efeaccdb3c6aa9c1c7936219d5791a8b7a8646"
+VER=0.12.0
+SRCS="git::commit=tags/v$VER::https://github.com/projectatomic/bubblewrap"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=10937"

--- a/topics/bubblewrap-0.12.0.toml
+++ b/topics/bubblewrap-0.12.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Bubblewrap 0.12.0"
+
+[caution]
+default = "Fixes a Path Traversal/Link Following vulnerability (Severity: High)"
+zh_CN = "修复一个路径遍历/路径跟随漏洞（严重性：高）"
+
+[packages-v2]
+"bubblewrap" = "< 0.12.0"


### PR DESCRIPTION
Topic Description
-----------------

- bubblewrap: security update to 0.12.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- bubblewrap: 0.12.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit bubblewrap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
