### PR TITLE
foot: update to 1.28.0

### DIFF
--- a/app-utils/foot/spec
+++ b/app-utils/foot/spec
@@ -1,4 +1,4 @@
-VER=1.27.0
+VER=1.28.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/foot"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=141611"


### PR DESCRIPTION
Topic Description
-----------------

- foot: update to 1.28.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- foot: 1.28.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit foot
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
