### PR TITLE
binutils+cross-arm-none-eabi: fix missing symlinks

### DIFF
--- a/app-devel/binutils/08-arm-none-eabi/build
+++ b/app-devel/binutils/08-arm-none-eabi/build
@@ -92,20 +92,10 @@ for i in "$PKGDIR"/opt/abcross/${__CROSS}/bin/$targ-*; do
   ln -svr $i "$PKGDIR"/opt/abcross/${__CROSS}/$targ/bin/${i##*-}
 done
 
-case $targ in
-  *aosc* )
-    abinfo "Creating host-prefixed symlinks (target: $targ) ..."
-    mkdir -pv "$PKGDIR"/usr/bin
-    cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
-    for i in *; do
-        ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-            "$PKGDIR"/usr/bin/$i
-        # vendor: unknown
-        ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-            "$PKGDIR"/usr/bin/${i/aosc-linux-gnu/unknown-linux-gnu}
-        # empty vendor
-        ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
-            "$PKGDIR"/usr/bin/${i/aosc-linux-gnu/linux-gnu}
-    done
-    ;;
-esac
+abinfo "Creating host-prefixed symlinks (target: $targ) ..."
+mkdir -pv "$PKGDIR"/usr/bin
+cd "$PKGDIR"/opt/abcross/${__CROSS}/bin/
+for i in arm-none-eabi-*; do
+    ln -sv ../../opt/abcross/${__CROSS}/bin/$i \
+        "$PKGDIR"/usr/bin/$i
+done

--- a/app-devel/binutils/spec
+++ b/app-devel/binutils/spec
@@ -1,5 +1,5 @@
 VER=2.47
-REL=4
+REL=5
 SRCS="tbl::https://ftp.gnu.org/pub/gnu/binutils/binutils-$VER.tar.xz"
 CHKSUMS="sha256::154ab23b60070e8f27013c22977f1129425d67d1e8acd6e13010e617811e4cff"
 CHKUPDATE="anitya::id=7981"


### PR DESCRIPTION
Topic Description
-----------------

- binutils+cross-arm-none-eabi: fix missing symlinks
    Autobuild4 ARCH_TARGET doesn't contain arm-none-eabi, avoid using it.
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- binutils: 2.47-4
- binutils+cross-amd64: 2.47-4
- binutils+cross-arm-none-eabi: 2.47-4
- binutils+cross-arm64: 2.47-4
- binutils+cross-i486: 2.47-4
- binutils+cross-loongarch64: 2.47-4
- binutils+cross-loongson3: 2.47-4
- binutils+cross-ppc64el: 2.47-4
- binutils+cross-riscv64: 2.47-4

Security Update?
----------------

No

Build Order
-----------

```
#buildit binutils
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
