### PR TITLE
lvm2: update to 2.03.42

### DIFF
--- a/app-admin/lvm2/autobuild/defines
+++ b/app-admin/lvm2/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=lvm2
 PKGSEC=admin
-PKGDEP="bash dbus-python readline systemd pyudev libaio thin-provisioning-tools"
+PKGDEP="bash dbus-python readline systemd pyudev libaio thin-provisioning-tools vdo"
 PKGDEP__RETRO="bash readline systemd libaio"
 PKGDEP__ARMV4="${PKGDEP__RETRO}"
 PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
@@ -37,6 +37,8 @@ AUTOTOOLS_AFTER=(
     '--with-device-gid=6'
     '--with-device-mode=0660'
     '--enable-blkid_wiping'
+    '--with-vdo=internal'
+    '--with-vdo-format=/usr/bin/vdoformat'
 )
 AUTOTOOLS_AFTER__RETRO=(
     "${AUTOTOOLS_AFTER[@]}"

--- a/app-admin/lvm2/spec
+++ b/app-admin/lvm2/spec
@@ -1,5 +1,4 @@
-VER=2.03.31
+VER=2.03.42
 SRCS="tbl::https://gcc.gnu.org/pub/lvm2/LVM2.$VER.tgz"
-CHKSUMS="sha256::5db2956a00fbf87d92274cccc92436387ec0c3faadece7413ece1ba1c10c98ff"
+CHKSUMS="sha256::352703ef5b72ebb22d4f250284a29b89fe64d4049c6bf64c693f9af486c8081e"
 CHKUPDATE="anitya::id=5354"
-REL="2"


### PR DESCRIPTION
Topic Description
-----------------

- lvm2: update to 2.03.42, enable VDO support

Package(s) Affected
-------------------

- lvm2: 2.03.42

Security Update?
----------------

No

Build Order
-----------

```
#buildit lvm2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
