### PR TITLE
telegram-desktop: update to 7.2.8

### DIFF
--- a/app-web/telegram-desktop/spec
+++ b/app-web/telegram-desktop/spec
@@ -1,11 +1,11 @@
-VER=7.2.7
+VER=7.2.8
 # Update tg_owt, tdlib, and tlottie to the latest Git snapshot when updating Telegram Desktop
 OWTVER=19d51d3c19632a63fdbe17c62f10332d978cb940
 TDLIBVER=d1085f9cebc5a62379991ae1652673954f229c1f
 SRCS="tbl::https://github.com/telegramdesktop/tdesktop/releases/download/v$VER/tdesktop-$VER-full.tar.gz \
       git::rename=tg_owt;commit=${OWTVER}::https://github.com/desktop-app/tg_owt.git \
       git::rename=td;commit=${TDLIBVER}::https://github.com/tdlib/td.git"
-CHKSUMS="sha256::a496b55cd662e05cd76d81c6b5e117ec73e27b8956a6ebb5808a41dd3b5ba3bc \
+CHKSUMS="sha256::d4a15b1fd2aec1ebd498dcf5ef0eb62a90c36c8dfe7f034441eef482e0f08574 \
          SKIP \
          SKIP"
 SUBDIR="tdesktop-$VER-full"

--- a/runtime-imaging/tlottie/spec
+++ b/runtime-imaging/tlottie/spec
@@ -1,7 +1,7 @@
 # FIXME: The upstream has not tagged any version yet. Use the latest commit
 # hash.
-VER=0+git20260908
-SRCS="git::commit=8ca87fc25a6ae5cbea4237feb5bae37940f37ae4::https://github.com/dkaraush/tlottie.git"
+VER=0+git20260911
+SRCS="git::commit=31f1b542f88e7b4be9a01e749920d857535fc715::https://github.com/dkaraush/tlottie.git"
 CHKSUMS="SKIP"
 
 # FIXME: No version yet. We don't know the versioning scheme either.


### PR DESCRIPTION
Topic Description
-----------------

- telegram-desktop: update to 7.2.8
- tlottie: update to 0+git20260911

Package(s) Affected
-------------------

- telegram-desktop: 7.2.8
- tlottie: 0+git20260911

Security Update?
----------------

No

Build Order
-----------

```
#buildit tlottie telegram-desktop
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
