### PR TITLE
nghttp3: update to 1.18.0

### DIFF
--- a/runtime-web/nghttp3/spec
+++ b/runtime-web/nghttp3/spec
@@ -1,4 +1,4 @@
-VER=1.16.0
+VER=1.18.0
 SRCS="git::commit=tags/v$VER::https://github.com/ngtcp2/nghttp3"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=243323"


### PR DESCRIPTION
Topic Description
-----------------

- nghttp3: update to 1.18.0
    Co-authored-by: \(@MutsukiC\)

Package(s) Affected
-------------------

- nghttp3: 1.18.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit nghttp3
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
