### PR TITLE
frr: update to 10.7.1

### DIFF
--- a/app-network/frr/spec
+++ b/app-network/frr/spec
@@ -1,4 +1,4 @@
-VER=10.7.0
+VER=10.7.1
 SRCS="git::commit=tags/frr-$VER::https://github.com/FRRouting/frr.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=18555"


### PR DESCRIPTION
Topic Description
-----------------

- frr: update to 10.7.1
    Co-authored-by: Pysio \(@pysio2007\)

Package(s) Affected
-------------------

- frr: 10.7.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit frr
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
