### PR TITLE
telegram desktop 7.1.3

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -2,12 +2,12 @@ PKGNAME=telegram-desktop
 PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
     openal-soft openssl lz4 qt-6 xxhash hunspell crc32c glibmm-2.68 fmt \
-    libjpeg-turbo opus pulseaudio rnnoise pipewire kcoreaddons ada"
+    libavif libheif libjpeg-turbo libjxl opus pulseaudio rnnoise pipewire \
+    ada"
 PKGDEP__MAINLINE_TIER2="${PKGDEP} libdispatch"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm gperf \
           extra-cmake-modules wayland-protocols plasma-wayland-protocols"
 PKGSUG="webkit2gtk"
-PKGRECOM="kimageformats"
 PKGDES="The official Telegram desktop application"
 
 PKGPROV="telegram tdesktop"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=7.1.2
+VER=7.1.3
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=19d51d3c19632a63fdbe17c62f10332d978cb940
 TDLIBVER=022d60202e446ad1287b9fb68e687c8a0760788b
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::415c05ef815bf8ae431ffbcbd27caa70f685c0357fccadc27ac035913933e5e5 \
+CHKSUMS="sha256:0d898d32b3cc6b9986505f767d0ec7387bd4d6b578120076b11f2f965b3ae270 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

update telegram desktop to 7.1.3
and remove unused dependencies (#17444).

Package(s) Affected
-------------------

telegram desktop: 7.1.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit tg-owt libtde2e telegram-desktop
```

Test Build(s) Done
------------------

<!-- The check boxes in this section should ONLY be set by the buildit
     infrastructure. Under no circumstances a person can set any of them
     by hand. Keep them unset for new pull requests, and unset them if
     you've made a change to the pull request after buildit set them. -->

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
