### PR TITLE
iverilog: update to 13.0

### DIFF
--- a/app-electronics/iverilog/autobuild/defines
+++ b/app-electronics/iverilog/autobuild/defines
@@ -1,14 +1,19 @@
 PKGNAME=iverilog
 PKGSEC=electronics
-PKGDEP="bzip2 gcc-runtime readline"
+PKGDEP="bzip2 gcc-runtime readline zlib ncurses"
+PKGRECOM="gcc"
 BUILDDEP="gperf"
-PKGDES="A Verilog simulation and synthesis tool"
+PKGDES="Verilog simulator and synthesizer"
 
-ABSHADOW=0
+# static libraries are needed to build VPI modules
 NOSTATIC=0
-NOPARALLEL=1
 
 ABTYPE=autotools
+# reconf is done by `$SRCDIR/autoconf.sh`
+# which is involked in `autobuild/prepare`
 RECONF=0
+AUTOTOOLS_AFTER=(
+    '--enable-libvvp'
+)
 
 PKGPROV="icarus-verilog"

--- a/app-electronics/iverilog/spec
+++ b/app-electronics/iverilog/spec
@@ -1,5 +1,4 @@
-VER=12.0
+VER=13.0
 SRCS="git::commit=tags/v${VER/./_}::https://github.com/steveicarus/iverilog"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=1409"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- iverilog: update to 13.0

    - add missing dependencies \`zlib\` and \`ncurses\`.
    - add \`gcc\` to \`PKGRECOM\`, as iverilog needs a C compiler to build
    VPI modules.
    - add \`--enable-libvvp\` to \`AUTOTOOLS_AFTER\`, which is a new option
    added this version to install a dynamic library.

Package(s) Affected
-------------------

- iverilog: 13.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit iverilog
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
