### PR TITLE
clash-verge-rev: Fix shortcuts

### DIFF
--- a/app-proxy/clash-verge-rev/autobuild/defines
+++ b/app-proxy/clash-verge-rev/autobuild/defines
@@ -1,16 +1,19 @@
 PKGNAME=clash-verge-rev
 PKGSEC=net
+# FIXME: Add libjxl to fix the issue with linking to libjxl.so.0.11
+#        although this rarely occurs.
 PKGDEP="bzip2 cairo gcc-runtime gdk-pixbuf glib \
         glibc gtk-3 libsoup-3 openssl pango webkit2gtk \
         libayatana-appindicator libappindicator \
-        xz mihomo clash-verge-service-ipc mihomo-rules-dat"
+        xz mihomo clash-verge-service-ipc mihomo-rules-dat \
+        libjxl"
 BUILDDEP="nodejs rustc llvm tauri-cli"
 PKGDES="GUI configuration manager for the Clash rule-based proxy"
 PKGPROV="clash-verge"
 PKGEPOCH=1
 
 # FIXME: Vite not supported.
-FAIL_ARCH="@(loongson3|riscv64)"
+FAIL_ARCH="@(loongson3|riscv64|i486)"
 
 # FIXME: ld.lld: error: undefined symbol: ring_core_0_17_8_LIMBS_are_zero
 NOLTO=1

--- a/app-proxy/clash-verge-rev/autobuild/overrides/usr/share/applications/io.github.clash-verge-rev.desktop
+++ b/app-proxy/clash-verge-rev/autobuild/overrides/usr/share/applications/io.github.clash-verge-rev.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Exec=WEBKIT_DISABLE_DMABUF_RENDERER=1 clash-verge
+Exec=/usr/bin/env WEBKIT_DISABLE_DMABUF_RENDERER=1 clash-verge
 Icon=clash-verge
 Categories=Network;
 StartupNotify=true

--- a/app-proxy/clash-verge-rev/spec
+++ b/app-proxy/clash-verge-rev/spec
@@ -3,4 +3,4 @@ SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/clash-verge-rev/
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=371843"
 ENVREQ="total_mem=30"
-REL=1
+REL=2


### PR DESCRIPTION
Topic Description
-----------------

- clash-verge-rev: Fix an issue where GNOME failed to recognize
  the `.desktop` file because its `Exec` entry did not conform to
  the Desktop Entry Specification.

  The Desktop Entry Specification requires Exec to begin with an executable.
  Use /usr/bin/env to set the environment variable before invoking
  clash-verge, allowing GNOME to parse and launch the desktop entry correctly.
  
  https://specifications.freedesktop.org/desktop-entry/latest/exec-variables.html

  Signed-off-by: Neko205 <neko200553@gmail.com>

Package(s) Affected
-------------------

- clash-verge-rev: 1:2.5.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit clash-verge-rev
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
