### PR TITLE
telegram-desktop: update to 7.2.7

### DIFF
--- a/app-web/telegram-desktop/autobuild/defines
+++ b/app-web/telegram-desktop/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=web
 PKGDEP="ffmpeg hicolor-icon-theme libnotify minizip abseil-cpp \
     openal-soft openssl lz4 qt-6 xxhash hunspell crc32c glibmm-2.68 fmt \
     libavif libheif libjpeg-turbo libjxl opus pulseaudio rnnoise pipewire \
-    ada"
+    ada tlottie"
 PKGDEP__MAINLINE_TIER2="${PKGDEP} libdispatch"
 BUILDDEP="cmake range-v3 python-3 tl-expected microsoft-gsl yasm gperf \
           extra-cmake-modules wayland-protocols plasma-wayland-protocols"

--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=7.2.5
-# Update tg_owt and tdlib to the latest Git snapshot when updating Telegram Desktop
+VER=7.2.7
+# Update tg_owt, tdlib, and tlottie to the latest Git snapshot when updating Telegram Desktop
 OWTVER=19d51d3c19632a63fdbe17c62f10332d978cb940
-TDLIBVER=022d60202e446ad1287b9fb68e687c8a0760788b
+TDLIBVER=d1085f9cebc5a62379991ae1652673954f229c1f
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
-      git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt
-      git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td"
-CHKSUMS="sha256::702422ac57209a069555bae58c27578629f9b4b63c4e6f0fa27f3c1e101e6588 \
+      git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt.git \
+      git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td.git"
+CHKSUMS="sha256::a496b55cd662e05cd76d81c6b5e117ec73e27b8956a6ebb5808a41dd3b5ba3bc \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"

--- a/runtime-imaging/tlottie/autobuild/beyond
+++ b/runtime-imaging/tlottie/autobuild/beyond
@@ -1,0 +1,3 @@
+abinfo "Installing C header ..."
+install -Dvm644 "$SRCDIR"/include/tlottie.h \
+    -t "$PKGDIR"/usr/include/

--- a/runtime-imaging/tlottie/autobuild/defines
+++ b/runtime-imaging/tlottie/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=tlottie
+PKGSEC=libs
+PKGDEP="glibc gcc-runtime"
+BUILDDEP="rustc llvm"
+PKGDES="Rust library to draw Lottie animations"
+
+ABTYPE=rust
+
+CARGO_AFTER=('--features' 'c-api')

--- a/runtime-imaging/tlottie/spec
+++ b/runtime-imaging/tlottie/spec
@@ -1,0 +1,8 @@
+# FIXME: The upstream has not tagged any version yet. Use the latest commit
+# hash.
+VER=0+git20260908
+SRCS="git::commit=8ca87fc25a6ae5cbea4237feb5bae37940f37ae4::https://github.com/dkaraush/tlottie.git"
+CHKSUMS="SKIP"
+
+# FIXME: No version yet. We don't know the versioning scheme either.
+# CHKUPDATE=""


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 7.2.7
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- telegram-desktop: 7.2.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit tlottie telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
