### PR TITLE
snapper: update to 0.13.2

### DIFF
--- a/app-admin/snapper/autobuild/patches/0002-Arch-Linux-fix-suse-cron-dir-name.patch
+++ b/app-admin/snapper/autobuild/patches/0002-Arch-Linux-fix-suse-cron-dir-name.patch
@@ -3,7 +3,7 @@ index 48a37965..77628748 100644
 --- a/scripts/Makefile.am
 +++ b/scripts/Makefile.am
 @@ -19,4 +19,4 @@ endif
- EXTRA_DIST = snapper-hourly $(pam_snapper_SCRIPTS)
+ EXTRA_DIST = snapper-hourly snapper-sync $(pam_snapper_SCRIPTS)
  
  install-data-local:
 -	install -D snapper-hourly $(DESTDIR)/etc/cron.hourly/suse.de-snapper

--- a/app-admin/snapper/spec
+++ b/app-admin/snapper/spec
@@ -1,5 +1,4 @@
-VER=0.13.1
+VER=0.13.2
 SRCS="git::commit=tags/v${VER}::https://github.com/openSUSE/snapper"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=4843"
-REL=1


### PR DESCRIPTION
Topic Description
-----------------

- snapper: update to 0.13.2
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- snapper: 0.13.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit snapper
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
