### PR TITLE
deno: update to 2.9.6

### DIFF
--- a/lang-js/deno/autobuild/defines
+++ b/lang-js/deno/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=deno
 PKGSEC=devel
-PKGDEP="gcc-runtime glibc zlib"
+PKGDEP="gcc-runtime glibc lcms2 libffi sqlite zlib zstd"
 PKGSUG="mesa"
 BUILDDEP="rustc llvm protobuf python-3 gn ninja"
 # Note: There is no pre-generated bindgen for aws-lc-rs on loongarch64 and ppc64el.

--- a/lang-js/deno/autobuild/prepare
+++ b/lang-js/deno/autobuild/prepare
@@ -32,3 +32,11 @@ export NINJA="/usr/bin/ninja"
 export PYTHON="/usr/bin/python3"
 export CLANG_BASE_PATH="/usr"
 export V8_FROM_SOURCE=1
+
+abinfo "Setting up environment for deno ..."
+# Adapted from archlinux build script
+export LCMS2_LIB_DIR="/usr/lib"
+export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+export ZSTD_SYS_USE_PKG_CONFIG=1
+# Use system libffi
+export CARGO_FEATURE_SYSTEM=1

--- a/lang-js/deno/spec
+++ b/lang-js/deno/spec
@@ -1,9 +1,9 @@
-VER=2.9.5
+VER=2.9.6
 # Note: This must match "v8" version in Cargo.lock.
 RUSTY_V8_VER=150.4.0
 SRCS="tbl::https://github.com/denoland/deno/releases/download/v$VER/deno_src.tar.gz \
       git::commit=tags/v${RUSTY_V8_VER};rename=rusty_v8::https://github.com/denoland/rusty_v8.git"
-CHKSUMS="sha256::b3d1d66e47d74f5bda84d5a80282135b7d8f2e336fbcf98c75be32f18130864a \
+CHKSUMS="sha256::dfd816eea5147eeafda5e235c241a3286e67aeaae1d0e50f9973ff6bf4f14fb2 \
          SKIP"
 SUBDIR="deno"
 CHKUPDATE="anitya::id=133196"


### PR DESCRIPTION
Topic Description
-----------------

- deno: update to 2.9.6
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- deno: 2.9.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit deno
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
