### PR TITLE
systemd-swap: drop, orpaned

### DIFF
--- a/app-admin/systemd-swap/autobuild/build
+++ b/app-admin/systemd-swap/autobuild/build
@@ -1,4 +1,0 @@
-abinfo "Building systemd-swap..."
-make
-abinfo "installing systemds-swap to $PKGDIR"
-make DESTDIR="$PKGDIR" install

--- a/app-admin/systemd-swap/autobuild/conffiles
+++ b/app-admin/systemd-swap/autobuild/conffiles
@@ -1,1 +1,0 @@
-/etc/systemd/swap.conf

--- a/app-admin/systemd-swap/autobuild/defines
+++ b/app-admin/systemd-swap/autobuild/defines
@@ -1,6 +1,0 @@
-PKGNAME=systemd-swap
-PKGDES="Script for creating hybrid swap space from zram swaps, swap files and swap partitions"
-PKGDEP="systemd util-linux python-systemd sysv-ipc"
-PKGSEC=admin
-
-ABHOST=noarch

--- a/app-admin/systemd-swap/spec
+++ b/app-admin/systemd-swap/spec
@@ -1,5 +1,0 @@
-VER=4.4.0
-REL=2
-SRCS="git::commit=tags/$VER::https://github.com/Nefelim4ag/systemd-swap.git"
-CHKSUMS="SKIP"
-CHKUPDATE="anitya::id=226825"

--- a/groups/python-setuptools-py2-5
+++ b/groups/python-setuptools-py2-5
@@ -1,6 +1,5 @@
 lang-python/sortedcontainers
 lang-python/structlog
-lang-python/sysv-ipc
 lang-python/testresources
 lang-python/tomlkit
 lang-python/toolbelt

--- a/lang-python/sysv-ipc/autobuild/defines
+++ b/lang-python/sysv-ipc/autobuild/defines
@@ -1,9 +1,0 @@
-PKGNAME="sysv-ipc"
-PKGDES="System V IPC for Python - Semaphores, Shared Memory and Message Queues"
-PKGDEP="python-3"
-BUILDDEP="setuptools-python3"
-PKGSEC="python"
-
-ABTYPE=python
-
-NOPYTHON2=1

--- a/lang-python/sysv-ipc/spec
+++ b/lang-python/sysv-ipc/spec
@@ -1,5 +1,0 @@
-VER="1.0.1"
-SRCS="tbl::http://semanchuk.com/philip/sysv_ipc/sysv_ipc-$VER.tar.gz"
-CHKSUMS="sha256::8eff10dd17789ddf21b422ce46ae0f6420088902a88e4296cb805cf2fde8b4dc"
-CHKUPDATE="anitya::id=20060"
-REL="4"


### PR DESCRIPTION
Topic Description
-----------------

- sysv-ipc: drop, orpaned
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>
- systemd-swap: drop, orpaned
    Signed-off-by: Xu Colin <colinxu2020@gmail.com>

Package(s) Affected
-------------------



Security Update?
----------------

No

Build Order
-----------

```
#buildit 
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
