### PR TITLE
codex: update to 0.152.1

### DIFF
--- a/app-utils/codex/spec
+++ b/app-utils/codex/spec
@@ -1,4 +1,4 @@
-VER=0.151.0
+VER=0.152.1
 # Note: This must match "v8" version in codex-rs/Cargo.lock.
 RUSTY_V8_VER=150.4.0
 SRCS="git::commit=tags/rust-v$VER::https://github.com/openai/codex.git \


### PR DESCRIPTION
Topic Description
-----------------

- codex: update to 0.152.1
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- codex: 0.152.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit codex
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] RISC-V 64-bit `riscv64`
