### PR TITLE
exiv2: security update to 0.28.9

### DIFF
--- a/runtime-imaging/exiv2/spec
+++ b/runtime-imaging/exiv2/spec
@@ -1,5 +1,4 @@
-VER=0.28.8
-REL=1
+VER=0.28.9
 SRCS="git::commit=tags/v${VER}::https://github.com/Exiv2/exiv2"
 CHKSUMS=SKIP
 CHKUPDATE="anitya::id=769"

--- a/topics/exiv2-0.28.9.toml
+++ b/topics/exiv2-0.28.9.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "Exiv2 0.28.9"
+
+[caution]
+default = "Fixes an Uncaught Exception vulnerability (CVE-2026-27631, Severity: Low)"
+zh_CN = "修复了 1 个未捕获异常漏洞（CVE-2026-27631，严重性：低）"
+
+[packages-v2]
+"exiv2" = "< 0.28.9"


### PR DESCRIPTION
Topic Description
-----------------

- exiv2: security update to 0.28.9
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- exiv2: 0.28.9

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit exiv2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
