### PR TITLE
netavark: update to 2.1.0

### DIFF
--- a/runtime-containers/netavark/autobuild/defines
+++ b/runtime-containers/netavark/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=netavark
 PKGSEC=admin
 PKGDES="Rust based network stack for containers"
-PKGDEP=""
+PKGDEP="glibc"
 BUILDDEP="rustc llvm go-md2man"
 PKGRECOM="aardvark-dns"
 
@@ -9,9 +9,4 @@ PKGRECOM="aardvark-dns"
 PKGPROV="container-network-stack==2"
 
 ABTYPE=rust
-
 USECLANG=1
-
-# FIXME: ld.lld is not yet available.
-NOLTO__LOONGSON3=1
-NOLTO__LOONGARCH64=1

--- a/runtime-containers/netavark/spec
+++ b/runtime-containers/netavark/spec
@@ -1,4 +1,4 @@
-VER=1.13.0
+VER=2.1.0
 SRCS="git::commit=tags/v${VER}::https://github.com/containers/netavark.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=242639"


### PR DESCRIPTION
Topic Description
-----------------

- netavark: update to 2.1.0
    Co-authored-by: 雨ノ宮 あめ \(@BillZhou233\)

Package(s) Affected
-------------------

- netavark: 2.1.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit netavark
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
