### PR TITLE
man-pages: update to 6.19+posix2017a

### DIFF
--- a/runtime-data/man-pages/spec
+++ b/runtime-data/man-pages/spec
@@ -1,9 +1,9 @@
-UPSTREAM_VER=6.18
+UPSTREAM_VER=6.19
 POSIXVER=2017-a
 VER=${UPSTREAM_VER}+posix${POSIXVER/-a/a}
 SRCS="tbl::https://www.kernel.org/pub/linux/docs/man-pages/man-pages-${UPSTREAM_VER}.tar.xz \
       tbl::https://www.kernel.org/pub/linux/docs/man-pages/man-pages-posix/man-pages-posix-${POSIXVER}.tar.xz"
 SUBDIR="man-pages-${UPSTREAM_VER}"
-CHKSUMS="sha256::c934fadc8b59748c68227a34f6581d2ddf8282b73cdcd52546c8cd88b74b24d1 \
+CHKSUMS="sha256::88a7c42ad2e03d8b96dc72d95e451f2d875ff0f43103a8eb8ac8242133bdcb05 \
          sha256::ce67bb25b5048b20dad772e405a83f4bc70faf051afa289361c81f9660318bc3"
 CHKUPDATE="anitya::id=1883"


### PR DESCRIPTION
Topic Description
-----------------

- man-pages: update to 6.19+posix2017a
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- man-pages: 6.19+posix2017a

Security Update?
----------------

No

Build Order
-----------

```
#buildit man-pages
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
