### PR TITLE
go: update to 1.27.1+tools0.49.0

### DIFF
--- a/lang-golang/go/spec
+++ b/lang-golang/go/spec
@@ -1,11 +1,11 @@
-GO_VER=1.27.0
+GO_VER=1.27.1
 # Go tools can be updated independently.
 TOOLS_VER=0.49.0
 
 VER="${GO_VER}+tools${TOOLS_VER}"
 SRCS="tbl::https://go.dev/dl/go${GO_VER}.src.tar.gz \
       git::commit=tags/v${TOOLS_VER};rename=tools::https://go.googlesource.com/tools"
-CHKSUMS="sha256::7002403d7cc44529ef6d26f69a44818263395ead7c16c05a5808ae047ebeb0e5 \
+CHKSUMS="sha256::4e408abae126d916b6164627193f2c54f0e3ca1312d693b86db45f862ab238b1 \
          SKIP"
 CHKUPDATE="anitya::id=1227"
 SUBDIR="go"


### PR DESCRIPTION
Topic Description
-----------------

- go: update to 1.27.1+tools0.49.0
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- go: 1.27.1+tools0.49.0
- go-runtime: 1.27.1+tools0.49.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit go
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
