### PR TITLE
rustc: update to 1.98.1

### DIFF
--- a/lang-rust/rustc/autobuild/patches/0001-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
+++ b/lang-rust/rustc/autobuild/patches/0001-ARCHLINUX-compiler-Swap-primary-and-secondary-lib-di.patch
@@ -1,4 +1,4 @@
-From e374cd3da9d212e96cf5b36e9221e4625c597cce Mon Sep 17 00:00:00 2001
+From 57f51510026b6e3a476e6c1f189038cdd479bfe7 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 20:12:53 +0200
 Subject: [PATCH 1/3] ARCHLINUX: compiler: Swap primary and secondary lib dirs

--- a/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
+++ b/lang-rust/rustc/autobuild/patches/0002-ARCHLINUX-bootstrap-Workaround-for-system-stage0.patch
@@ -1,4 +1,4 @@
-From 71bb326b79715ea6ea9ca66d542758bbff7e1407 Mon Sep 17 00:00:00 2001
+From 0eb2fe1841a8afe32a60c538070be0465d6024c6 Mon Sep 17 00:00:00 2001
 From: "Jan Alexander Steffens (heftig)" <heftig@archlinux.org>
 Date: Thu, 7 Aug 2025 19:01:26 +0200
 Subject: [PATCH 2/3] ARCHLINUX: bootstrap: Workaround for system stage0
@@ -9,7 +9,7 @@ See: http://github.com/rust-lang/rust/issues/143735
  1 file changed, 4 insertions(+), 1 deletion(-)
 
 diff --git a/src/bootstrap/src/core/build_steps/compile.rs b/src/bootstrap/src/core/build_steps/compile.rs
-index 68a4f92846..201d918d88 100644
+index ffbe4f4e74..f1bca477db 100644
 --- a/src/bootstrap/src/core/build_steps/compile.rs
 +++ b/src/bootstrap/src/core/build_steps/compile.rs
 @@ -822,7 +822,10 @@ impl Step for StdLink {

--- a/lang-rust/rustc/autobuild/patches/0003-AOSCOS-Add-i486-unknown-linux-gnu-compiler-target.patch
+++ b/lang-rust/rustc/autobuild/patches/0003-AOSCOS-Add-i486-unknown-linux-gnu-compiler-target.patch
@@ -1,4 +1,4 @@
-From ea020031878b7079514e2b95630e870a4fa14bd1 Mon Sep 17 00:00:00 2001
+From f37e7c68274ff904b085b43ce8bf831a71781ca6 Mon Sep 17 00:00:00 2001
 From: Xi Ruoyao <xry111@xry111.site>
 Date: Fri, 9 Feb 2024 18:48:33 -0800
 Subject: [PATCH 3/3] AOSCOS: Add i486-unknown-linux-gnu compiler target
@@ -10,10 +10,10 @@ Subject: [PATCH 3/3] AOSCOS: Add i486-unknown-linux-gnu compiler target
  create mode 100644 compiler/rustc_target/src/spec/targets/i486_unknown_linux_gnu.rs
 
 diff --git a/compiler/rustc_target/src/spec/mod.rs b/compiler/rustc_target/src/spec/mod.rs
-index d6a9e27c46..2f80461ea9 100644
+index 5c19b35e16..60404975da 100644
 --- a/compiler/rustc_target/src/spec/mod.rs
 +++ b/compiler/rustc_target/src/spec/mod.rs
-@@ -1459,6 +1459,7 @@ supported_targets! {
+@@ -1442,6 +1442,7 @@ supported_targets! {
      ("x86_64-unknown-linux-gnux32", x86_64_unknown_linux_gnux32),
      ("i686-unknown-linux-gnu", i686_unknown_linux_gnu),
      ("i586-unknown-linux-gnu", i586_unknown_linux_gnu),

--- a/lang-rust/rustc/spec
+++ b/lang-rust/rustc/spec
@@ -1,7 +1,7 @@
-VER=1.97.1
+VER=1.98.1
 # Note: Uncomment this if we have the last version built and ready.
 SRCS="tbl::https://static.rust-lang.org/dist/rustc-${VER}-src.tar.xz"
-CHKSUMS="sha256::0ed06fdaffd4722a7702e0b4eebfafc897ab8f513e8e1b247cdd7e5c6df6ded2"
+CHKSUMS="sha256::be1816e7f6c40abb90245ad6e024bed2a7e88d7dda4561e4d5470207df616b9f"
 
 # FIXME: Using local bootstrap tarball as we missed a release - rustc needs
 # to bootstrap from an adjacent release.


### PR DESCRIPTION
Topic Description
-----------------

- rustc: update to 1.98.1
    Track patches at AOSC-Tracking/rustc @ aosc/v1.98.1
    \(HEAD: f37e7c68274ff904b085b43ce8bf831a71781ca6\).

Package(s) Affected
-------------------

- rustc: 1:1.98.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit rustc
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
