### PR TITLE
rocm: Runtimes,Compilers,Tools update to TheRock-10.0

### DIFF
--- a/runtime-rocm/libhipcxx/spec
+++ b/runtime-rocm/libhipcxx/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER}::https://github.com/ROCm/libhipcxx"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391626"

--- a/runtime-rocm/rocm-amdsmi/spec
+++ b/runtime-rocm/rocm-amdsmi/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/amdsmi"

--- a/runtime-rocm/rocm-aqlprofile/spec
+++ b/runtime-rocm/rocm-aqlprofile/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/aqlprofile"

--- a/runtime-rocm/rocm-clr/spec
+++ b/runtime-rocm/rocm-clr/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems \
       git::commit=tags/therock-${VER};rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP \

--- a/runtime-rocm/rocm-cmake/spec
+++ b/runtime-rocm/rocm-cmake/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-$VER::https://github.com/ROCm/rocm-cmake"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231446"

--- a/runtime-rocm/rocm-comgr/spec
+++ b/runtime-rocm/rocm-comgr/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/comgr"

--- a/runtime-rocm/rocm-core/spec
+++ b/runtime-rocm/rocm-core/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocm-core"

--- a/runtime-rocm/rocm-cuid/spec
+++ b/runtime-rocm/rocm-cuid/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/cuid"

--- a/runtime-rocm/rocm-device-libs/spec
+++ b/runtime-rocm/rocm-device-libs/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-$VER;rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/amd/device-libs/"

--- a/runtime-rocm/rocm-half/spec
+++ b/runtime-rocm/rocm-half/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-$VER::https://github.com/ROCm/half"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378431"

--- a/runtime-rocm/rocm-hipblas-common/spec
+++ b/runtime-rocm/rocm-hipblas-common/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/projects/hipblas-common"

--- a/runtime-rocm/rocm-hipfile/spec
+++ b/runtime-rocm/rocm-hipfile/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/hipfile"

--- a/runtime-rocm/rocm-hipfort/spec
+++ b/runtime-rocm/rocm-hipfort/spec
@@ -1,4 +1,4 @@
-VER=7.2.4
+VER=7.14.0
 SRCS="git::commit=tags/rocm-${VER}::https://github.com/ROCm/hipfort.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378520"

--- a/runtime-rocm/rocm-hipify/spec
+++ b/runtime-rocm/rocm-hipify/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER}::https://github.com/ROCm/HIPIFY.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=378519"

--- a/runtime-rocm/rocm-llvm/spec
+++ b/runtime-rocm/rocm-llvm/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=llvm-project::https://github.com/ROCm/llvm-project"
 CHKSUMS="SKIP"
 SUBDIR="llvm-project/llvm"

--- a/runtime-rocm/rocm-origami/spec
+++ b/runtime-rocm/rocm-origami/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-libraries::https://github.com/ROCm/rocm-libraries.git"
 CHKSUMS="SKIP"
 SUBDIR="rocm-libraries/shared/origami"

--- a/runtime-rocm/rocm-rocdecode/spec
+++ b/runtime-rocm/rocm-rocdecode/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocdecode"

--- a/runtime-rocm/rocm-rocjpeg/spec
+++ b/runtime-rocm/rocm-rocjpeg/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocjpeg"

--- a/runtime-rocm/rocm-rocprofiler-register/spec
+++ b/runtime-rocm/rocm-rocprofiler-register/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocprofiler-register"

--- a/runtime-rocm/rocm-roctracer/spec
+++ b/runtime-rocm/rocm-roctracer/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/roctracer"

--- a/runtime-rocm/rocm-smi-lib/spec
+++ b/runtime-rocm/rocm-smi-lib/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocm-smi-lib"

--- a/runtime-rocm/rocminfo/spec
+++ b/runtime-rocm/rocminfo/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocminfo"

--- a/runtime-rocm/rocr-runtime/spec
+++ b/runtime-rocm/rocr-runtime/spec
@@ -1,4 +1,4 @@
-VER=7.14
+VER=10.0
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rocr-runtime"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-hipfile: update to 10.0
- libhipcxx: update to 10.0
- rocm-origami: update to 10.0
- rocm-hipblas-common: update to 10.0
- rocm-rocjpeg: update to 10.0
- rocm-rocdecode: update to 10.0
- rocm-aqlprofile: update to 10.0
- rocm-roctracer: update to 10.0
- rocm-hipfort: update to 7.14.0
- rocm-hipify: update to 10.0

... and 13 more commits

Package(s) Affected
-------------------

- libhipcxx: 10.0
- rocm-amdsmi: 10.0
- rocm-aqlprofile: 10.0
- rocm-clr: 10.0
- rocm-cmake: 10.0
- rocm-comgr: 10.0
- rocm-core: 10.0
- rocm-cuid: 10.0
- rocm-device-libs: 10.0
- rocm-half: 10.0
- rocm-hipblas-common: 10.0
- rocm-hipfile: 10.0
- rocm-hipfort: 7.14.0
- rocm-hipify: 10.0
- rocm-llvm: 10.0
- rocm-origami: 10.0
- rocm-rocdecode: 10.0
- rocm-rocjpeg: 10.0
- rocm-rocprofiler-register: 10.0
- rocm-roctracer: 10.0
- rocm-smi-lib: 10.0
- rocminfo: 10.0
- rocr-runtime: 10.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit rocm-core rocm-llvm rocm-device-libs rocm-comgr rocm-cmake rocm-rocprofiler-register rocm-cuid rocr-runtime rocminfo rocm-clr rocm-half rocm-amdsmi rocm-smi-lib rocm-hipify rocm-hipfort rocm-roctracer rocm-aqlprofile rocm-rocdecode rocm-rocjpeg rocm-hipblas-common rocm-origami libhipcxx rocm-hipfile
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`

**Secondary Architectures**

- [ ] RISC-V 64-bit `riscv64`
