### PR TITLE
xz{,+32}: update to 5.8.4

### DIFF
--- a/app-utils/xz/spec
+++ b/app-utils/xz/spec
@@ -1,5 +1,4 @@
-VER=5.8.3
-REL=1
-SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
+VER=5.8.4
+SRCS="tbl::https://github.com/tukaani-project/xz/releases/download/v$VER/xz-$VER.tar.xz"
+CHKSUMS="sha256::4ce24038fd4221e0d13bc1a2de7a4db56e90b92b3bf75321f6c14be73f65de4b"
 CHKUPDATE="anitya::id=5277"

--- a/runtime-optenv32/xz+32/spec
+++ b/runtime-optenv32/xz+32/spec
@@ -1,4 +1,4 @@
-VER=5.8.3
-SRCS="tbl::https://tukaani.org/xz/xz-$VER.tar.xz"
-CHKSUMS="sha256::fff1ffcf2b0da84d308a14de513a1aa23d4e9aa3464d17e64b9714bfdd0bbfb6"
+VER=5.8.4
+SRCS="tbl::https://github.com/tukaani-project/xz/releases/download/v$VER/xz-$VER.tar.xz"
+CHKSUMS="sha256::4ce24038fd4221e0d13bc1a2de7a4db56e90b92b3bf75321f6c14be73f65de4b"
 CHKUPDATE="anitya::id=5277"

--- a/topics/xz-5.8.4.toml
+++ b/topics/xz-5.8.4.toml
@@ -1,0 +1,13 @@
+security = true
+must_match_all = false
+
+[name]
+default = "XZ 5.8.4"
+
+[caution]
+default = "Fixes an invalid memory access vulnerability in liblzma decoder functions - GHSA-5qpq-xqfv-j9pg (CVE pending)"
+zh_CN = "修复 liblzma 解码器函数中一处无效内存访问漏洞，漏洞编号 GHSA-5qpq-xqfv-j9pg（CVE 编号待定）"
+
+[packages-v2]
+"xz" = "< 5.8.4"
+"xz+32" = "< 5.8.4"

--- a/topics/xz-5.8.4.toml
+++ b/topics/xz-5.8.4.toml
@@ -5,8 +5,8 @@ must_match_all = false
 default = "XZ 5.8.4"
 
 [caution]
-default = "Fixes an invalid memory access vulnerability in liblzma decoder functions - GHSA-5qpq-xqfv-j9pg (CVE pending)"
-zh_CN = "修复 liblzma 解码器函数中一处无效内存访问漏洞，漏洞编号 GHSA-5qpq-xqfv-j9pg（CVE 编号待定）"
+default = "Fixes a Use-After-Free vulnerability in liblzma's decoder functions - GHSA-5qpq-xqfv-j9pg (CVE pending, Severity: High)"
+zh_CN = "修复 liblzma 解码器函数中的一个释放后使用 (use-after-free) 漏洞，漏洞编号 GHSA-5qpq-xqfv-j9pg（CVE 编号待定，严重性：高）"
 
 [packages-v2]
 "xz" = "< 5.8.4"


### PR DESCRIPTION
Topic Description
-----------------

- xz+32: update to 5.8.4
    Switch SRCS to GitHub releases per maintainer request.
    This commit is authored with assistance from AI/LLM:
    - Model: Kimi K3 \(kimi-code/k3\)
    - Platform: Kimi API \(api.kimi.com\)
    - Agent platform: Kimi Code CLI \(https://www.kimi.com/code\)
    - Prompt:
    Update xz to 5.8.4, tarball link
    https://github.com/tukaani-project/xz/releases/download/v5.8.4/xz-5.8.4.tar.xz,
    remember to fetch the remote and open topic branch according to
    guidelines in https://github.com/AOSC-Dev/wiki.
    Assisted-by: Kimi Code \(Kimi K3\)
- topics: add xz-5.8.4.toml
    This commit is authored with assistance from AI/LLM:
    - Model: Kimi K3 \(kimi-code/k3\)
    - Platform: Kimi API \(api.kimi.com\)
    - Agent platform: Kimi Code CLI \(https://www.kimi.com/code\)
    - Prompt:
    Update xz to 5.8.4, tarball link
    https://github.com/tukaani-project/xz/releases/download/v5.8.4/xz-5.8.4.tar.xz,
    remember to fetch the remote and open topic branch according to
    guidelines in https://github.com/AOSC-Dev/wiki.
    Assisted-by: Kimi Code \(Kimi K3\)
- xz: update to 5.8.4
    Switch SRCS to GitHub releases per maintainer request.
    This commit is authored with assistance from AI/LLM:
    - Model: Kimi K3 \(kimi-code/k3\)
    - Platform: Kimi API \(api.kimi.com\)
    - Agent platform: Kimi Code CLI \(https://www.kimi.com/code\)
    - Prompt:
    Update xz to 5.8.4, tarball link
    https://github.com/tukaani-project/xz/releases/download/v5.8.4/xz-5.8.4.tar.xz,
    remember to fetch the remote and open topic branch according to
    guidelines in https://github.com/AOSC-Dev/wiki.
    Assisted-by: Kimi Code \(Kimi K3\)

Package(s) Affected
-------------------

- xz: 5.8.4
- xz+32: 5.8.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit xz xz+32
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [ ] AArch64 `arm64`
- [ ] LoongArch 64-bit `loongarch64`
- [ ] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [ ] Loongson 3 `loongson3`
- [ ] PowerPC 64-bit (Little Endian) `ppc64el`
- [ ] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
