### PR TITLE
pkgconf: update to 3.0.7

### DIFF
--- a/app-devel/pkgconf/spec
+++ b/app-devel/pkgconf/spec
@@ -1,4 +1,4 @@
-VER=3.0.6
+VER=3.0.7
 SRCS="tbl::https://distfiles.ariadne.space/pkgconf/pkgconf-$VER.tar.xz"
-CHKSUMS="sha256::c88a653fbabfa2a5857a30f6b6ad6c40dbacc3b7c72cc066e5c7dc4571cbddaa"
+CHKSUMS="sha256::c926ff491cbd9a331a589160811bd97ab1749b4d5198a519338f2cdfabe6940a"
 CHKUPDATE="anitya::id=12753"


### PR DESCRIPTION
Topic Description
-----------------

- pkgconf: update to 3.0.7
    Co-authored-by: yidaduizuoye \(@CAB233\)

Package(s) Affected
-------------------

- pkgconf: 3.0.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit pkgconf
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
