### PR TITLE
openocd: bump rel for libgpiod

### DIFF
--- a/app-devel/openocd/spec
+++ b/app-devel/openocd/spec
@@ -1,5 +1,5 @@
 VER=0.12.0
-REL=1
+REL=2
 SRCS="git::commit=tags/v${VER};copy-repo=true::https://github.com/openocd-org/openocd"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=2557"


### PR DESCRIPTION
Topic Description
-----------------

- openocd: bump rel for libgpiod
    Signed-off-by: ilikara <3435193369@qq.com>

Package(s) Affected
-------------------

- openocd: 0.12.0-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit openocd
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
