### PR TITLE
wine: update to 11.17+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

### DIFF
--- a/app-emulation/wine/autobuild/defines
+++ b/app-emulation/wine/autobuild/defines
@@ -10,24 +10,29 @@ PKGDEP__RETRO=" \
         alsa-lib gnutls giflib cups lcms2 openldap libjpeg-turbo libxml2 \
         libxslt mpg123 ncurses openal-soft v4l-utils samba libgphoto2 \
         sane-backends"
-PKGDEP__I486="${PKGDEP__RETRO}"
 PKGRECOM="ntsync-enablement"
 PKGSUG="noto-fonts noto-cjk-fonts"
 PKGSUG__RETRO=""
-PKGSUG__I486="${PKGSUG__RETRO}"
 BUILDDEP="chrpath dos2unix llvm opencl-registry-api wayland-protocols"
+BUILDDEP__RETRO="chrpath dos2unix llvm"
+
+ABTYPE=self
 
 # Note: AMD64 build requires MingW-w64.
 #
 # See https://bugs.winehq.org/show_bug.cgi?id=49436#c27.
 BUILDDEP__AMD64="${BUILDDEP} gcc+w64 binutils+w64 mingw+w64"
-
-BUILDDEP__RETRO="chrpath dos2unix"
-BUILDDEP__I486="${BUILDDEP__RETRO}"
 PKGDES="Runtime/Compatibility Layer for running programs designed for Microsoft Windows"
 
 # Note: Wine seems to prefer Clang.
 USECLANG=1
+
+# FIXME:
+#
+# Disable stack protector due to incompatibility with wow64 and upstream disables it by default.
+# Link: https://gitlab.winehq.org/wine/wine/-/commit/684c272aa794757627ee0eee264a19fcd1052190
+# Link: https://bugs.winehq.org/show_bug.cgi?id=48161
+AB_FLAGS_SSP=0
 
 # FIXME: /usr/bin/ld: /tmp/cc2aPEVj.ltrans0.ltrans.o: in function `_start':
 # <artificial>:(.text+0x12): undefined reference to `thread_data'
@@ -69,7 +74,6 @@ AUTOTOOLS_AFTER=(
     '--with-sane'
     '--with-sdl'
     '--with-udev'
-    '--with-unwind'
     '--with-usb'
     '--with-v4l2'
     '--with-vulkan'
@@ -101,19 +105,15 @@ AUTOTOOLS_AFTER__ARM64=(
 )
 AUTOTOOLS_AFTER__I486=(
     "${AUTOTOOLS_AFTER[@]}"
-    '--without-gtk3'
     '--without-pulse'
     '--without-vulkan'
     '--without-mingw'
+    '--without-wayland'
+    '--without-opencl'
+    '--without-sdl'
+    '--without-netapi'
+    'CC=gcc'
 )
 
-# Wine is currently not available for Loongson and POWER.
+# FIXME: Wine is currently not available for MIPS, LoongArch, or POWER.
 FAIL_ARCH="!(amd64|arm64|i486)"
-
-PKGEPOCH=3
-
-# FIXME: 
-# Disable stack protector due to incompatibility with wow64 and upstream disables it by default.
-# Link: https://gitlab.winehq.org/wine/wine/-/commit/684c272aa794757627ee0eee264a19fcd1052190
-# Link: https://bugs.winehq.org/show_bug.cgi?id=48161
-AB_FLAGS_SSP=0

--- a/app-emulation/wine/autobuild/prepare
+++ b/app-emulation/wine/autobuild/prepare
@@ -1,10 +1,6 @@
-if ab_match_arch amd64 || \
-   ab_match_arch i486; then
-    abinfo "Setting -fPIC ..."
-    export CFLAGS="${CFLAGS} -fPIC"
-    export LDFLAGS="${LDFLAGS} -fPIC"
+if ab_match_arch i486; then
+    # Note: Wine requires i586 for 64-bit compare-and-swap.
+    abinfo "Removing -march=i486 and follow upstream for -march=i586 ..."
+    export CFLAGS="${CFLAGS/-march=i486/}"
+    export LDFLAGS="${LDFLAGS/-march=i486/}"
 fi
-
-abinfo "Dropping -ffunction-sections, -fdata-sections, --gc-sections flags to fix build ..."
-export CFLAGS="${CFLAGS/-ffunction-sections -fdata-sections/}"
-export LDFLAGS="${LDFLAGS/-Wl,--gc-sections/}"

--- a/app-emulation/wine/spec
+++ b/app-emulation/wine/spec
@@ -1,9 +1,10 @@
 __GECKO_VER=2.47.4
-__MONO_VER=11.2.0
-__DXVK_VER=3.0.2
+__MONO_VER=11.3.0
+__DXVK_VER=3.1
 __VKD3D_PROTON_VER=3.0.1
-UPSTREAM_VER=11.15
+UPSTREAM_VER=11.17
 VER=${UPSTREAM_VER}+gecko${__GECKO_VER}+mono${__MONO_VER}+dxvk${__DXVK_VER}+vkd3dproton${__VKD3D_PROTON_VER}
+EPOCH=3
 SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTREAM_VER}.tar.xz \
       git::rename=wine-staging;commit=tags/v${UPSTREAM_VER}::https://github.com/wine-staging/wine-staging \
       tbl::rename=wine-gecko-${__GECKO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-gecko/${__GECKO_VER}/wine-gecko-${__GECKO_VER}-x86.tar.xz \
@@ -11,13 +12,12 @@ SRCS="tbl::https://dl.winehq.org/wine/source/${UPSTREAM_VER%%.*}.x/wine-${UPSTRE
       tbl::rename=wine-mono-${__MONO_VER}-x86.tar.xz::https://dl.winehq.org/wine/wine-mono/${__MONO_VER}/wine-mono-${__MONO_VER}-x86.tar.xz \
       tbl::rename=dxvk-${__DXVK_VER}.tar.gz::https://github.com/doitsujin/dxvk/releases/download/v${__DXVK_VER}/dxvk-${__DXVK_VER}.tar.gz \
       tbl::rename=vkd3d-proton-${__VKD3D_PROTON_VER}.tar.zst::https://github.com/HansKristian-Work/vkd3d-proton/releases/download/v${__VKD3D_PROTON_VER}/vkd3d-proton-${__VKD3D_PROTON_VER}.tar.zst"
-CHKSUMS="sha256::5046f36dae210b198ea69792774d4401feed975d465eca6c251c9394400ec272 \
+CHKSUMS="sha256::8e752e29bba2901ad9f915139345c6ee67184b099d425704d915971ca5c055fc \
          SKIP \
          sha256::2cfc8d5c948602e21eff8a78613e1826f2d033df9672cace87fed56e8310afb6 \
          sha256::fd88fc7e537d058d7a8abf0c1ebc90c574892a466de86706a26d254710a82814 \
-         sha256::c9fb2e2823acf30b000b8806177db0f40751786136dd3f8fb2be7897b1643d06 \
-         sha256::9c538924110a7cdef871ca36dee218c0774124374ffdeb38af4b76be55bdf7c2 \
+         sha256::54a1b0111c3fe4b785eae688af94d27e64995707ad648b6fee8000381b80d298 \
+         sha256::30f9cc326874be344285582275446968cfa4c069db31ce56df312d6644179154 \
          sha256::3cf2315522af5e43605ef6d3c41dad91387040bf97199934f3f7ab76caaa2f0c"
 CHKUPDATE="anitya::id=15657"
 SUBDIR="wine-${UPSTREAM_VER}"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- wine: update to 11.16+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wine: 3:11.16+gecko2.47.4+mono11.2.0+dxvk3.0.2+vkd3dproton3.0.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit wine
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`

**Afterglow Architectures**

- [x] 32-bit Intel 486 `i486`
