### PR TITLE
openssl+32: fix build, enable manpages

### DIFF
--- a/runtime-optenv32/openssl+32/autobuild/build
+++ b/runtime-optenv32/openssl+32/autobuild/build
@@ -7,7 +7,7 @@ abinfo "Configuring openssl+32 ..."
     --prefix=/opt/32 \
     --openssldir=/opt/32/etc/ssl \
     --libdir=lib \
-    shared zlib enable-ssl2 no-tests disable-docs \
+    shared zlib enable-ssl2 no-tests \
     -Wa,--noexecstack linux-x86
 
 abinfo "Building openssl+32 ..."

--- a/runtime-optenv32/openssl+32/spec
+++ b/runtime-optenv32/openssl+32/spec
@@ -1,4 +1,5 @@
 VER=3.6.4
+REL=1
 SRCS="git::commit=tags/openssl-$VER::https://github.com/openssl/openssl"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2566"


### PR DESCRIPTION
Topic Description
-----------------

- openssl+32: fix build, enable manpages
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- openssl+32: 3.6.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit openssl+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
