### PR TITLE
util-linux: security update to 2.42.3

### DIFF
--- a/app-utils/util-linux/01-libraries/patches/0001-libmount-add-missing-fileutils.h-include-to-hook_idm.patch
+++ b/app-utils/util-linux/01-libraries/patches/0001-libmount-add-missing-fileutils.h-include-to-hook_idm.patch
@@ -1,0 +1,37 @@
+From 3072db6acd33cbe85c359f35aa6cb9502a06e7b4 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Wed, 2 Sep 2026 13:32:27 +0200
+Subject: [PATCH 1/2] libmount: add missing fileutils.h include to hook_idmap.c
+
+The hook_idmap.c uses RESOLVE_NO_SYMLINKS (added by commit fb8e26535)
+but does not include fileutils.h, which provides the fallback #define
+for this constant.
+
+On Fedora (glibc 2.40+), this is masked because glibc's
+<bits/fcntl-linux.h> transitively includes <linux/openat2.h>, which
+defines RESOLVE_NO_SYMLINKS. On Ubuntu (and other distros with older
+glibc), <fcntl.h> does not pull in openat2.h, so the build fails:
+
+  hook_idmap.c:335:33: error: 'RESOLVE_NO_SYMLINKS' undeclared
+
+Fixes: fb8e26535 ("libmount: pin source path with openat2() for restricted users")
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ libmount/src/hook_idmap.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libmount/src/hook_idmap.c b/libmount/src/hook_idmap.c
+index 77494e298..2c697b171 100644
+--- a/libmount/src/hook_idmap.c
++++ b/libmount/src/hook_idmap.c
+@@ -23,6 +23,7 @@
+ 
+ #include "strutils.h"
+ #include "all-io.h"
++#include "fileutils.h"
+ #include "namespace.h"
+ 
+ #include "mountP.h"
+-- 
+2.34.1
+

--- a/app-utils/util-linux/01-libraries/patches/0002-libmount-use-USE_LIBMOUNT_MOUNTFD_SUPPORT-for-idmap-.patch
+++ b/app-utils/util-linux/01-libraries/patches/0002-libmount-use-USE_LIBMOUNT_MOUNTFD_SUPPORT-for-idmap-.patch
@@ -1,0 +1,125 @@
+From af18d527bc8ab2ea51f5440ea75c3fb25b23bd9e Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Thu, 3 Sep 2026 10:01:29 +0200
+Subject: [PATCH 2/2] libmount: use USE_LIBMOUNT_MOUNTFD_SUPPORT for idmap hook
+
+The idmap hookset was originally guarded by HAVE_MOUNTFD_API (kernel
+headers have the new mount syscalls) rather than
+USE_LIBMOUNT_MOUNTFD_SUPPORT (libmount is built with mountfd support).
+
+This was intentional (commit 9040c0900, 2022) -- the idea was to keep
+idmap working even with --disable-libmount-mountfd-support by calling
+the raw open_tree() syscall directly, while using an inner #ifdef
+USE_LIBMOUNT_MOUNTFD_SUPPORT to optionally reuse the sysapi fd_tree.
+
+This fine-grained approach broke when the CVE-2026-78410 fix replaced
+the raw open_tree() call with mnt_open_tree(), which is only available
+under USE_LIBMOUNT_MOUNTFD_SUPPORT. The build fails with
+--disable-libmount-mountfd-support because mnt_open_tree() is
+undeclared.
+
+Rather than maintaining two code paths for a feature that fundamentally
+depends on the new mount API, gate the entire idmap hookset on
+USE_LIBMOUNT_MOUNTFD_SUPPORT -- consistent with how hookset_mount is
+guarded. Remove the now-redundant inner #ifdef.
+
+Also add a note to mount.8 that X-mount.idmap requires the new
+fd-based mount API.
+
+Addresses: https://github.com/util-linux/util-linux/issues/4598
+Signed-off-by: Karel Zak <kzak@redhat.com>
+
+
+this commit is backported to fix the build error below:
+/var/cache/acbs/build/acbs.8fcb5wra/util-linux-2.42.3/libmount/src/hook_idmap.c:335:33: error: 'RESOLVE_NO_SYMLINKS' undeclared (first use in this function)
+335 | RESOLVE_NO_SYMLINKS : 0);
+| ^~~~~~~~~~~~~~~~~~~
+/var/cache/acbs/build/acbs.8fcb5wra/util-linux-2.42.3/libmount/src/hook_idmap.c:335:33: note: each undeclared identifier is reported only once for each function it appears in
+Signed-off-by: stydxm <stydxm@outlook.com>
+---
+ libmount/src/hook_idmap.c | 6 ++----
+ libmount/src/hooks.c      | 2 +-
+ libmount/src/version.c    | 2 +-
+ sys-utils/mount.8.adoc    | 5 +++--
+ 4 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/libmount/src/hook_idmap.c b/libmount/src/hook_idmap.c
+index 2c697b171..b1477ac66 100644
+--- a/libmount/src/hook_idmap.c
++++ b/libmount/src/hook_idmap.c
+@@ -32,7 +32,7 @@
+ # include <linux/nsfs.h>
+ #endif
+ 
+-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
++#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 
+ typedef enum idmap_type_t {
+ 	ID_TYPE_UID,	/* uidmap entry */
+@@ -317,7 +317,6 @@ static int hook_mount_post(
+ 	 * Once a mount has been attached to the filesystem it can't be
+ 	 * idmapped anymore. So create a new detached mount.
+ 	 */
+-#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 	{
+ 		struct libmnt_sysapi *api = mnt_context_get_sysapi(cxt);
+ 
+@@ -327,7 +326,6 @@ static int hook_mount_post(
+ 			DBG(HOOK, ul_debugobj(hs, " reuse tree FD"));
+ 		}
+ 	}
+-#endif
+ 	if (fd_tree < 0)
+ 		fd_tree = mnt_open_tree(AT_FDCWD, target,
+ 			    OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC |
+@@ -544,4 +542,4 @@ const struct libmnt_hookset hookset_idmap =
+ 	.deinit = hookset_deinit
+ };
+ 
+-#endif /* HAVE_MOUNTFD_API && HAVE_LINUX_MOUNT_H */
++#endif /* USE_LIBMOUNT_MOUNTFD_SUPPORT */
+diff --git a/libmount/src/hooks.c b/libmount/src/hooks.c
+index 23eca4efd..5ae91edd7 100644
+--- a/libmount/src/hooks.c
++++ b/libmount/src/hooks.c
+@@ -45,7 +45,7 @@ static const struct libmnt_hookset *const hooksets[] =
+ 	&hookset_mount,
+ #endif
+ 	&hookset_mount_legacy,
+-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
++#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 	&hookset_idmap,
+ #endif
+ 	&hookset_owner
+diff --git a/libmount/src/version.c b/libmount/src/version.c
+index 5ec0d490c..30cb340ab 100644
+--- a/libmount/src/version.c
++++ b/libmount/src/version.c
+@@ -37,7 +37,7 @@ static const char *lib_features[] = {
+ #ifdef USE_LIBMOUNT_SUPPORT_NAMESPACES
+ 	"namespaces",
+ #endif
+-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
++#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 	"idmapping",
+ #endif
+ #ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+diff --git a/sys-utils/mount.8.adoc b/sys-utils/mount.8.adoc
+index 8a6e09f1a..99e32fd90 100644
+--- a/sys-utils/mount.8.adoc
++++ b/sys-utils/mount.8.adoc
+@@ -826,8 +826,9 @@ Set _mountpoint_'s mode after mounting.
+ 
+ *X-mount.idmap*=__id-type__:__id-mount__:__id-host__:__id-range__ [__id-type__:__id-mount__:__id-host__:__id-range__], *X-mount.idmap*=__file__::
+ Use this option to create an idmapped mount.
+-An idmapped mount allows to change ownership of all files located under a mount according to the ID-mapping associated with a user namespace.
+-The ownership change is tied to the lifetime and localized to the relevant mount.
++This feature requires the new file-descriptor-based mount API (available since Linux 5.2).
++An idmapped mount allows the ownership of all files located under a mount to be changed according to the ID-mapping associated with a user namespace.
++The ownership change is tied to the lifetime of, and localized to, the relevant mount.
+ The relevant ID-mapping can be specified in two ways:
+ +
+ * A user can specify the ID-mapping directly.
+-- 
+2.34.1
+

--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,4 @@
-VER=2.42
-REL=2
+VER=2.42.3
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::3452b260bbaa775d6e749ac3bb22111785003fc1f444970025c8da26dfa758e9"
+CHKSUMS="sha256::66ac7c0e725278eb2b039e3104f2c91119341d941b41bac7a285c695f940bd57"
 CHKUPDATE="anitya::id=8179"

--- a/runtime-optenv32/util-linux+32/autobuild/patches/0001-libmount-add-missing-fileutils.h-include-to-hook_idm.patch
+++ b/runtime-optenv32/util-linux+32/autobuild/patches/0001-libmount-add-missing-fileutils.h-include-to-hook_idm.patch
@@ -1,0 +1,37 @@
+From 3072db6acd33cbe85c359f35aa6cb9502a06e7b4 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Wed, 2 Sep 2026 13:32:27 +0200
+Subject: [PATCH 1/2] libmount: add missing fileutils.h include to hook_idmap.c
+
+The hook_idmap.c uses RESOLVE_NO_SYMLINKS (added by commit fb8e26535)
+but does not include fileutils.h, which provides the fallback #define
+for this constant.
+
+On Fedora (glibc 2.40+), this is masked because glibc's
+<bits/fcntl-linux.h> transitively includes <linux/openat2.h>, which
+defines RESOLVE_NO_SYMLINKS. On Ubuntu (and other distros with older
+glibc), <fcntl.h> does not pull in openat2.h, so the build fails:
+
+  hook_idmap.c:335:33: error: 'RESOLVE_NO_SYMLINKS' undeclared
+
+Fixes: fb8e26535 ("libmount: pin source path with openat2() for restricted users")
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ libmount/src/hook_idmap.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libmount/src/hook_idmap.c b/libmount/src/hook_idmap.c
+index 77494e298..2c697b171 100644
+--- a/libmount/src/hook_idmap.c
++++ b/libmount/src/hook_idmap.c
+@@ -23,6 +23,7 @@
+ 
+ #include "strutils.h"
+ #include "all-io.h"
++#include "fileutils.h"
+ #include "namespace.h"
+ 
+ #include "mountP.h"
+-- 
+2.34.1
+

--- a/runtime-optenv32/util-linux+32/autobuild/patches/0002-libmount-use-USE_LIBMOUNT_MOUNTFD_SUPPORT-for-idmap-.patch
+++ b/runtime-optenv32/util-linux+32/autobuild/patches/0002-libmount-use-USE_LIBMOUNT_MOUNTFD_SUPPORT-for-idmap-.patch
@@ -1,0 +1,125 @@
+From af18d527bc8ab2ea51f5440ea75c3fb25b23bd9e Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Date: Thu, 3 Sep 2026 10:01:29 +0200
+Subject: [PATCH 2/2] libmount: use USE_LIBMOUNT_MOUNTFD_SUPPORT for idmap hook
+
+The idmap hookset was originally guarded by HAVE_MOUNTFD_API (kernel
+headers have the new mount syscalls) rather than
+USE_LIBMOUNT_MOUNTFD_SUPPORT (libmount is built with mountfd support).
+
+This was intentional (commit 9040c0900, 2022) -- the idea was to keep
+idmap working even with --disable-libmount-mountfd-support by calling
+the raw open_tree() syscall directly, while using an inner #ifdef
+USE_LIBMOUNT_MOUNTFD_SUPPORT to optionally reuse the sysapi fd_tree.
+
+This fine-grained approach broke when the CVE-2026-78410 fix replaced
+the raw open_tree() call with mnt_open_tree(), which is only available
+under USE_LIBMOUNT_MOUNTFD_SUPPORT. The build fails with
+--disable-libmount-mountfd-support because mnt_open_tree() is
+undeclared.
+
+Rather than maintaining two code paths for a feature that fundamentally
+depends on the new mount API, gate the entire idmap hookset on
+USE_LIBMOUNT_MOUNTFD_SUPPORT -- consistent with how hookset_mount is
+guarded. Remove the now-redundant inner #ifdef.
+
+Also add a note to mount.8 that X-mount.idmap requires the new
+fd-based mount API.
+
+Addresses: https://github.com/util-linux/util-linux/issues/4598
+Signed-off-by: Karel Zak <kzak@redhat.com>
+
+
+this commit is backported to fix the build error below:
+/var/cache/acbs/build/acbs.8fcb5wra/util-linux-2.42.3/libmount/src/hook_idmap.c:335:33: error: 'RESOLVE_NO_SYMLINKS' undeclared (first use in this function)
+335 | RESOLVE_NO_SYMLINKS : 0);
+| ^~~~~~~~~~~~~~~~~~~
+/var/cache/acbs/build/acbs.8fcb5wra/util-linux-2.42.3/libmount/src/hook_idmap.c:335:33: note: each undeclared identifier is reported only once for each function it appears in
+Signed-off-by: stydxm <stydxm@outlook.com>
+---
+ libmount/src/hook_idmap.c | 6 ++----
+ libmount/src/hooks.c      | 2 +-
+ libmount/src/version.c    | 2 +-
+ sys-utils/mount.8.adoc    | 5 +++--
+ 4 files changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/libmount/src/hook_idmap.c b/libmount/src/hook_idmap.c
+index 2c697b171..b1477ac66 100644
+--- a/libmount/src/hook_idmap.c
++++ b/libmount/src/hook_idmap.c
+@@ -32,7 +32,7 @@
+ # include <linux/nsfs.h>
+ #endif
+ 
+-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
++#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 
+ typedef enum idmap_type_t {
+ 	ID_TYPE_UID,	/* uidmap entry */
+@@ -317,7 +317,6 @@ static int hook_mount_post(
+ 	 * Once a mount has been attached to the filesystem it can't be
+ 	 * idmapped anymore. So create a new detached mount.
+ 	 */
+-#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 	{
+ 		struct libmnt_sysapi *api = mnt_context_get_sysapi(cxt);
+ 
+@@ -327,7 +326,6 @@ static int hook_mount_post(
+ 			DBG(HOOK, ul_debugobj(hs, " reuse tree FD"));
+ 		}
+ 	}
+-#endif
+ 	if (fd_tree < 0)
+ 		fd_tree = mnt_open_tree(AT_FDCWD, target,
+ 			    OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC |
+@@ -544,4 +542,4 @@ const struct libmnt_hookset hookset_idmap =
+ 	.deinit = hookset_deinit
+ };
+ 
+-#endif /* HAVE_MOUNTFD_API && HAVE_LINUX_MOUNT_H */
++#endif /* USE_LIBMOUNT_MOUNTFD_SUPPORT */
+diff --git a/libmount/src/hooks.c b/libmount/src/hooks.c
+index 23eca4efd..5ae91edd7 100644
+--- a/libmount/src/hooks.c
++++ b/libmount/src/hooks.c
+@@ -45,7 +45,7 @@ static const struct libmnt_hookset *const hooksets[] =
+ 	&hookset_mount,
+ #endif
+ 	&hookset_mount_legacy,
+-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
++#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 	&hookset_idmap,
+ #endif
+ 	&hookset_owner
+diff --git a/libmount/src/version.c b/libmount/src/version.c
+index 5ec0d490c..30cb340ab 100644
+--- a/libmount/src/version.c
++++ b/libmount/src/version.c
+@@ -37,7 +37,7 @@ static const char *lib_features[] = {
+ #ifdef USE_LIBMOUNT_SUPPORT_NAMESPACES
+ 	"namespaces",
+ #endif
+-#if defined(HAVE_MOUNTFD_API) && defined(HAVE_LINUX_MOUNT_H)
++#ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+ 	"idmapping",
+ #endif
+ #ifdef USE_LIBMOUNT_MOUNTFD_SUPPORT
+diff --git a/sys-utils/mount.8.adoc b/sys-utils/mount.8.adoc
+index 8a6e09f1a..99e32fd90 100644
+--- a/sys-utils/mount.8.adoc
++++ b/sys-utils/mount.8.adoc
+@@ -826,8 +826,9 @@ Set _mountpoint_'s mode after mounting.
+ 
+ *X-mount.idmap*=__id-type__:__id-mount__:__id-host__:__id-range__ [__id-type__:__id-mount__:__id-host__:__id-range__], *X-mount.idmap*=__file__::
+ Use this option to create an idmapped mount.
+-An idmapped mount allows to change ownership of all files located under a mount according to the ID-mapping associated with a user namespace.
+-The ownership change is tied to the lifetime and localized to the relevant mount.
++This feature requires the new file-descriptor-based mount API (available since Linux 5.2).
++An idmapped mount allows the ownership of all files located under a mount to be changed according to the ID-mapping associated with a user namespace.
++The ownership change is tied to the lifetime of, and localized to, the relevant mount.
+ The relevant ID-mapping can be specified in two ways:
+ +
+ * A user can specify the ID-mapping directly.
+-- 
+2.34.1
+

--- a/runtime-optenv32/util-linux+32/spec
+++ b/runtime-optenv32/util-linux+32/spec
@@ -1,4 +1,4 @@
-VER=2.42
+VER=2.42.3
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
-CHKSUMS="sha256::3452b260bbaa775d6e749ac3bb22111785003fc1f444970025c8da26dfa758e9"
+CHKSUMS="sha256::66ac7c0e725278eb2b039e3104f2c91119341d941b41bac7a285c695f940bd57"
 CHKUPDATE="anitya::id=8179"

--- a/topics/util-linux-2.42.3.toml
+++ b/topics/util-linux-2.42.3.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "util-linux 2.42.3"
+
+[caution]
+default = "Fixes a Use After Free vulnerability (CVE-2026-13595, Severity: Medium)"
+zh_CN = "修复 1 处释放后使用漏洞（CVE-2026-13595，严重性：中）"
+
+[packages-v2]
+"util-linux" = "< 2.42.3"
+"util-linux+32" = "< 2.42.3"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add util-linux-2.42.3.toml
    Signed-off-by: stydxm <stydxm@outlook.com>
- util-linux+32: security update to 2.42.3
    Signed-off-by: stydxm <stydxm@outlook.com>
- util-linux: security update to 2.42.3
    Signed-off-by: stydxm <stydxm@outlook.com>

Package(s) Affected
-------------------

- util-linux: 2.42.3
- util-linux-runtime: 2.42.3

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
