### PR TITLE
freetype: switch harfbuzz to dlopen instead of hard link

### DIFF
--- a/runtime-desktop/freetype/autobuild/defines
+++ b/runtime-desktop/freetype/autobuild/defines
@@ -5,21 +5,14 @@ PKGDEP="brotli bzip2 libpng zlib"
 # dependency loop causing dpkg to fail.
 PKGRECOM="harfbuzz"
 PKGDEP__RETRO="libpng zlib bzip2"
-PKGDEP__ARMV4="${PKGDEP__RETRO}"
-PKGDEP__ARMV6HF="${PKGDEP__RETRO}"
-PKGDEP__ARMV7HF="${PKGDEP__RETRO}"
-PKGDEP__I486="${PKGDEP__RETRO}"
-PKGDEP__LOONGSON2F="${PKGDEP__RETRO}"
-PKGDEP__M68K="${PKGDEP__RETRO}"
-PKGDEP__POWERPC="${PKGDEP__RETRO}"
-PKGDEP__PPC64="${PKGDEP__RETRO}"
 PKGDES="Font rendering engine"
 BUILDDEP="x11-lib harfbuzz"
+BUILDDEP__RETRO="x11-lib"
 
 ABTYPE=meson
 MESON_AFTER="-Dbrotli=enabled \
              -Dbzip2=enabled \
-             -Dharfbuzz=enabled \
+             -Dharfbuzz=dynamic \
              -Dmmap=enabled \
              -Dpng=enabled \
              -Dzlib=system"
@@ -27,14 +20,6 @@ MESON_AFTER__RETRO=" \
              ${MESON_AFTER} \
              -Dbrotli=disabled \
              -Dharfbuzz=disabled"
-MESON_AFTER__ARMV4="${MESON_AFTER__RETRO}"
-MESON_AFTER__ARMV6HF="${MESON_AFTER__RETRO}"
-MESON_AFTER__ARMV7HF="${MESON_AFTER__RETRO}"
-MESON_AFTER__I486="${MESON_AFTER__RETRO}"
-MESON_AFTER__LOONGSON2F="${MESON_AFTER__RETRO}"
-MESON_AFTER__M68K="${MESON_AFTER__RETRO}"
-MESON_AFTER__POWERPC="${MESON_AFTER__RETRO}"
-MESON_AFTER__PPC64="${MESON_AFTER__RETRO}"
 
 # Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
 FAIL_ARCH="!(mainline|retro)"

--- a/runtime-desktop/freetype/spec
+++ b/runtime-desktop/freetype/spec
@@ -1,4 +1,5 @@
 VER=2.14.2
+REL=1
 SRCS="tbl::https://download-mirror.savannah.gnu.org/releases/freetype/freetype-$VER.tar.xz"
 CHKSUMS="sha256::4b62dcab4c920a1a860369933221814362e699e26f55792516d671e6ff55b5e1"
 CHKUPDATE="anitya::id=854"


### PR DESCRIPTION
Topic Description
-----------------

- freetype: switch harfbuzz to dlopen instead of hard link

Package(s) Affected
-------------------

- freetype: 2.14.2-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit freetype
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
