### PR TITLE
topics: rework for curl-8.22.0.toml

### DIFF
--- a/topics/curl-8.22.0.toml
+++ b/topics/curl-8.22.0.toml
@@ -1,4 +1,5 @@
 security = true
+must_match_all = false
 
 [name]
 default = "curl 8.22.0"


### PR DESCRIPTION
Topic Description
-----------------

- topics: rework for curl-8.22.0.toml
    Added missing must_match_all field
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
