### PR TITLE
qtcreator: fix multiple REL caused by auto rebase

### DIFF
--- a/app-devel/qtcreator/spec
+++ b/app-devel/qtcreator/spec
@@ -1,6 +1,5 @@
 VER=20.0.0
-REL=1
+REL=2
 SRCS="tbl::https://download.qt.io/official_releases/qtcreator/${VER%.*}/$VER/qt-creator-opensource-src-$VER.tar.xz"
 CHKSUMS="sha256::76e094ac8ae56e8611bc2dae07e972652860b2ae9d59baff49768523a4cff289"
 CHKUPDATE="anitya::id=4136"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- qtcreator: fix multiple REL caused by auto rebase

Package(s) Affected
-------------------

- qtcreator: 20.0.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit qtcreator
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
