### PR TITLE
ffmpeg: fix libavcodec/vulkan_encode incorrupt return value which cause sigsegv

### DIFF
--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0001-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0001-fix-libavutil-mips-Only-use-cpuinfo-to-read-cpu-ISAs.patch
@@ -1,7 +1,7 @@
-From 2b83617fc15f4f99fa9e4e4edf286743d6c1c0a0 Mon Sep 17 00:00:00 2001
+From 6b36dbb7b43510170438790043de97fe28074ea2 Mon Sep 17 00:00:00 2001
 From: Icenowy Zheng <icenowy@aosc.io>
 Date: Mon, 7 Sep 2020 03:49:55 +0800
-Subject: [PATCH 1/4] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
+Subject: [PATCH 1/6] fix(libavutil/mips): Only use cpuinfo to read cpu ISAs
 
 Signed-off-by: Icenowy Zheng <icenowy@aosc.io>
 ---
@@ -129,5 +129,5 @@ index 2009c70f71..5002261b25 100644
      /* Assume no SIMD ASE supported */
      return 0;
 -- 
-2.54.0
+2.55.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0002-fix-libavcodec-mips-constify-src-for-mmi.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0002-fix-libavcodec-mips-constify-src-for-mmi.patch
@@ -1,7 +1,7 @@
-From 685c0fcecf9c0f38a754ab9606e3ddec885f46ba Mon Sep 17 00:00:00 2001
+From c4bd00d21a870f54cda570a83b50166f66fe3a23 Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 30 Dec 2024 11:36:37 +0800
-Subject: [PATCH 2/4] fix(libavcodec/mips): constify src for mmi
+Subject: [PATCH 2/6] fix(libavcodec/mips): constify src for mmi
 
 ---
  libavcodec/mips/vp8dsp_mmi.c | 72 ++++++++++++++++++------------------
@@ -336,5 +336,5 @@ index 6de405bfb5..ac8b07bca1 100644
  {
  #if 1
 -- 
-2.54.0
+2.55.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0003-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0003-fix-libavcodec-mips-use-mmi-mnemonics-supported-by-b.patch
@@ -1,7 +1,7 @@
-From ded795e35b17c7f2dbb4cc7be46fd61e534ec473 Mon Sep 17 00:00:00 2001
+From 7f8c374822515997cbdfaa699c8bfe56be675f4d Mon Sep 17 00:00:00 2001
 From: Henry Chen <henry.chen@oss.cipunited.com>
 Date: Mon, 30 Dec 2024 16:08:58 +0800
-Subject: [PATCH 3/4] fix(libavcodec/mips): use mmi mnemonics supported by
+Subject: [PATCH 3/6] fix(libavcodec/mips): use mmi mnemonics supported by
  binutils 2.43.1
 
 Apparently Loongson's staff's proposal has never been upstreamed.
@@ -2489,5 +2489,5 @@ index 1a6781ae77..82e16f929b 100644
          // low 4 loop
          MMI_LDC1(%[ftmp1], %[block], 0x00)
 -- 
-2.54.0
+2.55.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0004-Add-av_stream_get_first_dts-for-Chromium.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0004-Add-av_stream_get_first_dts-for-Chromium.patch
@@ -1,7 +1,7 @@
-From b17b167416ea3212ce2ea084af0b1e72b13ce992 Mon Sep 17 00:00:00 2001
+From f9990cea1ad1dddec0f3574a1b715e034e733367 Mon Sep 17 00:00:00 2001
 From: Frank Liberato <liberato@chromium.org>
 Date: Wed, 7 Jul 2021 19:01:22 -0700
-Subject: [PATCH 4/4] Add av_stream_get_first_dts for Chromium
+Subject: [PATCH 4/6] Add av_stream_get_first_dts for Chromium
 
 ---
  libavformat/avformat.h | 4 ++++
@@ -42,5 +42,5 @@ index 7a74e63d68..a096497675 100644
  #define SANE_CHUNK_SIZE (50000000)
  
 -- 
-2.54.0
+2.55.0
 

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0005-LIZARDBYTE-Fix-vulkan_encode-returning-success-when-.patch
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0005-LIZARDBYTE-Fix-vulkan_encode-returning-success-when-.patch
@@ -1,0 +1,35 @@
+From 3ab285c9dd29095ecd52ad22fc8907af717fd553 Mon Sep 17 00:00:00 2001
+From: neatnoise <neatnoise@gmail.com>
+Date: Sun, 6 Sep 2026 03:12:15 +0800
+Subject: [PATCH 5/6] [LIZARDBYTE] Fix vulkan_encode returning success when
+ video encode queue is missing
+
+When ff_vk_qf_find() fails to find a video encode queue, the error path
+returns the stale 'err' variable which is 0 from the previous successful
+ff_vk_load_functions() call. This causes avcodec_open2() to report success
+despite the encoder being in a broken state, leading to a SIGSEGV when
+the caller attempts to encode a frame.
+
+[ https://github.com/LizardByte/build-deps/pull/660 ]
+
+Signed-off-by: Lain "Fearyncess" Yang <i@lain.vg>
+---
+ libavcodec/vulkan_encode.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/vulkan_encode.c b/libavcodec/vulkan_encode.c
+index 39c43300c4..8f50963bf1 100644
+--- a/libavcodec/vulkan_encode.c
++++ b/libavcodec/vulkan_encode.c
+@@ -813,7 +813,7 @@ av_cold int ff_vulkan_encode_init(AVCodecContext *avctx, FFVulkanEncodeContext *
+     if (!ctx->qf_enc) {
+         av_log(avctx, AV_LOG_ERROR, "Encoding of %s is not supported by this device\n",
+                avcodec_get_name(avctx->codec_id));
+-        return err;
++        return AVERROR(ENOSYS);
+     }
+ 
+     /* Load all properties */
+-- 
+2.55.0
+

--- a/app-multimedia/ffmpeg/01-ffmpeg/patches/0006-configure-disable-HAVE_7REGS-for-i486.patch.i486
+++ b/app-multimedia/ffmpeg/01-ffmpeg/patches/0006-configure-disable-HAVE_7REGS-for-i486.patch.i486
@@ -1,7 +1,7 @@
-From a6efb0c208777b0b79b18c6249677578d6f5c50a Mon Sep 17 00:00:00 2001
+From df28193b1568945037f6cb8c863af4f9cdb12fb4 Mon Sep 17 00:00:00 2001
 From: Xinhui Yang <cyan@cyano.uk>
 Date: Sun, 28 Jun 2026 14:35:52 +0000
-Subject: [PATCH] configure: disable HAVE_7REGS for i486
+Subject: [PATCH 6/6] configure: disable HAVE_7REGS for i486
 
 Apparently GCC is not happy when an inline assembly block uses 7
 "r"/"+r" register operands on x86, which only has 8 registers.
@@ -10,7 +10,7 @@ Apparently GCC is not happy when an inline assembly block uses 7
  1 file changed, 1 insertion(+), 3 deletions(-)
 
 diff --git a/configure b/configure
-index 1759694..541d9b3 100755
+index 1759694274..541d9b34a6 100755
 --- a/configure
 +++ b/configure
 @@ -6752,9 +6752,7 @@ return i;
@@ -25,5 +25,5 @@ index 1759694..541d9b3 100755
      check_inline_asm xmm_clobbers '"":::"%xmm0"'
  
 -- 
-2.52.0
+2.55.0
 

--- a/app-multimedia/ffmpeg/spec
+++ b/app-multimedia/ffmpeg/spec
@@ -1,5 +1,5 @@
 VER=8.1.2
-REL=1
+REL=2
 SRCS="tbl::https://ffmpeg.org/releases/ffmpeg-$VER.tar.xz"
 CHKSUMS="sha256::464beb5e7bf0c311e68b45ae2f04e9cc2af88851abb4082231742a74d97b524c"
 CHKUPDATE="anitya::id=5405"


### PR DESCRIPTION
Topic Description
-----------------

- ffmpeg: fix libavcodec/vulkan_encode incorrupt return value which cause sigsegv

Package(s) Affected
-------------------

- ffmpeg: 8.1.2-2
- ffmpeg-static-libs-for-sunshine: 8.1.2-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit ffmpeg
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
