### PR TITLE
shadowsocks-rust: update to 1.25.0

### DIFF
--- a/app-proxy/shadowsocks-rust/autobuild/defines
+++ b/app-proxy/shadowsocks-rust/autobuild/defines
@@ -2,9 +2,10 @@ PKGNAME=shadowsocks-rust
 PKGSEC=net
 PKGDEP="openssl libsodium"
 BUILDDEP="asciidoc pkg-config llvm rustc"
+PKGDES="SOCKS5 tunnel proxy"
+
+ABTYPE=rust
 USECLANG=1
 
-PKGDES="A Rust port of shadowsocks, lightweight yet secured SOCKS5 proxy"
-
-# FIXME: ld.lld not yet available
-NOLTO__LOONGSON3=1
+# FIXME: ld.lld: error: undefined symbol: aws_lc_0_45_0_EVP_AEAD_CTX_free
+NOLTO=1

--- a/app-proxy/shadowsocks-rust/spec
+++ b/app-proxy/shadowsocks-rust/spec
@@ -1,4 +1,4 @@
-VER=1.24.0
+VER=1.25.0
 SRCS="git::commit=tags/v$VER::https://github.com/shadowsocks/shadowsocks-rust.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230992"


### PR DESCRIPTION
Topic Description
-----------------

- shadowsocks-rust: update to 1.25.0
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- shadowsocks-rust: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit shadowsocks-rust
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
