### PR TITLE
rustc: update to 1.97.1

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,4 +1,4 @@
-From cd053d69ae1b2766a9cdcb4832b80ffce7873766 Mon Sep 17 00:00:00 2001
+From e374cd3da9d212e96cf5b36e9221e4625c597cce Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 20:12:53 +0200
 Subject: [PATCH 1/3] ARCHLINUX: compiler: Swap primary and secondary lib dirs
@@ -9,10 +9,10 @@ Arch Linux (editor's note: also AOSC OS) prefers "lib" over "lib64".
  1 file changed, 7 insertions(+), 5 deletions(-)
 
 diff --git a/compiler/rustc_target/src/lib.rs b/compiler/rustc_target/src/lib.rs
-index 1dc62cb3659..6913c965e4f 100644
+index d46802bf45..9a8a3e2dc2 100644
 --- a/compiler/rustc_target/src/lib.rs
 +++ b/compiler/rustc_target/src/lib.rs
-@@ -50,20 +50,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
+@@ -48,20 +48,22 @@ fn find_relative_libdir(sysroot: &Path) -> std::borrow::Cow<'static, str> {
      // If --libdir is set during configuration to the value other than
      // "lib" (i.e., non-default), this value is used (see issue #16552).
  

--- a/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,4 +1,4 @@
-From 6251eade2a5fcd5b6dcaf0aa00bf455128ae7f62 Mon Sep 17 00:00:00 2001
+From 71bb326b79715ea6ea9ca66d542758bbff7e1407 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 19:01:26 +0200
 Subject: [PATCH 2/3] ARCHLINUX: bootstrap: Workaround for system stage0
@@ -9,10 +9,10 @@ See: http://github.com/rust-lang/rust/issues/143735
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
-index 46d05b9d5d2..0c8ab4e0eb9 100644
+index 68a4f92846..201d918d88 100644
 --- a/src/bootstrap/src/core/build_steps/compile.rs
 +++ b/src/bootstrap/src/core/build_steps/compile.rs
-@@ -812,7 +812,10 @@ fn run(self, builder: &Builder<'_>) {
+@@ -822,7 +822,10 @@ impl Step for StdLink {
                  let _ = fs::remove_dir_all(sysroot.join("lib/rustlib/src/rust"));
              }
  

--- a/lang-rust/rustc/autobuild/patches/0003-AOSCOS-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-AOSCOS-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From 6c8700e7bf3785390e8e79db8a8761b9c8c6cea1 Mon Sep 17 00:00:00 2001
+From ea020031878b7079514e2b95630e870a4fa14bd1 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 3/3] AOSCOS: Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 3/3] AOSCOS: Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index d9c872c9b43..e16eb6a5b89 100644
+index d6a9e27c46..2f80461ea9 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1436,6 +1436,7 @@ fn $module() {
+@@ -1459,6 +1459,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),
@@ -23,7 +23,7 @@ index d9c872c9b43..e16eb6a5b89 100644
      ("m68k-unknown-linux-gnu", m68k_unknown_linux_gnu),
 diff --git a/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 new file mode 100644
-index 00000000000..8095de4b388
+index 0000000000..8095de4b38
 --- /dev/null
 +++ b/compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 @@ -0,0 +1,16 @@

--- a/lang-rust/rustc/autobuild/prepare
+++ b/lang-rust/rustc/autobuild/prepare
@@ -153,18 +153,18 @@ elif ab_match_arch i486; then
     # FIXME: an absolute path is needed in the [patch.crates-io] section
     # because it has to be correct for all projects in the workspace.
     # Thus sed is used instead of patch.
-    sed -i 's@arch == "i386"@& || arch == "i486"@' vendor/blake3-1.8.4/build.rs
+    sed -i 's@arch == "i386"@& || arch == "i486"@' vendor/blake3-1.8.5/build.rs
 
     cat >> Cargo.toml << EOF
 [patch.crates-io]
-blake3 = { path = '$PWD/vendor/blake3-1.8.4' }
+blake3 = { path = '$PWD/vendor/blake3-1.8.5' }
 EOF
 
     cargo update --offline -p blake3
 
     cat >> src/tools/cargo/Cargo.toml << EOF
 [patch.crates-io]
-blake3 = { path = '$PWD/vendor/blake3-1.8.4' }
+blake3 = { path = '$PWD/vendor/blake3-1.8.5' }
 EOF
 
     cargo update --offline -p blake3 --manifest-path src/tools/cargo/Cargo.toml

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,7 +1,7 @@
-VER=1.96.0
+VER=1.97.1
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::b99ce16cdf0ecfc761b585ac84d131b46733465a02f8ecd0ff2de9713c62ee09"
+CHKSUMS="sha256::0ed06fdaffd4722a7702e0b4eebfafc897ab8f513e8e1b247cdd7e5c6df6ded2"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.97.1
    Track patches at AOSC-Tracking/rustc @ aosc/v1.97.1
    \(HEAD: ea020031878b7079514e2b95630e870a4fa14bd1\).

Package(s) Affected
-------------------

- rustc: 1:1.97.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
