### PR TITLE
ouch: update to 0.8.2

### DIFF
--- a/app-utils/ouch/autobuild/beyond
+++ b/app-utils/ouch/autobuild/beyond
@@ -1,6 +1,6 @@
 abinfo "Installing manpage and completions ..."
 for i in "$SRCDIR"/artifacts/ouch*.1; do
-    install -Dvm644 $i -t "$PKGDIR"/usr/share/man/man1/
+    install -Dvm644 "$i" -t "$PKGDIR"/usr/share/man/man1/
 done
 
 install -Dvm644 "$SRCDIR"/artifacts/ouch.bash \

--- a/app-utils/ouch/autobuild/defines
+++ b/app-utils/ouch/autobuild/defines
@@ -4,12 +4,17 @@ PKGDEP="glibc zlib bzip2 xz gcc-runtime bzip3"
 BUILDDEP="rustc llvm"
 PKGSEC="util"
 
-USECLANG=1
 ABTYPE=rust
-CARGO_AFTER__I486=('--target=i486-unknown-linux-gnu')
 
-# FIXME: Build error before appending `-Clink-arg=-lc++ -Clink-arg=-lc++abi`.
-# cargo:warning=vendor/unrar/os.hpp:12:10: fatal error: 'new' file not found                                  
-# cargo:warning=   12 | #include <new>                                                                        
-# cargo:warning=      |          ^~~~~
-FAIL_ARCH="@(loongson3|retro)"
+# FIXME: unrar-ng-sys was compiled with libc++, but linked against libstdc++,
+# so keep USECLANG=0.
+# error: linking with `clang` failed: exit status: 1
+#   = note:  "clang" "-m64" "<1 object files omitted>" "-Wl,--as-needed" "-Wl,-Bstatic" "[...]/ouch/target/release/deps/rustcrQtcY6/{libzstd_sys-e89548ae53285ea1,liblibbzip3_sys-e514c45479cd419c,libunrar_ng_sys-c7a66815e11f95a9}.rlib" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-*.rlib" "-Wl,-Bdynamic" "-lstdc++" "-lpthread" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-L" "[...]/ouch/target/release/deps/rustcrQtcY6/raw-dylibs" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-Wl,-plugin-opt=O3,-plugin-opt=mcpu=x86-64" "-L" "[...]/ouch/target/release/build/libbzip3-sys-49c29b7d6d26de0b/out" "-L" "[...]/ouch/target/release/build/unrar-ng-sys-ec62d98dcf35090f/out" "-L" "[...]/ouch/target/release/build/zstd-sys-f74d0633525ca2ac/out" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "[...]/ouch/target/release/deps/ouch-2f18c1c0faf92bc0" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-Wl,-O1" "-nodefaultlibs" "-flto" "-fuse-ld=lld" "-Wl,-build-id=sha1" "-Wl,--lto-O3"
+#   = note: ld.lld: error: undefined symbol: std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>::assign(char const*)
+
+# FIXME:
+# ld.lld: error: undefined symbol: ZSTD_DStreamInSize
+# ld.lld: error: undefined symbol: bz3_new
+NOLTO=1
+
+FAIL_ARCH="@(retro)"

--- a/app-utils/ouch/autobuild/prepare
+++ b/app-utils/ouch/autobuild/prepare
@@ -1,8 +1,3 @@
 # Note: To generate manpage and completions.
 abinfo "Setting OUCH_ARTIFACTS_FOLDER ..."
 export OUCH_ARTIFACTS_FOLDER="$SRCDIR"/artifacts
-
-# FIXME: unrar-ng-sys may build UnRAR with libc++,
-# link libc++ explicitly.
-abinfo "Fixing build with unrar-ng-sys ..."
-export RUSTFLAGS="${RUSTFLAGS} -Clink-arg=-lc++ -Clink-arg=-lc++abi"

--- a/app-utils/ouch/spec
+++ b/app-utils/ouch/spec
@@ -1,5 +1,4 @@
-VER=0.8.1
+VER=0.8.2
 SRCS="git::commit=tags/$VER::https://github.com/ouch-org/ouch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=368665"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- ouch: update to 0.8.2
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- ouch: 0.8.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ouch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
