### PR TITLE
confuse: security update to 3.4

### DIFF
--- a/runtime-common/confuse/autobuild/defines
+++ b/runtime-common/confuse/autobuild/defines
@@ -2,4 +2,7 @@ PKGNAME=confuse
 PKGSEC=libs
 PKGDEP="glibc"
 PKGDES="C library for parsing configuration files"
+
+ABTYPE=autotools
+
 PKGBREAK="bmon<=4.0-1 i3status<=2.15 owntone<=28.12-1 tilda<=2.0.0-1"

--- a/runtime-common/confuse/spec
+++ b/runtime-common/confuse/spec
@@ -1,4 +1,4 @@
-VER=3.3
+VER=3.4
 SRCS="git::commit=tags/v$VER::https://github.com/martinh/libconfuse"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1581"

--- a/topics/confuse-3.4.toml
+++ b/topics/confuse-3.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "confuse 3.4"
+
+[caution]
+default = "Fixes an Out-of-bounds Read vulnerability (CVE-2022-40320, Severity: High)"
+zh_CN = "修复一个越界读取漏洞（CVE-2022-40320，严重性：高）"
+
+[packages-v2]
+"confuse" = "< 3.4"


### PR DESCRIPTION
Topic Description
-----------------

- confuse: security update to 3.4
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- confuse: 3.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit confuse
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
