### PR TITLE
opentimelineio: fix so path

### DIFF
--- a/runtime-multimedia/opentimelineio/autobuild/defines
+++ b/runtime-multimedia/opentimelineio/autobuild/defines
@@ -4,9 +4,11 @@ PKGDEP="python-3 imath"
 BUILDDEP="pybind11 setuptools"
 PKGDES="Open Source API and interchange format for editorial timeline information"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
     '-DBUILD_TESTING=OFF'
     '-DOTIO_FIND_IMATH=ON'
+    '-DOTIO_FIND_PYBIND11=ON'
     '-DOTIO_PYTHON_INSTALL=ON'
     "-DOTIO_PYTHON_INSTALL_DIR=/usr/lib/python${ABPY3VER}/site-packages/"
     '-DOTIO_SHARED_LIBS=ON'

--- a/runtime-multimedia/opentimelineio/autobuild/patches/0001-FEDORA-cmake-install.patch
+++ b/runtime-multimedia/opentimelineio/autobuild/patches/0001-FEDORA-cmake-install.patch
@@ -1,0 +1,117 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ca7f097..7c0322d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -81,7 +81,6 @@ if(OTIO_PYTHON_INSTALL)
+     if(OTIO_PYTHON_INSTALL_DIR STREQUAL "" AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+         # neither install directory supplied from the command line
+         set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${Python_SITEARCH}")
+-        set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
+         message(STATUS "OTIO Defaulting Python install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
+     else()
+         # either python_install or install_prefix have been set
+@@ -92,21 +91,21 @@ if(OTIO_PYTHON_INSTALL)
+             # In order to not require setting $PYTHONPATH to point at the .so,
+             # the shared libraries are installed into the python library
+             # location.
+-            set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
+             message(STATUS "OTIO Defaulting Python install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
+         else()
+             # OTIO_PYTHON_INSTALL_DIR was set, so install everything into the python package
+             set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}")
+-            set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
+         endif()
+     endif()
+ 
+     if (WIN32)
+         string(REPLACE "\\" "/" OTIO_RESOLVED_PYTHON_INSTALL_DIR ${OTIO_RESOLVED_PYTHON_INSTALL_DIR})
+     endif()
+-
+-else()
+-    set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib")
++endif()
++	
++if(OTIO_CXX_INSTALL)
++    include(GNUInstallDirs)
++    set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${CMAKE_INSTALL_FULL_LIBDIR}")
+     message(STATUS "OTIO C++ installing to ${CMAKE_INSTALL_PREFIX}")
+ endif()
+ 
+diff --git a/src/opentime/CMakeLists.txt b/src/opentime/CMakeLists.txt
+index 9133e4e..88829d9 100644
+--- a/src/opentime/CMakeLists.txt
++++ b/src/opentime/CMakeLists.txt
+@@ -26,6 +26,7 @@ target_include_directories(
+ set_target_properties(opentime PROPERTIES 
+     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
+     LIBRARY_OUTPUT_NAME "opentime"
++    VERSION "${OTIO_VERSION}"
+     POSITION_INDEPENDENT_CODE TRUE)
+ 
+ if(OTIO_SHARED_LIBS)
+@@ -73,7 +74,7 @@ if(OTIO_CXX_INSTALL)
+             RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
+ 
+     install(EXPORT OpenTimeTargets
+-            DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime"
++            DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/cmake/opentime"
+             NAMESPACE OTIO:: )
+ 
+     include(CMakePackageConfigHelpers)
+@@ -81,7 +82,7 @@ if(OTIO_CXX_INSTALL)
+         ${CMAKE_CURRENT_SOURCE_DIR}/OpenTimeConfig.cmake.in
+         ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfig.cmake
+         INSTALL_DESTINATION
+-            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime
++            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/cmake/opentime
+         NO_SET_AND_CHECK_MACRO
+         NO_CHECK_REQUIRED_COMPONENTS_MACRO
+     )
+@@ -90,7 +91,7 @@ if(OTIO_CXX_INSTALL)
+         FILES
+             ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfig.cmake
+         DESTINATION
+-            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime
++            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/cmake/opentime
+     )
+ 
+     install(
+diff --git a/src/opentimelineio/CMakeLists.txt b/src/opentimelineio/CMakeLists.txt
+index 2ca319b..4c7dfb7 100644
+--- a/src/opentimelineio/CMakeLists.txt
++++ b/src/opentimelineio/CMakeLists.txt
+@@ -101,6 +101,7 @@ target_link_libraries(opentimelineio
+ set_target_properties(opentimelineio PROPERTIES
+     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
+     LIBRARY_OUTPUT_NAME "opentimelineio"
++    VERSION "${OTIO_VERSION}"
+     POSITION_INDEPENDENT_CODE TRUE)
+ 
+ if(OTIO_SHARED_LIBS)
+@@ -151,7 +152,7 @@ if(OTIO_CXX_INSTALL)
+            RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
+ 
+     install(EXPORT OpenTimelineIOTargets
+-           DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio"
++           DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/cmake/opentimelineio"
+            NAMESPACE OTIO:: )
+ 
+     include(CMakePackageConfigHelpers)
+@@ -159,7 +160,7 @@ if(OTIO_CXX_INSTALL)
+         ${CMAKE_CURRENT_SOURCE_DIR}/OpenTimelineIOConfig.cmake.in
+         ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfig.cmake
+         INSTALL_DESTINATION
+-            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio
++            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/cmake/opentimelineio
+         NO_SET_AND_CHECK_MACRO
+         NO_CHECK_REQUIRED_COMPONENTS_MACRO
+     )
+@@ -168,7 +169,7 @@ if(OTIO_CXX_INSTALL)
+         FILES
+             ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfig.cmake
+         DESTINATION
+-            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio
++            ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/cmake/opentimelineio
+     )
+ 
+     install(

--- a/runtime-multimedia/opentimelineio/spec
+++ b/runtime-multimedia/opentimelineio/spec
@@ -1,4 +1,5 @@
 VER=0.18.1
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AcademySoftwareFoundation/OpenTimelineIO"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=86451"


### PR DESCRIPTION
Topic Description
-----------------

- opentimelineio: fix so path
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- opentimelineio: 0.18.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit opentimelineio
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
