### PR TITLE
Re-enable Backblaze B2 API in duplicity

### DIFF
--- a/app-utils/duplicity/autobuild/defines
+++ b/app-utils/duplicity/autobuild/defines
@@ -1,7 +1,7 @@
 PKGNAME=duplicity
 PKGSEC=util
 PKGDEP="librsync cryptography fasteners httplib2 pysocks requests requests-oauthlib"
-PKGSUG="boto3 botocore dropbox paramiko pyrax swiftclient"
+PKGSUG=" b2sdk boto3 botocore dropbox paramiko pyrax swiftclient"
 BUILDDEP="setuptools-python3 setuptools-scm pipx"
 PKGDES="Encrypted backup utility using rsync algorithm"
 

--- a/app-utils/duplicity/spec
+++ b/app-utils/duplicity/spec
@@ -1,4 +1,5 @@
 VER=3.1.0
+REL=1
 SRCS="git::commit=tags/rel.$VER;copy-repo=true::https://gitlab.com/duplicity/duplicity"
 CHKSUMS="SKIP"
 CHKUPDATE="anitya::id=635"

--- a/lang-python/b2sdk/autobuild/defines
+++ b/lang-python/b2sdk/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=b2sdk
+PKGSEC=python
+PKGDEP="python-3 tqdm pydantic logfury requests annotated-types"
+BUILDDEP="hatchling hatch-vcs"
+PKGDES="Python bindings for Backblaze B2 storage APIs"
+
+NOPYTHON2=1
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/b2sdk/spec
+++ b/lang-python/b2sdk/spec
@@ -1,0 +1,4 @@
+VER=2.12.0
+SRCS="git::commit=v${VER};copy-repo=true::https://github.com/Backblaze/b2-sdk-python.git"
+CHKSUMS="SKIP"
+CHKUPDATE="anitya::id=23387"

--- a/lang-python/logfury/autobuild/defines
+++ b/lang-python/logfury/autobuild/defines
@@ -1,0 +1,9 @@
+PKGNAME=logfury
+PKGSEC=python
+PKGDEP="python-3"
+BUILDDEP="setuptools setuptools-scm"
+PKGDES="Responsible, reusable logging toolkit"
+
+NOPYTHON2=1
+ABHOST=noarch
+ABTYPE=pep517

--- a/lang-python/logfury/autobuild/patches/0001-nuke-legacy-setup.py-and-replace-with-pyproject.toml.patch
+++ b/lang-python/logfury/autobuild/patches/0001-nuke-legacy-setup.py-and-replace-with-pyproject.toml.patch
@@ -1,0 +1,152 @@
+From 81f8ad58ed080b80674058ea9c6a40222f2990c2 Mon Sep 17 00:00:00 2001
+From: Tianhao Chai <cth451@gmail.com>
+Date: Sat, 12 Sep 2026 15:53:08 -0400
+Subject: [PATCH] nuke legacy setup.py and replace with pyproject.toml
+
+Convertion with claude on local Qwen3-Coder-Next@Q4 + human edit.
+---
+ pyproject.toml | 47 ++++++++++++++++++++++++++++++
+ setup.py       | 77 --------------------------------------------------
+ 2 files changed, 47 insertions(+), 77 deletions(-)
+ create mode 100644 pyproject.toml
+ delete mode 100644 setup.py
+
+diff --git a/pyproject.toml b/pyproject.toml
+new file mode 100644
+index 0000000..347a07f
+--- /dev/null
++++ b/pyproject.toml
+@@ -0,0 +1,47 @@
++[build-system]
++requires = ["setuptools>=61", "setuptools_scm>=8.0"]
++build-backend = "setuptools.build_meta"
++
++[project]
++name = "logfury"
++description = "Toolkit for responsible, low-boilerplate logging of library method calls"
++readme = "README.rst"
++license = {"text" = "BSD"}
++keywords = ["logging", "tracing"]
++classifiers = [
++    "Development Status :: 6 - Mature",
++    "Intended Audience :: Developers",
++    "Topic :: Software Development :: Libraries :: Python Modules",
++    "Topic :: System :: Logging",
++    "Natural Language :: English",
++    "License :: OSI Approved :: BSD License",
++    "Operating System :: OS Independent",
++    "Programming Language :: Python",
++    "Programming Language :: Python :: 3",
++    "Programming Language :: Python :: 3.5",
++    "Programming Language :: Python :: 3.6",
++    "Programming Language :: Python :: 3.7",
++    "Programming Language :: Python :: 3.8",
++    "Programming Language :: Python :: 3.9",
++    "Programming Language :: Python :: 3.10",
++    "Programming Language :: Python :: Implementation :: CPython",
++    "Programming Language :: Python :: Implementation :: PyPy",
++]
++authors = [
++    {name = "Pawel Polewicz", email = "p.polewicz@gmail.com"}
++]
++dynamic = ["version"]
++
++[project.urls]
++Homepage = "https://github.com/reef-technologies/logfury"
++"Download URL" = "https://github.com/reef-technologies/logfury/releases"
++
++[tool.setuptools]
++packages = ["logfury"]
++
++[tool.setuptools.package-data]
++logfury = ["requirements.txt", "LICENSE"]
++
++[tool.setuptools_scm]
++version_scheme = "no-guess-dev"
++local_scheme = "no-local-version"
+diff --git a/setup.py b/setup.py
+deleted file mode 100644
+index b244da4..0000000
+--- a/setup.py
++++ /dev/null
+@@ -1,77 +0,0 @@
+-# noqa
+-
+-import os.path
+-from codecs import open
+-
+-from setuptools import find_packages, setup
+-
+-################################################################### yapf: disable
+-
+-NAME         = 'logfury'
+-
+-AUTHOR       = 'Pawel Polewicz'
+-AUTHOR_EMAIL = 'p.polewicz@gmail.com'
+-
+-DESCRIPTION  = 'Toolkit for responsible, low-boilerplate logging of library method calls',
+-LICENSE      = 'BSD'
+-KEYWORDS     = ['logging', 'tracing']
+-URL          = 'https://github.com/reef-technologies/logfury'
+-DOWNLOAD_URL = URL + '/releases'
+-
+-CLASSIFIERS = [
+-    'Development Status :: 6 - Mature',
+-
+-    'Intended Audience :: Developers',
+-    'Topic :: Software Development :: Libraries :: Python Modules',
+-    'Topic :: System :: Logging',
+-
+-    'Natural Language :: English',
+-
+-    'License :: OSI Approved :: BSD License',
+-
+-    'Operating System :: OS Independent',
+-    'Programming Language :: Python',
+-    'Programming Language :: Python :: 3',
+-    'Programming Language :: Python :: 3.5',
+-    'Programming Language :: Python :: 3.6',
+-    'Programming Language :: Python :: 3.7',
+-    'Programming Language :: Python :: 3.8',
+-    'Programming Language :: Python :: 3.9',
+-    'Programming Language :: Python :: 3.10',
+-    'Programming Language :: Python :: Implementation :: CPython',
+-    'Programming Language :: Python :: Implementation :: PyPy',
+-]
+-
+-################################################################### yapf: enable
+-
+-here = os.path.abspath(os.path.dirname(__file__))
+-
+-
+-def read_file_contents(filename):
+-    with open(os.path.join(here, filename), 'rb', encoding='utf-8') as f:
+-        return f.read()
+-
+-
+-setup(
+-    name             = NAME,
+-    url              = URL,
+-    download_url     = DOWNLOAD_URL,
+-
+-    author           = AUTHOR,
+-    author_email     = AUTHOR_EMAIL,
+-    maintainer       = AUTHOR,
+-    maintainer_email = AUTHOR_EMAIL,
+-
+-    packages         = find_packages(exclude=['test*']),
+-    license          = LICENSE,
+-
+-    description      = DESCRIPTION,
+-    long_description = read_file_contents('README.rst'),
+-    keywords         = KEYWORDS,
+-
+-    classifiers      = CLASSIFIERS,
+-    package_data     = {NAME: ['requirements.txt', 'LICENSE']},
+-
+-    setup_requires   = ['setuptools_scm<6.0'],  # setuptools_scm>=6.0 doesn't support Python 3.5
+-    use_scm_version  = True,
+-)  # yapf: disable
+-- 
+2.55.0
+

--- a/lang-python/logfury/spec
+++ b/lang-python/logfury/spec
@@ -1,0 +1,5 @@
+VER=1.0.1
+SRCS="tbl::https://pypi.io/packages/source/l/logfury/logfury-$VER.tar.gz"
+CHKSUMS="sha256::130a5daceab9ad534924252ddf70482aa2c96662b3a3825a7d30981d03b76a26"
+CHKUPDATE="anitya::id=231357"
+REL=3


### PR DESCRIPTION
Topic Description
-----------------

- duplicity: mark b2sdk as PKGSUG
- b2sdk: reintroduce, 2.12.0
    Partially reverts commit 07bbe70b2c0eebedac23de8580bce82d8175a0d9.
    Adds missing dependencies \`logfury\` and \`annotated-types\`.
- logfury: reintroduce, 1.0.1-3
    Partially reverts commit fb934f675875b39581f37b37649e3efd46fb4de4.
    Remove legacy setup.py and replace with pyproject.toml

Package(s) Affected
-------------------

- b2sdk: 2.12.0
- duplicity: 3.1.0-1
- logfury: 1.0.1-3

Security Update?
----------------

No

Build Order
-----------

```
#buildit logfury b2sdk duplicity
```

Test Build(s) Done
------------------

**Primary Architectures**

- [x] AMD64 `amd64`
- [x] AArch64 `arm64`
- [x] LoongArch 64-bit `loongarch64`
- [x] LoongArch 64-bit (No SIMD) `loongarch64_nosimd`

**Secondary Architectures**

- [x] Loongson 3 `loongson3`
- [x] PowerPC 64-bit (Little Endian) `ppc64el`
- [x] RISC-V 64-bit `riscv64`
