### PR TITLE
dhcpcd: security update to 10.5.2

### DIFF
--- a/app-network/dhcpcd/autobuild/defines
+++ b/app-network/dhcpcd/autobuild/defines
@@ -1,14 +1,18 @@
 PKGNAME=dhcpcd
 PKGSEC=net
 PKGDES="RFC2131 compliant DHCP client daemon"
-PKGDEP=glibc
+PKGDEP="glibc"
 
-# This package has an available configure script in source root,
-# indicating it uses the GNU autotools-based build system.
 ABTYPE=autotools
-AUTOTOOLS_AFTER="--rundir=/run \
-                 --dbdir=/var/lib/dhcpcd"
+AUTOTOOLS_AFTER=(
+    '--rundir=/run'
+    '--dbdir=/var/lib/dhcpcd'
+)
+
+# FIXME: make: *** No targets specified and no makefile found.  Stop.
 ABSHADOW=0
+
+# FIXME: Necessary files not found for script regeneration
 RECONF=0
 
 # Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.

--- a/app-network/dhcpcd/spec
+++ b/app-network/dhcpcd/spec
@@ -1,4 +1,4 @@
-VER=10.3.0
+VER=10.5.2
 SRCS="git::commit=tags/v$VER::https://github.com/NetworkConfiguration/dhcpcd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=11429"

--- a/topics/dhcpcd-10.5.2.toml
+++ b/topics/dhcpcd-10.5.2.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "dhcpcd 10.5.2"
+
+[caution]
+default = "Fixes 4 security vulnerabilities (including 1 of high severity and 3 of medium severity)"
+zh_CN = "修复 4 个安全漏洞（含 1 个高危漏洞和 3 个中危漏洞）"
+
+[packages-v2]
+"dhcpcd" = "< 10.5.2"


### PR DESCRIPTION
Topic Description
-----------------

- dhcpcd: security update to 10.5.2
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- dhcpcd: 10.5.2

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit dhcpcd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
