### PR TITLE
bakaxl-bunny: update to 4.0.0+git20260909

### DIFF
--- a/app-games/bakaxl-bunny/spec
+++ b/app-games/bakaxl-bunny/spec
@@ -6,11 +6,11 @@
 # that APT will always recognise an update.
 
 # For the link in SRCS to download .deb
-UPSTREAM_VER="4.0.0+bunny-aac68df"
+UPSTREAM_VER="4.0.0+bunny-dd77110"
 # For makeup VER
-COMMIT_DATE=20260814
+COMMIT_DATE=20260909
 
 VER="${UPSTREAM_VER%+*}+git${COMMIT_DATE}"
 SRCS="file::rename=bakaxl-bunny.deb::https://github.com/BakaXL-Launcher/BakaXL/releases/download/${UPSTREAM_VER}/bakaxl-${UPSTREAM_VER}-linux-x86_64.deb"
-CHKSUMS="sha256::feb803cb133c47fae65a6494c7f9ea7969295bdfef80c27033f0d930ac4c5411"
+CHKSUMS="sha256::beffbe40f4feb2a0c90a7a5c538b010f29a0c56f7f76f333864499c592213f54"
 CHKUPDATE="anitya::391806"


### PR DESCRIPTION
Topic Description
-----------------

- bakaxl-bunny: update to 4.0.0+git20260909
- fish: update to 4.9.3
    Co-authored-by: Kaiyang "COMPL.EXE" Wu \(@OriginCode\)

Package(s) Affected
-------------------

- ed: 1.22.5
- nano: 9.2+nanorc2024.1.16

Security Update?
----------------

No

Build Order
-----------

```
#buildit nano ed
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [ ] ARMv4 `armv4`
- [ ] 32-bit Intel 486 `i486`
