### PR TITLE
tinycss2: (upstream patch) fix FTBFS with flit core 4

### DIFF
--- a/lang-python/tinycss2/autobuild/patches/0001-Permit-building-with-flit-core-4.patch
+++ b/lang-python/tinycss2/autobuild/patches/0001-Permit-building-with-flit-core-4.patch
@@ -1,0 +1,21 @@
+From e905d8c5321be436f1478877bbcf19b0e5b6c7be Mon Sep 17 00:00:00 2001
+From: Xu Colin <colinxu2020@gmail.com>
+Date: Sun, 30 Aug 2026 11:34:18 +0800
+Subject: [PATCH] Permit building with flit core 4
+
+Signed-off-by: Xu Colin <colinxu2020@gmail.com>
+---
+ pyproject.toml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index d1663a7..90243f3 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,5 +1,5 @@
+ [build-system]
+-requires = ['flit_core >=3.2,<4']
++requires = ['flit_core >=3.2,<5']
+ build-backend = 'flit_core.buildapi'
+ 
+ [project]


### PR DESCRIPTION
Topic Description
-----------------

- tinycss2: \(upstream patch\) fix FTBFS with flit core 4
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- tinycss2: 1.0.2-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tinycss2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
