### PR TITLE
motrix-next: modify patch to fix aria2-next startup

### DIFF
--- a/app-web/motrix-next/autobuild/build
+++ b/app-web/motrix-next/autobuild/build
@@ -11,15 +11,15 @@ install -Dvm755 "$SRCDIR"/src-tauri/target/release/motrix-next \
 
 abinfo "Installing aria2 config and data..."
 install -Dvm644 "$SRCDIR"/src-tauri/binaries/aria2.conf \
-    "$PKGDIR"/usr/lib/motrix-next/binaries/aria2.conf
+    "$PKGDIR"/usr/lib/MotrixNext/binaries/aria2.conf
 install -Dvm644 "$SRCDIR"/src-tauri/data/ed2k-bootstrap/server.met \
-    "$PKGDIR"/usr/lib/motrix-next/data/ed2k-bootstrap/server.met
+    "$PKGDIR"/usr/lib/MotrixNext/data/ed2k-bootstrap/server.met
 install -Dvm644 "$SRCDIR"/src-tauri/data/ed2k-bootstrap/nodes.dat \
-    "$PKGDIR"/usr/lib/motrix-next/data/ed2k-bootstrap/nodes.dat
+    "$PKGDIR"/usr/lib/MotrixNext/data/ed2k-bootstrap/nodes.dat
 install -Dvm644 "$SRCDIR"/src-tauri/data/dbip-country-lite.mmdb \
-    "$PKGDIR"/usr/lib/motrix-next/data/dbip-country-lite.mmdb
+    "$PKGDIR"/usr/lib/MotrixNext/data/dbip-country-lite.mmdb
 install -Dvm644 "$SRCDIR"/src-tauri/data/bt-peer-blocklist.txt \
-    "$PKGDIR"/usr/lib/motrix-next/data/bt-peer-blocklist.txt
+    "$PKGDIR"/usr/lib/MotrixNext/data/bt-peer-blocklist.txt
 
 abinfo "Installing application icon ..."
 for i in 32 64 128; do

--- a/app-web/motrix-next/autobuild/defines
+++ b/app-web/motrix-next/autobuild/defines
@@ -3,7 +3,7 @@ PKGSEC=web
 PKGDEP="cairo gcc-runtime glib glibc gdk-pixbuf\
         gtk-3 libsoup-3 pango webkit2gtk \
         libayatana-appindicator aria2-next"
-BUILDDEP="nodejs rustc llvm tauri-cli"
+BUILDDEP="nodejs rustc llvm tauri-cli pkgconf"
 PKGDES="Full-featured download manager rebuilt with Tauri 2"
 PKGPROV="motrixnext"
 

--- a/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c-next.patch
+++ b/app-web/motrix-next/autobuild/patches/0003-feat-use-system-aria2c-next.patch
@@ -1,4 +1,4 @@
-From ddbe128c84647b832ecb436cf7e3c884691e38c5 Mon Sep 17 00:00:00 2001
+From e27440094ada302198d8c8590caa35646ef1b635 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Thu, 6 Aug 2026 22:53:08 +0800
 Subject: [PATCH 3/5] feat: use system aria2c-next
@@ -10,7 +10,7 @@ Subject: [PATCH 3/5] feat: use system aria2c-next
  3 files changed, 9 insertions(+), 15 deletions(-)
 
 diff --git a/src-tauri/src/engine/cleanup.rs b/src-tauri/src/engine/cleanup.rs
-index d6d92875..394a61ca 100644
+index d6d92875..4dac0513 100644
 --- a/src-tauri/src/engine/cleanup.rs
 +++ b/src-tauri/src/engine/cleanup.rs
 @@ -4,10 +4,10 @@
@@ -39,14 +39,14 @@ index d6d92875..394a61ca 100644
 -        ));
 -        assert!(is_supported_engine_process(
 -            "/usr/bin/motrix-next-engine --conf-path=/usr/lib/MotrixNext/binaries/aria2.conf"
-+            "/usr/bin/aria2-next --conf-path=/usr/lib/motrix-next/binaries/aria2.conf"
++            "/usr/bin/aria2-next --conf-path=/usr/lib/MotrixNext/binaries/aria2.conf"
          ));
      }
  
      #[test]
      fn is_supported_engine_process_does_not_trust_truncated_comm_names() {
 -        assert!(!is_supported_engine_process("motrix-next-eng"));
-+        assert!(!is_supported_engine_process("aria2-nex"));
++        assert!(!is_supported_engine_process("aria2-next"));
      }
  
      #[test]

--- a/app-web/motrix-next/autobuild/patches/0004-chore-pnpm-relax-supportedArchitectures.cpu-to-curre.patch
+++ b/app-web/motrix-next/autobuild/patches/0004-chore-pnpm-relax-supportedArchitectures.cpu-to-curre.patch
@@ -1,4 +1,4 @@
-From d8dba9141d985b65fd947ad1407f0adbb97c10b4 Mon Sep 17 00:00:00 2001
+From 78ac17be69092338261c2a47191936e3c6f9d5c5 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Thu, 6 Aug 2026 22:55:45 +0800
 Subject: [PATCH 4/5] chore(pnpm): relax supportedArchitectures.cpu to current

--- a/app-web/motrix-next/autobuild/patches/0005-chore-override-dependencies-to-support-loongarch.patch.loongarch64
+++ b/app-web/motrix-next/autobuild/patches/0005-chore-override-dependencies-to-support-loongarch.patch.loongarch64
@@ -1,4 +1,4 @@
-From e8848aff2ce1a06e769e9bdaa8c5f9c35f322494 Mon Sep 17 00:00:00 2001
+From 0b1f41aecf440cc247e0c374d0d9aed1917f2bd4 Mon Sep 17 00:00:00 2001
 From: miwu04 <me@alanlin.icu>
 Date: Thu, 6 Aug 2026 23:04:37 +0800
 Subject: [PATCH 5/5] chore: override dependencies to support loongarch

--- a/app-web/motrix-next/spec
+++ b/app-web/motrix-next/spec
@@ -1,4 +1,5 @@
 VER=3.9.7
+REL=1
 SRCS="git::commit=tags/v$VER::https://github.com/AnInsomniacy/motrix-next.git"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=389590"


### PR DESCRIPTION
Topic Description
-----------------

- motrix-next: modify patch to fix aria2-next startup

Package(s) Affected
-------------------

- motrix-next: 3.9.7

Security Update?
----------------

No

Build Order
-----------

```
#buildit motrix-next
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
