### PR TITLE
protonplus: update to 0.6.6

### DIFF
--- a/app-utils/protonplus/spec
+++ b/app-utils/protonplus/spec
@@ -1,4 +1,4 @@
-VER=0.6.5
+VER=0.6.6
 SRCS="git::commit=tags/v$VER::https://github.com/Vysp3r/ProtonPlus"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=381419"


### PR DESCRIPTION
Topic Description
-----------------

- protonplus: update to 0.6.6
    Co-authored-by: SkyBird \(@SkyBird233\)

Package(s) Affected
-------------------

- protonplus: 0.6.6

Security Update?
----------------

No

Build Order
-----------

```
#buildit protonplus
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
