### PR TITLE
nghttp2: security update to 1.70.0

### DIFF
--- a/runtime-web/nghttp2/autobuild/defines
+++ b/runtime-web/nghttp2/autobuild/defines
@@ -9,24 +9,6 @@ BUILDDEP__RETRO=""
 # Building the libbpf binding requires generating a eBPF program, which must be
 # built with Clang.
 USECLANG=1
-# FIXME: Linker test fails on loongson3.
-#
-# /usr/bin/mips64el-aosc-linux-gnuabi64-ld: conftest: `.got.plt' entry VMA of
-# 0x120010fe8 outside the 32-bit range supported; consider using `-Ttext-segment=...'
-USECLANG__LOONGSON3=0
-# FIXME: Disabling Clang on riscv64.
-#
-# /usr/bin/riscv64-aosc-linux-gnu-ld: error: LLVM gold plugin: linking module
-# flags 'SmallDataLimit': IDs have conflicting values in
-# '../third-party/.libs/liburl-parser.a.llvm.184.url_parser.c' and 'ld-temp.o'
-USECLANG__RISCV64=0
-# FIXME: Disabling Clang on ppc64el.
-#
-# During configure...
-# /usr/include/bits/wchar-ldbl.h:84:1: error: cannot apply asm label to
-# function after its first use
-USECLANG__PPC64EL=0
-
 USECLANG__RETRO=0
 
 # FIXME: Disabling PIC and PIE flags to make Python module build with GCC.
@@ -67,21 +49,9 @@ AUTOTOOLS_AFTER=(
     '--with-libbpf'
 )
 # FIXME: Clang build fails on loongson3, ppc64el, and riscv64, disabling libbpf.
-AUTOTOOLS_AFTER__NOBPF=(
+AUTOTOOLS_AFTER__RETRO=(
     "${AUTOTOOLS_AFTER[@]}"
     '--with-libbpf=no'
-)
-AUTOTOOLS_AFTER__LOONGSON3=(
-    "${AUTOTOOLS_AFTER__NOBPF[@]}"
-)
-AUTOTOOLS_AFTER__PPC64EL=(
-    "${AUTOTOOLS_AFTER__NOBPF[@]}"
-)
-AUTOTOOLS_AFTER__RISCV64=(
-    "${AUTOTOOLS_AFTER__NOBPF[@]}"
-)
-AUTOTOOLS_AFTER__RETRO=(
-    "${AUTOTOOLS_AFTER__NOBPF[@]}"
     '--without-jemalloc'
 )
 

--- a/runtime-web/nghttp2/autobuild/defines.stage2
+++ b/runtime-web/nghttp2/autobuild/defines.stage2
@@ -3,6 +3,7 @@ PKGSEC=libs
 PKGDEP="c-ares jansson jemalloc libev"
 PKGDES="Library to implement the HTTP/2 protocol and the HPACK header compression algorithm"
 
+ABTYPE=autotools
 # FIXME: --disable-examples to skip broken examples (event.h incompatibility).
 AUTOTOOLS_AFTER=(
     '--disable-werror'

--- a/runtime-web/nghttp2/spec
+++ b/runtime-web/nghttp2/spec
@@ -1,5 +1,4 @@
-VER=1.69.0
-REL=2
-SRCS="tbl::https://github.com/nghttp2/nghttp2/releases/download/v$VER/nghttp2-$VER.tar.xz"
-CHKSUMS="sha256::1fb324b6ec2c56f6bde0658f4139ffd8209fa9e77ce98fd7a5f63af8d0e508ad"
+VER=1.70.0
+SRCS="git::commit=tags/v$VER::https://github.com/nghttp2/nghttp2"
+CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=8651"

--- a/topics/nghttp2-1.70.0.toml
+++ b/topics/nghttp2-1.70.0.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "nghttp2 1.70.0"
+
+[caution]
+default = "Fixes a HTTP Request/Response Smuggling vulnerability (CVE-2026-58055, Severity: Medium)"
+zh_CN = "修复 1 个 HTTP 请求/响应欺骗漏洞（CVE-2026-58055，严重性：中）"
+
+[packages-v2]
+"nghttp2" = "< 1.70.0"


### PR DESCRIPTION
Topic Description
-----------------

- nghttp2: security update to 1.70.0
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- nghttp2: 1.70.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit nghttp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
