### PR TITLE
mpd: update to 0.24.15

### DIFF
--- a/app-multimedia/mpd/spec
+++ b/app-multimedia/mpd/spec
@@ -1,4 +1,4 @@
-VER=0.24.14
+VER=0.24.15
 SRCS="tbl::https://www.musicpd.org/download/mpd/${VER%.*}/mpd-$VER.tar.xz"
-CHKSUMS="sha256::367e85debb4427605cccb5415f2858ebb401d849a80615553f59520f4640811e"
+CHKSUMS="sha256::524c70bce3fcd268016156bdc97abcf5be1904f0c6fd622688999123e3c4c457"
 CHKUPDATE="anitya::id=14864"


### PR DESCRIPTION
Topic Description
-----------------

- mpd: update to 0.24.15
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- mpd: 0.24.15

Security Update?
----------------

No

Build Order
-----------

```
#buildit mpd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
