### PR TITLE
upx: update to 5.2.1

### DIFF
--- a/app-devel/upx/spec
+++ b/app-devel/upx/spec
@@ -1,4 +1,4 @@
-VER=5.1.1
+VER=5.2.1
 SRCS="tbl::https://github.com/upx/upx/releases/download/v$VER/upx-$VER-src.tar.xz"
-CHKSUMS="sha256::8eb914115b306fd9fd2110bd3d27ddb8ae7c5a03bb965f7d10f046a3a4ff9dfe"
+CHKSUMS="sha256::a7d457be4ef942e46844ee8f301206b111394cbcbde3599747a6904c54ff116b"
 CHKUPDATE="anitya::id=13737"


### PR DESCRIPTION
Topic Description
-----------------

- upx: update to 5.2.1
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- upx: 5.2.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit upx
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
