### PR TITLE
aosc-xdg-menu: dependency fix

### DIFF
--- a/app-admin/desktop-file-utils/autobuild/defines
+++ b/app-admin/desktop-file-utils/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=desktop-file-utils
 PKGDES="Command line utilities for working with desktop entries"
 PKGSEC=misc
-PKGDEP="glib aosc-xdg-menu"
+PKGDEP="glib"
 
 # Note: Extra Provides for Spiral.
 PKGPROV="desktop-file-utils_spiral"

--- a/app-admin/desktop-file-utils/autobuild/defines
+++ b/app-admin/desktop-file-utils/autobuild/defines
@@ -8,3 +8,6 @@ PKGPROV="desktop-file-utils_spiral"
 
 # Needed by Afterglow, whereas FAIL_ARCH defaults to mainline-only.
 FAIL_ARCH="!(mainline|retro)"
+
+PKGBREAK="desktop-file-utils<=0.28-1 aosc-xdg-menu<=20200412-2"
+PKGREP="desktop-file-utils<=0.28-1"

--- a/app-admin/desktop-file-utils/autobuild/triggers
+++ b/app-admin/desktop-file-utils/autobuild/triggers
@@ -1,1 +1,1 @@
-interest /usr/share/applications
+interest-noawait /usr/share/applications

--- a/app-admin/desktop-file-utils/spec
+++ b/app-admin/desktop-file-utils/spec
@@ -1,5 +1,5 @@
 VER=0.28
-REL=1
+REL=2
 SRCS="tbl::https://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-$VER.tar.xz"
 CHKSUMS="sha256::4401d4e231d842c2de8242395a74a395ca468cd96f5f610d822df33594898a70"
 CHKUPDATE="anitya::id=421"

--- a/app-utils/pinentry/autobuild/defines
+++ b/app-utils/pinentry/autobuild/defines
@@ -4,6 +4,9 @@ PKGDEP="libassuan libcap ncurses libsecret pcre2"
 BUILDDEP="gcr-4 gtk-2 qt-5 qt-6"
 PKGSUG="gcr-4 gtk-2 qt-5 qt-6"
 
+# FIXME: too early to trigger desktop-file-utils, trigger dep resolve failed
+PKGPRDEP__MAINLINE="desktop-file-utils"
+
 # NOTE: Incompatible with TQt 14.x. Tqt disabled.
 PKGSUG__RETRO="gtk-2"
 BUILDDEP__RETRO="gtk-2"

--- a/app-utils/pinentry/spec
+++ b/app-utils/pinentry/spec
@@ -1,4 +1,5 @@
 VER=1.3.3
+REL=1
 SRCS="tbl::https://gnupg.org/ftp/gcrypt/pinentry/pinentry-$VER.tar.bz2"
 CHKSUMS="sha256::c2970f16d6afb66ecddfca767d743936c86239bff936eed7fd7597a678414b63"
 CHKUPDATE="anitya::id=3643"

--- a/runtime-data/aosc-xdg-menu/autobuild/defines
+++ b/runtime-data/aosc-xdg-menu/autobuild/defines
@@ -1,6 +1,6 @@
 PKGNAME=aosc-xdg-menu
 PKGSEC=misc
-PKGDEP="perl-xml-parser"
+PKGDEP="perl perl-xml-parser"
 PKGDES="XDG Menu specifications for WM-based DE"
 
 ABHOST=noarch

--- a/runtime-data/aosc-xdg-menu/spec
+++ b/runtime-data/aosc-xdg-menu/spec
@@ -1,5 +1,5 @@
 VER=20200412
-REL=2
+REL=3
 SRCS="git::commit=tags/v$VER::https://github.com/AOSC-Dev/aosc-xdg-menu"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=230635"


### PR DESCRIPTION
Topic Description
-----------------

- desktop-file-utils: use interest-noawait in trigger
- pinentry: add a PKGPRDEP hack for desktop-util-files trigger
- desktop-file-utils: limit pkgbreak
- desktop-file-utils: remove aosc-xdg-menu from PKGDEP
- aosc-xdg-menu: add perl to PKGDEP

Package(s) Affected
-------------------

- aosc-xdg-menu: 20200412-3
- desktop-file-utils: 0.28-2
- pinentry: 1.3.3-1

Security Update?
----------------

No

Build Order
-----------

```
#buildit aosc-xdg-menu desktop-file-utils pinentry
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
