### PR TITLE
NVIDIA Drivers 615.71.09

### DIFF
--- a/app-devel/cuda/autobuild/build
+++ b/app-devel/cuda/autobuild/build
@@ -1,12 +1,13 @@
 # Adapted from archlinux build script
 abinfo "Extrating CUDA installer ..."
-sh cuda_${PKGVER/+/_}_linux.run --target "${SRCDIR}" --noexec
+sh cuda_${PKGVER}_linux.run --target "${SRCDIR}" --noexec
 
 CUDA_ROOT="/usr/lib/cuda"
 
 abinfo "Removing uninstaller and runfile itself"
 rm -fv "$SRCDIR"/builds/*.run
 rm -frv "$SRCDIR"/builds/bin
+rm -frv "$SRCDIR"/builds/cuda_documentation/bin/cuda-uninstaller
 
 abinfo "Creating installation directories ..."
 mkdir -pv "$PKGDIR"/"$CUDA_ROOT"/extras

--- a/app-devel/cuda/spec
+++ b/app-devel/cuda/spec
@@ -1,10 +1,8 @@
-UPSTREAM_VER=13.3.1
-MIN_DRIVER_VER=610.43.02
-VER=${UPSTREAM_VER}+${MIN_DRIVER_VER}
+VER=13.4.1
 CHKUPDATE="anitya::id=13462"
 
-SRCS__AMD64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux.run"
-CHKSUMS__AMD64="sha256::9f98ec1f6c950401041d3f1308e221f0d5db8771a8e10569001b64caaee31a92"
+SRCS__AMD64="file::rename=cuda_${VER}_linux.run::https://developer.download.nvidia.com/compute/cuda/${VER}/local_installers/cuda_${VER}_linux.run"
+CHKSUMS__AMD64="sha256::ae07f10b7023012f0f9ccafe8cd70be378528dfeab7bca883d856ca0cfde9634"
 
-SRCS__ARM64="file::rename=cuda_${VER/+/_}_linux.run::https://developer.download.nvidia.com/compute/cuda/${UPSTREAM_VER}/local_installers/cuda_${VER/+/_}_linux_sbsa.run"
-CHKSUMS__ARM64="sha256::075bbf17cd95badf13a546229e0035af9f38fd9e7cd0102585bd43195603923d"
+SRCS__ARM64="file::rename=cuda_${VER}_linux.run::https://developer.download.nvidia.com/compute/cuda/${VER}/local_installers/cuda_${VER}_linux_sbsa.run"
+CHKSUMS__ARM64="sha256::b5f51c726a1e02a0d97a6fd9be2e3e8a95e0d200a031f6ce108559735276c66b"

--- a/runtime-display/libxnvctrl/spec
+++ b/runtime-display/libxnvctrl/spec
@@ -1,4 +1,4 @@
-VER=610.57.04
+VER=615.71.09
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"

--- a/runtime-display/nvidia-open/spec
+++ b/runtime-display/nvidia-open/spec
@@ -1,4 +1,4 @@
-VER=610.57.04
+VER=615.71.09
 SRCS="git::rename=nvidia-driver;commit=tags/${VER}::https://github.com/NVIDIA/open-gpu-kernel-modules
 	git::rename=nvidia-xconfig;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-xconfig
 	git::rename=nvidia-persistenced;commit=tags/${VER}::https://github.com/NVIDIA/nvidia-persistenced"

--- a/runtime-display/nvidia/01-utils/build
+++ b/runtime-display/nvidia/01-utils/build
@@ -113,10 +113,10 @@ install -Dvm755 "libnvidia-ml.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-ml.so.$PKGVER
 install -Dvm755 "libnvidia-sandboxutils.so.$PKGVER" \
     "$PKGDIR"/usr/lib/libnvidia-sandboxutils.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.5" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.5
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.5" \
-    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.5
+install -Dvm766 "libnvidia-egl-xlib.so.1.0.6" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xlib.so.1.0.6
+install -Dvm766 "libnvidia-egl-xcb.so.1.0.6" \
+    "$PKGDIR"/usr/lib/libnvidia-egl-xcb.so.1.0.6
 install -Dvm644 "20_nvidia_xlib.json" \
     "$PKGDIR"/usr/share/egl/egl_external_platform.d/20_nvidia_xlib.json
 install -Dvm644 "20_nvidia_xcb.json" \
@@ -201,9 +201,18 @@ install_for_all 755 "libnvidia-present.so.$PKGVER" "$PKGDIR"/usr/lib
 abinfo 'Installing Tile IR library ...'
 install_for_all 755 "libnvidia-tileiras.so.$PKGVER" "$PKGDIR"/usr/lib
 
+abinfo 'Installing Fabric Manager library ...'
+install_for_all 755 "libnvidia-fmdrv.so.$PKGVER" "$PKGDIR"/usr/lib
+
+abinfo 'Installing Import/Export library ...'
+install_for_all 755 "libnvidia-imex.so.$PKGVER" "$PKGDIR"/usr/lib
+
 if ab_match_arch arm64; then
     abinfo 'Installing cuExtend library ...'
     install_for_all 755 "libnvcuextend.so.$PKGVER" "$PKGDIR"/usr/lib
+
+    abinfo 'Installing Jetson utility library ...'
+    install_for_all 755 "libnvidia-rmapi-tegra.so.$PKGVER" "$PKGDIR"/usr/lib
 fi
 
 abinfo "Debug and core dump utility..."

--- a/runtime-display/nvidia/01-utils/build-optenv32
+++ b/runtime-display/nvidia/01-utils/build-optenv32
@@ -33,10 +33,10 @@ install -Dvm755 "libnvidia-opticalflow.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-opticalflow.so.$PKGVER
 install -Dvm755 "libnvidia-nvvm.so.$PKGVER" \
     "$PKGDIR"/opt/32/lib/libnvidia-nvvm.so.$PKGVER
-install -Dvm755 "libnvidia-egl-xlib.so.1.0.5" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.5
-install -Dvm755 "libnvidia-egl-xcb.so.1.0.5" \
-    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.5
+install -Dvm766 "libnvidia-egl-xlib.so.1.0.6" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xlib.so.1.0.6
+install -Dvm766 "libnvidia-egl-xcb.so.1.0.6" \
+    "$PKGDIR"/opt/32/lib/libnvidia-egl-xcb.so.1.0.6
 install -Dvm755 "libnvidia-egl-gbm.so.1.1.3" \
     "$PKGDIR"/opt/32/lib/libnvidia-egl-gbm.so.1.1.3
 

--- a/runtime-display/nvidia/02-firmware/build
+++ b/runtime-display/nvidia/02-firmware/build
@@ -13,10 +13,8 @@ esac
 
 pushd "$SRCDIR"/NVIDIA-Linux-${NV_ARCH}-${PKGVER}
 
-abinfo "Installing GSP binaries ..."
-install -Dvm644 firmware/gsp_ga10x.bin \
-    "${PKGDIR}"/usr/lib/firmware/nvidia/"${PKGVER}"/gsp_ga10x.bin
-install -Dvm644 firmware/gsp_tu10x.bin \
-    "${PKGDIR}"/usr/lib/firmware/nvidia/"${PKGVER}"/gsp_tu10x.bin
+abinfo "Installing firmware binaries ..."
+install -Dvm644 firmware/*.bin \
+    -t "$PKGDIR"/usr/lib/firmware/nvidia/"$PKGVER"/
 
 popd

--- a/runtime-display/nvidia/spec
+++ b/runtime-display/nvidia/spec
@@ -1,8 +1,8 @@
-VER=610.57.04
+VER=615.71.09
 SRCS__AMD64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-x86_64/$VER/NVIDIA-Linux-x86_64-$VER.run"
-CHKSUMS__AMD64="sha256::b2e935c66b83bb00c0c857bc8e0ee0fd52de9286b40c9cc1eec29a7ce7eb116d"
+CHKSUMS__AMD64="sha256::cdceed22bbeb61248d1a6deabc2596673e3a6501698ee71ac8d2fdc28f3b70fe"
 SRCS__ARM64="file::rename=NVIDIA-Linux-$VER.run::https://download.nvidia.com/XFree86/Linux-aarch64/$VER/NVIDIA-Linux-aarch64-$VER.run"
-CHKSUMS__ARM64="sha256::40279facc0429a93b0b8ec97bf59391a3d2207609894f8271b7253a14c3f8f9e"
+CHKSUMS__ARM64="sha256::21b7a442113b7057e69cf65a2d8f4d0d8705ec2a0d67ed906fbb1177810e8163"
 
 SUBDIR=.
 CHKUPDATE="anitya::id=5454"

--- a/runtime-optenv32/libxnvctrl+32/spec
+++ b/runtime-optenv32/libxnvctrl+32/spec
@@ -1,4 +1,4 @@
-VER=610.57.04
+VER=615.71.09
 SRCS="git::commit=tags/$VER::https://github.com/NVIDIA/nvidia-settings"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=5435"


### PR DESCRIPTION
Topic Description
-----------------

- libxnvctrl+32: update to 615.71.09
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- libxnvctrl: update to 615.71.09
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- cuda: update to 13.4.1
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia-open: update to 615.71.09
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>
- nvidia: update to 615.71.09
    Signed-off-by: Kaiyang Wu <origincode@aosc.io>

Package(s) Affected
-------------------

- libxnvctrl: 615.71.09
- nvidia: 615.71.09
- nvidia-firmware: 615.71.09
- nvidia-open: 615.71.09
- nvidia-utils: 615.71.09

Security Update?
----------------

No

Build Order
-----------

```
#buildit nvidia nvidia-open cuda libxnvctrl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
