### PR TITLE
unrar: update to 7.2.7

### DIFF
--- a/app-utils/unrar/spec
+++ b/app-utils/unrar/spec
@@ -1,5 +1,5 @@
-VER=7.2.1
+VER=7.2.7
 SRCS="tbl::http://www.rarlab.com/rar/unrarsrc-$VER.tar.gz"
-CHKSUMS="sha256::3fe3b4d710da45521625353dc2e023dad48c010f02a93302756e1061a8f3ae8e"
+CHKSUMS="sha256::01d903a7dcf413cb2925696d7796e48e38d471f79bfe7ef3ad2aebf6c12dbefd"
 CHKUPDATE="anitya::id=13306"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- unrar: update to 7.2.7
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- unrar: 7.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit unrar
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
