### PR TITLE
kmscon: support afterglow

### DIFF
--- a/app-utils/kmscon/autobuild/defines
+++ b/app-utils/kmscon/autobuild/defines
@@ -2,14 +2,6 @@ PKGNAME=kmscon
 PKGSEC=utils
 PKGDEP="libdrm libtsm mesa pango systemd unifont xkeyboard-config"
 PKGDEP__RETRO="libdrm libtsm systemd unifont xkeyboard-config"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="Terminal emulator based on Kernel Mode Setting (KMS)"
 
 MESON_AFTER=(
@@ -42,3 +34,6 @@ MESON_AFTER__RETRO=(
 
 PKGREP="kmscon-enablement"
 PKGBREAK="kmscon-enablement"
+
+# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"

--- a/app-utils/kmscon/spec
+++ b/app-utils/kmscon/spec
@@ -1,4 +1,5 @@
 VER=9.3.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/kmscon/kmscon"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231600"

--- a/runtime-common/libtsm/autobuild/defines
+++ b/runtime-common/libtsm/autobuild/defines
@@ -9,3 +9,6 @@ MESON_AFTER=(
 	# This is only an example.
 	'-Dgtktsm=false'
 )
+
+# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-common/libtsm/spec
+++ b/runtime-common/libtsm/spec
@@ -1,4 +1,5 @@
 VER=4.4.2
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/kmscon/libtsm.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230181"


### PR DESCRIPTION
Topic Description
-----------------

- kmscon: support afterglow
 - libtsm: support afterglow

Package(s) Affected
-------------------

- kmscon: 9.3.1
- libtsm: 4.4.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit libtsm kmscon
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
