### PR TITLE
ngtcp2: update to 1.25.0

### DIFF
--- a/runtime-web/ngtcp2/spec
+++ b/runtime-web/ngtcp2/spec
@@ -1,5 +1,4 @@
-VER=1.23.0
-REL=2
+VER=1.25.0
 SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/ngtcp2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=370247"


### PR DESCRIPTION
Topic Description
-----------------

- ngtcp2: update to 1.25.0
    Co-authored-by: \(@MutsukiC\)

Package(s) Affected
-------------------

- ngtcp2: 1.25.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit ngtcp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
