### PR TITLE
libcbor: update to 0.14.0

### DIFF
--- a/app-virtualization/qemu/spec
+++ b/app-virtualization/qemu/spec
@@ -1,4 +1,5 @@
 VER=11.0.1
+REL=1
 SRCS="tbl::https://download.qemu.org/qemu-${VER/\~/-}.tar.xz"
 CHKSUMS="sha256::0d235f5820278d914a3155ec27af8e4258d697ea892895570807d69c0cb8cd64"
 CHKUPDATE="anitya::id=13607"

--- a/runtime-common/libcbor/autobuild/defines
+++ b/runtime-common/libcbor/autobuild/defines
@@ -1,11 +1,12 @@
 PKGNAME=libcbor
 PKGSEC=libs
-PKGDES="A C implementation of the CBOR protocol"
+PKGDES="C implementation of the CBOR protocol"
 PKGDEP="glibc"
 
+ABTYPE=cmakeninja
 CMAKE_AFTER=("-DBUILD_SHARED_LIBS=ON")
 
-PKGBREAK="fwupd<=1.9.25 libfido2<=1.13.0 qemu<=9.2.2"
+PKGBREAK="fwupd<=1.9.25 libfido2<=1.17.0-1 qemu<=11.0.1"
 
 # Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
 FAIL_ARCH="!(mainline|retro)"

--- a/runtime-common/libcbor/spec
+++ b/runtime-common/libcbor/spec
@@ -1,4 +1,4 @@
-VER=0.12.0
+VER=0.14.0
 SRCS="git::commit=tags/v$VER::https://github.com/PJK/libcbor.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=15699"

--- a/runtime-devices/libfido2/spec
+++ b/runtime-devices/libfido2/spec
@@ -1,5 +1,5 @@
 VER=1.17.0
-REL=1
+REL=2
 SRCS="https://developers.yubico.com/libfido2/Releases/libfido2-${VER}.tar.gz"
 CHKSUMS="sha256::c1012c8871d71b65872fd5ff1a9d6b0838a55683a03e85ba97479ce57129c736"
 CHKUPDATE="anitya::id=78296"


### PR DESCRIPTION
Topic Description
-----------------

- libcbor: update to 0.14.0
    Co-authored-by: \(@stydxm\) <stydxm@outlook.com>

Package(s) Affected
-------------------

- libcbor: 0.14.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit libcbor:-pkgbreak libfido2 qemu libcbor
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
