### PR TITLE
pixi: update to 0.79.0

### DIFF
--- a/app-devel/pixi/spec
+++ b/app-devel/pixi/spec
@@ -1,4 +1,4 @@
-VER=0.77.1
+VER=0.79.0
 SRCS="git::commit=tags/v$VER::https://github.com/prefix-dev/pixi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=379204"


### PR DESCRIPTION
Topic Description
-----------------

- pixi: update to 0.79.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- pixi: 0.79.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pixi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
