### PR TITLE
typing-extensions: (upstream patch) fix FTBFS with flit-core 4

### DIFF
--- a/lang-python/typing-extensions/autobuild/patches/0001-Allow-building-this-package-with-flit-core-4-787.patch
+++ b/lang-python/typing-extensions/autobuild/patches/0001-Allow-building-this-package-with-flit-core-4-787.patch
@@ -1,0 +1,21 @@
+From 996d4d71b18eee56c53dde6a609dea188bb26a96 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miro=20Hron=C4=8Dok?= <miro@hroncok.cz>
+Date: Mon, 24 Aug 2026 18:40:42 +0200
+Subject: [PATCH] Allow building this package with flit-core 4 (#787)
+
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index ed826f81..6dde0165 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,6 +1,6 @@
+ # Build system requirements.
+ [build-system]
+-requires = ["flit_core >=3.11,<4"]
++requires = ["flit_core >=3.11,<5"]
+ build-backend = "flit_core.buildapi"
+ 
+ # Project metadata

--- a/lang-python/typing-extensions/spec
+++ b/lang-python/typing-extensions/spec
@@ -2,3 +2,4 @@ VER=4.15.0
 SRCS="pypi::version=$VER::typing-extensions"
 CHKSUMS="sha256::0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
 CHKUPDATE="anitya::id=19755"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- typing-extensions: \(upstream patch\) fix FTBFS with flit-core 4
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- typing-extensions: 4.15.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit typing-extensions
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
