### PR TITLE
Haskell Survey 20260828

### DIFF
--- a/app-doc/pandoc/autobuild/defines
+++ b/app-doc/pandoc/autobuild/defines
@@ -6,4 +6,4 @@ BUILDDEP="cabal-install ghc zlib-static numactl libffi"
 PKGRECOM="typst"
 
 # Note: Sync with GHC.
-FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64|loongson3|i486)"

--- a/app-doc/pandoc/spec
+++ b/app-doc/pandoc/spec
@@ -1,4 +1,5 @@
 VER=3.10.2
+REL=1
 SRCS="git::commit=tags/$VER::https://github.com/jgm/pandoc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2589"

--- a/lang-haskell/cabal-install/autobuild/build
+++ b/lang-haskell/cabal-install/autobuild/build
@@ -3,7 +3,6 @@ cabal update
 cabal v2-build -j \
 	--prefix=/usr \
 	--project-file=cabal.release.project \
-	--allow-newer \
 	cabal-install
 
 abinfo "Installing Cabal ..."
@@ -11,5 +10,4 @@ cabal v2-install -j \
 	--install-method=copy \
 	--installdir="$PKGDIR"/usr/bin \
 	--project-file=cabal.release.project \
-	--allow-newer \
 	cabal-install

--- a/lang-haskell/cabal-install/autobuild/build.stage2
+++ b/lang-haskell/cabal-install/autobuild/build.stage2
@@ -1,18 +1,9 @@
-CABAL="qemu-x86_64-static ""$SRCDIR""/../cabal-3.16.1.0"
-chmod +x "$SRCDIR"/../cabal-3.16.1.0
+GHC_VER=9.14.1
 
-abinfo "Building Cabal using prebuilt Cabal ..."
-$CABAL update
-$CABAL v2-build -j \
-	--prefix=/usr \
-	--project-file=cabal.release.project \
-	--allow-newer \
-	cabal-install
+abinfo "Executing bootstrapping process for Cabal ..."
+"$SRCDIR"/bootstrap/bootstrap.py \
+	-d "$SRCDIR"/bootstrap/linux-${GHC_VER}.json \
+	-w /usr/bin/ghc
 
 abinfo "Installing Cabal ..."
-$CABAL v2-install -j \
-	--install-method=copy \
-	--installdir="$PKGDIR"/usr/bin \
-	--project-file=cabal.release.project \
-	--allow-newer \
-	cabal-install
+install -Dvm755 "$SRCDIR"/_build/bin/cabal "$PKGDIR"/usr/bin/cabal

--- a/lang-haskell/cabal-install/autobuild/defines
+++ b/lang-haskell/cabal-install/autobuild/defines
@@ -10,4 +10,4 @@ AB_FLAGS_SPECS=0
 ABSPLITDBG=0
 
 # Note: Sync with GHC.
-FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64|loongson3|i486)"

--- a/lang-haskell/cabal-install/autobuild/defines.stage2
+++ b/lang-haskell/cabal-install/autobuild/defines.stage2
@@ -1,7 +1,7 @@
 PKGNAME=cabal-install
 PKGSEC=haskell
 PKGDEP="gmp libffi"
-BUILDDEP="ghc qemu-x86-64-static"
+BUILDDEP="ghc"
 BUILDDEP__ARM64="${BUILDDEP} llvm"
 PKGDES="A user interface to the Cabal/Hackage automation and package management system"
 

--- a/lang-haskell/cabal-install/autobuild/prepare.stage2
+++ b/lang-haskell/cabal-install/autobuild/prepare.stage2
@@ -1,0 +1,2 @@
+GHC_VER="9.14.1"
+cp -v "$SRCDIR"/../linux-${GHC_VER}.json "$SRCDIR"/bootstrap

--- a/lang-haskell/cabal-install/spec
+++ b/lang-haskell/cabal-install/spec
@@ -1,7 +1,8 @@
-VER=3.16.1.0
+VER=3.18.1.0
+GHC_VER=9.14.1
 EPOCH=1
 SRCS="git::commit=tags/cabal-install-v$VER::https://github.com/haskell/cabal \
-      file::use-url-name=true::https://repo.aosc.io/aosc-repacks/cabal-3.16.1.0"
+      file::use-url-name=true::https://repo.aosc.io/aosc-repacks/linux-$GHC_VER.json"
 CHKSUMS="SKIP \
-         sha256::48d80f720ccc1ef6306c5a8092ed380df58e73c4b01e9b574af73b3142c20dba"
+         sha256::39826740ae7b40ce0fbf9e59124c096ae98accc0f805a15d73df7c0a084bbd54"
 CHKUPDATE="anitya::id=243"

--- a/lang-haskell/ghc/autobuild/build.stage2
+++ b/lang-haskell/ghc/autobuild/build.stage2
@@ -9,6 +9,10 @@ elif ab_match_arch ppc64el; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-powerpc64le-unknown-linux
 elif ab_match_arch riscv64; then
 	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-riscv64-unknown-linux
+elif ab_match_arch loongson3; then
+	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-mips-unknown-linux
+elif ab_match_arch i486; then
+	pushd "$SRCDIR"/../ghc-${BOOTSTRAP_VER}-i386-unknown-linux
 fi
 
 abinfo "Configuring prebuilt ghc ..."

--- a/lang-haskell/ghc/autobuild/defines
+++ b/lang-haskell/ghc/autobuild/defines
@@ -12,7 +12,7 @@ NOLTO=1
 ABSPLITDBG=0
 
 # Requires prebuilt tarballs
-FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64|loongson3|i486)"
 
 # Issue #463.
 # https://github.com/AOSC-Dev/aosc-os-abbs/issues/463

--- a/lang-haskell/ghc/autobuild/defines.stage2
+++ b/lang-haskell/ghc/autobuild/defines.stage2
@@ -12,7 +12,7 @@ NOLTO=1
 ABSPLITDBG=0
 
 # Requires prebuilt tarballs
-FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64)"
+FAIL_ARCH="!(amd64|arm64|loongarch64|loongarch64_nosimd|ppc64el|riscv64|loongson3|i486)"
 
 # Issue #463.
 # https://github.com/AOSC-Dev/aosc-os-abbs/issues/463

--- a/lang-haskell/ghc/autobuild/prepare
+++ b/lang-haskell/ghc/autobuild/prepare
@@ -1,2 +1,7 @@
 abinfo "Relaxing dependency requirements to allow bootstrapping with newer GHC toolchains ..."
 echo "allow-newer: all" >> "$SRCDIR"/hadrian/cabal.project.local
+
+if ab_match_arch loongson3; then
+	abinfo "FIXME: loongson3 requires C backend which does not support newer C standards ..."
+	export CC="gcc -std=gnu11"
+fi

--- a/lang-haskell/ghc/spec
+++ b/lang-haskell/ghc/spec
@@ -1,17 +1,22 @@
 VER=9.14.1
 BOOTSTRAP_VER=9.14.1
 EPOCH=1
+REL=1
 SRCS="tbl::https://www.haskell.org/ghc/dist/$VER/ghc-${VER}-src.tar.xz \
       tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-x86_64-deb10-linux.tar.xz \
       tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-aarch64-deb12-linux.tar.xz \
+      tbl::https://downloads.haskell.org/~ghc/${BOOTSTRAP_VER}/ghc-${BOOTSTRAP_VER}-i386-deb10-linux.tar.xz \
       tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-loongarch64-unknown-linux-20260404.tar.xz \
       tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-powerpc64le-unknown-linux-20260404.tar.xz \
-      tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-riscv64-unknown-linux-20260405.tar.xz"
+      tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-riscv64-unknown-linux-20260405.tar.xz \
+      tbl::https://repo.aosc.io/aosc-repacks/ghc-${BOOTSTRAP_VER}-mips-unknown-linux-20260828.tar.xz"
 CHKSUMS="sha256::2a83779c9af86554a3289f2787a38d6aa83d00d136aa9f920361dd693c101e77 \
          sha256::c812cbadc685eba6e92778f9de1ebd0f1ea513cdea42db2d487fbd17e88ca3d1 \
          sha256::6aa27a377451851c851eefdd869e8f5a9217b02ce66c6ca9b418b72efee28427 \
+         sha256::c656e060c11c1a195fe4c2faf54268ce7dac3cd464aebc0eca8b796772950098 \
          sha256::9f9be922a7a8578ba1024fb51508b1a11d9af592fe413bd379790b4105b7824a \
          sha256::4be80e33253a6eae510aee3195e1366b82bc9349d8c5d432f8cc4e58760d9f93 \
-         sha256::dee715348d70e2c6899696f49b518ea3ba0a8971af25c11795c8216df92f71cd"
+         sha256::dee715348d70e2c6899696f49b518ea3ba0a8971af25c11795c8216df92f71cd \
+         sha256::1cbfbf4dc82c9a9e77857d681d23e3ae4ccba103f5646d49c490dc57e918ad35"
 SUBDIR=ghc-${VER}
 CHKUPDATE="anitya::id=906"


### PR DESCRIPTION
Topic Description
-----------------

- pandoc: add loongson3 and i486
- cabal-install: update to 3.18.1.0
    - add loongson3 and i486
    This commit is authored with assistance from AI/LLM:
    - Model: DeepSeek-V4-Flash
    - Platform: DeepSeek API \(api.deepseek.com\)
    - Agent platform: OpenAI Codex \(github.com/openai/codex\)
    - Prompt:
    对于 cabal-install，找到之前另一种打包 stage2 的做法。阅读 cabal-install 的文档，生成 9.14.1 对应的 json（我会自己上传到 repacks），并根据此修改 cabal-install 的打包并 amend 到最近一个 cabal-install 的 commit。
- ghc: add loongson3 and i486

Package(s) Affected
-------------------

- cabal-install: 3.18.1.0
- ghc: 9.14.1-1
- pandoc: 3.10.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit ghc:+stage2 cabal-install:+stage2 ghc cabal-install pandoc
```

Test Build(s) Done
------------------

