### PR TITLE
libclc: update to 22.1.8

### DIFF
--- a/runtime-devices/libclc/autobuild/defines
+++ b/runtime-devices/libclc/autobuild/defines
@@ -1,10 +1,9 @@
 PKGNAME=libclc
 PKGSEC=libs
-PKGDEP=""
+PKGDEP="glibc"
 BUILDDEP="llvm spirv-llvm-translator spirv-tools"
 PKGDES="Library requirements of the OpenCL C programming language"
 
 USECLANG=1
 ABHOST=noarch
-
-PKGEPOCH=1
+ABTYPE=cmakeninja

--- a/runtime-devices/libclc/spec
+++ b/runtime-devices/libclc/spec
@@ -1,6 +1,7 @@
-VER=18.1.8
-SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-${VER}/libclc-${VER}.src.tar.xz"
-CHKSUMS="sha256::905bd59e9f810d6bd0ae6874725a8f8a3c91cb416199c03f2b98b57437cfb32e"
+VER=22.1.8
+EPOCH=1
+SRCS="tbl::https://github.com/llvm/llvm-project/releases/download/llvmorg-$VER/llvm-project-$VER.src.tar.xz"
+CHKSUMS="sha256::922f1817a0df7b1489272d18134ee0087a8b068828f87ac63b9861b1a9965888"
 CHKUPDATE="anitya::id=1830"
 
-SUBDIR="libclc-${VER}.src"
+SUBDIR="llvm-project-$VER.src/libclc"


### PR DESCRIPTION
Topic Description
-----------------

- libclc: update to 22.1.8

Package(s) Affected
-------------------

- libclc: 1:22.1.8

Security Update?
----------------

No

Build Order
-----------

```
#buildit libclc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
