### PR TITLE
feh: update to 3.13

### DIFF
--- a/app-imaging/feh/spec
+++ b/app-imaging/feh/spec
@@ -1,4 +1,4 @@
-VER=3.12.4
+VER=3.13
 SRCS="tbl::https://feh.finalrewind.org/feh-$VER.tar.bz2"
-CHKSUMS="sha256::97e89bb2cf5ada41e8c8e916ea4d7d64c51faaae4847f00fcc088fa06e1b5ca1"
+CHKSUMS="sha256::dcbc79d4c00f8964eeed9edc82010eead8c1ed16c12e2ae116f2e7cc7cd94716"
 CHKUPDATE="anitya::id=790"


### PR DESCRIPTION
Topic Description
-----------------

- feh: update to 3.13
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- feh: 3.13

Security Update?
----------------

No

Build Order
-----------

```
#buildit feh
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
