### PR TITLE
metasploit-framework: update to 6.5.3

### DIFF
--- a/app-penetration/metasploit-framework/spec
+++ b/app-penetration/metasploit-framework/spec
@@ -1,4 +1,4 @@
-VER=6.4.131
+VER=6.5.3
 SRCS="git::commit=tags/$VER::https://github.com/rapid7/metasploit-framework"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=190993"


### PR DESCRIPTION
Topic Description
-----------------

- metasploit-framework: update to 6.5.3
    Signed-off-by: Neko205 <neko200553@gmail.com>

Package(s) Affected
-------------------

- metasploit-framework: 6.5.3

Security Update?
----------------

No

Build Order
-----------

```
#buildit metasploit-framework
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
