### PR TITLE
pcre2: security update to 10.48

### DIFF
--- a/runtime-common/pcre2/autobuild/beyond
+++ b/runtime-common/pcre2/autobuild/beyond
@@ -1,0 +1,2 @@
+abinfo "removing docs ..."
+rm -rv "$PKGDIR"/usr/share/doc/pcre2/html/

--- a/runtime-common/pcre2/autobuild/defines
+++ b/runtime-common/pcre2/autobuild/defines
@@ -3,6 +3,7 @@ PKGSEC=libs
 PKGDEP="zlib bzip2 readline glibc"
 PKGDES="Perl Compatible Regular Expression (2nd Edition)"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-pcre2-16'
     '--enable-pcre2-32'

--- a/runtime-common/pcre2/spec
+++ b/runtime-common/pcre2/spec
@@ -1,5 +1,4 @@
-VER=10.46
-REL=1
+VER=10.48
 SRCS="git::commit=tags/pcre2-$VER::https://github.com/PCRE2Project/pcre2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5832"

--- a/runtime-optenv32/pcre2+32/autobuild/defines
+++ b/runtime-optenv32/pcre2+32/autobuild/defines
@@ -4,6 +4,7 @@ PKGDEP="aosc-aaa+32 bzip2+32 readline+32 zlib+32"
 BUILDDEP="devel-base+32"
 PKGDES="Perl Compatible Regular Expression (2nd Edition, 32-bit x86 runtime)"
 
+ABTYPE=autotools
 AUTOTOOLS_AFTER=(
     '--enable-pcre2-16'
     '--enable-pcre2-32'

--- a/runtime-optenv32/pcre2+32/spec
+++ b/runtime-optenv32/pcre2+32/spec
@@ -1,4 +1,4 @@
-VER=10.44
+VER=10.48
 SRCS="git::commit=tags/pcre2-$VER::https://github.com/PCRE2Project/pcre2"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5832"

--- a/topics/pcre2-10.48.toml
+++ b/topics/pcre2-10.48.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "PCRE2 10.48"
+
+[caution]
+default = "Fixes 5 security vulnerabilities (1 of high severity and 2 of medium severity)"
+zh_CN = "修复 5 个安全漏洞（含 1 个高危漏洞和 2 个中危漏洞）"
+
+[packages-v2]
+"pcre2" = "< 10.48"
+"pcre2+32" = "< 10.48"


### PR DESCRIPTION
Topic Description
-----------------

- topics: add pcre2-10.48.toml
- pcre2+32: security update to 10.48
- pcre2: security update to 10.48

Package(s) Affected
-------------------

- pcre2: 10.48

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit pcre2
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
