### PR TITLE
bakaxl-bunny: update to 4.0.0+git20260909

### DIFF
--- a/app-games/bakaxl-bunny/spec
+++ b/app-games/bakaxl-bunny/spec
@@ -6,11 +6,11 @@
 # that APT will always recognise an update.
 
 # For the link in SRCS to download .deb
-UPSTREAM_VER="4.0.0+bunny-aac68df"
+UPSTREAM_VER="4.0.0+bunny-dd77110"
 # For makeup VER
-COMMIT_DATE=20260814
+COMMIT_DATE=20260909
 
 VER="${UPSTREAM_VER%+*}+git${COMMIT_DATE}"
 SRCS="file::rename=bakaxl-bunny.deb::https://github.com/BakaXL-Launcher/BakaXL/releases/download/${UPSTREAM_VER}/bakaxl-${UPSTREAM_VER}-linux-x86_64.deb"
-CHKSUMS="sha256::feb803cb133c47fae65a6494c7f9ea7969295bdfef80c27033f0d930ac4c5411"
+CHKSUMS="sha256::beffbe40f4feb2a0c90a7a5c538b010f29a0c56f7f76f333864499c592213f54"
 CHKUPDATE="anitya::391806"


### PR DESCRIPTION
Topic Description
-----------------

- bakaxl-bunny: update to 4.0.0+git20260909

Package(s) Affected
-------------------

- bakaxl-bunny: 4.0.0+git20260909

Security Update?
----------------

No

Build Order
-----------

```
#buildit bakaxl-bunny
```

Test Build(s) Done
------------------

**Primary Architectures**

- [ ] AMD64 `amd64`
