### PR TITLE
json-c: update to 0.19

### DIFF
--- a/runtime-common/json-c/autobuild/defines
+++ b/runtime-common/json-c/autobuild/defines
@@ -1,12 +1,12 @@
 PKGNAME=json-c
-PKGDES="A JSON implementation in C"
+PKGDES="JSON implementation in C"
 PKGSEC=libs
 PKGDEP=glibc
 
-ABSHADOW=0
 # Note: Needed by GDAL.
 NOSTATIC=0
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=(
 	-DBUILD_STATIC_LIBS=OFF
 )

--- a/runtime-common/json-c/spec
+++ b/runtime-common/json-c/spec
@@ -1,6 +1,5 @@
-UPSTREAM_VER=0.18-20240915
-VER=${UPSTREAM_VER/-/+}
-REL=1
+UPSTREAM_VER=0.19-20260627
+VER=${UPSTREAM_VER%%-*}
 SRCS="git::commit=tags/json-c-${UPSTREAM_VER}::https://github.com/json-c/json-c"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1477"

--- a/runtime-optenv32/json-c+32/autobuild/defines
+++ b/runtime-optenv32/json-c+32/autobuild/defines
@@ -2,6 +2,6 @@ PKGNAME=json-c+32
 PKGSEC=libs
 PKGDEP="aosc-aaa+32 glibc+32"
 BUILDDEP="devel-base+32"
-PKGDES="A JSON implementation in C (32-bit x86 runtime)"
+PKGDES="JSON implementation in C (32-bit x86 runtime)"
 
 ABHOST=optenv32

--- a/runtime-optenv32/json-c+32/spec
+++ b/runtime-optenv32/json-c+32/spec
@@ -1,4 +1,4 @@
-UPSTREAM_VER=0.18-20240915
+UPSTREAM_VER=0.19-20260627
 VER=${UPSTREAM_VER%%-*}
 SRCS="git::commit=tags/json-c-${UPSTREAM_VER}::https://github.com/json-c/json-c"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- json-c+32: update to 0.19
- json-c: update to 0.19

Package(s) Affected
-------------------

- json-c: 0.19

Security Update?
----------------

No

Build Order
-----------

```
#buildit json-c
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
