### PR TITLE
amo: update to 0.6.0

### DIFF
--- a/app-admin/amo/autobuild/postinst
+++ b/app-admin/amo/autobuild/postinst
@@ -2,9 +2,11 @@ systemctl preset amo.service
 
 # Derived from scripts automatically added by dh_installinit/13.6ubuntu1
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
-        if [ -f "/usr/lib/systemd/system/amo.service" ]; then
-                systemctl enable --now amo.service || true
-        fi
-	# Reload on upgrade.
-	systemctl try-restart amo.service
+	if [ -f "/usr/lib/systemd/system/amo.service" ]; then
+		systemctl enable --now amo.service || true
+	fi
+	# Start amo if not running, leave it be otherwise - the current clients
+	# are not yet able to handle service reloads.
+	systemctl is-active amo.service || \
+		systemctl try-restart amo.service
 fi

--- a/app-admin/amo/spec
+++ b/app-admin/amo/spec
@@ -1,5 +1,4 @@
-VER=0.5.0
-REL=1
+VER=0.6.0
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/amo"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=391048"

--- a/topics/amo-0.6.0.toml
+++ b/topics/amo-0.6.0.toml
@@ -1,0 +1,12 @@
+security = true
+must_match_all = false
+
+[name]
+default = "amo 0.6.0"
+
+[caution]
+default = "Fixes an Authorization Bypass via PID Reuse vulnerability in zbus_polkit < 5.1.0 (RUSTSEC-2026-0278, Severity: High)"
+zh_CN = "修复 zbus_polkit < 5.1.0 中一个通过复用 PID 实现的提权绕过漏洞（RUSTSEC-2026-0278，严重性：高）"
+
+[packages-v2]
+"amo" = "< 0.6.0"


### PR DESCRIPTION
Topic Description
-----------------

- amo: update to 0.6.0
    Co-authored-by: Mag Mell \(@eatradish\)

Package(s) Affected
-------------------

- amo: 0.6.0

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit amo
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
