### PR TITLE
doggo: update to 1.4.0

### DIFF
--- a/app-network/doggo/autobuild/beyond
+++ b/app-network/doggo/autobuild/beyond
@@ -1,0 +1,7 @@
+abinfo "Installing shell completion scripts..."
+"$PKGDIR"/usr/bin/doggo completions bash | \
+    install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/bash-completion/completions/doggo
+"$PKGDIR"/usr/bin/doggo completions zsh | \
+    install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/zsh/site-functions/_doggo
+"$PKGDIR"/usr/bin/doggo completions fish | \
+    install -Dvm644 /dev/stdin "$PKGDIR"/usr/share/fish/vendor_completions.d/doggo.fish

--- a/app-network/doggo/spec
+++ b/app-network/doggo/spec
@@ -1,5 +1,4 @@
-VER=1.3.0
-REL=1
+VER=1.4.0
 SRCS="git::commit=tags/v$VER::https://github.com/mr-karan/doggo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=373317"


### PR DESCRIPTION
Topic Description
-----------------

- doggo: update to 1.4.0
    - Install shell completions
    Signed-off-by: MutsukiC <mutsuki@aosc.io>

Package(s) Affected
-------------------

- doggo: 1.4.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit doggo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
