### PR TITLE
weechat: update to 4.10.1

### DIFF
--- a/app-web/weechat/spec
+++ b/app-web/weechat/spec
@@ -1,4 +1,4 @@
-VER=4.10.0
+VER=4.10.1
 SRCS="tbl::https://weechat.org/files/src/weechat-$VER.tar.xz"
-CHKSUMS="sha256::c3a7e7c6a5401dde9a46d0264fa44aa3032ca98aa86410c454d3de5c69505c54"
+CHKSUMS="sha256::b8744c6f5dc5543062791f563e0516dbc96a36161e1a03c468b3b7dcc8be5aff"
 CHKUPDATE="anitya::id=5122"

--- a/topics/weechat-4.10.1.toml
+++ b/topics/weechat-4.10.1.toml
@@ -1,0 +1,12 @@
+security = true
+
+[name]
+default = "WeeChat 4.10.1"
+
+[caution]
+default = "Fixes 6 vulnerabilities disclosed in WeeChat Security Advisories on Sep 5, 2026 (including 1 of Critical, 3 of High, and 2 of Medium severity)"
+zh_CN = "修复 WeeChat 安全公告在 2026 年 9 月 5 日披露的 6 个安全漏洞（含 1 个严重漏洞、3 个高危漏洞和 2 个中危漏洞）"
+zh_TW = "修復 WeeChat 安全公告在 2026 年 9 月 5 日披露的 6 個安全漏洞（含 1 個嚴重漏洞、3 個高危漏洞和 2 個中危漏洞）"
+
+[packages-v2]
+"weechat" = "< 4.10.1"


### PR DESCRIPTION
Topic Description
-----------------

- weechat: update to 4.10.1
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- weechat: 4.10.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit weechat
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
