### PR TITLE
libpcap: security update to 1.10.7

### DIFF
--- a/runtime-network/libpcap/spec
+++ b/runtime-network/libpcap/spec
@@ -1,4 +1,4 @@
-VER=1.10.6
+VER=1.10.7
 SRCS="tbl::https://www.tcpdump.org/release/libpcap-$VER.tar.gz"
-CHKSUMS="sha256::872dd11337fe1ab02ad9d4fee047c9da244d695c6ddf34e2ebb733efd4ed8aa9"
+CHKSUMS="sha256::0b394ac90dbc0a9838ff97468e05c9c9a3e873dec2514cd58db65d859d296e31"
 CHKUPDATE="anitya::id=1702"

--- a/topics/libpcap-1.10.7.toml
+++ b/topics/libpcap-1.10.7.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libpcap 1.10.7"
+
+[caution]
+default = "Fixes 7 security vulnerabilities (including 1 of high severity and 6 of medium severity)"
+zh_CN = "修复 7 个安全漏洞（含 1 个高危漏洞及 6 个中危漏洞）"
+
+[packages-v2]
+"libpcap" = "< 1.10.7"


### PR DESCRIPTION
Topic Description
-----------------

- libpcap: security update to 1.10.7

Package(s) Affected
-------------------

- libpcap: 1.10.7

Security Update?
----------------

Yes

Build Order
-----------

```
#buildit libpcap
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
