### PR TITLE
wireplumber: update to 0.5.17

### DIFF
--- a/app-multimedia/wireplumber/autobuild/defines
+++ b/app-multimedia/wireplumber/autobuild/defines
@@ -2,24 +2,14 @@ PKGNAME=wireplumber
 PKGSEC=sound
 PKGDES="Modular session/policy manager for PipeWire"
 PKGDEP="glib pipewire lua-5.4 systemd"
-BUILDDEP="meson gobject-introspection lxml doxygen sphinx \
-          sphinx-rtd-theme breathe"
-BUILDDEP__RETRO="meson"
+BUILDDEP="meson gobject-introspection lxml doxygen"
 
 ABTYPE=meson
 MESON_AFTER=(
     '-Dsystem-lua=true'
-    '-Ddoc=enabled'
+    '-Ddoc=disabled'
     '-Dsystemd=enabled'
     '-Dsystemd-user-service=true'
     '-Dintrospection=enabled'
     '-Delogind=disabled'
 )
-MESON_AFTER__RETRO=(
-    "${MESON_AFTER[@]}"
-    '-Dintrospection=disabled'
-    '-Ddoc=disabled'
-)
-
-# Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
-FAIL_ARCH="!(mainline|retro)"

--- a/app-multimedia/wireplumber/spec
+++ b/app-multimedia/wireplumber/spec
@@ -1,5 +1,4 @@
-VER=0.5.15
-REL=1
+VER=0.5.17
 SRCS="git::commit=tags/$VER::https://gitlab.freedesktop.org/pipewire/wireplumber"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=235056"


### PR DESCRIPTION
Topic Description
-----------------

- wireplumber: update to 0.5.17
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- wireplumber: 0.5.17

Security Update?
----------------

No

Build Order
-----------

```
#buildit wireplumber
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
