### PR TITLE
openlist: update to 4.2.5

### DIFF
--- a/app-web/openlist/spec
+++ b/app-web/openlist/spec
@@ -1,8 +1,7 @@
-VER=4.2.4
-REL=1
+VER=4.2.5
 SRCS="git::copy-repo=true;commit=tags/v${VER}::https://github.com/OpenListTeam/OpenList \
       tbl::https://github.com/OpenListTeam/OpenList-Frontend/releases/download/v$VER/openlist-frontend-dist-v$VER.tar.gz"
 CHKSUMS="SKIP \
-         sha256::f8de22c2957a104487b54c10aef511c31baa9b76f556ffdbde4ae595428a7378"
+         sha256::78e957e5b8855e30d00767458ab90ec11125a0344a238cc1e1990f46553d4308"
 CHKUPDATE="anitya::id=389246"
 SUBDIR="openlist"


### PR DESCRIPTION
Topic Description
-----------------

- openlist: update to 4.2.5
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- openlist: 4.2.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit openlist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
