### PR TITLE
codex: update to 0.150.1

### DIFF
--- a/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
+++ b/app-utils/codex/autobuild/patches/0001-AOSCOS-use-local-patched-rusty_v8.patch
@@ -1,4 +1,4 @@
-From 8a44414f0498722559dcc60717755440ace12415 Mon Sep 17 00:00:00 2001
+From 9b806b5f1e57eee3884b7200e4432f25c72febd4 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 22 Aug 2026 09:31:57 +0800
 Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
@@ -9,10 +9,10 @@ Subject: [PATCH 1/3] AOSCOS: use local patched rusty_v8
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 471c342ff9..56d68e6c56 100644
+index 600bc10c7b..383235eb4d 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -14874,8 +14874,6 @@ dependencies = [
+@@ -14933,8 +14933,6 @@ dependencies = [
  [[package]]
  name = "v8"
  version = "150.4.0"
@@ -22,10 +22,10 @@ index 471c342ff9..56d68e6c56 100644
   "bindgen",
   "bitflags 2.13.1",
 diff --git a/codex-rs/Cargo.toml b/codex-rs/Cargo.toml
-index 6e5fa01dda..7e4675e55b 100644
+index 74a45554ab..ebe44c6c53 100644
 --- a/codex-rs/Cargo.toml
 +++ b/codex-rs/Cargo.toml
-@@ -590,5 +590,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
+@@ -596,5 +596,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev
  # Uncomment to debug local changes.
  # rmcp = { path = "../../rust-sdk/crates/rmcp" }
  

--- a/app-utils/codex/autobuild/patches/0002-AOSCOS-use-system-protobuf.patch
+++ b/app-utils/codex/autobuild/patches/0002-AOSCOS-use-system-protobuf.patch
@@ -1,4 +1,4 @@
-From 8e5ae3a74c0ac23d96180324ef16aa11bba2535e Mon Sep 17 00:00:00 2001
+From 95105a155439343a8f2664a959bf0cedb21c1be1 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 22 Aug 2026 19:41:19 +0800
 Subject: [PATCH 2/3] AOSCOS: use system protobuf
@@ -10,10 +10,10 @@ Subject: [PATCH 2/3] AOSCOS: use system protobuf
  3 files changed, 67 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index 56d68e6c56..f0217bacd1 100644
+index 383235eb4d..d56e859636 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
-@@ -2607,7 +2607,6 @@ dependencies = [
+@@ -2624,7 +2624,6 @@ dependencies = [
   "glob",
   "pretty_assertions",
   "prost",
@@ -21,7 +21,7 @@ index 56d68e6c56..f0217bacd1 100644
   "serde",
   "serde_json",
   "tokio",
-@@ -10837,70 +10836,6 @@ dependencies = [
+@@ -10895,70 +10894,6 @@ dependencies = [
   "prost",
  ]
  

--- a/app-utils/codex/autobuild/patches/0003-AOSCOS-fix-cargo.lock.patch
+++ b/app-utils/codex/autobuild/patches/0003-AOSCOS-fix-cargo.lock.patch
@@ -1,14 +1,14 @@
-From 5b6f05d97c4f3f6a4993dc288e76504823bf5770 Mon Sep 17 00:00:00 2001
+From 53218809e9841f9f7194d16301920c7f432eeb73 Mon Sep 17 00:00:00 2001
 From: CAB233 <yidaduizuoye@outlook.com>
 Date: Sat, 22 Aug 2026 09:32:23 +0800
 Subject: [PATCH 3/3] AOSCOS: fix cargo.lock
 
 ---
- codex-rs/Cargo.lock | 278 ++++++++++++++++++++++----------------------
- 1 file changed, 139 insertions(+), 139 deletions(-)
+ codex-rs/Cargo.lock | 284 ++++++++++++++++++++++----------------------
+ 1 file changed, 142 insertions(+), 142 deletions(-)
 
 diff --git a/codex-rs/Cargo.lock b/codex-rs/Cargo.lock
-index f0217bacd1..66d0ecb4d2 100644
+index d56e859636..f41cba3c3a 100644
 --- a/codex-rs/Cargo.lock
 +++ b/codex-rs/Cargo.lock
 @@ -394,7 +394,7 @@ checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
@@ -16,7 +16,7 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "app_test_support"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
@@ -25,7 +25,7 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-agent-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-core",
@@ -34,7 +34,7 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-agent-graph-store"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "codex-state",
@@ -43,953 +43,971 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-agent-identity"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
 @@ -1917,7 +1917,7 @@ dependencies = [
  
  [[package]]
+ name = "codex-agent-roles"
+-version = "0.0.0"
++version = "0.150.1"
+ dependencies = [
+  "codex-config",
+  "codex-file-system",
+@@ -1930,7 +1930,7 @@ dependencies = [
+ 
+ [[package]]
  name = "codex-analytics"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-app-server-protocol",
   "codex-git-utils",
-@@ -1938,7 +1938,7 @@ dependencies = [
+@@ -1951,7 +1951,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ansi-escape"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "ansi-to-tui",
   "ratatui",
-@@ -1947,7 +1947,7 @@ dependencies = [
+@@ -1960,7 +1960,7 @@ dependencies = [
  
  [[package]]
  name = "codex-api"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "assert_matches",
-@@ -1982,7 +1982,7 @@ dependencies = [
+@@ -1995,7 +1995,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -2082,7 +2082,7 @@ dependencies = [
+@@ -2097,7 +2097,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-app-server",
   "codex-app-server-protocol",
-@@ -2109,7 +2109,7 @@ dependencies = [
+@@ -2124,7 +2124,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-daemon"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol",
-@@ -2130,7 +2130,7 @@ dependencies = [
+@@ -2145,7 +2145,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-app-server-protocol-noop-macros",
-@@ -2163,11 +2163,11 @@ dependencies = [
+@@ -2179,11 +2179,11 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-protocol-noop-macros"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  
  [[package]]
  name = "codex-app-server-test-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2189,7 +2189,7 @@ dependencies = [
+@@ -2205,7 +2205,7 @@ dependencies = [
  
  [[package]]
  name = "codex-app-server-transport"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2231,7 +2231,7 @@ dependencies = [
+@@ -2247,7 +2247,7 @@ dependencies = [
  
  [[package]]
  name = "codex-apply-patch"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2251,7 +2251,7 @@ dependencies = [
+@@ -2267,7 +2267,7 @@ dependencies = [
  
  [[package]]
  name = "codex-arg0"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-apply-patch",
-@@ -2271,7 +2271,7 @@ dependencies = [
+@@ -2288,7 +2288,7 @@ dependencies = [
  
  [[package]]
  name = "codex-async-utils"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
   "tokio",
-@@ -2280,7 +2280,7 @@ dependencies = [
+@@ -2297,7 +2297,7 @@ dependencies = [
  
  [[package]]
  name = "codex-aws-auth"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "aws-config",
   "aws-credential-types",
-@@ -2295,7 +2295,7 @@ dependencies = [
+@@ -2312,7 +2312,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -2315,7 +2315,7 @@ dependencies = [
+@@ -2332,7 +2332,7 @@ dependencies = [
  
  [[package]]
  name = "codex-backend-openapi-models"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "serde",
   "serde_json",
-@@ -2324,7 +2324,7 @@ dependencies = [
+@@ -2341,7 +2341,7 @@ dependencies = [
  
  [[package]]
  name = "codex-build-info"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-install-context",
   "pretty_assertions",
-@@ -2336,7 +2336,7 @@ dependencies = [
+@@ -2353,7 +2353,7 @@ dependencies = [
  
  [[package]]
  name = "codex-bwrap"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "cc",
   "libc",
-@@ -2345,7 +2345,7 @@ dependencies = [
+@@ -2362,7 +2362,7 @@ dependencies = [
  
  [[package]]
  name = "codex-chatgpt"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -2367,7 +2367,7 @@ dependencies = [
+@@ -2384,7 +2384,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cli"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -2455,7 +2455,7 @@ dependencies = [
+@@ -2472,7 +2472,7 @@ dependencies = [
  
  [[package]]
  name = "codex-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-http-client",
   "eventsource-stream",
-@@ -2468,7 +2468,7 @@ dependencies = [
+@@ -2485,7 +2485,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-config"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "chrono",
-@@ -2493,7 +2493,7 @@ dependencies = [
+@@ -2510,7 +2510,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2526,7 +2526,7 @@ dependencies = [
+@@ -2543,7 +2543,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2541,7 +2541,7 @@ dependencies = [
+@@ -2558,7 +2558,7 @@ dependencies = [
  
  [[package]]
  name = "codex-cloud-tasks-mock-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "chrono",
   "codex-cloud-tasks-client",
-@@ -2550,7 +2550,7 @@ dependencies = [
+@@ -2567,7 +2567,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-code-mode-protocol",
   "codex-http-client",
-@@ -2574,7 +2574,7 @@ dependencies = [
+@@ -2591,7 +2591,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-host"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "axum",
-@@ -2601,7 +2601,7 @@ dependencies = [
+@@ -2618,7 +2618,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-protocol"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "glob",
-@@ -2618,7 +2618,7 @@ dependencies = [
+@@ -2635,7 +2635,7 @@ dependencies = [
  
  [[package]]
  name = "codex-code-mode-runtime"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-code-mode-protocol",
   "codex-protocol",
-@@ -2634,11 +2634,11 @@ dependencies = [
+@@ -2651,11 +2651,11 @@ dependencies = [
  
  [[package]]
  name = "codex-collaboration-mode-templates"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  
  [[package]]
  name = "codex-config"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -2686,7 +2686,7 @@ dependencies = [
+@@ -2704,7 +2704,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2708,7 +2708,7 @@ dependencies = [
+@@ -2726,7 +2726,7 @@ dependencies = [
  
  [[package]]
  name = "codex-connectors-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-connectors",
   "codex-core-plugins",
-@@ -2722,7 +2722,7 @@ dependencies = [
+@@ -2740,7 +2740,7 @@ dependencies = [
  
  [[package]]
  name = "codex-context-fragments"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -2730,7 +2730,7 @@ dependencies = [
+@@ -2748,7 +2748,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -2861,7 +2861,7 @@ dependencies = [
+@@ -2881,7 +2881,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-api"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-analytics",
   "codex-app-server-protocol",
-@@ -2884,7 +2884,7 @@ dependencies = [
+@@ -2904,7 +2904,7 @@ dependencies = [
  
  [[package]]
  name = "codex-core-plugins"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -2940,7 +2940,7 @@ dependencies = [
+@@ -2960,7 +2960,7 @@ dependencies = [
  
  [[package]]
  name = "codex-diagnostics"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -2948,7 +2948,7 @@ dependencies = [
+@@ -2968,7 +2968,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -2995,7 +2995,7 @@ dependencies = [
+@@ -3015,7 +3015,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -3053,7 +3053,7 @@ dependencies = [
+@@ -3074,7 +3074,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server-protocol"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "codex-file-system",
-@@ -3068,7 +3068,7 @@ dependencies = [
+@@ -3089,7 +3089,7 @@ dependencies = [
  
  [[package]]
  name = "codex-exec-server-test-support"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-exec-server",
   "codex-http-client",
-@@ -3076,7 +3076,7 @@ dependencies = [
+@@ -3097,7 +3097,7 @@ dependencies = [
  
  [[package]]
  name = "codex-execpolicy"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3094,7 +3094,7 @@ dependencies = [
+@@ -3115,7 +3115,7 @@ dependencies = [
  
  [[package]]
  name = "codex-experimental-api-macros"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "proc-macro2",
   "quote",
-@@ -3103,7 +3103,7 @@ dependencies = [
+@@ -3124,7 +3124,7 @@ dependencies = [
  
  [[package]]
  name = "codex-extension-api"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-config",
   "codex-context-fragments",
-@@ -3120,7 +3120,7 @@ dependencies = [
+@@ -3141,7 +3141,7 @@ dependencies = [
  
  [[package]]
  name = "codex-extension-items"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-utils-absolute-path",
   "pretty_assertions",
-@@ -3132,7 +3132,7 @@ dependencies = [
+@@ -3153,7 +3153,7 @@ dependencies = [
  
  [[package]]
  name = "codex-external-agent-migration"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "chrono",
   "codex-analytics",
-@@ -3162,7 +3162,7 @@ dependencies = [
+@@ -3183,7 +3183,7 @@ dependencies = [
  
  [[package]]
  name = "codex-features"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-otel",
   "codex-protocol",
-@@ -3175,7 +3175,7 @@ dependencies = [
+@@ -3196,7 +3196,7 @@ dependencies = [
  
  [[package]]
  name = "codex-feedback"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-http-client",
-@@ -3193,7 +3193,7 @@ dependencies = [
+@@ -3214,7 +3214,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-search"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3209,7 +3209,7 @@ dependencies = [
+@@ -3230,7 +3230,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-system"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "bytes",
   "codex-protocol",
-@@ -3221,7 +3221,7 @@ dependencies = [
+@@ -3242,7 +3242,7 @@ dependencies = [
  
  [[package]]
  name = "codex-file-watcher"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "notify",
   "pretty_assertions",
-@@ -3232,7 +3232,7 @@ dependencies = [
+@@ -3253,7 +3253,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-attribution"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-backend-client",
   "codex-extension-api",
-@@ -3245,7 +3245,7 @@ dependencies = [
+@@ -3266,7 +3266,7 @@ dependencies = [
  
  [[package]]
  name = "codex-git-utils"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3271,7 +3271,7 @@ dependencies = [
+@@ -3292,7 +3292,7 @@ dependencies = [
  
  [[package]]
  name = "codex-goal-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3295,7 +3295,7 @@ dependencies = [
+@@ -3316,7 +3316,7 @@ dependencies = [
  
  [[package]]
  name = "codex-guardian-v2"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-api",
-@@ -3317,7 +3317,7 @@ dependencies = [
+@@ -3339,7 +3339,7 @@ dependencies = [
  
  [[package]]
  name = "codex-history"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-protocol",
-@@ -3329,7 +3329,7 @@ dependencies = [
+@@ -3351,7 +3351,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-history-notes-extension"
+-version = "0.0.0"
++version = "0.150.1"
+ dependencies = [
+  "codex-api",
+  "codex-client",
+@@ -3374,7 +3374,7 @@ dependencies = [
  
  [[package]]
  name = "codex-home"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-extension-api",
   "codex-utils-absolute-path",
-@@ -3340,7 +3340,7 @@ dependencies = [
+@@ -3385,7 +3385,7 @@ dependencies = [
  
  [[package]]
  name = "codex-hooks"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "async-channel",
-@@ -3365,7 +3365,7 @@ dependencies = [
+@@ -3411,7 +3411,7 @@ dependencies = [
  
  [[package]]
  name = "codex-http-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "bytes",
   "codex-utils-cargo-bin",
-@@ -3397,7 +3397,7 @@ dependencies = [
+@@ -3443,7 +3443,7 @@ dependencies = [
  
  [[package]]
  name = "codex-image-generation-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3424,7 +3424,7 @@ dependencies = [
+@@ -3470,7 +3470,7 @@ dependencies = [
  
  [[package]]
  name = "codex-install-context"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-utils-absolute-path",
   "codex-utils-home-dir",
-@@ -3437,7 +3437,7 @@ dependencies = [
+@@ -3483,7 +3483,7 @@ dependencies = [
  
  [[package]]
  name = "codex-keyring-store"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "keyring",
   "tracing",
-@@ -3445,7 +3445,7 @@ dependencies = [
+@@ -3491,7 +3491,7 @@ dependencies = [
  
  [[package]]
  name = "codex-linux-sandbox"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "clap",
   "codex-core",
-@@ -3470,7 +3470,7 @@ dependencies = [
+@@ -3516,7 +3516,7 @@ dependencies = [
  
  [[package]]
  name = "codex-lmstudio"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-core",
   "codex-http-client",
-@@ -3484,7 +3484,7 @@ dependencies = [
+@@ -3530,7 +3530,7 @@ dependencies = [
  
  [[package]]
  name = "codex-login"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3527,7 +3527,7 @@ dependencies = [
+@@ -3573,7 +3573,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "arc-swap",
-@@ -3565,7 +3565,7 @@ dependencies = [
+@@ -3611,7 +3611,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-config",
   "codex-connectors",
-@@ -3591,7 +3591,7 @@ dependencies = [
+@@ -3637,7 +3637,7 @@ dependencies = [
  
  [[package]]
  name = "codex-mcp-server"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -3630,7 +3630,7 @@ dependencies = [
+@@ -3676,7 +3676,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-core",
   "codex-extension-api",
-@@ -3651,7 +3651,7 @@ dependencies = [
+@@ -3697,7 +3697,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-read"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -3661,7 +3661,7 @@ dependencies = [
+@@ -3707,7 +3707,7 @@ dependencies = [
  
  [[package]]
  name = "codex-memories-write"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -3698,7 +3698,7 @@ dependencies = [
+@@ -3744,7 +3744,7 @@ dependencies = [
  
  [[package]]
  name = "codex-message-history"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-config",
   "memchr",
-@@ -3712,7 +3712,7 @@ dependencies = [
+@@ -3758,7 +3758,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-agent-identity",
   "codex-api",
-@@ -3735,7 +3735,7 @@ dependencies = [
+@@ -3782,7 +3782,7 @@ dependencies = [
  
  [[package]]
  name = "codex-model-provider-info"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-api",
   "codex-protocol",
-@@ -3751,7 +3751,7 @@ dependencies = [
+@@ -3799,7 +3799,7 @@ dependencies = [
  
  [[package]]
  name = "codex-models-manager"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "chrono",
   "codex-collaboration-mode-templates",
-@@ -3771,7 +3771,7 @@ dependencies = [
+@@ -3819,7 +3819,7 @@ dependencies = [
  
  [[package]]
  name = "codex-network-proxy"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -3809,7 +3809,7 @@ dependencies = [
+@@ -3857,7 +3857,7 @@ dependencies = [
  
  [[package]]
  name = "codex-ollama"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "assert_matches",
   "async-stream",
-@@ -3829,7 +3829,7 @@ dependencies = [
+@@ -3877,7 +3877,7 @@ dependencies = [
  
  [[package]]
  name = "codex-otel"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "chrono",
   "codex-api",
-@@ -3862,7 +3862,7 @@ dependencies = [
+@@ -3910,7 +3910,7 @@ dependencies = [
  
  [[package]]
  name = "codex-plugin"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-config",
   "codex-protocol",
-@@ -3875,7 +3875,7 @@ dependencies = [
+@@ -3923,7 +3923,7 @@ dependencies = [
  
  [[package]]
  name = "codex-process-hardening"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "libc",
   "pretty_assertions",
-@@ -3883,7 +3883,7 @@ dependencies = [
+@@ -3931,7 +3931,7 @@ dependencies = [
  
  [[package]]
  name = "codex-prompts"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-context-fragments",
-@@ -3897,7 +3897,7 @@ dependencies = [
+@@ -3945,7 +3945,7 @@ dependencies = [
  
  [[package]]
  name = "codex-protocol"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chardetng",
-@@ -3939,7 +3939,7 @@ dependencies = [
+@@ -3988,7 +3988,7 @@ dependencies = [
  
  [[package]]
  name = "codex-queue-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-core",
-@@ -3960,7 +3960,7 @@ dependencies = [
+@@ -4009,7 +4009,7 @@ dependencies = [
  
  [[package]]
  name = "codex-response-debug-context"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "codex-api",
-@@ -3971,7 +3971,7 @@ dependencies = [
+@@ -4020,7 +4020,7 @@ dependencies = [
  
  [[package]]
  name = "codex-responses-api-proxy"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -3988,7 +3988,7 @@ dependencies = [
+@@ -4037,7 +4037,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rmcp-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "axum",
-@@ -4034,7 +4034,7 @@ dependencies = [
+@@ -4083,7 +4083,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -4061,7 +4061,7 @@ dependencies = [
+@@ -4110,7 +4110,7 @@ dependencies = [
  
  [[package]]
  name = "codex-rollout-trace"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-code-mode",
-@@ -4077,7 +4077,7 @@ dependencies = [
+@@ -4126,7 +4126,7 @@ dependencies = [
  
  [[package]]
  name = "codex-sandboxing"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-network-proxy",
-@@ -4101,7 +4101,7 @@ dependencies = [
+@@ -4150,7 +4150,7 @@ dependencies = [
  
  [[package]]
  name = "codex-secrets"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "age",
   "anyhow",
-@@ -4122,7 +4122,7 @@ dependencies = [
+@@ -4171,7 +4171,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-command"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4145,7 +4145,7 @@ dependencies = [
+@@ -4194,7 +4194,7 @@ dependencies = [
  
  [[package]]
  name = "codex-shell-escalation"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -4165,7 +4165,7 @@ dependencies = [
+@@ -4214,7 +4214,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "codex-shell-command",
-@@ -4182,7 +4182,7 @@ dependencies = [
+@@ -4231,7 +4231,7 @@ dependencies = [
  
  [[package]]
  name = "codex-skills-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
+  "assert_matches",
   "codex-analytics",
-  "codex-config",
-@@ -4218,7 +4218,7 @@ dependencies = [
+@@ -4268,7 +4268,7 @@ dependencies = [
  
  [[package]]
  name = "codex-state"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "chrono",
-@@ -4242,7 +4242,7 @@ dependencies = [
+@@ -4292,7 +4292,7 @@ dependencies = [
  
  [[package]]
  name = "codex-stdio-to-uds"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-uds",
-@@ -4254,7 +4254,7 @@ dependencies = [
+@@ -4304,7 +4304,7 @@ dependencies = [
  
  [[package]]
  name = "codex-terminal-detection"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
   "tracing",
-@@ -4262,7 +4262,7 @@ dependencies = [
+@@ -4312,7 +4312,7 @@ dependencies = [
  
  [[package]]
  name = "codex-test-binary-support"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-arg0",
   "tempfile",
-@@ -4270,7 +4270,7 @@ dependencies = [
+@@ -4320,7 +4320,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-manager-sample"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "clap",
-@@ -4281,7 +4281,7 @@ dependencies = [
+@@ -4331,7 +4331,7 @@ dependencies = [
  
  [[package]]
  name = "codex-thread-store"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "chrono",
   "codex-app-server-protocol",
-@@ -4311,7 +4311,7 @@ dependencies = [
+@@ -4361,7 +4361,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tools"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "bitflags 2.13.1",
   "codex-code-mode",
-@@ -4337,7 +4337,7 @@ dependencies = [
+@@ -4386,7 +4386,7 @@ dependencies = [
  
  [[package]]
  name = "codex-tui"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "app_test_support",
-@@ -4449,7 +4449,7 @@ dependencies = [
+@@ -4499,7 +4499,7 @@ dependencies = [
  
  [[package]]
  name = "codex-uds"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "async-io",
   "pretty_assertions",
-@@ -4461,7 +4461,7 @@ dependencies = [
+@@ -4511,7 +4511,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-absolute-path"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "dirs",
   "dunce",
-@@ -4475,14 +4475,14 @@ dependencies = [
+@@ -4525,14 +4525,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-approval-presets"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
  ]
@@ -997,143 +1015,152 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-utils-audio"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "codex-protocol",
-@@ -4496,7 +4496,7 @@ dependencies = [
+@@ -4546,7 +4546,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cache"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "lru",
   "sha1 0.10.6",
-@@ -4505,7 +4505,7 @@ dependencies = [
+@@ -4555,7 +4555,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cargo-bin"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "assert_cmd",
   "runfiles",
-@@ -4514,7 +4514,7 @@ dependencies = [
+@@ -4564,7 +4564,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-cli"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "clap",
   "codex-protocol",
-@@ -4526,15 +4526,15 @@ dependencies = [
+@@ -4576,15 +4576,15 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-elapsed"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  
  [[package]]
  name = "codex-utils-fuzzy-match"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  
  [[package]]
  name = "codex-utils-home-dir"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-utils-absolute-path",
   "dirs",
-@@ -4544,7 +4544,7 @@ dependencies = [
+@@ -4594,7 +4594,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-image"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-cache",
-@@ -4557,7 +4557,7 @@ dependencies = [
+@@ -4607,7 +4607,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-json-to-toml"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
   "serde_json",
-@@ -4566,7 +4566,7 @@ dependencies = [
+@@ -4616,7 +4616,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-oss"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-core",
   "codex-lmstudio",
-@@ -4576,7 +4576,7 @@ dependencies = [
+@@ -4626,7 +4626,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-output-truncation"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "codex-utils-string",
-@@ -4585,7 +4585,7 @@ dependencies = [
+@@ -4635,7 +4635,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-utils-absolute-path",
   "dunce",
-@@ -4595,7 +4595,7 @@ dependencies = [
+@@ -4645,7 +4645,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-path-uri"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "base64 0.22.1",
   "codex-utils-absolute-path",
-@@ -4611,7 +4611,7 @@ dependencies = [
+@@ -4661,7 +4661,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-plugins"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-exec-server",
   "codex-exec-server-protocol",
-@@ -4625,7 +4625,7 @@ dependencies = [
+@@ -4675,7 +4675,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-pty"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "filedescriptor",
-@@ -4641,7 +4641,7 @@ dependencies = [
+@@ -4691,7 +4691,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-readiness"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "assert_matches",
   "thiserror 2.0.18",
-@@ -4651,14 +4651,14 @@ dependencies = [
+@@ -4701,7 +4701,7 @@ dependencies = [
+ 
+ [[package]]
+ name = "codex-utils-redacted-string"
+-version = "0.0.0"
++version = "0.150.1"
+ dependencies = [
+  "schemars 0.8.22",
+  "serde",
+@@ -4709,14 +4709,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-rustls-provider"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "rustls",
  ]
@@ -1141,25 +1168,25 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-utils-sandbox-summary"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-protocol",
   "codex-utils-absolute-path",
-@@ -4667,7 +4667,7 @@ dependencies = [
+@@ -4725,7 +4725,7 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-sleep-inhibitor"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "core-foundation 0.9.4",
   "libc",
-@@ -4677,14 +4677,14 @@ dependencies = [
+@@ -4735,14 +4735,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-stream-parser"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1167,16 +1194,16 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-utils-string"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
   "regex-lite",
-@@ -4694,14 +4694,14 @@ dependencies = [
+@@ -4752,14 +4752,14 @@ dependencies = [
  
  [[package]]
  name = "codex-utils-template"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
  ]
@@ -1184,61 +1211,61 @@ index f0217bacd1..66d0ecb4d2 100644
  [[package]]
  name = "codex-v8-poc"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "pretty_assertions",
   "v8",
-@@ -4709,7 +4709,7 @@ dependencies = [
+@@ -4767,7 +4767,7 @@ dependencies = [
  
  [[package]]
  name = "codex-web-search-extension"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-api",
   "codex-core",
-@@ -4730,7 +4730,7 @@ dependencies = [
+@@ -4788,7 +4788,7 @@ dependencies = [
  
  [[package]]
  name = "codex-websocket-client"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-http-client",
   "codex-utils-rustls-provider",
-@@ -4746,7 +4746,7 @@ dependencies = [
+@@ -4804,7 +4804,7 @@ dependencies = [
  
  [[package]]
  name = "codex-windows-sandbox"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "base64 0.22.1",
-@@ -4772,7 +4772,7 @@ dependencies = [
+@@ -4830,7 +4830,7 @@ dependencies = [
  
  [[package]]
  name = "codex-workload-identity"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "codex-http-client",
   "pretty_assertions",
-@@ -5012,7 +5012,7 @@ dependencies = [
+@@ -5070,7 +5070,7 @@ dependencies = [
  
  [[package]]
  name = "core_test_support"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "assert_cmd",
-@@ -9274,7 +9274,7 @@ dependencies = [
+@@ -9332,7 +9332,7 @@ dependencies = [
  
  [[package]]
  name = "mcp_test_support"
 -version = "0.0.0"
-+version = "0.149.0"
++version = "0.150.1"
  dependencies = [
   "anyhow",
   "codex-login",

--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.149.0
+VER=0.150.1
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=150.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.150.1
    This commit is authored with assistance from AI/LLM:
    - Model: Deepseek-v4-flash
    - Platform: DeepSeek API \(https://api.deepseek.com/\)
    - Agent platform: OpenAI Codex \(https://developers.openai.com/codex/\)
    - Prompt:
    rebase 所有 codex 的补丁

Package(s) Affected
-------------------

- codex: 0.150.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

