### PR TITLE
expat: security update to 2.8.4

### DIFF
--- a/runtime-common/expat/spec
+++ b/runtime-common/expat/spec
@@ -1,4 +1,4 @@
-VER=2.8.2
+VER=2.8.4
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/runtime-optenv32/expat+32/spec
+++ b/runtime-optenv32/expat+32/spec
@@ -1,4 +1,4 @@
-VER=2.8.2
+VER=2.8.4
 SRCS="git::commit=tags/R_${VER//./_}::https://github.com/libexpat/libexpat"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=770"

--- a/topics/expat-2.8.4.toml
+++ b/topics/expat-2.8.4.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "Expat 2.8.4"
+
+[caution]
+default = "Fixes 5 security vulnerabilities (including 2 of High Severity and 3 of Medium Severity)"
+zh_CN = "修复 5 个安全漏洞（含 2 个高危漏洞和 3 个中危漏洞）"
+
+[packages-v2]
+"expat" = "< 2.8.4"
+"expat+32" = "< 2.8.4"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add expat-2.8.4.toml
- expat+32: security update to 2.8.4
- expat: security update to 2.8.4

Package(s) Affected
-------------------

- expat: 2.8.4

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit expat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
