### PR TITLE
libheif: update to 1.23.4

### DIFF
--- a/runtime-imaging/libheif/spec
+++ b/runtime-imaging/libheif/spec
@@ -1,4 +1,4 @@
-VER=1.23.1
+VER=1.23.4
 SRCS="git::commit=tags/v$VER::https://github.com/strukturag/libheif"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=64439"

--- a/topics/libheif-1.23.4.toml
+++ b/topics/libheif-1.23.4.toml
@@ -1,0 +1,11 @@
+security = true
+
+[name]
+default = "libheif 1.23.4"
+
+[caution]
+default = "Fixes 23 security vulnerabilities disclosed since 1.23.1 (3 of Critical severity, 10 of High severity)"
+zh_CN = "修复从 1.23.1 版本至今披露的 23 个安全漏洞（含 3 个严重漏洞、10 个高危漏洞）"
+
+[packages-v2]
+"libheif" = "< 1.23.4"


### PR DESCRIPTION
Topic Description
-----------------

- libheif: update to 1.23.4
    Co-authored-by: Lain Yang \(@Fearyncess\) <i@lain.vg>

Package(s) Affected
-------------------

- libheif: 1.23.4

Security Update?
----------------

No

Build Order
-----------

```
#buildit libheif
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
