### PR TITLE
libdeflate: update to 1.26

### DIFF
--- a/runtime-common/libdeflate/spec
+++ b/runtime-common/libdeflate/spec
@@ -1,5 +1,4 @@
-VER=1.25
-REL=1
+VER=1.26
 SRCS="tbl::https://github.com/ebiggers/libdeflate/releases/download/v$VER/libdeflate-$VER.tar.gz"
-CHKSUMS="sha256::fed5cd22f00f30cc4c2e5329f94e2b8a901df9fa45ee255cb70e2b0b42344477"
+CHKSUMS="sha256::125856d4656e0feab660f94842f835923410c9281fedbcee64598c918da42b5a"
 CHKUPDATE="anitya::id=242778"


### PR DESCRIPTION
Topic Description
-----------------

- libdeflate: update to 1.26
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libdeflate: 1.26

Security Update?
----------------

No

Build Order
-----------

```
#buildit libdeflate
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
