### PR TITLE
vscode: update to 1.137.0

### DIFF
--- a/app-editors/vscode/spec
+++ b/app-editors/vscode/spec
@@ -1,8 +1,8 @@
-VER=1.136.2
+VER=1.137.0
 SRCS__AMD64="file::https://update.code.visualstudio.com/${VER}/linux-deb-x64/stable"
 SRCS__ARM64="file::https://update.code.visualstudio.com/${VER}/linux-deb-arm64/stable"
-CHKSUMS__AMD64="sha256::2493226f723f66c8e83b9d806e3fbe83dcc43f381ece51eaa03d88889542b0c0"
-CHKSUMS__ARM64="sha256::2e6f3289ddd418ac3a80c37d617f59afd101a245edc99c98782d5297f2812f70"
+CHKSUMS__AMD64="sha256::fd4dff72c44598d3acb885b448256f5d82cf53f59538d97fc7d3c8d8d9d574d3"
+CHKSUMS__ARM64="sha256::8bff558a659d351328f5a1e319802073b59dac42f95cc0f9b2ef1b0c27387431"
 __SHA256SUM_AMD64="${CHKSUMS__AMD64}"
 __SHA256SUM_ARM64="${CHKSUMS__ARM64}"
 CHKUPDATE="anitya::id=243355"


### PR DESCRIPTION
Topic Description
-----------------

- vscode: update to 1.137.0
    Co-authored-by: LJL \(@ljlofficial\) <lkjmlk@aosc.io>

Package(s) Affected
-------------------

- vscode: 1.137.0

Security Update?
----------------

No

Build Order
-----------

```
#buildit vscode
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
