### PR TITLE
iosevka-fonts: update to 34.8.1

### DIFF
--- a/desktop-fonts/iosevka-fonts/spec
+++ b/desktop-fonts/iosevka-fonts/spec
@@ -1,4 +1,4 @@
-VER=34.8.0
+VER=34.8.1
 SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-Iosevka-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaAile-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaCurly-${VER}.zip \
@@ -24,30 +24,30 @@ SRCS="tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS17-${VER}.zip \
       tbl::https://github.com/be5invis/Iosevka/releases/download/v$VER/SuperTTC-IosevkaSS18-${VER}.zip \
       git::commit=tags/v$VER::https://github.com/be5invis/Iosevka"
-CHKSUMS="sha256::fd64d3e261225a53029775c755451bce89a20030afa19711f547677c0845025c \
-         sha256::5993bc2675eda5062e962a7d336b6637ec25b1cbf61de287e6f08025b41ba9ad \
-         sha256::ac18dc2c3acc45420d27e32b4c78b1afa8c61ffaefefbbc90f8e4c8b5ed5a7b1 \
-         sha256::7fb1d48f6f0e6ca483d914d9dc25a492aff00b428badac923703ac19d4be5628 \
-         sha256::b4c7040112b239a1f8365461232cff67f5c2c4823c48e2526d04edce8f2161cd \
-         sha256::dbb695e1c0b684eb376af60bbc73e78390e0d900ffe00305052165b819648e6e \
-         sha256::43a58b72608c9f97f1d8d6f5a32395e9f9fb8b6c560695a2f9660994bc4a9470 \
-         sha256::419f0f5dc6909564459588d510a2c8a316c9999b775d704d3b0043fafc1969db \
-         sha256::c484b269e04b49efd6863feeeb3a0ba5809864789eb0d5a79efb363161dcce6b \
-         sha256::18cad13ea2d8a6c49c1a3a0c638be8ff0e7fca42c6692af538e89847e23ebd91 \
-         sha256::2b9550c5376e1e5b9314653a1662747fe21bfd82b390a64354e15bcc6bac6e04 \
-         sha256::e151267a86c4966fc695c518769e674fbcf3f1c89bf096c9979db05dd6d0a0a3 \
-         sha256::050234ff3f87959b9a1ec15e76922701d24756b9e526dfe56add35930019cd13 \
-         sha256::7a8094e6f005e76fef141f993febc2b130c11b47d8cc36dddb403d0ea00cc635 \
-         sha256::14a7ca5adcb0648890ed5e3a0cb07355f296a6e654d6f542f22db8edaf97ca54 \
-         sha256::04f06395721d8606278fd80121ffa0ed1ea89cd5dd82abc6aa2ebde3e11f95ce \
-         sha256::83b82346d4424f5446c66685640fad099934a6cfb18e948a2feaa5cc5023a350 \
-         sha256::a2821272de39bcfd90d9b8875e10107282dd54f2f9587198ec8f8479b8745951 \
-         sha256::37b74ec4207c6bbdb3e94a6fbd64cf7af99a21f108f8eac0a7344122bcfdc00a \
-         sha256::5e3d523d808acc48426fb1b63b43825b57fadcc7bdde532c8985e0fe7bc70be8 \
-         sha256::e6e9fa6ce10ab8b3d042315c55830bbce6903026c45cd8180c3f4543e0ebe697 \
-         sha256::7ae62d54ca412e1f4fff09461c3227426affae84d87f689068de168d9e9d4046 \
-         sha256::c4104880d96b38cbc65441673e1fd4033efb8bf0844f6343fca212d13e4cadde \
-         sha256::9b9881ecd895775a56f0c236043cecf8c63e0ae82a559a6dd1db2c7bcdc5c551 \
+CHKSUMS="sha256::ce04ad495fb36deab10acd0760ad36916ed74a9436399731c7fe49c6d0462573 \
+         sha256::6cd61ff3a2cc7f4142a1cd96d571820dff5c52ef58d7e0979afbaa2d88d859cb \
+         sha256::df20ce326b36185c583bc35768de8a9d6f992966a2cd737b239561cd0cb320b1 \
+         sha256::4aecfbf4a433fd4591805ac32e492b1f3956de572c9ef8b6ab5818a7aa5b2a79 \
+         sha256::50d3c91ee71c982f7c34e80da21e1d00e7a5339c8b5f122faebf5d5e271c4e2f \
+         sha256::baae30c5ff2855ffff8baf6293bcb137324b202e54a2e04e6d66afb886b317ee \
+         sha256::4cacff581bbbcabdb5fc8af8926e36cefe39edb65f673d9478ea58008411fbeb \
+         sha256::efb26f4b080ba52bb3136b2c396f6a938c126bcaab74e675cedfb1ef14d38060 \
+         sha256::d9701bd8eb17eccca4ca9e1189b8ee8569a7ffdf0b18bd79af1f77c59ca7803b \
+         sha256::12a2fc5b8afe8599fbd5ec2fd977257cbb2f9b49447b24d28f0a3176fca02539 \
+         sha256::ccb5f03be69b4f3679770bc060fb971bc66109a35c0022a468f648bab7ab32cd \
+         sha256::dbb273fa1471f454158a96a7b58bb34d3b59732fc948d6bc9ef17184d2e1b666 \
+         sha256::b476b67206c5b2335734d2207fdca4a8a82ba0a29d251c9ffad333edbfec7d96 \
+         sha256::faabab2d25d8bb805935db26d1e1928c27d1739f6c41681de97c244db1b36b5f \
+         sha256::ba6e76a6f084495da9a1c64f9703282cca24804a1d85a7c268e4f321716ec711 \
+         sha256::d2a130c26e67455a73c23c16df18634cf60d9924f812574c78e343f699e92608 \
+         sha256::4f472c5bd90ae0590bd06635505806c612dd17ced74b945fe944df7bd332e5c9 \
+         sha256::c77743959e61d863af7274168868fdfa58eb96d1d362952ae6ab7558e680127d \
+         sha256::275d89db596e7f7d6bf3ac04fed7288ee5ecd28e3d7e2182a361ef0b00690083 \
+         sha256::ba9be24308032e89da8158359cb0bc19586ced2790dba8dbee276effa53891f1 \
+         sha256::92ed93c1f14efffbbd7d8bf01e1ed6cab3b77a3a9097c4d5ffa5343c90455846 \
+         sha256::6b5513edc6fb650bea5359965969bc8293508b3ddb7262729b6a8df228bfd37c \
+         sha256::347d297ea90214238ab853190b8ef1525ab6922703f312c26272897bedab3b50 \
+         sha256::f38f3b69f03b06772b13431fb572513b8b002f701d9aa7445d4454904f9598d7 \
          SKIP"
 SUBDIR=.
 CHKUPDATE="anitya::id=227585"


### PR DESCRIPTION
Topic Description
-----------------

- iosevka-fonts: update to 34.8.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- iosevka-fonts: 34.8.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit iosevka-fonts
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
