### PR TITLE
fastfetch: update to 2.68.1

### DIFF
--- a/app-utils/fastfetch/autobuild/patches/0001-AOSCOS-LOONGSON3-CPU-Linux-detect-cpu-via-proc-cpuin.patch.loongson3
+++ b/app-utils/fastfetch/autobuild/patches/0001-AOSCOS-LOONGSON3-CPU-Linux-detect-cpu-via-proc-cpuin.patch.loongson3
@@ -1,18 +1,19 @@
-From cef6429b649ee94e460f5b00dd3f6cbeae96bbaa Mon Sep 17 00:00:00 2001
+From eddc5c9958dab96454d00823fefad3282ac29d8a Mon Sep 17 00:00:00 2001
 From: Qing Yun <kf@aosc.io>
-Date: Mon, 4 Aug 2025 10:17:45 +0800
-Subject: [PATCH] AOSCOS: LOONGSON3: CPU (Linux): detect cpu via /proc/cpuinfo
- on loongson3
+Date: Fri, 4 Sep 2026 14:43:50 +0800
+Subject: [PATCH 1/2] AOSCOS: LOONGSON3: CPU (Linux): detect cpu via
+ /proc/cpuinfo on loongson3
 
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  src/detection/cpu/cpu_linux.c | 9 ++++++++-
  1 file changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/src/detection/cpu/cpu_linux.c b/src/detection/cpu/cpu_linux.c
-index da73a207..8feac75e 100644
+index 589d0ac01..b91786b6c 100644
 --- a/src/detection/cpu/cpu_linux.c
 +++ b/src/detection/cpu/cpu_linux.c
-@@ -583,7 +583,8 @@ static const char* parseCpuInfo(
+@@ -600,7 +600,8 @@ static const char* parseCpuInfo(
              (cpuMHz->length == 0 && ffParsePropLine(line, "clock :", cpuMHz)) ||
              (cpu->name.length == 0 && ffParsePropLine(line, "cpu :", &cpu->name)) ||
  #elif __mips__ || __mips
@@ -22,7 +23,7 @@ index da73a207..8feac75e 100644
  #elif __loongarch__
              (cpu->name.length == 0 && ffParsePropLine(line, "Model Name :", &cpu->name)) ||
              (cpuMHz->length == 0 && ffParsePropLine(line, "CPU MHz :", cpuMHz)) ||
-@@ -943,6 +944,12 @@ FF_A_UNUSED static void detectSocName(FFCPUResult* cpu) {
+@@ -977,6 +978,12 @@ static const char* detectPhysicalCores(FFCPUResult* cpu) {
          ffStrbufSetStatic(&cpu->vendor, "Apple");
      }
      #endif
@@ -33,8 +34,8 @@ index da73a207..8feac75e 100644
 +    }
 +    #endif
      else if (ffStrEquals(vendor, "qcom")) {
-         // https://elixir.bootlin.com/linux/v6.11/source/arch/arm64/boot/dts/qcom
-         if (ffStrStartsWith(model, "x")) {
+         // https://elixir.bootlin.com/linux/latest/source/arch/arm64/boot/dts/qcom
+         if (!detectSnapdragonX(&cpu->name, model)) {
 -- 
-2.52.0
+2.55.0
 

--- a/app-utils/fastfetch/autobuild/patches/0002-AOSCOS-REVERT-Revert-Display-defaults-disableLinewra.patch
+++ b/app-utils/fastfetch/autobuild/patches/0002-AOSCOS-REVERT-Revert-Display-defaults-disableLinewra.patch
@@ -1,21 +1,22 @@
-From ee8db53f6c254b6a2a2bd98d17a99044ca330ae4 Mon Sep 17 00:00:00 2001
+From f66da061b8a063567194c2882937bb7d0c396286 Mon Sep 17 00:00:00 2001
 From: Mingcong Bai <jeffbai@aosc.io>
 Date: Sun, 2 Aug 2026 01:36:08 +0800
-Subject: [PATCH] AOSCOS: REVERT: Revert "Display: defaults `disableLinewrap`
- to `false`"
+Subject: [PATCH 2/2] AOSCOS: REVERT: Revert "Display: defaults
+ `disableLinewrap` to `false`"
 
 This reverts commit 104b33c1f7dd79c1482c364cc38723747e079a34.
 
 Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+Signed-off-by: Kaiyang Wu <origincode@aosc.io>
 ---
  src/options/display.c | 6 ++++--
  1 file changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/src/options/display.c b/src/options/display.c
-index fe948190..62eaea8e 100644
+index 3dbfce1ec..15a736073 100644
 --- a/src/options/display.c
 +++ b/src/options/display.c
-@@ -834,9 +834,11 @@ void ffOptionsInitDisplay(FFOptionsDisplay* options) {
+@@ -953,9 +953,11 @@ void ffOptionsInitDisplay(FFOptionsDisplay* options) {
  
      options->showErrors = false;
      options->pipe = !isatty(STDOUT_FILENO) || !!getenv("NO_COLOR");

--- a/app-utils/fastfetch/spec
+++ b/app-utils/fastfetch/spec
@@ -1,4 +1,4 @@
-VER=2.67.1
+VER=2.68.1
 SRCS="git::commit=tags/$VER::https://github.com/fastfetch-cli/fastfetch"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=279670"


### PR DESCRIPTION
Topic Description
-----------------

- fastfetch: update to 2.68.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- fastfetch: 2.68.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit fastfetch
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
