### PR TITLE
freerdp: update to 3.31.0

### DIFF
--- a/app-network/freerdp/autobuild/defines
+++ b/app-network/freerdp/autobuild/defines
@@ -72,8 +72,6 @@ CMAKE_AFTER=(
     '-DCMAKE_INSTALL_LIBDIR=/usr/lib'
 )
 
-PKGEPOCH=2
-
 PKGBREAK="gnome-boxes<=42.3-1 gnome-remote-desktop<=42.4 \
           gtk-frdp<=3.37.1+git20220411 remmina<=1.4.31-1 vinagre<=3.22.0-6 \
           weston<=14.0.0"

--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,5 @@
 VER=3.31.0
+EPOCH=2
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
 CHKSUMS="sha256::56dfa983536de7fa379257c36061667bcf5cc15726036d218eb5eff76e1ffe5a"
 CHKUPDATE="anitya::id=10442"

--- a/app-network/freerdp/spec
+++ b/app-network/freerdp/spec
@@ -1,4 +1,4 @@
-VER=3.30.0
+VER=3.31.0
 SRCS="tbl::https://pub.freerdp.com/releases/freerdp-${VER/rc/-rc}.tar.gz"
-CHKSUMS="sha256::e2687d02dea6fede004d36391dac1a74ce57a210f8867fd95033171d4909590c"
+CHKSUMS="sha256::56dfa983536de7fa379257c36061667bcf5cc15726036d218eb5eff76e1ffe5a"
 CHKUPDATE="anitya::id=10442"

--- a/topics/freerdp-3.31.0.toml
+++ b/topics/freerdp-3.31.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "FreeRDP 3.31.0"
+
+[caution]
+default = "Fixes 22 security vulnerabilities partially publicly disclosed by FreeRDP Security Team (including 1 of critical severity, 7 of high severity)"
+zh_CN = "修复 FreeRDP 安全团队部分披露的 22 个安全漏洞（含 1 个严重漏洞，7 个高危漏洞）"
+
+[packages-v2]
+freerdp = "< 2:3.31.0"


### PR DESCRIPTION
Topic Description
-----------------

- freerdp: update to 3.31.0
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- freerdp: 2:3.31.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit freerdp
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
