### PR TITLE
grpc: update to 1.83.1

### DIFF
--- a/app-network/grpc/autobuild/defines
+++ b/app-network/grpc/autobuild/defines
@@ -43,5 +43,5 @@ CMAKE_AFTER=(
 ## with exit code 1 when building python-grpcio
 NOLTO__LOONGSON3=1
 
-PKGBREAK="grpcio<=1.56.2 apache-arrow<=23.0.1 bear<=3.1.6-3 proton-bridge<=3.21.2-9"
+PKGBREAK="grpcio bear<=3.1.6-3 apache-arrow<=25.0.0 proton-bridge<=3.21.2-14 rocm-rdc<=7.14"
 PKGREP="grpcio"

--- a/app-network/grpc/spec
+++ b/app-network/grpc/spec
@@ -1,5 +1,4 @@
-VER=1.81.1
-REL=1
+VER=1.83.1
 SRCS="git::commit=tags/v$VER::https://github.com/grpc/grpc"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=19117"

--- a/app-web/proton-bridge/spec
+++ b/app-web/proton-bridge/spec
@@ -1,5 +1,5 @@
 VER=3.21.2
-REL=14
+REL=15
 SRCS="git::copy-repo=true;submodule=false;commit=tags/v$VER::https://github.com/ProtonMail/proton-bridge"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=231962"

--- a/runtime-database/apache-arrow/spec
+++ b/runtime-database/apache-arrow/spec
@@ -1,4 +1,5 @@
 VER=25.0.0
+REL=1
 SRCS="git::commit=tags/apache-arrow-$VER::https://github.com/apache/arrow"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=20697"

--- a/runtime-rocm/rocm-rdc/spec
+++ b/runtime-rocm/rocm-rdc/spec
@@ -1,4 +1,5 @@
 VER=7.14
+REL=1
 SRCS="git::commit=tags/therock-${VER};rename=rocm-systems;copy-repo=true::https://github.com/ROCm/rocm-systems"
 CHKSUMS="SKIP"
 SUBDIR="rocm-systems/projects/rdc"


### PR DESCRIPTION
Topic Description
-----------------

- rocm-rdc: rebuild for grpc
- proton-bridge: rebuild for grpc
- apache-arrow: rebuild for grpc
- grpc: update to 1.83.1
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- apache-arrow: 25.0.0-1
- grpc: 1.83.1
- proton-bridge: 3.21.2-15
- rocm-rdc: 7.14-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit grpc apache-arrow proton-bridge rocm-rdc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
