### PR TITLE
tsukimi: update to 26.9.2

### DIFF
--- a/app-multimedia/tsukimi/autobuild/defines
+++ b/app-multimedia/tsukimi/autobuild/defines
@@ -8,3 +8,7 @@ PKGDEP="gcc-runtime gdk-pixbuf glib graphene gstreamer gtk-4 libadwaita mpv \
 ABTYPE=meson
 
 USECLANG=1
+
+# FIXME: aws-lc-rs fails to build with LTO again...
+# ld.lld: error: undefined symbol: aws_lc_0_45_0_EVP_parse_private_key
+NOLTO=1

--- a/app-multimedia/tsukimi/spec
+++ b/app-multimedia/tsukimi/spec
@@ -1,4 +1,4 @@
-VER=26.9.1
-SRCS="git::commit=tags/v$VER;rename=tsukimi::https://github.com/tsukinaha/tsukimi"
+VER=26.9.2
+SRCS="git::commit=tags/v$VER::https://github.com/tsukinaha/tsukimi"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=376111"


### PR DESCRIPTION
Topic Description
-----------------

- tsukimi: update to 26.9.2
    Co-authored-by: \(@MutsukiC\) <mutsuki.so.1.0@gmail.com>
    Signed-off-by: MutsukiC <mutsuki.so.1.0@gmail.com>

Package(s) Affected
-------------------

- tsukimi: 26.9.2

Security Update?
----------------

No

Build Order
-----------

```
#buildit tsukimi
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
