### PR TITLE
containers-common: update to 0.69.0+shortnames2025.03.19+skopeo1.24.0

### DIFF
--- a/runtime-containers/containers-common/autobuild/prepare
+++ b/runtime-containers/containers-common/autobuild/prepare
@@ -1,11 +1,11 @@
 abinfo "Grabbing configuration files from upstream repositories ..."
 export BASE_DIR="${SRCDIR}/.."
 export BUILD_DIR="${BASE_DIR}/build"
-export COMMON_DIR="${BASE_DIR}/common"
-export IMAGE_DIR="${BASE_DIR}/image"
+export COMMON_DIR="${BASE_DIR}/container-libs/common"
+export IMAGE_DIR="${BASE_DIR}/container-libs/image"
 export SHORTNAMES_DIR="${BASE_DIR}/shortnames"
 export SKOPEO_DIR="${BASE_DIR}/skopeo"
-export STORAGE_DIR="${BASE_DIR}/storage"
+export STORAGE_DIR="${BASE_DIR}/container-libs/storage"
 
 # Ref: https://github.com/containers/podman/blob/main/contrib/containers-common/containers-common.spec.in
 mkdir -v "${BUILD_DIR}"
@@ -21,7 +21,7 @@ cp -v "${IMAGE_DIR}/docs/containers-auth.json.5.md" .
 cp -v "${IMAGE_DIR}/docs/containers-certs.d.5.md" .
 cp -v "${IMAGE_DIR}/docs/containers-policy.json.5.md" .
 cp -v "${IMAGE_DIR}/docs/containers-registries.conf.5.md" .
-cp -v "${IMAGE_DIR}/docs/containers-registries.conf.d.5.md" .
+cp -v "${IMAGE_DIR}/docs/containers-registries.conf.d.5" .
 cp -v "${IMAGE_DIR}/docs/containers-registries.d.5.md" .
 cp -v "${IMAGE_DIR}/docs/containers-signature.5.md" .
 cp -v "${IMAGE_DIR}/docs/containers-sigstore-signing-params.yaml.5.md" .

--- a/runtime-containers/containers-common/spec
+++ b/runtime-containers/containers-common/spec
@@ -1,24 +1,18 @@
-UPSTREAM_VER=0.64.2
+UPSTREAM_VER=0.69.0
 # Find dependency versions at
 #
 # https://github.com/containers/common/blob/v$PKGVER/go.sum
-__IMAGE_VER=5.34.3
-__STORAGE_VER=1.57.2
 # FIXME: the following two dependencies are not in the go.sum file above.
 __SHORTNAMES_VER=2025.03.19
-__SKOPEO_VER=1.18.0
+__SKOPEO_VER=1.24.0
 
-VER=${UPSTREAM_VER}+image${__IMAGE_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}+storage${__STORAGE_VER}
+VER=${UPSTREAM_VER}+shortnames${__SHORTNAMES_VER}+skopeo${__SKOPEO_VER}
 __ORG_URL="https://github.com/containers"
-SRCS="git::commit=tags/v${UPSTREAM_VER};rename=common::${__ORG_URL}/common \
-      git::commit=tags/v${__IMAGE_VER};rename=image::${__ORG_URL}/image \
+SRCS="git::commit=tags/common/v${UPSTREAM_VER};rename=container-libs::${__ORG_URL}/container-libs \
       git::commit=tags/v${__SHORTNAMES_VER};rename=shortnames::${__ORG_URL}/shortnames \
-      git::commit=tags/v${__SKOPEO_VER};rename=skopeo::${__ORG_URL}/skopeo \
-      git::commit=tags/v${__STORAGE_VER};rename=storage::${__ORG_URL}/storage"
+      git::commit=tags/v${__SKOPEO_VER};rename=skopeo::${__ORG_URL}/skopeo"
 CHKSUMS="SKIP \
          SKIP \
-         SKIP \
-         SKIP \
          SKIP"
-SUBDIR="common"
+SUBDIR="container-libs"
 CHKUPDATE="anitya::id=327044"


### PR DESCRIPTION
Topic Description
-----------------

- containers-common: update to 0.69.0+shortnames2025.03.19+skopeo1.24.0
    Co-authored-by: 雨ノ宮 あめ \(@BillZhou233\)

Package(s) Affected
-------------------

- containers-common: 0.69.0+shortnames2025.03.19+skopeo1.24.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit containers-common
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
