### PR TITLE
qt-6: update to 6.11.2

### DIFF
--- a/runtime-desktop/qt-6/spec
+++ b/runtime-desktop/qt-6/spec
@@ -1,7 +1,6 @@
-VER=6.11.1
-REL=1
+VER=6.11.2
 SRCS="https://download.qt.io/official_releases/qt/${VER%.*}/${VER}/single/qt-everywhere-src-${VER}.tar.xz"
-CHKSUMS="sha256::252acef8c5ae68074d91cadba2ee4a83465051bbb970dd26e8f0daa0f3904e03"
+CHKSUMS="sha256::6dcfbca271d76a6502741a2c0dc6fc98ef7dd0b7b4cfd0abcebb285a86a26f33"
 CHKUPDATE="anitya::id=7927"
 # Note: Prefer larger RAM.
 ENVREQ="total_mem=60"


### PR DESCRIPTION
Topic Description
-----------------

- qt-6: update to 6.11.2

Package(s) Affected
-------------------

- qt-6: 6.11.2
- qt-6-doc: 6.11.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qt-6 qt-6-doc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
