### PR TITLE
telegram-desktop: update to 7.1.5

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=7.1.2
+VER=7.1.5
 # Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
 OWTVER=19d51d3c19632a63fdbe17c62f10332d978cb940
 TDLIBVER=022d60202e446ad1287b9fb68e687c8a0760788b
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::415c05ef815bf8ae431ffbcbd27caa70f685c0357fccadc27ac035913933e5e5 \
+CHKSUMS="sha256::0d898d32b3cc6b9986505f767d0ec7387bd4d6b578120076b11f2f965b3ae270 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 7.1.5
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- telegram-desktop: 7.1.5

Security Update?
----------------

No

Build Order
-----------

```
#buildit telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
