### PR TITLE
Pytest Plugins Survey 20260905

### DIFF
--- a/lang-python/execnet/autobuild/defines
+++ b/lang-python/execnet/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=execnet
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="hatchling hatch-vcs"
+PKGDES="Library to interact with Python interpreters across version, platform and network barriers"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/execnet/spec
+++ b/lang-python/execnet/spec
@@ -1,0 +1,4 @@
+VER=2.1.2
+SRCS="pypi::version=$VER::execnet"
+CHKSUMS="sha256::63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd"
+CHKUPDATE="anitya::id=3858"

--- a/lang-python/pytest-asyncio/autobuild/defines
+++ b/lang-python/pytest-asyncio/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pytest-asyncio
+PKGSEC=python
+PKGDEP="python-3 pytest"
+BUILDDEP="setuptools setuptools-scm"
+PKGDES="Pytest support for asyncio"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytest-asyncio/spec
+++ b/lang-python/pytest-asyncio/spec
@@ -1,0 +1,4 @@
+VER=1.4.0
+SRCS="pypi::version=$VER::pytest-asyncio"
+CHKSUMS="sha256::c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42"
+CHKUPDATE="anitya::id=7273"

--- a/lang-python/pytest-cov/autobuild/defines
+++ b/lang-python/pytest-cov/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pytest-cov
+PKGSEC=python
+PKGDEP="python-3 coverage pluggy pytest"
+BUILDDEP="hatchling hatch-fancy-pypi-readme"
+PKGDES="Pytest plugin for measuring coverage"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytest-cov/spec
+++ b/lang-python/pytest-cov/spec
@@ -1,0 +1,4 @@
+VER=7.1.0
+SRCS="pypi::version=$VER::pytest-cov"
+CHKSUMS="sha256::30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2"
+CHKUPDATE="anitya::id=6509"

--- a/lang-python/pytest-rerunfailures/autobuild/defines
+++ b/lang-python/pytest-rerunfailures/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pytest-rerunfailures
+PKGSEC=python
+PKGDEP="python-3 pytest packaging"
+BUILDDEP="setuptools"
+PKGDES="Pytest plugin to re-run tests to eliminate flaky failures"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytest-rerunfailures/spec
+++ b/lang-python/pytest-rerunfailures/spec
@@ -1,0 +1,4 @@
+VER=16.6.1
+SRCS="pypi::version=$VER::pytest-rerunfailures"
+CHKSUMS="sha256::20ac38d31f9319c4e8f43fe0d0e9c22755508e8e7987a88de6d7fd93fc6bdabb"
+CHKUPDATE="anitya::id=86566"

--- a/lang-python/pytest-xdist/autobuild/defines
+++ b/lang-python/pytest-xdist/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=pytest-xdist
+PKGSEC=python
+PKGDEP="python-3 pytest execnet"
+BUILDDEP="setuptools setuptools-scm"
+PKGDES="Pytest xdist plugin for distributed testing"
+
+ABTYPE=pep517
+ABHOST=noarch
+NOPYTHON2=1

--- a/lang-python/pytest-xdist/spec
+++ b/lang-python/pytest-xdist/spec
@@ -1,0 +1,4 @@
+VER=3.8.0
+SRCS="pypi::version=$VER::pytest-xdist"
+CHKSUMS="sha256::7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"
+CHKUPDATE="anitya::id=11485"


### PR DESCRIPTION
Topic Description
-----------------

- pytest-xdist: new, 3.8.0
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- execnet: new, 2.1.2
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- pytest-rerunfailures: new, 16.6.1
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- pytest-asyncio: new, 1.4.0
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- pytest-cov: new, 7.1.0
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------

- execnet: 2.1.2
- pytest-asyncio: 1.4.0
- pytest-cov: 7.1.0
- pytest-rerunfailures: 16.6.1
- pytest-xdist: 3.8.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit pytest-cov pytest-asyncio pytest-rerunfailures execnet pytest-xdist
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
