### PR TITLE
fuzzel: update to 1.15.0

### DIFF
--- a/app-utils/fuzzel/spec
+++ b/app-utils/fuzzel/spec
@@ -1,4 +1,4 @@
-VER=1.14.1
+VER=1.15.0
 SRCS="git::commit=tags/$VER::https://codeberg.org/dnkl/fuzzel"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=190841"


### PR DESCRIPTION
Topic Description
-----------------

- fuzzel: update to 1.15.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- fuzzel: 1.15.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit fuzzel
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
