### PR TITLE
shfmt: update to 3.14.0

### DIFF
--- a/app-devel/shfmt/autobuild/defines
+++ b/app-devel/shfmt/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=shfmt
 PKGSEC=devel
-PKGDES='Parser, formatter and interpreter for sh/bash/mksh'
-BUILDDEP='go scdoc'
+PKGDES="Parser, formatter and interpreter for sh/bash/mksh"
+BUILDDEP="go scdoc"
 AB_TYPE=gomod
-GO_PACKAGES=('cmd/shfmt')
+GO_PACKAGES=("cmd/shfmt")

--- a/app-devel/shfmt/spec
+++ b/app-devel/shfmt/spec
@@ -1,5 +1,5 @@
 VER=3.13.1
 REL=1
 SRCS="git::commit=tags/v${VER}::https://github.com/mvdan/sh"
-CHKSUMS='SKIP'
-CHKUPDATE='anitya::id=242179'
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=242179"

--- a/app-devel/shfmt/spec
+++ b/app-devel/shfmt/spec
@@ -1,5 +1,4 @@
-VER=3.13.1
-REL=1
+VER=3.14.0
 SRCS="git::commit=tags/v${VER}::https://github.com/mvdan/sh"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242179"


### PR DESCRIPTION
Topic Description
-----------------

- shfmt: update to 3.14.0
- shfmt: use double quotes to prevent problems with /bump

Package(s) Affected
-------------------

- shfmt: 3.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit shfmt
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
