### PR TITLE
util-linux: switch cryptsetup dep to dlopen

### DIFF
--- a/app-utils/util-linux/01-libraries/defines
+++ b/app-utils/util-linux/01-libraries/defines
@@ -1,11 +1,10 @@
 PKGNAME=util-linux-runtime
 PKGSEC=utils
 PKGDES="Utilities and management tools for Linux (runtime libraries)"
-PKGDEP="cryptsetup"
-PKGDEP__RETRO="glibc"
-# We need the full dependency to build binaries.
+PKGDEP="glibc"
+# We need the full dependency to build binaries. cryptsetup used via dlopen
 BUILDDEP="asciidoctor coreutils file libcap-ng libeconf libutempter slang \
-          systemd zlib"
+          systemd zlib cryptsetup"
 # setcap and setpriv requires libcap-ng.
 BUILDDEP__RETRO="coreutils file libcap-ng"
 
@@ -158,7 +157,7 @@ AUTOTOOLS_AFTER=(
     '--without-smack'
     '--without-econf'
     '--without-python'
-    '--with-cryptsetup'
+    '--with-cryptsetup=dlopen'
 )
 
 AUTOTOOLS_AFTER__RETRO=(

--- a/app-utils/util-linux/spec
+++ b/app-utils/util-linux/spec
@@ -1,5 +1,5 @@
 VER=2.42.3
-REL=1
+REL=2
 SRCS="tbl::https://www.kernel.org/pub/linux/utils/util-linux/v${VER:0:4}/util-linux-$VER.tar.xz"
 CHKSUMS="sha256::66ac7c0e725278eb2b039e3104f2c91119341d941b41bac7a285c695f940bd57"
 CHKUPDATE="anitya::id=8179"


### PR DESCRIPTION
Topic Description
-----------------

- util-linux: switch cryptsetup dep to dlopen

Package(s) Affected
-------------------

- util-linux: 2.42.3-2
- util-linux-runtime: 2.42.3-2

Security Update?
----------------

No

Build Order
-----------

```
#buildit util-linux
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`

**Afterglow Architectures**

- [x] ARMv4 `armv4`
- [x] 32-bit Intel 486 `i486`
