### PR TITLE
pcre-static: remove remnant file

### DIFF
--- a/runtime-common/pcre-static/spec
+++ b/runtime-common/pcre-static/spec
@@ -1,5 +1,0 @@
-VER=8.44
-SRCS="tbl::https://ftp.exim.org/pub/pcre/pcre-$VER.tar.gz"
-CHKSUMS="sha256::aecafd4af3bd0f3935721af77b889d9024b2e01d96b58471bd91a3063fb47728"
-CHKUPDATE="anitya::id=2610"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- pcre-static: remove redundant file

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
