### PR TITLE
libphonenumber: disable static build

### DIFF
--- a/runtime-i18n/libphonenumber/autobuild/defines
+++ b/runtime-i18n/libphonenumber/autobuild/defines
@@ -7,6 +7,10 @@ PKGDES="Common library for parsing, formatting, storing, and validating internat
 PKGBREAK="evolution-data-server<=3.28.3"
 ABTYPE=cmake
 
+CMAKE_AFTER=(
+    '-DBUILD_STATIC_LIB=OFF'
+    '-DBUILD_TESTING=FALSE'
+)
 # FIXME: Parallelism may generates bad source.
 #
 # [...]/libphonenumber/cpp/src/phonenumbers/metadata.cc:10971:44: error: null character(s) ignored [-Werror]

--- a/runtime-i18n/libphonenumber/spec
+++ b/runtime-i18n/libphonenumber/spec
@@ -1,5 +1,5 @@
 VER=9.0.31
-REL=1
+REL=2
 SRCS="git::commit=tags/v$VER::https://github.com/google/libphonenumber"
 CHKUPDATE="anitya::id=89344"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- libphonenumber: disable static build

Package(s) Affected
-------------------

- libphonenumber: 9.0.31-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit libphonenumber
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
