### PR TITLE
nghttp2: fix building shared library on loongson3

### DIFF
--- a/runtime-web/nghttp2/autobuild/defines
+++ b/runtime-web/nghttp2/autobuild/defines
@@ -11,6 +11,9 @@ BUILDDEP__RETRO=""
 USECLANG=1
 USECLANG__RETRO=0
 
+# FIXME: Clang fails to build shared lib on lonngson3.
+USECLANG__LOONGSON3=0
+
 # FIXME: Disabling PIC and PIE flags to make Python module build with GCC.
 AB_FLAGS_PIC=0
 AB_FLAGS_PIE=0
@@ -48,7 +51,12 @@ AUTOTOOLS_AFTER=(
     '--with-libnghttp3=no'
     '--with-libbpf'
 )
-# FIXME: Clang build fails on loongson3, ppc64el, and riscv64, disabling libbpf.
+# FIXME: Clang fails to build shared lib on loongson3, disabling libbpf.
+AUTOTOOLS_AFTER__LOONGSON3=(
+    "${AUTOTOOLS_AFTER[@]}"
+    '--with-libbpf=no'
+)
+
 AUTOTOOLS_AFTER__RETRO=(
     "${AUTOTOOLS_AFTER[@]}"
     '--with-libbpf=no'

--- a/runtime-web/nghttp2/spec
+++ b/runtime-web/nghttp2/spec
@@ -1,4 +1,5 @@
 VER=1.70.0
-SRCS="git::commit=tags/v$VER::https://github.com/nghttp2/nghttp2"
-CHKSUMS="SKIP"
+SRCS="tbl::https://github.com/nghttp2/nghttp2/releases/download/v$VER/nghttp2-$VER.tar.xz"
+CHKSUMS="sha256::e05cb1388eaca3830aded4ccf20044b6e1ac1a61411dcca11b0437c4285c8bc2"
 CHKUPDATE="anitya::id=8651"
+REL=1


### PR DESCRIPTION
Topic Description
-----------------

- nghttp2: fix building shared library on loongson3

Package(s) Affected
-------------------

- nghttp2: 1.70.0-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit nghttp2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
