### PR TITLE
Python Packages Survey 20260830

### DIFF
--- a/lang-python/pyte/autobuild/defines
+++ b/lang-python/pyte/autobuild/defines
@@ -1,9 +1,9 @@
 PKGNAME=pyte
 PKGSEC=python
 PKGDEP="wcwidth"
-BUILDDEP="pip setuptools"
 PKGDES="Simple VTXXX-compatible terminal emulator"
 
+ABTYPE=python
 ABHOST=noarch
 
 NOPYTHON2=1

--- a/lang-python/pyte/spec
+++ b/lang-python/pyte/spec
@@ -1,5 +1,4 @@
-VER=0.8.0
-REL="5"
-SRCS="tbl::https://pypi.io/packages/source/p/pyte/pyte-$VER.tar.gz"
-CHKSUMS="sha256::7e71d03e972d6f262cbe8704ff70039855f05ee6f7ad9d7129df9c977b5a88c5"
+VER=0.8.2
+SRCS="pypi::version=$VER::pyte"
+CHKSUMS="sha256::5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f"
 CHKUPDATE="anitya::id=231384"

--- a/lang-python/python-build/autobuild/defines
+++ b/lang-python/python-build/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=python-build
 PKGSEC=python
-PKGDEP="tomli virtualenv pyproject-hooks packaging"
+PKGDEP="pyproject-hooks packaging"
 BUILDDEP="flit-core"
-PKGDES="A compliant PEP 517 build frontend"
+PKGDES="PEP 517-compliant build frontend"
 
 ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/python-build/autobuild/defines.stage2
+++ b/lang-python/python-build/autobuild/defines.stage2
@@ -2,7 +2,7 @@ PKGNAME=python-build
 PKGSEC=python
 PKGDEP="tomli pyproject-hooks"
 BUILDDEP="flit-core"
-PKGDES="A compliant PEP 517 build frontend"
+PKGDES="PEP 517-compliant build frontend"
 
 ABHOST=noarch
 NOPYTHON2=1

--- a/lang-python/python-build/spec
+++ b/lang-python/python-build/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=2
-SRCS="tbl::https://pypi.io/packages/source/b/build/build-$VER.tar.gz"
-CHKSUMS="sha256::698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397"
+VER=1.6.0
+SRCS="pypi::version=$VER::build"
+CHKSUMS="sha256::bd2c8afc603e7a2e0ce70e2ea85f0a6d02043bafbd307f5bada0f98669eca5af"
 CHKUPDATE="anitya::id=132276"

--- a/lang-python/python-cloudflare/spec
+++ b/lang-python/python-cloudflare/spec
@@ -1,4 +1,4 @@
-VER=5.2.0
+VER=5.6.0
 SRCS="pypi::version=$VER::cloudflare"
-CHKSUMS="sha256::dcf5cb4b54f543b000a68095297bcc16a9c618b98c09747d7b78e59e3d865292"
+CHKSUMS="sha256::b8c81586aecd0ce48f0daaa859cce554f7b975b01d312b60d1a91ad0ea4b67ff"
 CHKUPDATE="anitya::id=17053"

--- a/lang-python/python-crc/autobuild/defines
+++ b/lang-python/python-crc/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=python-crc
 PKGDES="Python library to calculate/verify CRC checksums"
 PKGDEP="python-3"
-BUILDDEP="poetry-core"
+BUILDDEP="hatchling"
 PKGSEC=python
 
 ABTYPE=pep517

--- a/lang-python/python-crc/spec
+++ b/lang-python/python-crc/spec
@@ -1,5 +1,4 @@
-VER=7.0.0
-SRCS="tbl::https://github.com/Nicoretti/crc/releases/download/7.0.0/crc-7.0.0.tar.gz"
-CHKSUMS="sha256::b9fc521042167f2b59d9183ce27acc0897e4a17748421e8b304ccdf7ebf4280a"
+VER=8.0.0
+SRCS="pypi::version=$VER::crc"
+CHKSUMS="sha256::e1ef893b042c26c9f47fd32f3c17507b7d1bd81169acebaef908774856fdaa3e"
 CHKUPDATE="anitya::id=86881"
-REL="1"

--- a/lang-python/python-cssselect/autobuild/defines
+++ b/lang-python/python-cssselect/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=python-cssselect
 PKGSEC=python
 PKGDEP="python-3"
 BUILDDEP="hatchling"
-PKGDES="A Python library that parses CSS3 Selectors and translates them to XPath 1.0"
+PKGDES="Python library to parse and translate CSS3 Selectors to XPath 1.0"
 
 ABHOST=noarch
 ABTYPE=pep517

--- a/lang-python/python-cssselect/spec
+++ b/lang-python/python-cssselect/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
+VER=1.5.0
 SRCS="pypi::version=$VER::cssselect"
-CHKSUMS="sha256::57f8a99424cfab289a1b6a816a43075a4b00948c86b4dcf3ef4ee7e15f7ab0c7"
+CHKSUMS="sha256::3cbe82dd7acbee9ba9e5723b5f9e4749826912f1fb31cd7f92aabed5fde15b15"
 CHKUPDATE="anitya::id=11593"
-REL="1"

--- a/lang-python/python-dbusmock/autobuild/defines
+++ b/lang-python/python-dbusmock/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="dbus-python python-3"
 BUILDDEP="setuptools-scm"
 PKGDES="Mock D-Bus objects"
 
+ABTYPE=pep517
 ABHOST=noarch

--- a/lang-python/python-dbusmock/spec
+++ b/lang-python/python-dbusmock/spec
@@ -1,5 +1,4 @@
-VER=0.37.1
+VER=0.38.1
 SRCS="pypi::version=$VER::python-dbusmock"
-CHKSUMS="sha256::a65aeedc17d8bbc1f0bf3f0b295988914c48619882d77b9afa4117eed95fc594"
+CHKSUMS="sha256::221b65e1c2e48de9fd11bf7e8c165adaf91648f49a11f390d086a498386f2984"
 CHKUPDATE="anitya::id=19778"
-REL="1"

--- a/lang-python/python-discid/spec
+++ b/lang-python/python-discid/spec
@@ -1,5 +1,4 @@
-VER=1.2.0
-REL="2"
-SRCS="https://files.pythonhosted.org/packages/source/d/discid/discid-${VER}.tar.gz"
-CHKSUMS="sha256::cd9630bc53f5566df92819641040226e290b2047573f2c74a6e92b8eed9e86b9"
+VER=1.4.2
+SRCS="pypi::version=$VER::discid"
+CHKSUMS="sha256::0cbb4b96949c68cbc63c9fc4585ef9b7ec2b9d39e23bce0b4db5d61c6f7b81e6"
 CHKUPDATE="anitya::id=309145"

--- a/lang-python/python-discovery/autobuild/defines
+++ b/lang-python/python-discovery/autobuild/defines
@@ -1,8 +1,8 @@
 PKGNAME=python-discovery
 PKGDES="Python library to discover installed Python interpreters"
 PKGSEC=python
-PKGDEP="python-3 py-filelock platformdirs"
-BUILDDEP="python-build python-installer wheel tomli hatch-vcs hatchling setuptools-scm"
+PKGDEP="python-3 py-filelock"
+BUILDDEP="hatch-vcs hatchling"
 
 ABHOST=noarch
 ABTYPE=pep517

--- a/lang-python/python-discovery/spec
+++ b/lang-python/python-discovery/spec
@@ -1,4 +1,4 @@
-VER=1.3.0
+VER=1.6.0
 SRCS="pypi::version=$VER::python-discovery"
-CHKSUMS="sha256::d098f1e86be5d45fe4d14bf1029294aabbd332f4321179dec85e76cddce834b0"
+CHKSUMS="sha256::6393b4eae1be8b2182670635e7baff89ac21cb9f8e86fd1ff40c7b1144febb4c"
 CHKUPDATE="anitya::id=388662"

--- a/lang-python/python-evdev/autobuild/defines
+++ b/lang-python/python-evdev/autobuild/defines
@@ -4,4 +4,5 @@ PKGDEP="libevdev python-3"
 BUILDDEP="setuptools"
 PKGDES="Python interfaces for Linux event device handling"
 
+ABTYPE=pep517
 NOPYTHON2=1

--- a/lang-python/python-evdev/spec
+++ b/lang-python/python-evdev/spec
@@ -1,5 +1,4 @@
-VER=1.7.1
-REL="2"
-SRCS="tbl::https://pypi.io/packages/source/e/evdev/evdev-$VER.tar.gz"
-CHKSUMS="sha256::0c72c370bda29d857e188d931019c32651a9c1ea977c08c8d939b1ced1637fde"
+VER=2.0.0
+SRCS="pypi::version=$VER::evdev"
+CHKSUMS="sha256::442fb3f4c8dfc9e61e901133c356220c02d663eca8f34722e0cecdd637eba504"
 CHKUPDATE="anitya::id=12300"

--- a/lang-python/python-graphviz/autobuild/defines
+++ b/lang-python/python-graphviz/autobuild/defines
@@ -2,7 +2,8 @@ PKGNAME=python-graphviz
 PKGSEC=python
 PKGDEP="graphviz python-3"
 BUILDDEP="setuptools"
-PKGDES="Module for creating and rendering Graphviz graphs using Python"
+PKGDES="Python module to create and render Graphviz graphics"
 
+ABTYPE=pep517
 NOPYTHON2=1
 ABHOST=noarch

--- a/lang-python/python-graphviz/spec
+++ b/lang-python/python-graphviz/spec
@@ -1,5 +1,4 @@
-VER=0.16
-SRCS="tbl::https://pypi.io/packages/source/g/graphviz/graphviz-$VER.zip"
-CHKSUMS="sha256::d2d25af1c199cad567ce4806f0449cb74eb30cf451fd7597251e1da099ac6e57"
+VER=0.21
+SRCS="pypi::version=$VER::graphviz"
+CHKSUMS="sha256::20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78"
 CHKUPDATE="anitya::id=19032"
-REL="2"


### PR DESCRIPTION
Topic Description
-----------------

- python-graphviz: update to 0.21
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-evdev: update to 2.0.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-discovery: update to 1.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-discid: update to 1.4.2
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-dbusmock: update to 0.38.1
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-cssselect: update to 1.5.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-crc: update to 8.0.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-cloudflare: update to 5.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- python-build: update to 1.6.0
    Signed-off-by: stydxm <stydxm@outlook.com>
- pyte: update to 0.8.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit pyte python-build python-cloudflare python-crc python-cssselect python-dbusmock python-discid python-discovery python-evdev python-graphviz
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
