### PR TITLE
dankmaterialshell: update to 1.6.0

### DIFF
--- a/app-utils/dankcalendar/autobuild/build
+++ b/app-utils/dankcalendar/autobuild/build
@@ -1,0 +1,33 @@
+abinfo "Syncing shell(Bake the quickshell UI into the binary) ..."
+cd "$SRCDIR"/core
+make sync-shell
+
+abinfo "Building dankcalendar ..."
+cd "$SRCDIR"/core/cmd/dcal
+go build \
+    -v \
+    -tags withshell \
+    -ldflags "-s -w \
+        -X main.Version=$PKGVER \
+        -X 'main.Commit=$(git rev-parse HEAD~1)' \
+        -X 'main.BuildTime=$(date)'" \
+    -o dcal
+
+abinfo "Installing dankcalendar binary ..."
+install -Dvm755 "$SRCDIR"/core/cmd/dcal/dcal "$PKGDIR"/usr/bin/dcal
+
+abinfo "Installing desktop entry and systemd services..."
+install -Dvm644 "$SRCDIR"/assets/com.danklinux.dankcalendar.svg \
+    "$PKGDIR"/usr/share/icons/hicolor/scalable/apps/com.danklinux.dankcalendar.svg
+install -Dvm644 "$SRCDIR"/assets/com.danklinux.dankcalendar.desktop \
+    "$PKGDIR"/usr/share/applications/com.danklinux.dankcalendar.desktop
+install -Dvm644 "$SRCDIR"/assets/systemd/dcal.service \
+    "$PKGDIR"/usr/lib/systemd/user/dcal.service
+
+abinfo "Installing shell completions ..."
+"$SRCDIR"/core/cmd/dcal/dcal completion bash > "$SRCDIR"/bash-completions
+"$SRCDIR"/core/cmd/dcal/dcal completion fish > "$SRCDIR"/fish-completions
+"$SRCDIR"/core/cmd/dcal/dcal completion zsh > "$SRCDIR"/zsh-completions
+install -Dvm644 "$SRCDIR"/bash-completions "$PKGDIR"/usr/share/bash-completion/completions/dcal
+install -Dvm644 "$SRCDIR"/fish-completions "$PKGDIR"/usr/share/fish/vendor_completions.d/dcal.fish
+install -Dvm644 "$SRCDIR"/zsh-completions "$PKGDIR"/usr/share/zsh/site-functions/_dcal

--- a/app-utils/dankcalendar/autobuild/defines
+++ b/app-utils/dankcalendar/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=dankcalendar
+PKGSEC=utils
+PKGDES="Calendar from the Dank Linux Suite"
+PKGDEP="glibc quickshell"
+BUILDDEP="go"
+
+FAIL_ARCH="@(loongson3|retro)"

--- a/app-utils/dankcalendar/spec
+++ b/app-utils/dankcalendar/spec
@@ -1,0 +1,4 @@
+VER=1.6.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AvengeMedia/dankcalendar.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=392113"

--- a/app-utils/danksearch/autobuild/patches/0001-edit-executable-path.patch
+++ b/app-utils/danksearch/autobuild/patches/0001-edit-executable-path.patch
@@ -1,5 +1,5 @@
 diff --git a/assets/dsearch.service b/assets/dsearch.service
-index ff06758..879f078 100644
+index c7812f8..2dee26e 100644
 --- a/assets/dsearch.service
 +++ b/assets/dsearch.service
 @@ -5,7 +5,7 @@ After=network.target
@@ -10,4 +10,4 @@ index ff06758..879f078 100644
 +ExecStart=/usr/bin/dsearch serve
  Restart=on-failure
  RestartSec=5s
- 
+ TimeoutStopSec=30s

--- a/app-utils/danksearch/spec
+++ b/app-utils/danksearch/spec
@@ -1,5 +1,4 @@
-VER=0.3.2
-REL=1
+VER=1.6.0
 SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AvengeMedia/danksearch.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=106455"

--- a/app-utils/dgop/spec
+++ b/app-utils/dgop/spec
@@ -1,5 +1,4 @@
-VER=0.2.3
-REL=1
+VER=1.6.0
 SRCS="git::commit=tags/v$VER::https://github.com/AvengeMedia/dgop.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388379"

--- a/desktop-displaymanagers/dank-greeter/autobuild/build
+++ b/desktop-displaymanagers/dank-greeter/autobuild/build
@@ -1,0 +1,28 @@
+abinfo "Syncing shell(Bake the quickshell UI into the binary) ..."
+cd "$SRCDIR"/core
+make sync-shell
+
+abinfo "Building dms-greeter ..."
+cd "$SRCDIR"/core/cmd/dms-greeter
+go build \
+    -v \
+    -tags withshell \
+    -ldflags "-s -w \
+        -X main.Version=$PKGVER \
+        -X 'main.Commit=$(git rev-parse HEAD~1)' \
+        -X 'main.BuildTime=$(date)'" \
+    -o dms-greeter
+
+abinfo "Installing dms-greeter binary ..."
+install -Dvm755 "$SRCDIR"/core/cmd/dms-greeter/dms-greeter "$PKGDIR"/usr/bin/dms-greeter
+
+abinfo "Installing systemd tmpfiles.d configuration ..."
+install -Dvm644 "$SRCDIR"/assets/systemd/tmpfiles-dms-greeter.conf -t "$PKGDIR"/usr/lib/tmpfiles.d/dms-greeter.conf
+
+abinfo "Installing shell completions ..."
+"$SRCDIR"/core/cmd/dms-greeter/dms-greeter completion bash > "$SRCDIR"/bash-completions
+"$SRCDIR"/core/cmd/dms-greeter/dms-greeter completion fish > "$SRCDIR"/fish-completions
+"$SRCDIR"/core/cmd/dms-greeter/dms-greeter completion zsh > "$SRCDIR"/zsh-completions
+install -Dvm644 "$SRCDIR"/bash-completions "$PKGDIR"/usr/share/bash-completion/completions/dms-greeter
+install -Dvm644 "$SRCDIR"/fish-completions "$PKGDIR"/usr/share/fish/vendor_completions.d/dms-greeter.fish
+install -Dvm644 "$SRCDIR"/zsh-completions "$PKGDIR"/usr/share/zsh/site-functions/_dms-greeter

--- a/desktop-displaymanagers/dank-greeter/autobuild/defines
+++ b/desktop-displaymanagers/dank-greeter/autobuild/defines
@@ -1,0 +1,5 @@
+PKGNAME=dank-greeter
+PKGSEC=x11
+PKGDES="Greetd-based Greeter for the Dank Linux Suite"
+PKGDEP="glibc greetd quickshell"
+BUILDDEP="go"

--- a/desktop-displaymanagers/dank-greeter/spec
+++ b/desktop-displaymanagers/dank-greeter/spec
@@ -1,0 +1,4 @@
+VER=1.6.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AvengeMedia/dank-greeter.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=392111"

--- a/runtime-desktop/dankmaterialshell/autobuild/build
+++ b/runtime-desktop/dankmaterialshell/autobuild/build
@@ -1,17 +1,21 @@
+abinfo "Syncing shell(Bake the quickshell UI into the binary) ..."
+cd "$SRCDIR"/core
+make sync-shell
+
 abinfo "Building dms ..."
 cd "$SRCDIR"/core/cmd/dms
 go build \
     -v \
+    -tags distro_binary \
+    -tags withshell \
     -trimpath \
+	-mod=readonly \
+	-modcacherw \
     -ldflags "-X main.Version=$PKGVER -s -w" \
     -o dms
 
 abinfo "Installing dms binary ..."
 install -Dvm755 "$SRCDIR"/core/cmd/dms/dms "$PKGDIR"/usr/bin/dms
-
-abinfo "Installing quickshell files ..."
-install -dvm755 "$PKGDIR"/usr/share/quickshell/dms
-cp -av "$SRCDIR"/quickshell/. "$PKGDIR"/usr/share/quickshell/dms/
 
 abinfo "Installing systemd unit" \
        "and desktop assets ..."

--- a/runtime-desktop/dankmaterialshell/autobuild/defines
+++ b/runtime-desktop/dankmaterialshell/autobuild/defines
@@ -2,8 +2,8 @@ PKGNAME=dankmaterialshell
 PKGSEC=libs
 PKGDES="Desktop shell for Wayland compositors built with Quickshell and Go"
 PKGDEP="quickshell glibc"
-PKGRECOM="cava cliphist wl-clipboard matugen dgop danksearch"
-PKGSUG="i2c-tools accountsservice tuned cups-pk-helper greetd"
+PKGRECOM="cava cliphist wl-clipboard matugen danksearch"
+PKGSUG="i2c-tools accountsservice tuned cups-pk-helper dgop dank-greeter dankcalendar"
 PKGPROV="dms dms-shell"
 
 BUILDDEP="go"

--- a/runtime-desktop/dankmaterialshell/spec
+++ b/runtime-desktop/dankmaterialshell/spec
@@ -1,5 +1,4 @@
-VER=1.5.3
-REL=2
-SRCS="git::commit=tags/v$VER::https://github.com/AvengeMedia/DankMaterialShell.git"
+VER=1.6.0
+SRCS="git::commit=tags/v$VER;copy-repo=true::https://github.com/AvengeMedia/DankMaterialShell.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=388076"


### PR DESCRIPTION
Topic Description
-----------------

- dankmaterialshell: update to 1.6.0
- dankcalendar: new, 1.6.0
- dank-greeter: new, 1.6.0
- danksearch: update to 1.6.0
- dgop: update to 1.6.0

Package(s) Affected
-------------------

- dank-greeter: 1.6.0
- dankcalendar: 1.6.0
- dankmaterialshell: 1.6.0
- danksearch: 1.6.0
- dgop: 1.6.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit dgop danksearch dank-greeter dankcalendar dankmaterialshell
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
