### PR TITLE
espresso: new, 2.5.1

### DIFF
--- a/app-electronics/espresso/autobuild/defines
+++ b/app-electronics/espresso/autobuild/defines
@@ -1,0 +1,7 @@
+PKGNAME=espresso
+PKGSEC=electronics
+PKGDEP="gcc-runtime"
+BUILDDEP="asciidoctor"
+PKGDES="Boolean logic minimizer for digital logic gate circuits"
+
+ABTYPE=cmakeninja

--- a/app-electronics/espresso/spec
+++ b/app-electronics/espresso/spec
@@ -1,0 +1,4 @@
+VER=2.5.1
+SRCS="git::commit=tags/v$VER::https://github.com/chipsalliance/espresso"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=392175"


### PR DESCRIPTION
Topic Description
-----------------

- espresso: new, 2.5.1

Package(s) Affected
-------------------

- espresso: 2.5.1

Security Update?
----------------

No

Build Order
-----------

```
#buildit espresso
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`
