### PR TITLE
icewm: support afterglow

### DIFF
--- a/desktop-wm/icewm/autobuild/defines
+++ b/desktop-wm/icewm/autobuild/defines
@@ -2,18 +2,12 @@ PKGNAME=icewm
 PKGSEC=x11
 PKGDES="A lightweighted window manager for the X Window System"
 PKGDEP="x11-lib x11-font x11-app fribidi aosc-xdg-menu imlib2"
-PKGDEP__RETRO="gdk-pixbuf-xlib x11-lib x11-app fribidi aosc-xdg-menu"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
-
+PKGDEP__RETRO="gdk-pixbuf-xlib x11-lib x11-app fribidi aosc-xdg-menu imlib2"
 NOLTO__LOONGSON2F=1
 
 AUTOTOOLS_AFTER="""
 --with-icesound=ALSA,OSS
 """
+
+# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"

--- a/desktop-wm/icewm/spec
+++ b/desktop-wm/icewm/spec
@@ -1,4 +1,5 @@
 VER=3.9.0
+REL=1
 SRCS="tbl::https://github.com/ice-wm/icewm/releases/download/${VER}/icewm-${VER}.tar.lz"
 CHKSUMS="sha256::1323527a9a49db66e9ce7b08e6ec43c87700243432fc6679681df367c67b2dc0"
 CHKUPDATE="anitya::id=1358"

--- a/runtime-imaging/gdk-pixbuf-xlib/autobuild/defines
+++ b/runtime-imaging/gdk-pixbuf-xlib/autobuild/defines
@@ -3,14 +3,6 @@ PKGDES="A toolkit for image loading and pixel buffer manipulation (Xlib componen
 PKGDEP="gdk-pixbuf x11-lib"
 BUILDDEP="gobject-introspection gtk-doc vim"
 BUILDDEP__RETRO=""
-BUILDDEP__ARMV4="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV6HF="${BUILDDEP__RETRO}"
-BUILDDEP__ARMV7HF="${BUILDDEP__RETRO}"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
-BUILDDEP__LOONGSON2F="${BUILDDEP__RETRO}"
-BUILDDEP__M68K="${BUILDDEP__RETRO}"
-BUILDDEP__POWERPC="${BUILDDEP__RETRO}"
-BUILDDEP__PPC64="${BUILDDEP__RETRO}"
 PKGSEC=libs
 
 MESON_AFTER="-Dgtk_doc=true"
@@ -18,3 +10,6 @@ MESON_AFTER__RETRO="-Dgtk_doc=false"
 
 PKGBREAK="gdk-pixbuf<=2.38.2-1"
 PKGREP="gdk-pixbuf<=2.38.2-1"
+
+# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-imaging/gdk-pixbuf-xlib/spec
+++ b/runtime-imaging/gdk-pixbuf-xlib/spec
@@ -1,5 +1,5 @@
 VER=2.40.2
-REL=2
+REL=3
 SRCS="https://gitlab.gnome.org/Archive/gdk-pixbuf-xlib/-/archive/$VER/gdk-pixbuf-xlib-$VER.tar.gz"
 CHKSUMS="sha256::e7d9b6a8ca53b6500a82ee8d5a1b3c17780740a6ca7bf04a5dabba0fe50bb7ff"
 CHKUPDATE="anitya::id=229509"

--- a/runtime-imaging/imlib2/autobuild/defines
+++ b/runtime-imaging/imlib2/autobuild/defines
@@ -12,3 +12,6 @@ AUTOTOOLS_AFTER__AMD64=(
     "${AUTOTOOLS_AFTER[@]}"
     '--enable-amd64'
 )
+
+# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-imaging/imlib2/spec
+++ b/runtime-imaging/imlib2/spec
@@ -1,4 +1,5 @@
 VER=1.12.6
+REL=1
 SRCS="tbl::https://sourceforge.net/projects/enlightenment/files/imlib2-src/$VER/imlib2-$VER.tar.gz/download"
 CHKSUMS="sha256::59743ce82aefa9c1ec9476af608d541b74164714d2928fbd84ff5db6c4399079"
 CHKUPDATE="anitya::id=21676"

--- a/runtime-multimedia/libid3tag/autobuild/defines
+++ b/runtime-multimedia/libid3tag/autobuild/defines
@@ -4,3 +4,6 @@ PKGSEC=libs
 PKGDEP="zlib"
 BUILDDEP="gperf"
 ABTYPE=cmakeninja
+
+# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
+FAIL_ARCH="!(mainline|retro)"

--- a/runtime-multimedia/libid3tag/spec
+++ b/runtime-multimedia/libid3tag/spec
@@ -1,4 +1,5 @@
 VER=0.16.3
+REL=1
 SRCS="git::commit=tags/$VER::https://codeberg.org/tenacityteam/libid3tag"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=21478"


### PR DESCRIPTION
Topic Description
-----------------

- icewm: support afterglow
 - gdk-pixbuf-xlib: support afterglow
 - imlib2: support afterglow
 - libid3tag: support afterglow

Package(s) Affected
-------------------

- icewm: 3.9.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit icewm
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
