### PR TITLE
hmcl: update to 3.17.0.355

### DIFF
--- a/app-games/hmcl/spec
+++ b/app-games/hmcl/spec
@@ -1,4 +1,4 @@
-VER=3.16.3
+VER=3.17.0.355
 SRCS="git::commit=tags/release-$VER::https://github.com/HMCL-dev/HMCL"
 CHKUPDATE="anitya::id=371893"
 CHKSUMS="SKIP"


### PR DESCRIPTION
Topic Description
-----------------

- hmcl: update to 3.17.0.355
    Co-authored-by: Suyun \(@Suyun114\)

Package(s) Affected
-------------------

- hmcl: 3.17.0.355

Security Update?
----------------

No

Build Order
-----------

```
#buildit hmcl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] Architecture-independent `noarch`
