### PR TITLE
bitwarden: update to 2026.8.0

### DIFF
--- a/app-utils/bitwarden/autobuild/defines
+++ b/app-utils/bitwarden/autobuild/defines
@@ -2,7 +2,7 @@ PKGNAME=bitwarden
 PKGSEC=utils
 PKGDEP="alsa-lib at-spi2-core cairo cups dbus expat gcc-runtime glib glibc \
         gtk-3 libxcb libxkbcommon mesa nspr nss pango systemd x11-lib"
-BUILDDEP="nodejs rustc llvm-20"
+BUILDDEP="nodejs rustc llvm-22"
 PKGDES="Desktop client for Bitwarden password manager"
 
 USECLANG=1

--- a/app-utils/bitwarden/autobuild/patches/0001-napi-enable-lto.patch.deferred.bitwarden
+++ b/app-utils/bitwarden/autobuild/patches/0001-napi-enable-lto.patch.deferred.bitwarden
@@ -1,4 +1,4 @@
-From 91a81a9bb7c2a891d401b66a5bc897f01822d535 Mon Sep 17 00:00:00 2001
+From 3a5ba9ddce0cd17792307fa575493fa6a3bc32f7 Mon Sep 17 00:00:00 2001
 From: Kaiyang Wu <self@origincode.me>
 Date: Sat, 31 Aug 2024 00:01:51 -0700
 Subject: [PATCH 1/5] napi: enable lto
@@ -9,10 +9,10 @@ Signed-off-by: Kaiyang Wu <self@origincode.me>
  1 file changed, 6 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/napi/Cargo.toml b/apps/desktop/desktop_native/napi/Cargo.toml
-index ed33c6ba59..22aa6290d9 100644
+index 61615c34ed..fd7c6a822b 100644
 --- a/apps/desktop/desktop_native/napi/Cargo.toml
 +++ b/apps/desktop/desktop_native/napi/Cargo.toml
-@@ -38,3 +38,9 @@ napi-build = { workspace = true }
+@@ -39,3 +39,9 @@ napi-build = { workspace = true }
  
  [lints]
  workspace = true

--- a/app-utils/bitwarden/autobuild/patches/0002-bitwarden-remove-update-related-code.patch.deferred.bitwarden
+++ b/app-utils/bitwarden/autobuild/patches/0002-bitwarden-remove-update-related-code.patch.deferred.bitwarden
@@ -1,4 +1,4 @@
-From c882dfc487d1cfcb92a3784e0f0e3286484d1934 Mon Sep 17 00:00:00 2001
+From d9da3fe4f19e7b015d7800eafaccf4c55da70f3f Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Tue, 21 Apr 2026 18:38:40 +0800
 Subject: [PATCH 2/5] bitwarden: remove update related code

--- a/app-utils/bitwarden/autobuild/patches/0003-bitwarden-add-loong64-for-napi-index.js.patch.deferred.loongarch64.bitwarden
+++ b/app-utils/bitwarden/autobuild/patches/0003-bitwarden-add-loong64-for-napi-index.js.patch.deferred.loongarch64.bitwarden
@@ -1,4 +1,4 @@
-From 8906e3fd4af62b3862419817eef0d8580822107c Mon Sep 17 00:00:00 2001
+From 7b5eee9e6c445b9bb90c7c2a8ad992d697fca387 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Tue, 21 Apr 2026 18:39:52 +0800
 Subject: [PATCH 3/5] bitwarden: add loong64 for napi/index.js

--- a/app-utils/bitwarden/autobuild/patches/0004-bitwarden-replace-Electron-with-LoongDotJS-version.patch.deferred.loongarch64.bitwarden
+++ b/app-utils/bitwarden/autobuild/patches/0004-bitwarden-replace-Electron-with-LoongDotJS-version.patch.deferred.loongarch64.bitwarden
@@ -1,4 +1,4 @@
-From cb6a88419f0b429f9840502cadcaa0a75f94a64f Mon Sep 17 00:00:00 2001
+From f44f4f6057b6d6582dfe0fc91b4315cef09dcd3f Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Tue, 21 Apr 2026 18:40:51 +0800
 Subject: [PATCH 4/5] bitwarden: replace Electron with LoongDotJS version
@@ -10,29 +10,29 @@ Signed-off-by: Kaiyang Wu <origincode@aosc.io>
  2 files changed, 4 insertions(+), 3 deletions(-)
 
 diff --git a/apps/desktop/electron-builder.json b/apps/desktop/electron-builder.json
-index a6e76e6a2e..d9f01dbcf1 100644
+index 2578912f4b..a71efe3e14 100644
 --- a/apps/desktop/electron-builder.json
 +++ b/apps/desktop/electron-builder.json
-@@ -23,7 +23,7 @@
+@@ -22,7 +22,7 @@
      "!node_modules/@bitwarden/desktop-napi/build.rs",
      "!node_modules/@bitwarden/desktop-napi/package.json"
    ],
--  "electronVersion": "41.7.2",
-+  "electronVersion": "42.3.0",
+-  "electronVersion": "43.2.0",
++  "electronVersion": "43.4.1",
    "generateUpdatesFilesForAllChannels": true,
    "publish": {
      "provider": "generic",
 diff --git a/package.json b/package.json
-index e94b5ffd8c..0d86953544 100644
+index 8639c6fd59..3a9f2547c9 100644
 --- a/package.json
 +++ b/package.json
 @@ -105,8 +105,9 @@
      "copy-webpack-plugin": "14.0.0",
      "cross-env": "10.1.0",
      "css-loader": "7.1.4",
--    "electron": "41.7.2",
+-    "electron": "43.2.0",
 -    "electron-builder": "26.9.0",
-+    "electron": "42.3.0",
++    "electron": "43.4.1",
 +    "electron-builder": "npm:@loongdotjs/electron-builder@26.15.6",
 +    "builder-util": "npm:@loongdotjs/builder-util@26.15.3",
      "electron-log": "5.4.3",

--- a/app-utils/bitwarden/autobuild/patches/0005-bitwarden-replace-rust-lang-libc-with-patched-versio.patch.deferred.loongarch64.bitwarden
+++ b/app-utils/bitwarden/autobuild/patches/0005-bitwarden-replace-rust-lang-libc-with-patched-versio.patch.deferred.loongarch64.bitwarden
@@ -1,4 +1,4 @@
-From 75f314efbaefe4b13acd1a4b5b17cb8afd1eda0f Mon Sep 17 00:00:00 2001
+From b347c6ca2d251d9b81b9b7e645d401ef4d4c1317 Mon Sep 17 00:00:00 2001
 From: SkyBird233 <52884766+SkyBird233@users.noreply.github.com>
 Date: Tue, 21 Apr 2026 18:42:44 +0800
 Subject: [PATCH 5/5] bitwarden: replace rust-lang/libc with patched version
@@ -9,10 +9,10 @@ Subject: [PATCH 5/5] bitwarden: replace rust-lang/libc with patched version
  1 file changed, 3 insertions(+)
 
 diff --git a/apps/desktop/desktop_native/Cargo.toml b/apps/desktop/desktop_native/Cargo.toml
-index 2ba8f0d044..9632904bd7 100644
+index a98abfd436..7c1c93b764 100644
 --- a/apps/desktop/desktop_native/Cargo.toml
 +++ b/apps/desktop/desktop_native/Cargo.toml
-@@ -92,3 +92,6 @@ print_stdout = "deny"
+@@ -99,3 +99,6 @@ print_stdout = "deny"
  string_slice = "warn"
  unused_async = "deny"
  unwrap_used = "deny"

--- a/app-utils/bitwarden/spec
+++ b/app-utils/bitwarden/spec
@@ -1,4 +1,4 @@
-VER=2026.7.0
+VER=2026.8.0
 RUST_LANG_LIBC_VER=0.2.178 # Match libc version in bitwarden/apps/desktop/desktop_native/Cargo.lock
 SRCS="git::commit=tags/desktop-v$VER;rename=bitwarden::https://github.com/bitwarden/clients"
 SRCS__LOONGARCH64="$SRCS \


### PR DESCRIPTION
Topic Description
-----------------

- bitwarden: update to 2026.8.0

Package(s) Affected
-------------------

- bitwarden: 2026.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit bitwarden
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
