### PR TITLE
tsukimi: update to 26.8.4

### DIFF
--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -8,3 +8,5 @@ PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv \
 ABTYPE=meson
 
 USECLANG=1
+# FIXME: https://github.com/aws/aws-lc-rs/issues/1211
+NOLTO=1

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,4 @@
-VER=26.8.1
+VER=26.8.4
 UAPI_CRATE_VER=0.2.13
 SRCS="git::commit=tags/v$VER;rename=tsukimi::https://github.com/tsukinaha/tsukimi"
 SRCS__LOONGARCH64="${SRCS} \


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: update to 26.8.4

Package(s) Affected
-------------------

- tsukimi: 26.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
