### PR TITLE
fcitx5-pinyin-moegirl: update to 20260911

### DIFF
--- a/app-i18n/fcitx5-pinyin-moegirl/spec
+++ b/app-i18n/fcitx5-pinyin-moegirl/spec
@@ -1,9 +1,8 @@
-VER=20260812
+VER=20260911
 SRCS="file::rename=moegirl.dict::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict \
       file::rename=moegirl.dict.yaml::https://github.com/outloudvi/mw2fcitx/releases/download/$VER/moegirl.dict.yaml \
       file::rename=LICENSE::https://github.com/outloudvi/mw2fcitx/raw/pkg-moegirl/LICENSE.content"
-CHKSUMS="sha256::24ddcf2404b6c7616cbf1da2419f8ad0c60e4787ac1c61ceb13565fba7596551 \
-         sha256::5836c87507415f4dcdb0fc45aecf4dd7ae82183a650cdd7930e1e663e32e3a24 \
+CHKSUMS="sha256::1591a2d7eb7a44b43b074ebc2052ec4a492fcb27eb632f215c198feccb9816d0 \
+         sha256::161147f707d469be7f5f60f24735aac2bfa078213ce228e67d596810e3352e0d \
          sha256::95f13d3047233ade320b4fce712d1b17de395649d6958c4254f1c21148cc7de8"
-CHKUPDATE="anitya::id=228871"
 SUBDIR=.


### PR DESCRIPTION
Topic Description
-----------------

- fcitx5-pinyin-moegirl: update to 20260911

Package(s) Affected
-------------------

- fcitx5-pinyin-moegirl: 20260911
- rime-pinyin-moegirl: 20260911

Security Update?
----------------

No

Build Order
-----------

```
#buildit fcitx5-pinyin-moegirl
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] Architecture-independent `noarch`
